### PR TITLE
Block can specify type of `self`

### DIFF
--- a/lib/ruby/signature/scaffold/rbi.rb
+++ b/lib/ruby/signature/scaffold/rbi.rb
@@ -376,13 +376,16 @@ module Ruby
           if block
             if (type = vars[block])
               if type.is_a?(Types::Proc)
-                method_block = MethodType::Block.new(required: true, type: type.type)
+                method_block = MethodType::Block.new(required: true,
+                                                     type: type.type,
+                                                     self_type: nil)
               else
                 STDERR.puts "Unexpected block type: #{type}"
                 PP.pp args_node, STDERR
                 method_block = MethodType::Block.new(
                   required: true,
-                  type: Types::Function.empty(Types::Bases::Any.new(location: nil))
+                  type: Types::Function.empty(Types::Bases::Any.new(location: nil)),
+                  self_type: nil
                 )
               end
             end

--- a/test/ruby/signature/method_type_parsing_test.rb
+++ b/test/ruby/signature/method_type_parsing_test.rb
@@ -30,4 +30,18 @@ class Ruby::Signature::MethodTypeParsingTest < Minitest::Test
 
     assert_equal "}", error.error_value
   end
+
+  def test_self_type
+    Parser.parse_method_type("[A] () { () -> A } @ Integer -> A").yield_self do |type|
+      assert_equal "Integer", type.block.self_type.to_s
+    end
+
+    Parser.parse_method_type("[A] () { () -> A } @ singleton(Integer) -> A").yield_self do |type|
+      assert_equal "singleton(Integer)", type.block.self_type.to_s
+    end
+
+    Parser.parse_method_type("[A] () { () -> A } @ self -> A").yield_self do |type|
+      assert_equal "self", type.block.self_type.to_s
+    end
+  end
 end

--- a/test/ruby/signature/rbi_scaffold_test.rb
+++ b/test/ruby/signature/rbi_scaffold_test.rb
@@ -408,4 +408,27 @@ class Dir
 end
     EOF
   end
+
+  def test_bind_proc
+    parser = RBI.new
+
+    parser.parse <<-EOF
+class Hello
+  sig do
+    type_parameters(:U)
+    .params(
+        blk: T.proc.bind(T.untyped).params().returns(T.type_parameter(:U)),
+    )
+    .returns(T.type_parameter(:U))
+  end
+  def instance_eval(arg0=T.unsafe(nil), filename=T.unsafe(nil), lineno=T.unsafe(nil), &blk); end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  def instance_eval: [U] () { () -> U } @ any -> U
+end
+    EOF
+  end
 end

--- a/test/ruby/signature/writer_test.rb
+++ b/test/ruby/signature/writer_test.rb
@@ -129,4 +129,12 @@ class Bar
 end
     SIG
   end
+
+  def test_block_self
+    assert_writer <<-SIG
+class Foo
+  def instance_eval: [A] () { () -> A } @ self -> A
+end
+    SIG
+  end
 end


### PR DESCRIPTION
Some Ruby methods like `instance_eval` or `Rails.application.configure` swaps `self` in the given block. This patch is to support writing the type of them.

```
def configure: () { () -> void } @ self -> void
```

Using `@` following the type of block specifies the type of `self` in the block.

Note that you need a space between `@` and the type to avoid confusion between instance variables. (TODO: fix parser.)