### PR TITLE
Allow rbs keyword method names and aguments

### DIFF
--- a/lib/ruby/signature/parser.y
+++ b/lib/ruby/signature/parser.y
@@ -506,7 +506,7 @@ rule
       kCLASS | kVOID | kNIL | kTRUE | kFALSE | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
     | kTYPE | kMODULE | kPRIVATE | kPUBLIC | kEND | kINCLUDE | kEXTEND | kPREPEND
     | kATTRREADER | kATTRACCESSOR | kATTRWRITER | kDEF | kEXTENSION | kSELF | kINCOMPATIBLE
-    | kUNCHECKED
+    | kUNCHECKED | kINTERFACE | kSUPER | kALIAS | kIN | kOUT
 
   module_type_params:
       { result = nil }


### PR DESCRIPTION
This allows to describe a few methods that are accepted by Ruby but are not (yet?) by ruby-signature.

Example:
```ruby
class Test
  def interface; end
  def in(in:); end
  # And a few others
end
```
 I'm not advocating that Ruby code is a good production code but I think there should be parity between what's accepted by Ruby and what can be described by rbs.

That said, I'm afraid I would need a bit of help with the parser. In particular I have issues with `self`. The change in the PR doesn't work properly for `def self` and on top of that seemingly breaks interfaces. I don't get broken tests for interfaces but a few exceptions that I don't get on master.