### PR TITLE
Fix order of arguments in `inject`

### DIFF
--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -133,7 +133,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
 
   def inject: (untyped init, Symbol method) -> untyped
             | (Symbol method) -> untyped
-            | [A] (A initial) { (Elem, A) -> A } -> Elem
+            | [A] (A initial) { (A, Elem) -> A } -> A
             | () { (Elem, Elem) -> Elem } -> Elem
 
   # Returns the object in *enum* with the maximum value. The first form

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require "rbs/test/test_helper"
 
 class EnumerableTest < StdlibTest
   target Enumerable
@@ -104,5 +105,33 @@ class EnumerableTest < StdlibTest
 
       include Enumerable
     }.new
+  end
+end
+
+class EnumerableTest2 < Minitest::Test
+  include RBS::Test::TypeAssertions
+
+  class TestEnumerable
+    include Enumerable
+
+    def each
+      yield '1'
+      yield '2'
+      yield '3'
+      self
+    end
+  end
+
+  testing "::Enumerable[String, TestEnumerable]"
+
+  def test_inject
+    assert_send_type "(String init, Symbol method) -> untyped", TestEnumerable.new, :inject, '', :<<
+    assert_send_type "(Symbol method) -> String", TestEnumerable.new, :inject, :+
+    assert_send_type("(Integer initial) { (Integer, String) -> Integer } -> Integer", TestEnumerable.new, :inject, 0) do |memo, item|
+      memo ^ item.hash
+    end
+    assert_send_type("() { (String, String) -> String } -> String", TestEnumerable.new, :inject) do |memo, item|
+      memo + item
+    end
   end
 end


### PR DESCRIPTION
One of the signatures for `inject` appears to have the `initial` and `obj` arguments swapped. 

From ruby-doc

```
reduce(initial) { |memo, obj| block } → obj
```

From Enumerable.rbs

```
[A] (A initial) { (Elem, A) -> A } -> Elem
```

I suspect that `(untyped initial) { (untyped, Elem) -> untyped } -> untyped` might be most honest, as the block doesn't have to be bound by the types of its arguments. If it is valuable to have a signature where `initial` differs from `Elem`, I think the one I've added is more correct.

Would anyone be able to help me write a test case for this? I wasn't able to set up a test case that demonstrated the argument swapping, and instead have been using steep with my branch as submodule to confirm my change works.

```ruby
items = ['a', 'b', 'c']
items.reduce(0) do |memo, item|
  memo ^ item.hash
end
```