### PR TITLE
Fix constant resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Fix constant resolution [#288](https://github.com/ruby/rbs/pull/288)
+
 ## 0.2.0
 
 * The first release of RBS gem.

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -362,7 +362,7 @@ module RBS
       name = Namespace.parse(args[0]).to_type_name
       stdout.puts "Constant name: #{name}"
 
-      constant = table.resolve_constant_reference(name, context: namespace)
+      constant = table.resolve_constant_reference(name, context: namespace.ascend.to_a)
 
       if constant
         stdout.puts " => #{constant.name}: #{constant.type}"

--- a/lib/rbs/namespace.rb
+++ b/lib/rbs/namespace.rb
@@ -87,5 +87,23 @@ module RBS
         new(path: string.split("::").map(&:to_sym), absolute: false)
       end
     end
+
+
+    def ascend
+      if block_given?
+        current = self
+
+        until current.empty?
+          yield current
+          current = current.parent
+        end
+
+        yield current
+
+        self
+      else
+        enum_for(:ascend)
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm improving constant resolution in RBS to make it more Ruby compatible for the following case:

```rb
class A; end
class A::B; end
class A::B::String; end

class A
  pp String       # This is ::String
end

class A::B
  pp String       # This is A::B::String
end
```

So the constant name resolution should take account of every outer class/module declarations.