### PR TITLE
Update Enumerator::Yielder types

### DIFF
--- a/stdlib/builtin/enumerator.rbs
+++ b/stdlib/builtin/enumerator.rbs
@@ -250,9 +250,11 @@ class Enumerator::Lazy[out Elem, out Return] < Enumerator[Elem, Return]
 end
 
 class Enumerator::Yielder < Object
-  def <<: (*untyped arg0) -> void
+  def <<: (untyped arg0) -> void
 
   def yield: (*untyped arg0) -> void
+
+  def to_proc: () -> Proc
 end
 
 class Enumerator::Chain[out Elem, out Return] < Object

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -1,0 +1,40 @@
+require_relative "test_helper"
+require "rbs/test/test_helper"
+
+class EnumeratorYielderTest < Minitest::Test
+  include RBS::Test::TypeAssertions
+
+  testing "::Enumerator::Yielder"
+
+  def test_ltlt
+    Enumerator.new do |y|
+      assert_send_type "(untyped) -> void",
+                       y, :<<, 1
+    end.next
+  end
+
+  def test_yield
+    Enumerator.new do |y|
+      assert_send_type "() -> void",
+                       y, :yield
+    end.next
+
+    Enumerator.new do |y|
+      assert_send_type "(untyped) -> void",
+                       y, :yield, 1
+    end.next
+
+    Enumerator.new do |y|
+      assert_send_type "(untyped, untyped) -> void",
+                       y, :yield, 1, 2
+    end.next
+  end
+
+  def test_to_proc
+    Enumerator.new do |y|
+      assert_send_type "() -> Proc",
+                       y, :to_proc
+      y << 42 # To avoid StopIteration error
+    end.next
+  end
+end


### PR DESCRIPTION
This pull request contains two updates for Enumerator::Yielder class, and test for them.


First, it fixes the wrong type of `Enumerator::Yielder#<<`. The type took multiple arguments ,but it actually takes one argument.

Second, it adds `Enumerator::Yielder#to_proc` type. The method has been added since Ruby 2.7.
https://bugs.ruby-lang.org/issues/15618


This pull request only adds test for `Enumerator::Yielder`, not for `Enumerator`. Because I guess adding tests for `Enumerator` will be hard work.



