### PR TITLE
Add Encoding::CESU_8 constant

### DIFF
--- a/stdlib/builtin/encoding.rbs
+++ b/stdlib/builtin/encoding.rbs
@@ -173,6 +173,8 @@ Encoding::Big5_HKSCS_2008: Encoding
 
 Encoding::Big5_UAO: Encoding
 
+Encoding::CESU_8: Encoding
+
 Encoding::CP1250: Encoding
 
 Encoding::CP1251: Encoding


### PR DESCRIPTION
Encoding::CESU_8 is available since Ruby 2.7.
https://bugs.ruby-lang.org/issues/15931