### PR TITLE
Improve Fiber typing

### DIFF
--- a/stdlib/builtin/fiber.rbs
+++ b/stdlib/builtin/fiber.rbs
@@ -62,7 +62,11 @@
 class Fiber < Object
   def self.yield: (*untyped args) -> untyped
 
-  def initialize: () { () -> void } -> Fiber
+  def initialize: () { () -> untyped } -> void
 
   def resume: (*untyped args) -> untyped
+
+  def raise: () -> untyped
+           | (string message) -> untyped
+           | (_Exception exception, ?string message, ?Array[String] backtrace) -> untyped
 end

--- a/test/stdlib/Fiber_test.rb
+++ b/test/stdlib/Fiber_test.rb
@@ -1,17 +1,73 @@
 require_relative "test_helper"
+require "rbs/test/test_helper"
 
-class FiberTest < StdlibTest
-  target Fiber
-  using hook.refinement
+class FiberSingletonTest < Minitest::Test
+  include RBS::Test::TypeAssertions
 
-  def test_initialize
-    Fiber.new {}
+  testing "singleton(::Fiber)"
+
+  def test_new
+    assert_send_type "() { () -> untyped }-> Fiber",
+                     Fiber, :new do 42 end
   end
 
-  def test_resume_and_yield
-    f = Fiber.new { Fiber.yield(1); Fiber.yield('2', :foo) }
-    f.resume(1)
-    f.resume('2', :foo)
+  def test_yield
+    Fiber.new do
+      assert_send_type "() -> untyped",
+                       Fiber, :yield
+    end.resume
+
+    Fiber.new do
+      assert_send_type "(untyped) -> untyped",
+                       Fiber, :yield, 42
+    end.resume
+
+    Fiber.new do
+      assert_send_type "(untyped, untyped) -> untyped",
+                       Fiber, :yield, 42, '42'
+    end.resume
+  end
+end
+
+class FiberTest < Minitest::Test
+  include RBS::Test::TypeAssertions
+
+  testing "::Fiber"
+
+  def test_resume
+    f = Fiber.new do
+      loop { Fiber.yield }
+    end
+
+    assert_send_type "() -> untyped",
+                     f, :resume
+    assert_send_type "(untyped) -> untyped",
+                     f, :resume, 10
+    assert_send_type "(untyped, untyped) -> untyped",
+                     f, :resume, 10, :foo
+  end
+
+  def test_raise
+    f = Fiber.new do
+      Fiber.yield
+    rescue
+      retry
+    end
     f.resume
+
+    assert_send_type "() -> untyped",
+                     f, :raise
+    assert_send_type "(String) -> untyped",
+                     f, :raise, "Error!"
+    assert_send_type "(ToStr) -> untyped",
+                     f, :raise, ToStr.new('Error!')
+    assert_send_type "(singleton(StandardError)) -> untyped",
+                     f, :raise, StandardError
+    assert_send_type "(StandardError) -> untyped",
+                     f, :raise, StandardError.new('Error!')
+    assert_send_type "(singleton(StandardError), String) -> untyped",
+                     f, :raise, StandardError, 'Error!'
+    assert_send_type "(singleton(StandardError), String, Array[String]) -> untyped",
+                     f, :raise, StandardError, 'Error!', caller
   end
 end


### PR DESCRIPTION
This pull request improves Fiber typing.

It changes three things.

First, it updates `FIber#initialize` type.
The returned value of the block that is passed to `Fiber#initialize` can be used. So it should not be `void`.

```ruby
Fiber.new do
  42
end.tap do |f|
  p f.resume # => 42
end
```



Second, it adds `Fiber#raise` typing. The method is available since Ruby 2.7.
https://bugs.ruby-lang.org/issues/10344
Note that the returned value should be `untyped`, not `bot` like `Kernel.raise`. Because it returned a value if the raised exception is rescued in the child fiber.

```ruby
Fiber.new do
  Fiber.yield
rescue
  42
end.tap do |f|
  f.resume
  p f.raise # => 42
end
```

Third, it replaces the old-style test with `assert_send_type`.