### PR TITLE
[DOC] Update how to execute all stdlib tests

### DIFF
--- a/bin/test_runner.rb
+++ b/bin/test_runner.rb
@@ -9,8 +9,6 @@ unless RUBY_27
   exit
 end
 
-require "pathname"
-
 ARGV.each do |arg|
   load arg
 end

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -147,6 +147,6 @@ If the execution of the program escape from the class definition, the instrument
 You can run the test with:
 
 ```
-$ bundle exec ruby bin/test_runner.rb         # Run all tests
+$ bundle exec rake stdlib_test                # Run all tests
 $ bundle exec ruby test/stdlib/String_test.rb # Run specific tests
 ```


### PR DESCRIPTION
`bundle exec ruby bin/test_runner.rb` does nothing without file names since https://github.com/ruby/rbs/pull/172.
But the stdlib documentation includes the command, so this pull request replaces it with `rake stdlib_test`.


And it removes unnecessary `require 'pathname'`. It added by https://github.com/ruby/rbs/pull/103, but Pathname dependency has been removed by #172. 