### PR TITLE
Small fix for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ rbs methods ::Object
 $ rbs method ::Object tap
 ```
 
-### rbs [--class|--module|interface] list
+### rbs list [--class|--module|--interface]
 
 ```
 $ rbs list


### PR DESCRIPTION
As far as I've tried, README seemed to be a bit wrong.

* `list` subcommand should be placed after options like `--class`
* `interface` option also needs `--` prefix as same as `--class` or `--module`

In other words, `rbs list --interface` worked for me.