### PR TITLE
Add not-builtin fiber type

### DIFF
--- a/stdlib/fiber/fiber.rbs
+++ b/stdlib/fiber/fiber.rbs
@@ -54,25 +54,12 @@
 #     1000000
 #     FiberError: dead fiber called
 #
-class Fiber
+extension Fiber (Fiber)
   # Returns the current fiber. You need to `require 'fiber'` before using this
   # method. If you are not running in the context of a fiber this method will
   # return the root fiber.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     Fiber.current() -> fiber
-  #
-  def self.current: () -> untyped
-
-  # Yields control back to the context that resumed the fiber, passing along any
-  # arguments that were passed to it. The fiber will resume processing at this
-  # point when #resume is called next. Any arguments passed to the next #resume
-  # will be the value that this Fiber.yield expression evaluates to.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     Fiber.yield(args, ...) -> obj
-  #
-  def self.yield: (*untyped) -> untyped
+  def self.current: () -> Fiber
 
   public
 
@@ -80,59 +67,7 @@ class Fiber
   # finishing execution of the fiber block this method will always return false.
   # You need to `require 'fiber'` before using this method.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     fiber.alive? -> true or false
-  #
-  def alive?: () -> untyped
-
-  def blocking?: () -> untyped
-
-  # Returns fiber information string.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     inspect()
-  #
-  alias inspect to_s
-
-  # Raises an exception in the fiber at the point at which the last `Fiber.yield`
-  # was called. If the fiber has not been started or has already run to
-  # completion, raises `FiberError`.
-  #
-  # With no arguments, raises a `RuntimeError`. With a single `String` argument,
-  # raises a `RuntimeError` with the string as a message.  Otherwise, the first
-  # parameter should be the name of an `Exception` class (or an object that
-  # returns an `Exception` object when sent an `exception` message). The optional
-  # second parameter sets the message associated with the exception, and the third
-  # parameter is an array of callback information. Exceptions are caught by the
-  # `rescue` clause of `begin...end` blocks.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     fiber.raise                                 -> obj
-  #     fiber.raise(string)                         -> obj
-  #     fiber.raise(exception [, string [, array]]) -> obj
-  #
-  def raise: (*untyped) -> untyped
-
-  # Resumes the fiber from the point at which the last Fiber.yield was called, or
-  # starts running it if it is the first call to #resume. Arguments passed to
-  # resume will be the value of the Fiber.yield expression or will be passed as
-  # block parameters to the fiber's block if this is the first #resume.
-  #
-  # Alternatively, when resume is called it evaluates to the arguments passed to
-  # the next Fiber.yield statement inside the fiber's block or to the block value
-  # if it runs to completion without any Fiber.yield
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     fiber.resume(args, ...) -> obj
-  #
-  def resume: (*untyped) -> untyped
-
-  # Returns fiber information string.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     fiber.to_s   -> string
-  #
-  def to_s: () -> untyped
+  def alive?: () -> bool
 
   # Transfer control to another fiber, resuming it from where it last stopped or
   # starting it if it was not resumed before. The calling fiber will be suspended
@@ -178,12 +113,5 @@ class Fiber
   #     #<FiberError: cannot resume transferred Fiber>
   #     In Fiber 1 again
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     fiber.transfer(args, ...) -> obj
-  #
   def transfer: (*untyped) -> untyped
-
-  private
-
-  def initialize: (*untyped) -> untyped
 end

--- a/stdlib/fiber/fiber.rbs
+++ b/stdlib/fiber/fiber.rbs
@@ -1,22 +1,186 @@
+# Fibers are primitives for implementing light weight cooperative concurrency in
+# Ruby. Basically they are a means of creating code blocks that can be paused
+# and resumed, much like threads. The main difference is that they are never
+# preempted and that the scheduling must be done by the programmer and not the
+# VM.
+#
+# As opposed to other stackless light weight concurrency models, each fiber
+# comes with a stack.  This enables the fiber to be paused from deeply nested
+# function calls within the fiber block.  See the ruby(1) manpage to configure
+# the size of the fiber stack(s).
+#
+# When a fiber is created it will not run automatically. Rather it must be
+# explicitly asked to run using the Fiber#resume method. The code running inside
+# the fiber can give up control by calling Fiber.yield in which case it yields
+# control back to caller (the caller of the Fiber#resume).
+#
+# Upon yielding or termination the Fiber returns the value of the last executed
+# expression
+#
+# For instance:
+#
+#     fiber = Fiber.new do
+#       Fiber.yield 1
+#       2
+#     end
+#
+#     puts fiber.resume
+#     puts fiber.resume
+#     puts fiber.resume
+#
+# *produces*
+#
+#     1
+#     2
+#     FiberError: dead fiber called
+#
+# The Fiber#resume method accepts an arbitrary number of parameters, if it is
+# the first call to #resume then they will be passed as block arguments.
+# Otherwise they will be the return value of the call to Fiber.yield
+#
+# Example:
+#
+#     fiber = Fiber.new do |first|
+#       second = Fiber.yield first + 2
+#     end
+#
+#     puts fiber.resume 10
+#     puts fiber.resume 1_000_000
+#     puts fiber.resume "The fiber will be dead before I can cause trouble"
+#
+# *produces*
+#
+#     12
+#     1000000
+#     FiberError: dead fiber called
+#
 class Fiber
+  # Returns the current fiber. You need to `require 'fiber'` before using this
+  # method. If you are not running in the context of a fiber this method will
+  # return the root fiber.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     Fiber.current() -> fiber
+  #
   def self.current: () -> untyped
 
+  # Yields control back to the context that resumed the fiber, passing along any
+  # arguments that were passed to it. The fiber will resume processing at this
+  # point when #resume is called next. Any arguments passed to the next #resume
+  # will be the value that this Fiber.yield expression evaluates to.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     Fiber.yield(args, ...) -> obj
+  #
   def self.yield: (*untyped) -> untyped
 
   public
 
+  # Returns true if the fiber can still be resumed (or transferred to). After
+  # finishing execution of the fiber block this method will always return false.
+  # You need to `require 'fiber'` before using this method.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     fiber.alive? -> true or false
+  #
   def alive?: () -> untyped
 
   def blocking?: () -> untyped
 
+  # Returns fiber information string.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     inspect()
+  #
   alias inspect to_s
 
+  # Raises an exception in the fiber at the point at which the last `Fiber.yield`
+  # was called. If the fiber has not been started or has already run to
+  # completion, raises `FiberError`.
+  #
+  # With no arguments, raises a `RuntimeError`. With a single `String` argument,
+  # raises a `RuntimeError` with the string as a message.  Otherwise, the first
+  # parameter should be the name of an `Exception` class (or an object that
+  # returns an `Exception` object when sent an `exception` message). The optional
+  # second parameter sets the message associated with the exception, and the third
+  # parameter is an array of callback information. Exceptions are caught by the
+  # `rescue` clause of `begin...end` blocks.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     fiber.raise                                 -> obj
+  #     fiber.raise(string)                         -> obj
+  #     fiber.raise(exception [, string [, array]]) -> obj
+  #
   def raise: (*untyped) -> untyped
 
+  # Resumes the fiber from the point at which the last Fiber.yield was called, or
+  # starts running it if it is the first call to #resume. Arguments passed to
+  # resume will be the value of the Fiber.yield expression or will be passed as
+  # block parameters to the fiber's block if this is the first #resume.
+  #
+  # Alternatively, when resume is called it evaluates to the arguments passed to
+  # the next Fiber.yield statement inside the fiber's block or to the block value
+  # if it runs to completion without any Fiber.yield
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     fiber.resume(args, ...) -> obj
+  #
   def resume: (*untyped) -> untyped
 
+  # Returns fiber information string.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     fiber.to_s   -> string
+  #
   def to_s: () -> untyped
 
+  # Transfer control to another fiber, resuming it from where it last stopped or
+  # starting it if it was not resumed before. The calling fiber will be suspended
+  # much like in a call to Fiber.yield. You need to `require 'fiber'` before using
+  # this method.
+  #
+  # The fiber which receives the transfer call is treats it much like a resume
+  # call. Arguments passed to transfer are treated like those passed to resume.
+  #
+  # You cannot call `resume` on a fiber that has been transferred to. If you call
+  # `transfer` on a fiber, and later call `resume` on the the fiber, a
+  # `FiberError` will be raised. Once you call `transfer` on a fiber, the only way
+  # to resume processing the fiber is to call `transfer` on it again.
+  #
+  # Example:
+  #
+  #     fiber1 = Fiber.new do
+  #       puts "In Fiber 1"
+  #       Fiber.yield
+  #       puts "In Fiber 1 again"
+  #     end
+  #
+  #     fiber2 = Fiber.new do
+  #       puts "In Fiber 2"
+  #       fiber1.transfer
+  #       puts "Never see this message"
+  #     end
+  #
+  #     fiber3 = Fiber.new do
+  #       puts "In Fiber 3"
+  #     end
+  #
+  #     fiber2.resume
+  #     fiber3.resume
+  #     fiber1.resume rescue (p $!)
+  #     fiber1.transfer
+  #
+  # *produces*
+  #
+  #     In Fiber 2
+  #     In Fiber 1
+  #     In Fiber 3
+  #     #<FiberError: cannot resume transferred Fiber>
+  #     In Fiber 1 again
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     fiber.transfer(args, ...) -> obj
+  #
   def transfer: (*untyped) -> untyped
 
   private

--- a/stdlib/fiber/fiber.rbs
+++ b/stdlib/fiber/fiber.rbs
@@ -1,0 +1,25 @@
+class Fiber
+  def self.current: () -> untyped
+
+  def self.yield: (*untyped) -> untyped
+
+  public
+
+  def alive?: () -> untyped
+
+  def blocking?: () -> untyped
+
+  alias inspect to_s
+
+  def raise: (*untyped) -> untyped
+
+  def resume: (*untyped) -> untyped
+
+  def to_s: () -> untyped
+
+  def transfer: (*untyped) -> untyped
+
+  private
+
+  def initialize: (*untyped) -> untyped
+end

--- a/test/stdlib/Fiber_test.rb
+++ b/test/stdlib/Fiber_test.rb
@@ -71,3 +71,46 @@ class FiberTest < Minitest::Test
                      f, :raise, StandardError, 'Error!', caller
   end
 end
+
+require 'fiber'
+
+class FiberSingletonExtTest < Minitest::Test
+  include RBS::Test::TypeAssertions
+
+  library 'fiber'
+  testing 'singleton(::Fiber)'
+
+  def test_current
+    assert_send_type "() -> Fiber",
+                     Fiber, :current
+  end
+end
+
+class FiberExtTest < Minitest::Test
+  include RBS::Test::TypeAssertions
+
+  library 'fiber'
+  testing '::Fiber'
+
+  def test_alive?
+    f = Fiber.new {}
+    assert_send_type "() -> true",
+                     f, :alive?
+    f.resume
+    assert_send_type "() -> false",
+                     f, :alive?
+  end
+
+  def test_transfer
+    f = Fiber.new do
+      loop { Fiber.yield }
+    end
+
+    assert_send_type '() -> untyped',
+                     f, :transfer
+    assert_send_type '(untyped) -> untyped',
+                     f, :transfer, 1
+    assert_send_type '(untyped, untyped) -> untyped',
+                     f, :transfer, 1, 'foo'
+  end
+end


### PR DESCRIPTION
This pull request adds types of fiber extension, which is added methods by `require 'fiber'`.

The extension only has three methods.

* FIber.current
* Fiber#transfer
* Fiber#alive?



---


I added the test into the same place of fiber builtin library.
It's the same convention of other standard libraries, such as `test/stdlib/Pathname_test.rb`.
If you'd like to place the test cases to another file, please tell me it. I'll move the test cases.

