### PR TITLE
Fix `Symbol#{intern,to_sym}` return type

### DIFF
--- a/stdlib/builtin/symbol.rbs
+++ b/stdlib/builtin/symbol.rbs
@@ -152,7 +152,7 @@ class Symbol
   # In general, `to_sym` returns the Symbol corresponding to an object. As *sym*
   # is already a symbol, `self` is returned in this case.
   #
-  def intern: () -> self
+  def intern: () -> Symbol
 
   # Same as `sym.to_s.length`.
   #

--- a/test/stdlib/Symbol_test.rb
+++ b/test/stdlib/Symbol_test.rb
@@ -186,7 +186,7 @@ class SymbolInstanceTest < Minitest::Test
   end
 
   def test_intern
-    assert_send_type "() -> self",
+    assert_send_type "() -> Symbol",
                      :a, :intern
   end
 


### PR DESCRIPTION
If given the following method,

```rbs
def foo: (Symbol | String) -> Symbol
```

```rb
def foo(id)
  id.to_sym
end
```

Steep fails with the following error message:

```
MethodBodyTypeMismatch: method=foo, expected=::Symbol, actual=(::String | ::Symbol) (def foo(id))
  (::String | ::Symbol) <: ::Symbol
   ::String <: ::Symbol
```

This change aims to fix the failure by changing the return type of `Symbol#intern` (`#to_sym`).
Because the `Symbol` class cannot have own subclasses, I believe it acceptable to change the return type from `self` to a concrete class (that is, `Symbol`).

See also another reproduction:
https://gist.github.com/ybiquitous/1af8eed774ba2664b35c07a816573619