### PR TITLE
Use require_relative() for "prototype runtime --require-relative"

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -449,7 +449,7 @@ module RBS
         end
 
         relative_libs.each do |lib|
-          require(lib)
+          eval("require_relative(lib)", binding, "rbs")
         end
 
         decls = Prototype::Runtime.new(patterns: args, env: env, merge: merge, owners_included: owners_included).decls


### PR DESCRIPTION
As of now, `rbs prototype runtime --require-relative` is identical with `... --require` because it uses `require()`, not `require_relative()`.

This PR changes `--require-relative` to use `require_relative()`.

With this change, the below command works as expected with local rails application.

```
bundle exec rbs prototype runtime --require-relative config/environment ModelName
```

(Note: I needed to add `Rails.application.eager_load!` to environment.rb for proper recognition of classes)