### PR TITLE
`s/ruby.signare/rbs/g` with manual filtering

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,4 +1,4 @@
-ruby-signature is copyrighted free software by Soutaro Matsumoto <matsumoto@soutaro.com>.
+rbs is copyrighted free software by Soutaro Matsumoto <matsumoto@soutaro.com>.
 You can redistribute it and/or modify it under either the terms of the
 2-clause BSDL (see the file BSDL), or the conditions below:
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in ruby-signature.gemspec
+# Specify your gem's dependencies in rbs.gemspec
 gemspec
 
-gem "ruby-signature-amber", path: "test/assets/test-gem"
+gem "rbs-amber", path: "test/assets/test-gem"

--- a/README.md
+++ b/README.md
@@ -90,4 +90,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/ruby/ruby-signature.
+Bug reports and pull requests are welcome on GitHub at https://github.com/ruby/rbs.

--- a/Rakefile
+++ b/Rakefile
@@ -45,7 +45,7 @@ namespace :generate do
     raise "#{path} already exists!" if path.exist?
 
     require "erb"
-    require "ruby/signature"
+    require "rbs"
 
     class TestTemplateBuilder
       attr_reader :klass, :env

--- a/docs/sigs.md
+++ b/docs/sigs.md
@@ -16,7 +16,7 @@ See [syntax guide](syntax.md).
 ## Testing signatures
 
 When you finish writing signature, you may want to test the signature.
-ruby-signature provides a feature to test your signature.
+rbs provides a feature to test your signature.
 
 ```
 $ RBS_TEST_TARGET='Foo::*' bundle exec ruby -r rbs/test/setup test/foo_test.rb
@@ -68,7 +68,7 @@ ERROR -- : [Kaigi::Conference#speakers] UnexpectedBlockError: unexpected block i
 ### UnresolvedOverloadingError
 
 The error means there is a type error on overloaded methods.
-The `ruby-signature` test framework tries to the best error message for overloaded methods too, but it reports the `UnresolvedOverloadingError` when it fails.
+The `rbs` test framework tries to the best error message for overloaded methods too, but it reports the `UnresolvedOverloadingError` when it fails.
 
 ## Setting up the test
 
@@ -84,13 +84,13 @@ You can do it using `-r` option through command line argument or the `RUBYOPT` e
 
 ```
 $ ruby -r rbs/test/setup run_tests.rb
-$ RUBYOPT='-rruby/signature/test/setup' rake test
+$ RUBYOPT='-rrbs/test/setup' rake test
 ```
 
 When you are using Bundler, you may need to require `bundler/setup` explicitly.
 
 ```
-$ RUBYOPT='-rbundler/setup -rruby/signature/test/setup' bundle exec rake test
+$ RUBYOPT='-rbundler/setup -rrbs/test/setup' bundle exec rake test
 ```
 
 ### Environment variables
@@ -109,7 +109,7 @@ You need to specify `RBS_TEST_TARGET` to run the test, and you can customize the
 
 `RBS_TEST_SKIP` is to skip some of the classes which matches with `RBS_TEST_TARGET`.
 
-`RBS_TEST_OPT` is to pass the options for ruby signature handling.
+`RBS_TEST_OPT` is to pass the options for rbs handling.
 You may need to specify `-r` or `-I` to load signatures.
 The default is `-I sig`.
 
@@ -131,7 +131,7 @@ $ RBS_TEST_LOGLEVEL=error \
   RBS_TEST_SKIP='Kaigi::MonkeyPatch' \
   RBS_TEST_OPT='-rset -rpathname -Isig -Iprivate' \
   RBS_TEST_RAISE=true \
-  RUBYOPT='-rbundler/setup -rruby/signature/test/setup' \
+  RUBYOPT='-rbundler/setup -rrbs/test/setup' \
   bundle exec rake test
 ```
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,6 +1,6 @@
 # Stdlib Signatures Guide
 
-This is a guide for contributing to `ruby-signature` by writing/revising stdlib signatures.
+This is a guide for contributing to `rbs` by writing/revising stdlib signatures.
 
 The typical steps of writing signatures will be like the following:
 
@@ -17,7 +17,7 @@ To write signatures see [syntax guide](syntax.md).
 
 ## Generating prototypes
 
-`ruby-signature` provides a tool to generate a prototype of signatures, `rbs prototype`.
+`rbs` provides a tool to generate a prototype of signatures, `rbs prototype`.
 It provides several options, `rbi` from Sorbet RBI files, `rb` from Ruby code, and `runtime` from runtime API.
 `runtime` should be the best option for standard libraries because they may be implemented in C, no Ruby source code.
 

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -372,7 +372,7 @@ module RBS
     end
 
     def run_version(args, options)
-      stdout.puts "ruby-signature #{VERSION}"
+      stdout.puts "rbs #{VERSION}"
     end
 
     def run_paths(args, options)

--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -385,7 +385,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
                 | () { (Elem arg0) -> untyped } -> self
 
   # variadic type parameter is not supported yet
-  # https://github.com/ruby/ruby-signature/issues/21
+  # https://github.com/ruby/rbs/issues/21
   def zip: [Elem2, Return2] (::Enumerable[Elem2, Return2] enum) -> ::Array[[Elem, Elem2 | nil]]
          | [U, Elem2, Return2] (::Enumerable[Elem2, Return2]) { ([Elem, Elem2 | nil]) -> U } -> nil
 

--- a/test/assets/test-gem/amber.gemspec
+++ b/test/assets/test-gem/amber.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
-  spec.name          = "ruby-signature-amber"
+  spec.name          = "rbs-amber"
   spec.version       = "1.0.0"
   spec.authors       = ["Soutaro Matsumoto"]
   spec.email         = ["matsumoto@soutaro.com"]

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -162,11 +162,11 @@ singleton(::BasicObject)
     Dir.mktmpdir do |d|
       Dir.chdir(d) do
         with_cli do |cli|
-          cli.run(%w(vendor --vendor-dir=dir1 --stdlib ruby-signature-amber racc))
+          cli.run(%w(vendor --vendor-dir=dir1 --stdlib rbs-amber racc))
 
           assert_operator Pathname(d) + "dir1/stdlib", :directory?
           assert_operator Pathname(d) + "dir1/gems", :directory?
-          assert_operator Pathname(d) + "dir1/gems/ruby-signature-amber", :directory?
+          assert_operator Pathname(d) + "dir1/gems/rbs-amber", :directory?
           refute_operator Pathname(d) + "dir1/gems/racc", :directory?
         end
       end

--- a/test/rbs/vendorer_test.rb
+++ b/test/rbs/vendorer_test.rb
@@ -50,10 +50,10 @@ class RBS::VendorerTest < Minitest::Test
       vendorer = Vendorer.new(vendor_dir: vendor_dir)
 
       vendorer.stdlib!
-      vendorer.gem! "ruby-signature-amber", nil
+      vendorer.gem! "rbs-amber", nil
 
       assert_operator vendor_dir + "stdlib", :directory?
-      assert_operator vendor_dir + "gems/ruby-signature-amber", :directory?
+      assert_operator vendor_dir + "gems/rbs-amber", :directory?
     end
   end
 end

--- a/test/stdlib/LoadError_test.rb
+++ b/test/stdlib/LoadError_test.rb
@@ -6,7 +6,7 @@ class LoadErrorTest < StdlibTest
   using hook.refinement
 
   def test_path
-    Tempfile.open(['ruby-signature', 'rb']) do |tf|
+    Tempfile.open(['rbs', 'rb']) do |tf|
       path = tf.path
       tf.unlink
       require path

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -120,7 +120,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_binwrite
-    Tempfile.create('ruby-signature-pathname-binwrite-test') do |f|
+    Tempfile.create('rbs-pathname-binwrite-test') do |f|
       f.close
       path = Pathname(f.path)
 
@@ -163,7 +163,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_chmod
-    Tempfile.create('ruby-signature-pathname-chmod-test') do |f|
+    Tempfile.create('rbs-pathname-chmod-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '(Integer) -> Integer',
@@ -172,7 +172,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_chown
-    Tempfile.create('ruby-signature-pathname-chown-test') do |f|
+    Tempfile.create('rbs-pathname-chown-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '(Integer, Integer) -> Integer',
@@ -193,7 +193,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_delete
-    Tempfile.create('ruby-signature-pathname-delete-test') do |f|
+    Tempfile.create('rbs-pathname-delete-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '() -> Integer',
@@ -390,7 +390,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_lchmod
-    Tempfile.create('ruby-signature-pathname-lchmod-test') do |f|
+    Tempfile.create('rbs-pathname-lchmod-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '(Integer) -> Integer',
@@ -400,7 +400,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_lchown
-    Tempfile.create('ruby-signature-pathname-lchown-test') do |f|
+    Tempfile.create('rbs-pathname-lchown-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '(Integer, Integer) -> Integer',
@@ -476,7 +476,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_open
-    Tempfile.create('ruby-signature-pathname-binwrite-test') do |f|
+    Tempfile.create('rbs-pathname-binwrite-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '() -> File',
@@ -738,7 +738,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_truncate
-    Tempfile.create('ruby-signature-pathname-truncate-test') do |f|
+    Tempfile.create('rbs-pathname-truncate-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '(Integer) -> 0',
@@ -747,7 +747,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_unlink
-    Tempfile.create('ruby-signature-pathname-unlink-test') do |f|
+    Tempfile.create('rbs-pathname-unlink-test') do |f|
       path = Pathname(f.path)
 
       assert_send_type '() -> Integer',
@@ -761,7 +761,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_utime
-    Tempfile.create('ruby-signature-pathname-unlink-test') do |f|
+    Tempfile.create('rbs-pathname-unlink-test') do |f|
       path = Pathname(f.path)
       now = Time.now
       assert_send_type '(Time, Time) -> Integer',
@@ -793,7 +793,7 @@ class PathnameInstanceTest < Minitest::Test
   end
 
   def test_write
-    Tempfile.create('ruby-signature-pathname-write-test') do |f|
+    Tempfile.create('rbs-pathname-write-test') do |f|
       path = Pathname(f.path)
       assert_send_type '(String) -> Integer',
                        path, :write, 'foo'


### PR DESCRIPTION
Although `rbs` has been renamed from `ruby-signature`, the old name still seems to be around in many places. This may lead to misunderstanding.

This PR tries to clean up those. I confirmed all tests with `rake` are passed, but I recommend checking manually with your eyes :eyes: before merging.

Note that there is still one line when you run `git grep ruby.signature`. This has remained on purpose because the line is a warning message of deprecation.

> lib/ruby/signature.rb:STDERR.puts "🚨🚨 ruby-signature is renamed to rbs. require 'rbs' instead of 'ruby/signature'. 🚨🚨"
