### PR TITLE
Workaround: just skip anonymous superclasses and included modules

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -155,4 +155,30 @@ end
       end
     end
   end
+
+  module TestForAnonymous
+    class C < Class.new
+    end
+
+    class C2
+      include Module.new
+    end
+
+    module M
+      CONST = Class.new.new
+    end
+
+    module M2
+      include Module.new
+    end
+  end
+
+  def test_decls_for_anonymous_class_or_module
+    p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForAnonymous::*"],
+                    env: nil, merge: false)
+    silence_warnings do
+      p.decls
+    end
+    assert(true) # nothing raised above
+  end
 end


### PR DESCRIPTION
Fixes #301 and https://github.com/ruby/rbs/issues/301#issuecomment-641747375 based on the direction of https://github.com/ruby/rbs/issues/301#issuecomment-641726359.

For this `./c.rb`,

```ruby
class C < Class.new
  include Module.new
  def x; end
end
```

the command `bundle exec rbs prototype runtime --require ./c C` generates warning messages and  signatures:

```
W, [2020-06-10T15:39:12.732355 #28227]  WARN -- rbs: Skipping anonymous superclass #<Class:0x000055b123e491a0>
W, [2020-06-10T15:39:12.732475 #28227]  WARN -- rbs: Skipping anonymous module #<Module:0x000055b123e49010>
class C
  public

  def x: () -> untyped
end
```