### PR TITLE
`rbs prototype rb` guess return value type even if "def" has multiple statements

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -405,7 +405,7 @@ module RBS
             value_types << literal_to_type(v)
           end
 
-          if key_types.all? { |t| t.is_a?(Types::Literal) }
+          if !key_types.empty? && key_types.all? { |t| t.is_a?(Types::Literal) }
             fields = key_types.map { |t| t.literal }.zip(value_types).to_h
             Types::Record.new(fields: fields, location: nil)
           else

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -328,7 +328,19 @@ module RBS
         body = node.children[2]
         return Types::Bases::Nil.new(location: nil) unless body
 
-        literal_to_type(body)
+        if body.type == :BLOCK
+          return_stmts = any_node?(body) do |n|
+            n.type == :RETURN
+          end&.map do |return_node|
+            returned_value = return_node.children[0]
+            returned_value ? literal_to_type(returned_value) : Types::Bases::Nil.new(location: nil)
+          end || []
+          last_node = body.children.last
+          last_evaluated =  last_node ? literal_to_type(last_node) : Types::Bases::Nil.new(location: nil)
+          types_to_union_type([*return_stmts, last_evaluated])
+        else
+          literal_to_type(body)
+        end
       end
 
       def literal_to_type(node)
@@ -408,9 +420,11 @@ module RBS
 
       def types_to_union_type(types)
         return untyped if types.empty?
-        return untyped if types.include?(untyped)
 
-        Types::Union.new(types: types.uniq, location: nil)
+        uniq = types.uniq
+        return uniq.first if uniq.size == 1
+
+        Types::Union.new(types: uniq, location: nil)
       end
 
       def range_element_type(types)

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -145,7 +145,7 @@ class Hello
 
   def list1: () -> ::Array[1 | "2" | :x]
 
-  def list2: () -> ::Array[untyped]
+  def list2: () -> ::Array[1 | 2 | untyped]
 
   def range1: () -> ::Range[::Integer]
 
@@ -158,6 +158,60 @@ class Hello
   def hash2: () -> { foo: 1 }
 
   def hash3: () -> { foo: { bar: 42 }, x: { y: untyped } }
+end
+    EOF
+  end
+
+  def test_defs_return_type_with_block
+    parser = RB.new
+
+    rb = <<-'EOR'
+class Hello
+  def with_return
+    if cond
+      return 1
+    elsif cond2
+      return '2'
+    end
+    :x
+  end
+
+  def with_untyped_return
+    return foo if cond
+    :x
+  end
+
+  def with_return_same_types
+    return 1 if cond
+    return 1 if cond2
+    1
+  end
+
+  def with_return_without_value
+    return if cond
+    42
+  end
+
+  def when_last_is_nil
+    foo
+    nil
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  def with_return: () -> (1 | "2" | :x)
+
+  def with_untyped_return: () -> (untyped | :x)
+
+  def with_return_same_types: () -> 1
+
+  def with_return_without_value: () -> (nil | 42)
+
+  def when_last_is_nil: () -> nil
 end
     EOF
   end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -153,7 +153,7 @@ class Hello
 
   def range3: () -> ::Range[untyped]
 
-  def hash1: () -> { }
+  def hash1: () -> ::Hash[untyped, untyped]
 
   def hash2: () -> { foo: 1 }
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -128,6 +128,9 @@ SIG
     writer.write(decls)
 
     assert_equal string, writer.out.string
+
+    # Check syntax error
+    RBS::Parser.parse_signature(writer.out.string)
   end
 end
 


### PR DESCRIPTION
# Background 

Since #209, `rbs prototype rb` has been aware of returned type. But it only can be aware of the method body has only one statement and it is literal.


For example:


```ruby
# It will be: def good: () -> "foo"
def good
  "foo"
end

# But it will be: def bad: () -> untyped
def bad
  something
  "foo"
end
```


# What is this pull request


This pull request solves the `bad: () -> untyped`. It will be `bad: () -> "foo"`.


Previously `rbs prototype rb` only guessed returned types for methods that contain only one literal.
But it will guess types for `return` statements and the last statement of the method.