### PR TITLE
Fix syntax error for underscore started method with `!` or `?`

### DIFF
--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -500,7 +500,7 @@ rule
     | tQUOTEDIDENT
     | tWRITE_ATTR
 
-  method_name0: tUIDENT | tLIDENT | identifier_keywords
+  method_name0: tUIDENT | tLIDENT | tINTERFACEIDENT | identifier_keywords
 
   identifier_keywords:
       kCLASS | kVOID | kNIL | kTRUE | kFALSE | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -506,7 +506,7 @@ rule
       kCLASS | kVOID | kNIL | kTRUE | kFALSE | kANY | kUNTYPED | kTOP | kBOT | kINSTANCE | kBOOL | kSINGLETON
     | kTYPE | kMODULE | kPRIVATE | kPUBLIC | kEND | kINCLUDE | kEXTEND | kPREPEND
     | kATTRREADER | kATTRACCESSOR | kATTRWRITER | kDEF | kEXTENSION | kSELF | kINCOMPATIBLE
-    | kUNCHECKED
+    | kUNCHECKED | kINTERFACE | kSUPER | kALIAS | kOUT | kIN
 
   module_type_params:
       { result = nil }

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -550,6 +550,8 @@ class RBS::SignatureParsingTest < Minitest::Test
         def `\\``: -> untyped
         def def!: -> untyped
         def !: -> untyped
+        def _foo?: -> untyped
+        def _foo!: -> untyped
       end
     SIG
       expected_names = [
@@ -585,7 +587,9 @@ class RBS::SignatureParsingTest < Minitest::Test
         :attr_writer,
         :`,
         :def!,
-        :!
+        :!,
+        :_foo?,
+        :_foo!,
       ]
 
       assert_equal expected_names, decls[0].members.map(&:name)

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -533,6 +533,11 @@ class RBS::SignatureParsingTest < Minitest::Test
         def module: -> String
         def private: -> String
         def public: -> untyped
+        def interface: -> untyped
+        def super: -> untyped
+        def alias: -> untyped
+        def in: -> untyped
+        def out: -> untyped
         def &: (untyped) -> untyped
         def ^: (untyped) -> untyped
         def *: (untyped) -> untyped
@@ -571,6 +576,11 @@ class RBS::SignatureParsingTest < Minitest::Test
         :module,
         :private,
         :public,
+        :interface,
+        :super,
+        :alias,
+        :in,
+        :out,
         :&,
         :^,
         :*,


### PR DESCRIPTION
Curretnly `_foo?` method name is syntax error, but it is correct method name in Ruby.
So this pull request fixes the syntax error.

And I also found other syntax errors for keyword method name, like `def in?: -> untyped`. So this pull request also fixes them.