### PR TITLE
Module self types

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -408,7 +408,10 @@ _class-decl_ ::= `class` _class-name_ _module-type-parameters_ _members_ `end`
                | `class` _class-name_ _module-type-parameters_ `<` _class-name_ _type-arguments_ _members_ `end`
 
 _module-decl_ ::= `module` _module-name_ _module-type-parameters_ _members_ `end`
-                | `module` _module-name_ _module-type-parameters_ `:` _class-name_ _type-arguments_ _members_ `end`
+                | `module` _module-name_ _module-type-parameters_ `:` _module-self-types_ _members_ `end`
+
+_module-self-types_ ::= _class-name_ _type-arguments_ `,` _module-self-types_            (Class instance)
+                      | _interface-name_ _type-arguments_ `,` _module-self-types_        (Interface)
 
 _interface-decl_ ::= `interface` _interface-name_ _module-type-parameters_ _interface-members_ `end`
 

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -204,6 +204,44 @@ module RBS
       end
 
       class Module < Base
+        class Self
+          attr_reader :name
+          attr_reader :args
+          attr_reader :location
+
+          def initialize(name:, args:, location:)
+            @name = name
+            @args = args
+            @location = location
+          end
+
+          def ==(other)
+            other.is_a?(Self) && other.name == name && other.args == args
+          end
+
+          alias eql? ==
+
+          def hash
+            self.class.hash ^ name.hash ^ args.hash ^ location.hash
+          end
+
+          def to_json(*a)
+            {
+              name: name,
+              args: args,
+              location: location
+            }.to_json(*a)
+          end
+
+          def to_s
+            if args.empty?
+              name.to_s
+            else
+              "#{name}[#{args.join(", ")}]"
+            end
+          end
+        end
+
         include NestedDeclarationHelper
         include MixinHelper
 
@@ -212,13 +250,13 @@ module RBS
         attr_reader :members
         attr_reader :location
         attr_reader :annotations
-        attr_reader :self_type
+        attr_reader :self_types
         attr_reader :comment
 
-        def initialize(name:, type_params:, members:, self_type:, annotations:, location:, comment:)
+        def initialize(name:, type_params:, members:, self_types:, annotations:, location:, comment:)
           @name = name
           @type_params = type_params
-          @self_type = self_type
+          @self_types = self_types
           @members = members
           @annotations = annotations
           @location = location
@@ -229,14 +267,14 @@ module RBS
           other.is_a?(Module) &&
             other.name == name &&
             other.type_params == type_params &&
-            other.self_type == self_type &&
+            other.self_types == self_types &&
             other.members == members
         end
 
         alias eql? ==
 
         def hash
-          self.class.hash ^ name.hash ^ type_params.hash ^ self_type.hash ^ members.hash
+          self.class.hash ^ name.hash ^ type_params.hash ^ self_types.hash ^ members.hash
         end
 
         def to_json(*a)
@@ -245,7 +283,7 @@ module RBS
             name: name,
             type_params: type_params,
             members: members,
-            self_type: self_type,
+            self_types: self_types,
             annotations: annotations,
             location: location,
             comment: comment

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -243,11 +243,9 @@ module RBS
           end
 
           if entry.is_a?(Environment::ModuleEntry)
-            if self_type_ancestor = module_self_ancestor(type_name, entry)
-              definition_pairs.push [
-                                      self_type_ancestor,
-                                      build_interface(self_type_ancestor.name)
-                                    ]
+            entry.self_types.each do |module_self|
+              ancestor = Definition::Ancestor::Instance.new(name: module_self.name, args: module_self.args)
+              definition_pairs.push [ancestor, build_interface(module_self.name)]
             end
           end
 
@@ -257,29 +255,6 @@ module RBS
           raise
         end
       end
-    end
-
-    def module_self_ancestor(type_name, entry)
-      self_decls = entry.decls.select {|d| d.decl.self_type }
-
-      return if self_decls.empty?
-
-      selfs = self_decls.map do |d|
-        Definition::Ancestor::Instance.new(
-          name: d.decl.self_type.name,
-          args: d.decl.self_type.args
-        )
-      end
-
-      selfs.uniq!
-
-      return selfs[0] if selfs.size == 1
-
-      raise ModuleSelfTypeMismatchError.new(
-        name: type_name,
-        entry: entry,
-        location: self_decls[0].decl.location
-      )
     end
 
     def build_singleton(type_name)

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -198,20 +198,6 @@ module RBS
     end
   end
 
-  class ModuleSelfTypeMismatchError < StandardError
-    attr_reader :name
-    attr_reader :entry
-    attr_reader :location
-
-    def initialize(name:, entry:, location:)
-      @name = name
-      @entry = entry
-      @location = location
-
-      super "#{Location.to_string location}: Module self type mismatch: #{name}"
-    end
-  end
-
   class InconsistentMethodVisibilityError < StandardError
     attr_reader :type_name
     attr_reader :method_name

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -81,7 +81,7 @@ module RBS
           mod = AST::Declarations::Module.new(
             name: const_to_name(module_name),
             type_params: AST::Declarations::ModuleTypeParams.empty,
-            self_type: nil,
+            self_types: [],
             members: [],
             annotations: [],
             location: nil,

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -69,7 +69,7 @@ module RBS
           members: [],
           annotations: [],
           location: nil,
-          self_type: nil,
+          self_types: [],
           comment: comment
         )
 

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -370,7 +370,7 @@ module RBS
         decl = AST::Declarations::Module.new(
           name: type_name,
           type_params: AST::Declarations::ModuleTypeParams.empty,
-          self_type: nil,
+          self_types: [],
           members: [],
           annotations: [],
           location: nil,

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -85,8 +85,8 @@ module RBS
         puts "end"
 
       when AST::Declarations::Module
-        self_type = if decl.self_type
-                      " : #{decl.self_type}"
+        self_type = unless decl.self_types.empty?
+                      " : #{decl.self_types.join(", ")}"
                     end
 
         write_comment decl.comment

--- a/schema/decls.json
+++ b/schema/decls.json
@@ -226,15 +226,11 @@
             "$ref": "#/definitions/classMember"
           }
         },
-        "self_type": {
-          "oneOf": [
-            {
-              "$ref": "types.json"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        "self_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/moduleSelf"
+          }
         },
         "annotations": {
           "type": "array",
@@ -249,7 +245,22 @@
           "$ref": "location.json"
         }
       },
-      "required": ["declaration", "name", "type_params", "members", "self_type", "annotations", "location", "comment"]
+      "required": ["declaration", "name", "type_params", "members", "self_types", "annotations", "location", "comment"]
+    },
+    "moduleSelf": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "types.json"
+          }
+        }
+      },
+      "required": ["name", "args"]
     },
     "interfaceMember": {
       "oneOf": [

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -651,42 +651,6 @@ end
     end
   end
 
-  def test_build_instance_module_self_type
-    SignatureManager.new do |manager|
-      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
-interface _A
-end
-
-interface _B
-end
-
-module M : _A
-end
-
-module M : _B
-end
-
-module N : _A
-end
-
-module N
-end
-      EOF
-
-      manager.build do |env|
-        builder = DefinitionBuilder.new(env: env)
-
-        error = assert_raises RBS::ModuleSelfTypeMismatchError do
-          builder.build_instance(type_name("::M"))
-        end
-
-        assert_equal type_name("::M"), error.name
-
-        builder.build_instance(type_name("::N"))
-      end
-    end
-  end
-
   def test_build_one_instance_mixin
     SignatureManager.new do |manager|
       manager.files.merge!(Pathname("foo.rbs") => <<-EOF)

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -214,11 +214,11 @@ interface _Animal
   def bark: () -> void
 end
 
-module Foo
+module Foo : _Animal
   def foo: () -> void
 end
 
-module Foo : _Animal
+module Foo : Object
   def bar: () -> void
 end
 
@@ -236,8 +236,19 @@ EOF
 
       foo = env.class_decls[type_name("::Foo")]
 
-      assert_equal decls[2], foo.primary.decl
-      assert_equal parse_type("_Animal"), foo.self_type
+      assert_equal decls[1], foo.primary.decl
+      assert_equal [
+                     RBS::AST::Declarations::Module::Self.new(
+                       name: type_name("_Animal"),
+                       args: [],
+                       location: nil
+                     ),
+                     RBS::AST::Declarations::Module::Self.new(
+                       name: type_name("Object"),
+                       args: [],
+                       location: nil
+                     ),
+                   ], foo.self_types
     end
 
     Environment.new.tap do |env|


### PR DESCRIPTION
This PR is to update syntax to specify _self type constraint_ on modules.

The current syntax allows arbitrary types to be there.

```
module M : _Each[Integer, String]       # This is okay
end

module N : _Each[Integer, String] | Integer     # What does this mean???
end
```

This patch introduces a new syntax construct to limit the types to be there.

```
module X : _Each[Integer, String], _ToInt, _ToStr
end
```

This allows making having multiple module declarations more natural. The following has two module declarations for `X` and the _self type constraint_ means the same with the above.

```
module X : _Each[Integer, String], _ToInt
end

module X : _ToStr
end
```