### PR TITLE
Compress RBS::Environment#inspect

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -414,5 +414,10 @@ module RBS
         absolute_type_name(resolver, name, context: context)
       end
     end
+
+    def inspect
+      ivars = %i[@buffers @declarations @class_decls @interface_decls @alias_decls @constant_decls @global_decls]
+      "\#<RBS::Environment #{ivars.map { |iv| "#{iv}=(#{instance_variable_get(iv).size} items)"}.join(' ')}>"
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces `RBS::Environment#inspect` method to make `inspect`'s result shorter.



# Problem

In most cases, `RBS::Environment#inspect` displays too many characters. `#inspect` should return a human-readable string, but it actually returns NOT human-readable string.
For example:


```bash
$ ruby -Ilib -rrbs -e 'p RBS::Environment.from_loader(RBS::EnvironmentLoader.new).resolve_type_names'
# => 🙈
```


I got the too long inspection from IRB, error message and so on.


# Solution

Make the inspection shorter.
This pull request omits `inspect` for instance variables, displays only sizes instead.

For example:


```bash
$ ruby -Ilib -rrbs -e 'p RBS::Environment.from_loader(RBS::EnvironmentLoader.new).resolve_type_names'
#<RBS::Environment @buffers=(0 items) @declarations=(824 items) @class_decls=(266 items) @interface_decls=(14 items) @alias_decls=(6 items) @constant_decls=(538 items) @global_decls=(0 items)>
```


It has only a few pieces of information, but it is human-readable. I think readability is more important than omitted information.