### PR TITLE
Better signature error checks

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -77,6 +77,8 @@ module RBS
             super_args = []
           end
 
+          NoSuperclassFoundError.check!(super_name, env: env, location: primary.decl.location)
+
           super_ancestors = instance_ancestors(super_name, building_ancestors: building_ancestors)
           ancestors.unshift(*super_ancestors.apply(super_args, location: primary.decl.location))
         end
@@ -123,6 +125,8 @@ module RBS
             super_name = BuiltinNames::Object.name
           end
 
+          NoSuperclassFoundError.check!(super_name, env: env, location: primary.decl.location)
+
           super_ancestors = singleton_ancestors(super_name, building_ancestors: building_ancestors)
           ancestors.unshift(*super_ancestors.ancestors)
         else
@@ -143,6 +147,8 @@ module RBS
           case member
           when AST::Members::Extend
             if member.name.class?
+              NoMixinFoundError.check!(member.name, env: env, member: member)
+
               module_ancestors = instance_ancestors(member.name, building_ancestors: building_ancestors)
               ancestors.unshift(*module_ancestors.apply(member.args, location: member.location))
             end
@@ -174,6 +180,8 @@ module RBS
           case member
           when AST::Members::Include
             if member.name.class?
+              NoMixinFoundError.check!(member.name, env: env, member: member)
+
               module_name = member.name
               module_args = member.args.map {|type| type.sub(align_params) }
 
@@ -197,6 +205,8 @@ module RBS
         decl.each_mixin do |member|
           case member
           when AST::Members::Prepend
+            NoMixinFoundError.check!(member.name, env: env, member: member)
+
             module_name = member.name
             module_args = member.args.map {|type| type.sub(align_params) }
 
@@ -334,6 +344,8 @@ module RBS
           when AST::Members::Include, AST::Members::Extend
             if member.name.interface?
               if (kind == :instance && member.is_a?(AST::Members::Include)) || (kind == :singleton && member.is_a?(AST::Members::Extend))
+                NoMixinFoundError.check!(member.name, env: env, member: member)
+
                 interface_name = member.name
                 interface_args = member.args
 
@@ -877,6 +889,8 @@ module RBS
           end
 
           include_members.each do |member|
+            NoMixinFoundError.check!(member.name, env: env, member: member)
+
             mixin = build_interface(member.name)
 
             args = member.args

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -125,6 +125,49 @@ module RBS
     end
   end
 
+  class NoSuperclassFoundError < StandardError
+    attr_reader :type_name
+    attr_reader :location
+
+    def initialize(type_name:, location:)
+      @type_name = type_name
+      @location = location
+
+      super "#{Location.to_string location}: Could not find super class: #{type_name}"
+    end
+
+    def self.check!(type_name, env:, location:)
+      env.class_decls.key?(type_name) or raise new(type_name: type_name, location: location)
+    end
+  end
+
+  class NoMixinFoundError < StandardError
+    attr_reader :type_name
+    attr_reader :member
+
+    def initialize(type_name:, member:)
+      @type_name = type_name
+      @member = member
+
+      super "#{Location.to_string location}: Could not find mixin: #{type_name}"
+    end
+
+    def location
+      member.location
+    end
+
+    def self.check!(type_name, env:, member:)
+      dic = case
+            when type_name.class?
+              env.class_decls
+            when type_name.interface?
+              env.interface_decls
+            end
+
+      dic.key?(type_name) or raise new(type_name: type_name, member: member)
+    end
+  end
+
   class DuplicatedMethodDefinitionError < StandardError
     attr_reader :decl
     attr_reader :location


### PR DESCRIPTION
Introduces two error classes, `NoSupeclassFoundError` and `NoMixinFoundError`.