### PR TITLE
Omit generating duplicate method by `rbs prototype rb`

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -134,7 +134,7 @@ module RBS
               overload: false
             )
 
-            decls.push member
+            decls.push member unless decls.include?(member)
 
         when :FCALL
           # Inside method definition cannot reach here.

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -476,4 +476,30 @@ module Foo
 end
     EOF
   end
+
+  def test_duplicate_methods
+    parser = RB.new
+
+    rb = <<-'EOR'
+class C
+  if RUBY_VERSION >= '2.7'
+    def foo(x, y, z)
+      do_something_27
+    end
+  else
+    def foo(x, y, z)
+      do_something
+    end
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class C
+  def foo: (untyped x, untyped y, untyped z) -> untyped
+end
+    EOF
+  end
 end


### PR DESCRIPTION
# Problem


Sometimes we define the same methods with different bodies. For example:

```ruby
class C
  if RUBY_VERSION >= '2.7'
    def foo
      do_something_27
    end
  else
    def foo
      do_something
    end
  end
end
```

But `rbs prototype rb` generates exactly the same `foo` method twice.



```
$ exe/rbs prototype rb test.rb
class C
  def foo: () -> untyped

  def foo: () -> untyped
end
```






So I need to remove one of the methods manually.



We can find this situation from Active Support codebase.
For example: https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activesupport/lib/active_support/option_merger.rb#L30-L43


# Solution

Omit to generate duplicate method if the same method is already generated.


