### PR TITLE
Fix NoMethodError on duplicate constants

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -126,7 +126,7 @@ module RBS
 
     def cache_name(cache, name:, decl:, outer:)
       if cache.key?(name)
-        raise DuplicatedDeclarationError.new(name, decl, cache[name])
+        raise DuplicatedDeclarationError.new(name, decl, cache[name].decl)
       end
 
       cache[name] = SingleEntry.new(name: name, decl: decl, outer: outer)

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -129,6 +129,20 @@ EOF
     end
   end
 
+  def test_const_twice_duplication_error
+    env = Environment.new
+
+    decls = RBS::Parser.parse_signature(<<EOF)
+Foo: String
+Foo: String
+EOF
+
+    assert_raises RBS::DuplicatedDeclarationError do
+      env << decls[0]
+      env << decls[1]
+    end
+  end
+
   def test_generic_class
     env = Environment.new
 
@@ -154,8 +168,6 @@ EOF
   end
 
   def test_generic_class_error
-    env = Environment.new
-
     decls = RBS::Parser.parse_signature(<<EOF)
 module Foo[A, out B]
 end


### PR DESCRIPTION
# Problem

`rbs validate` unexpectedly raises NoMethodError on duplicate constants.

```rbs
Foo: String
Foo: String
```

```bash
$ rbs -I. validate
/home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/errors.rb:309:in `initialize': undefined method `location' for #<RBS::Environment::SingleEntry:0x000055dc26ebecb0 @name=#<RBS::TypeName:0x000055dc26ebedc8 @namespace=#<RBS::Namespace:0x000055dc26ebee18 @path=[], @absolute=true>, @name=:Foo, @kind=:class>, @decl=#<RBS::AST::Declarations::Constant:0x000055dc26ebf728 @name=#<RBS::TypeName:0x00005
5dc26ebf868 @namespace=#<RBS::Namespace:0x000055dc26ebf8b8 @path=[], @absolute=false>, @name=:Foo, @kind=:class>, @type=#<RBS::Types::ClassInstance:0x000055dc26ebf9a8 @name=#<RBS::TypeName:0x000055dc26ebfd40 @namespace=#<RBS::Namespace:0x000055dc26ebfd90 @path=[], @absolute=false>, @name=:String, @kind=:class>, @args=[], @location=#<RBS::Location:380 @buffer=test.rbs, @pos=5...11, source='String', start_line=1, start_c
olumn=5>>, @location=#<RBS::Location:400 @buffer=test.rbs, @pos=0...11, source='Foo: String', start_line=1, start_column=0>, @comment=nil>, @outer=[]> (NoMethodError)                                                     from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:129:in `new'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:129:in `cache_name'                                                                                               from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:185:in `insert_decl'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:197:in `<<'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment_loader.rb:131:in `block (2 levels) in load'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment_loader.rb:130:in `each'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment_loader.rb:130:in `block in load'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment_loader.rb:127:in `each'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment_loader.rb:127:in `load'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:123:in `block in from_loader'
        from <internal:kernel>:90:in `tap'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/environment.rb:122:in `from_loader'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/cli.rb:387:in `run_validate'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/lib/rbs/cli.rb:92:in `run'
        from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.8.0/gems/rbs-0.6.0/exe/rbs:7:in `<top (required)>'
        from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `load'
        from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `<main>'
```

Because DuplicateDeclarationError's last argument should be a decl, but actually it receives a SingleEntry.

# Solution

Pass a  decl instead of SingleEntry. It is the same way with other `DuplicatedDeclarationError.new` calls.

