### PR TITLE
Make `rbs validate` faster

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -838,7 +838,7 @@ module RBS
       methods[name] = Definition::Method.new(
         super_method: super_method,
         accessibility: method.accessibility,
-        defs: method.defs.map {|defn| defn.update(type: defn.type.sub(sub)) }
+        defs: sub.mapping.empty? ? method.defs : method.defs.map {|defn| defn.update(type: defn.type.sub(sub)) }
       )
     end
 


### PR DESCRIPTION
This pull request improves the performance of DefiniitonBuilder for `rbs validate`.


# How


`RBS::DefinitionBuilder#merge_method` is slow (see the profiling section). Because the method creates new object for all method types with `sub` method.

This pull request reduces method calls of `sub` method.
`sub` method replaces type parameters, so it is not necessary if the type parameter mapping is empty.



# Behavior change

It changes behavior of `instance` type. Previously `instance` type is replaced with `Types::Bases::Instance.new(location: nil)` with `Substitution`.
https://github.com/ruby/rbs/blob/77aaea0ab8ae8d21af784f113a43b75a22479bb4/lib/rbs/substitution.rb#L14
But it will be not changed by this patch.

I think it is not a problem because the previous behavior only changes `location` actually. The `location` will be kept, but I guess it is not affect anything.


# Benchmark


I used https://github.com/pocke/rbs_rails for the benchmark because it contains large RBS files.


```bash
$ rbs -rlogger -rpathname -rmutex_m -Isig -Iassets/sig validate > /dev/null
```

before: 15.85s
after: 4.20s

3.77x faster :rocket: 

# Profiling


I used stackprof for the above command, and got the following result.

```bash
$ stackprof stackprof-out --sort-total
==================================
  Mode: cpu(1000)
  Samples: 4643 (1.11% miss rate)
  GC: 2141 (46.11%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2502  (53.9%)           0   (0.0%)     <top (required)>
      2502  (53.9%)           0   (0.0%)     <top (required)>
      2502  (53.9%)           0   (0.0%)     Object#exec_command
      2502  (53.9%)           0   (0.0%)     Object#exec
      2502  (53.9%)           0   (0.0%)     Object#main
      2502  (53.9%)           0   (0.0%)     <top (required)>
      2502  (53.9%)           0   (0.0%)     <main>
      2502  (53.9%)           0   (0.0%)     <main>
      2494  (53.7%)           1   (0.0%)     RBS::CLI#run_validate
      2494  (53.7%)           0   (0.0%)     RBS::CLI#run
      2197  (47.3%)           0   (0.0%)     Kernel#tap
      2141  (46.1%)          16   (0.3%)     (garbage collection)
      1977  (42.6%)           4   (0.1%)     RBS::DefinitionBuilder#try_cache
      1780  (38.3%)           7   (0.2%)     RBS::DefinitionBuilder#merge_definitions
      1743  (37.5%)          42   (0.9%)     RBS::DefinitionBuilder#merge_method
      1627  (35.0%)        1627  (35.0%)     (marking)
      1422  (30.6%)          10   (0.2%)     RBS::MethodType#sub
      1288  (27.7%)           4   (0.1%)     RBS::DefinitionBuilder#build_singleton
      1168  (25.2%)          11   (0.2%)     RBS::MethodType#map_type
      1167  (25.1%)          26   (0.6%)     Kernel#yield_self
       931  (20.1%)         152   (3.3%)     RBS::Types::Function#map_type
       689  (14.8%)           2   (0.0%)     RBS::DefinitionBuilder#build_instance
       498  (10.7%)         498  (10.7%)     (sweeping)
       350   (7.5%)          58   (1.2%)     RBS::Types::Function::Param#map_type
       331   (7.1%)           1   (0.0%)     RBS::EnvironmentLoader#load
       331   (7.1%)           0   (0.0%)     RBS::Environment.from_loader
       313   (6.7%)         313   (6.7%)     Kernel#class
       312   (6.7%)           0   (0.0%)     Racc::Parser#do_parse
       312   (6.7%)           0   (0.0%)     RBS::Parser.parse_signature
       262   (5.6%)          67   (1.4%)     RBS::Substitution#without
```

We can confirm `RBS::DefinitionBuilder#merge_method` takes 37.5% exetuion time.