### PR TITLE
Improve the QoL of test/setup.rb

### DIFF
--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -38,14 +38,17 @@ def match(filter, name)
   end
 end
 
-factory = RBS::Factory.new()
+def to_absolute_typename(type_name)
+  RBS::Factory.new().type_name(type_name).absolute!
+end
+
 tester = RBS::Test::Tester.new(env: env)
 
 TracePoint.trace :end do |tp|
-  class_name = tp.self.name&.yield_self {|name| factory.type_name(name).absolute! }
+  class_name = tp.self.name&.yield_self {|name| to_absolute_typename name }
 
   if class_name
-    if filter.any? {|f| match(f, class_name.to_s) } && skips.none? {|f| match(f, class_name.to_s) }
+    if filter.any? {|f| match(to_absolute_typename(f).to_s, class_name.to_s) } && skips.none? {|f| match(f, class_name.to_s) }
       if tester.checkers.none? {|hook| hook.klass == tp.self }
         if env.class_decls.key?(class_name)
           logger.info "Setting up hooks for #{class_name}"
@@ -55,3 +58,4 @@ TracePoint.trace :end do |tp|
     end
   end
 end
+ 

--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -8,8 +8,8 @@ logger = Logger.new(STDERR)
 
 begin
   opts = Shellwords.shellsplit(ENV["RBS_TEST_OPT"] || "-I sig")
-  filter = ENV.fetch("RBS_TEST_TARGET").split(",")
-  skips = (ENV["RBS_TEST_SKIP"] || "").split(",")
+  filter = ENV.fetch('RBS_TEST_TARGET').split(',').map! { |e| e.strip }
+  skips = (ENV['RBS_TEST_SKIP'] || '').split(',').map! { |e| e.strip }
   sampling = !ENV.key?("RBS_TEST_NO_SAMPLE")
   RBS.logger_level = (ENV["RBS_TEST_LOGLEVEL"] || "info")
 rescue


### PR DESCRIPTION
This PR improves the "QoL" of test/setup.rb by allowing users to have some white space before and after the comma in the environment variables,`RBS_TEST_TARGET` and `RBS_TEST_SKIP`, and by converting relative type names to absolute type names to make the leading colon optional for some cases.