### PR TITLE
Print warning if no runtime type checker was installed

### DIFF
--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -58,4 +58,11 @@ TracePoint.trace :end do |tp|
     end
   end
 end
+
+at_exit do
+  if $!.nil? || $!.is_a?(SystemExit) && $!.success?
+    logger.warn "No type checker was installed! " if tester.checkers.empty?
+  end
+end
+
  


### PR DESCRIPTION
This PR adds an `at_exit` block to `setup.rb` to notify the user if there weren't any runtime type checkers installed upon exit.