### PR TITLE
Add PTY module

### DIFF
--- a/stdlib/pty/pty.rbs
+++ b/stdlib/pty/pty.rbs
@@ -1,0 +1,15 @@
+module PTY
+  def self.check: (*untyped) -> untyped
+
+  def self.getpty: (*untyped) -> untyped
+
+  def self.open: () -> untyped
+
+  def self.spawn: (*untyped) -> untyped
+
+  private
+
+  def getpty: (*untyped) -> untyped
+
+  def spawn: (*untyped) -> untyped
+end

--- a/stdlib/pty/pty.rbs
+++ b/stdlib/pty/pty.rbs
@@ -1,15 +1,159 @@
+# Creates and manages pseudo terminals (PTYs).  See also
+# http://en.wikipedia.org/wiki/Pseudo_terminal
+#
+# PTY allows you to allocate new terminals using ::open or ::spawn a new
+# terminal with a specific command.
+#
+# ## Example
+#
+# In this example we will change the buffering type in the `factor` command,
+# assuming that factor uses stdio for stdout buffering.
+#
+# If IO.pipe is used instead of PTY.open, this code deadlocks because factor's
+# stdout is fully buffered.
+#
+#     # start by requiring the standard library PTY
+#     require 'pty'
+#
+#     master, slave = PTY.open
+#     read, write = IO.pipe
+#     pid = spawn("factor", :in=>read, :out=>slave)
+#     read.close     # we dont need the read
+#     slave.close    # or the slave
+#
+#     # pipe "42" to the factor command
+#     write.puts "42"
+#     # output the response from factor
+#     p master.gets #=> "42: 2 3 7\n"
+#
+#     # pipe "144" to factor and print out the response
+#     write.puts "144"
+#     p master.gets #=> "144: 2 2 2 2 3 3\n"
+#     write.close # close the pipe
+#
+#     # The result of read operation when pty slave is closed is platform
+#     # dependent.
+#     ret = begin
+#             master.gets     # FreeBSD returns nil.
+#           rescue Errno::EIO # GNU/Linux raises EIO.
+#             nil
+#           end
+#     p ret #=> nil
+#
+# ## License
+#
+#     C) Copyright 1998 by Akinori Ito.
+#
+#     This software may be redistributed freely for this purpose, in full
+#     or in part, provided that this entire copyright notice is included
+#     on any copies of this software and applications and derivations thereof.
+#
+#     This software is provided on an "as is" basis, without warranty of any
+#     kind, either expressed or implied, as to any matter including, but not
+#     limited to warranty of fitness of purpose, or merchantability, or
+#     results obtained from use of this software.
+#
 module PTY
-  def self.check: (*untyped) -> untyped
+  # Checks the status of the child process specified by `pid`. Returns `nil` if
+  # the process is still alive.
+  #
+  # If the process is not alive, and `raise` was true, a PTY::ChildExited
+  # exception will be raised. Otherwise it will return a Process::Status instance.
+  #
+  # `pid`
+  # :   The process id of the process to check
+  # `raise`
+  # :   If `true` and the process identified by `pid` is no longer alive a
+  #     PTY::ChildExited is raised.
+  def self.check: (Integer pid) -> (Process::Status | nil)
+                | (Integer pid, FalseClass raise) -> (Process::Status | nil)
+                | (Integer pid, TrueClass raise) -> nil
 
-  def self.getpty: (*untyped) -> untyped
+  # Spawns the specified command on a newly allocated pty. You can also use the
+  # alias ::getpty.
+  #
+  # The command's controlling tty is set to the slave device of the pty and its
+  # standard input/output/error is redirected to the slave device.
+  #
+  # `command` and `command_line` are the full commands to run, given a String. Any
+  # additional `arguments` will be passed to the command.
+  #
+  # ### Return values
+  #
+  # In the non-block form this returns an array of size three, `[r, w, pid]`.
+  #
+  # In the block form these same values will be yielded to the block:
+  #
+  # `r`
+  # :   A readable IO that contains the command's standard output and standard
+  #     error
+  # `w`
+  # :   A writable IO that is the command's standard input
+  # `pid`
+  # :   The process identifier for the command.
+  def self.getpty: (*String command) -> [ IO, IO, Integer ]
+                 | (*String command) { ([ IO ,IO , Integer ]) -> untyped } -> untyped
 
-  def self.open: () -> untyped
+  # Allocates a pty (pseudo-terminal).
+  #
+  # In the block form, yields two arguments `master_io, slave_file` and the value
+  # of the block is returned from `open`.
+  #
+  # The IO and File are both closed after the block completes if they haven't been
+  # already closed.
+  #
+  #     PTY.open {|master, slave|
+  #       p master      #=> #<IO:masterpty:/dev/pts/1>
+  #       p slave      #=> #<File:/dev/pts/1>
+  #       p slave.path #=> "/dev/pts/1"
+  #     }
+  #
+  # In the non-block form, returns a two element array, `[master_io, slave_file]`.
+  #
+  #     master, slave = PTY.open
+  #     # do something with master for IO, or the slave file
+  #
+  # The arguments in both forms are:
+  #
+  # `master_io`
+  # :   the master of the pty, as an IO.
+  # `slave_file`
+  # :   the slave of the pty, as a File.  The path to the terminal device is
+  #     available via `slave_file.path`
+  #
+  #
+  # IO#raw! is usable to disable newline conversions:
+  #
+  #     require 'io/console'
+  #     PTY.open {|m, s|
+  #       s.raw!
+  #       ...
+  #     }
+  def self.open: () -> [ IO, File ]
+               | () { ([ IO , File ]) -> untyped } -> untyped
 
-  def self.spawn: (*untyped) -> untyped
-
-  private
-
-  def getpty: (*untyped) -> untyped
-
-  def spawn: (*untyped) -> untyped
+  # Spawns the specified command on a newly allocated pty. You can also use the
+  # alias ::getpty.
+  #
+  # The command's controlling tty is set to the slave device of the pty and its
+  # standard input/output/error is redirected to the slave device.
+  #
+  # `command` and `command_line` are the full commands to run, given a String. Any
+  # additional `arguments` will be passed to the command.
+  #
+  # ### Return values
+  #
+  # In the non-block form this returns an array of size three, `[r, w, pid]`.
+  #
+  # In the block form these same values will be yielded to the block:
+  #
+  # `r`
+  # :   A readable IO that contains the command's standard output and standard
+  #     error
+  # `w`
+  # :   A writable IO that is the command's standard input
+  # `pid`
+  # :   The process identifier for the command.
+  def self.spawn: (*String command) -> [ IO, IO, Integer ]
+                | (*String command) {([ IO , IO , Integer ]) -> untyped } -> untyped
 end

--- a/test/stdlib/PTY_test.rb
+++ b/test/stdlib/PTY_test.rb
@@ -1,0 +1,42 @@
+require_relative "test_helper"
+require "pty"
+
+class PTYSingletonTest < Minitest::Test
+  include TypeAssertions
+
+   library "pty"
+  testing "singleton(::PTY)"
+
+
+  def test_open
+    assert_send_type  "() -> [ ::IO, ::File ]",
+                      PTY, :open
+    assert_send_type  "() { ([ ::IO, ::File ]) -> untyped } -> untyped",
+                      PTY, :open do |master, slave| 1 end
+  end
+
+  def test_check
+    r, w, pid = PTY.spawn("echo")
+    assert_send_type  "(::Integer pid) -> (::Process::Status | nil)",
+                      PTY, :check, pid
+    assert_send_type  "(::Integer pid, ::FalseClass raise) -> (::Process::Status | nil)",
+                      PTY, :check, pid, false
+    assert_send_type  "(::Integer pid, ::TrueClass raise) -> nil",
+                      PTY, :check, pid, true
+  end
+
+  def test_getpty
+    assert_send_type  "(*::String command) -> [ ::IO, ::IO, ::Integer ]",
+                      PTY, :getpty, "echo"
+    assert_send_type  "(*String command) { ([ ::IO, ::IO, ::Integer ]) -> untyped } -> untyped",
+                      PTY, :getpty, "echo" do |r, w, pid| 1 end
+  end
+
+  def test_spawn
+    assert_send_type  "(*::String command) -> [ ::IO, ::IO, ::Integer ]",
+                      PTY, :spawn, "echo"
+    assert_send_type  "(*::String command) { ([ ::IO, ::IO, ::Integer ]) -> untyped } -> untyped",
+                      PTY, :spawn, "echo" do |r, w, pid| 1 end
+  end
+end
+


### PR DESCRIPTION
I do have a test in my local repository, however I'm not quite sure whether I should add it since it has to spawn a shell as well as (obviously) a PTY in order to run it's methods properly. However that would require us to choose a shell for the tests, for Linux and UNIX based Operating Systems that'd be `sh` I presume? On windows cmd?

If we don't want to mess with such details I can alternatively delete the tests as well, the type signatures aren't all too complex.


