### PR TITLE
`Enumerator#map` with no block should return `Array[untyped]` Enumerator

### DIFF
--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -46,7 +46,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
             | () { (Elem arg0) -> untyped } -> bool
 
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
-             | () -> ::Enumerator[Elem, Return]
+             | () -> ::Enumerator[Elem, ::Array[untyped]]
 
   def collect_concat: [U] () { (Elem arg0) -> ::Enumerator[U, untyped] } -> ::Array[U]
 
@@ -317,7 +317,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
               | () -> ::Enumerator[Elem, Return]
 
   def map: [U] () { (Elem arg0) -> U } -> ::Array[U]
-         | () -> ::Enumerator[Elem, Return]
+         | () -> ::Enumerator[Elem, ::Array[untyped]]
 
   def member?: (untyped arg0) -> bool
 

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -1,5 +1,19 @@
 require_relative "test_helper"
 
+class EnumeratorTest < Minitest::Test
+  include TypeAssertions
+
+  testing "::Enumerator[::Integer, Array[::Integer]]"
+
+  def test_map
+    g = [1,2,3].to_enum
+    assert_send_type "() { (Integer) -> String } -> Array[String]",
+                     g, :map do |x| x.to_s end
+    assert_send_type "() -> Enumerator[Integer, Array[untyped]]",
+                     g, :map
+  end
+end
+
 class EnumeratorYielderTest < Minitest::Test
   include TypeAssertions
 


### PR DESCRIPTION
According to the old RBS definition, the following code is considered to
return `Array[Integer]`:

```
[1,2,3].map.with_index {|x, _i| x.to_s }
```

... since `[1,2,3].map` returns `Enumerator[Integer, Array[Integer]]`
and `Enumerator#with_index` returns its second type variable.

However, it is obviously wrong since Ruby returns `Array[String]`.
It would be best if it can return `Array[String]`, but it seems hard to
represent it in the current RBS.

So, this changeset does next best; it makes `Enumerator#map` return
`Enumerator[Integer, Array[untyped]]`.  This is a bit unfortunate but
not wrong at least.