### PR TITLE
Fix prototype rb/rbi error handling

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -66,6 +66,10 @@ module RBS
       opts
     end
 
+    def has_parser?
+      defined?(RubyVM::AbstractSyntaxTree)
+    end
+
     def run(args)
       options = LibraryOptions.new
 
@@ -599,12 +603,18 @@ EOU
     end
 
     def run_prototype_file(format, args)
+      availability = unless has_parser?
+                       "\n** This command does not work on this interpreter (#{RUBY_ENGINE}) **\n"
+                     end
+
       opts = OptionParser.new
       opts.banner = <<EOU
 Usage: rbs prototype #{format} [options...] [files...]
-
+#{availability}
 Generate RBS prototype from source code.
-It parses specified Ruby code and and generates RBS prototypes. 
+It parses specified Ruby code and and generates RBS prototypes.
+
+It only works on MRI because it parses Ruby code with `RubyVM::AbstractSyntaxTree`.
 
 Examples:
 
@@ -612,6 +622,11 @@ Examples:
   $ rbs prototype rbi sorbet/rbi/foo.rbi
 EOU
       opts.parse!(args)
+
+      unless has_parser?
+        stdout.puts "Not supported on this interpreter (#{RUBY_ENGINE})."
+        exit 1
+      end
 
       if args.empty?
         stdout.puts opts

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -202,4 +202,25 @@ singleton(::BasicObject)
       end
     end
   end
+
+  def test_prototype_no_parser
+    Dir.mktmpdir do |dir|
+      with_cli do |cli|
+        def cli.has_parser?
+          false
+        end
+
+        assert_raises SystemExit do
+          cli.run(%w(prototype rb))
+        end
+
+        assert_raises SystemExit do
+          cli.run(%w(prototype rbi))
+        end
+
+        assert_equal "Not supported on this interpreter (ruby).\n", stdout.string.lines[0]
+        assert_equal "Not supported on this interpreter (ruby).\n", stdout.string.lines[1]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #348.

`rbs prototype rb` and `rbs prototype rbi` uses `RubyVM::AbstractSyntaxTree` which is not stable nor portable API. The CLI tests if the parser class is defined, and abort with an error message if not.