### PR TITLE
Optimize `push_comment` method

### DIFF
--- a/lib/rbs/ast/comment.rb
+++ b/lib/rbs/ast/comment.rb
@@ -22,6 +22,12 @@ module RBS
       def to_json(*a)
         { string: string, location: location }.to_json(*a)
       end
+
+      def concat(string:, location:)  
+        @string.concat string
+        @location.concat location
+        self
+      end
     end
   end
 end

--- a/lib/rbs/location.rb
+++ b/lib/rbs/location.rb
@@ -77,6 +77,21 @@ module RBS
       locations.inject {|l1, l2| l1 + l2 }
     end
 
+    def concat(*others)
+      others.each { |other| self << other }
+      self
+    end
+
+    def <<(other)
+      if other
+        raise "Invalid concat: buffer=#{buffer.name}, other.buffer=#{other.buffer.name}" unless other.buffer == buffer
+        @end_pos = other.end_pos
+        @source = nil
+        @end_loc = nil
+      end
+      self
+    end
+
     def pred?(loc)
       loc.is_a?(Location) &&
         loc.name == name &&

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -1150,15 +1150,13 @@ def leading_comment(location)
 end
 
 def push_comment(string, location)
-  new_comment = AST::Comment.new(string: string+"\n", location: location)
-
-  if (prev_comment = leading_comment(location)) && prev_comment.location.start_column == location.start_column
-    @comments.delete prev_comment.location.end_line
-    new_comment = AST::Comment.new(string: prev_comment.string + new_comment.string,
-                                   location: prev_comment.location + new_comment.location)
+  if (comment = leading_comment(location)) && comment.location.start_column == location.start_column
+    comment.concat(string: "#{string}\n", location: location)
+    @comments[comment.location.end_line] = comment
+  else
+    new_comment = AST::Comment.new(string: "#{string}\n", location: location)
+    @comments[new_comment.location.end_line] = new_comment
   end
-
-  @comments[new_comment.location.end_line] = new_comment
 end
 
 def new_token(type, value = input.matched)

--- a/test/rbs/comment_test.rb
+++ b/test/rbs/comment_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class RBS::CommentTest < Minitest::Test
+  include TestHelper
+
+  def test_concat
+    buffer = RBS::Buffer.new(name: Pathname("foo.rbs"), content: "")
+
+    comment = RBS::AST::Comment.new(
+      string: 'foo',
+      location: RBS::Location.new(buffer: buffer, start_pos: 0, end_pos: 3)
+    )
+    
+    comment.concat(
+      string: 'bar',
+      location: RBS::Location.new(buffer: buffer, start_pos: 4, end_pos: 7)
+    )
+    
+    assert_equal "foobar", comment.string
+    assert_equal 0, comment.location.start_pos
+    assert_equal 7, comment.location.end_pos
+  end
+end


### PR DESCRIPTION
This PR optimizes the `push_comment` method in `parser.rb` by concatenating to the previous comment instead of creating two new comments if it's not a new comment.