### PR TITLE
Test outer namespace presence

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -413,6 +413,7 @@ EOU
       env.constant_decls.each do |name, const|
         stdout.puts "Validating constant: `#{name}`..."
         validator.validate_type const.decl.type, context: const.context
+        builder.ensure_namespace!(name.namespace, location: const.decl.location)
       end
 
       env.global_decls.each do |name, global|
@@ -422,7 +423,9 @@ EOU
 
       env.alias_decls.each do |name, decl|
         stdout.puts "Validating alias: `#{name}`..."
-        validator.validate_type decl.decl.type, context: decl.context
+        builder.expand_alias(name).tap do |type|
+          validator.validate_type type, context: [Namespace.root]
+        end
       end
     end
 

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -385,9 +385,18 @@ module RBS
       end
     end
 
+    def ensure_namespace!(namespace, location:)
+      namespace.ascend do |ns|
+        unless ns.empty?
+          NoTypeFoundError.check!(ns.to_type_name, env: env, location: location)
+        end
+      end
+    end
+
     def build_instance(type_name)
       try_cache type_name, cache: instance_cache do
         entry = env.class_decls[type_name] or raise "Unknown name for build_instance: #{type_name}"
+        ensure_namespace!(type_name.namespace, location: entry.decls[0].decl.location)
 
         case entry
         when Environment::ClassEntry, Environment::ModuleEntry
@@ -434,6 +443,7 @@ module RBS
     def build_singleton(type_name)
       try_cache type_name, cache: singleton_cache do
         entry = env.class_decls[type_name] or raise "Unknown name for build_singleton: #{type_name}"
+        ensure_namespace!(type_name.namespace, location: entry.decls[0].decl.location)
 
         case entry
         when Environment::ClassEntry, Environment::ModuleEntry
@@ -1020,6 +1030,7 @@ module RBS
       try_cache(type_name, cache: interface_cache) do
         entry = env.interface_decls[type_name] or raise "Unknown name for build_interface: #{type_name}"
         declaration = entry.decl
+        ensure_namespace!(type_name.namespace, location: declaration.location)
 
         self_type = Types::Interface.new(
           name: type_name,
@@ -1111,6 +1122,7 @@ module RBS
 
     def expand_alias(type_name)
       entry = env.alias_decls[type_name] or raise "Unknown name for expand_alias: #{type_name}"
+      ensure_namespace!(type_name.namespace, location: entry.decl.location)
       entry.decl.type
     end
   end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -133,6 +133,49 @@ singleton(::BasicObject)
     with_cli do |cli|
       cli.run(%w(-r set validate))
     end
+
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        class Hello::World
+        end
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+
+        assert_equal "::Hello", error.type_name.to_s
+      end
+    end
+
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        Hello::World: Integer
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+
+        assert_equal "::Hello", error.type_name.to_s
+      end
+    end
+
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        type Hello::t = Integer
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+
+        assert_equal "::Hello", error.type_name.to_s
+      end
+    end
   end
 
   def test_constant

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1498,4 +1498,38 @@ end
       end
     end
   end
+
+  def test_build_absent_namespace
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class Hello::World
+end
+
+interface Hello::_World
+end
+
+type Hello::world = 30
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        assert_raises RBS::NoTypeFoundError do
+          builder.build_instance(type_name("::Hello::World"))
+        end
+
+        assert_raises RBS::NoTypeFoundError do
+          builder.build_singleton(type_name("::Hello::World"))
+        end
+
+        assert_raises RBS::NoTypeFoundError do
+          builder.build_interface(type_name("::Hello::_World"))
+        end
+
+        assert_raises RBS::NoTypeFoundError do
+          builder.expand_alias(type_name("::Hello::world"))
+        end
+      end
+    end
+  end
 end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -71,6 +71,13 @@ RBS::RuntimePrototypeTest::TestTargets::Test::NAME: String
   def test_merge_types
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
+class RBS
+  class RuntimePrototypeTest
+    class TestTargets
+    end
+  end
+end
+
 class RBS::RuntimePrototypeTest::TestTargets::Test
   def self.baz: () -> void
 

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -18,6 +18,8 @@ end
 
 class Foo
 end
+
+type Foo::Bar::Baz::t = Integer
       EOF
 
       manager.build do |env|


### PR DESCRIPTION
Ensure the outer namespaces of declarations are present.

```
# Error if there is no ::Foo definition
class Foo::Bar
end

# Error if there is no ::Foo definition
interface Foo::_Bar
end

# Error if there is no ::Foo definition
type Foo::bar = Integer

# Error if there is no ::Foo definition
Foo::Baz: String
```