### PR TITLE
Allow missing method implementation in Ruby code

### DIFF
--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -58,11 +58,9 @@ TracePoint.trace :end do |tp|
 
   if class_name
     if filter.any? {|f| match(to_absolute_typename(f).to_s, class_name.to_s) } && skips.none? {|f| match(f, class_name.to_s) }
-      unless tester.targets.include?(tp.self)
-        if env.class_decls.key?(class_name)
-          logger.info "Setting up hooks for #{class_name}"
-          tester.install!(tp.self, sample_size: sample_size)
-        end
+      if env.class_decls.key?(class_name)
+        logger.info "Setting up hooks for #{class_name}"
+        tester.install!(tp.self, sample_size: sample_size)
       end
     end
   end

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -76,13 +76,13 @@ RUBY
 
   def assert_test_success(other_env: {}, rbs_content: nil, ruby_content: nil)
     err, status = run_runtime_test(other_env: other_env, rbs_content: rbs_content, ruby_content: ruby_content)
-    assert_operator status, :success?
+    assert_predicate status, :success?, err
     err
   end
 
   def refute_test_success(other_env: {}, rbs_content: nil, ruby_content: nil)
     err, status = run_runtime_test(other_env: other_env, rbs_content: rbs_content, ruby_content: ruby_content)
-    refute_operator status, :success?
+    refute_predicate status, :success?, err
     err
   end
 
@@ -105,5 +105,25 @@ class TestClass
   end
 end
 RUBY
+  end
+
+  def test_open_decls
+    output = refute_test_success(ruby_content: <<RUBY, rbs_content: <<RBS)
+class Hello
+end
+
+class Hello
+  def world
+  end
+end
+
+Hello.new.world(3)
+RUBY
+class Hello
+  def world: () -> void
+end
+RBS
+
+    assert_match /TypeError: \[Hello#world\]/, output
   end
 end


### PR DESCRIPTION
Having multiple `module` and `class` declarations causes a problem of `undefined method `____'` on `alias_method` calls. This is because the hook installation happens on `:end` event of TracePoint.

```rb
module SuperLibrary
  # defines classes of the library
  class SomeClass
  end
end                        # Hook install happens here, but no `foo` method defined yet. 💣 💥 

module SuperLibrary
  # The library itself has methods
  def foo()
    # ...
  end
end
```

To avoid this error, it now does method existence check and hook definition duplication check. 