### PR TITLE
CMath

### DIFF
--- a/stdlib/cmath/cmath.rbs
+++ b/stdlib/cmath/cmath.rbs
@@ -3,121 +3,42 @@ module CMath
 
   RealMath: untyped
 
-  #
-  # Math::E raised to the +z+ power
-  #
-  #   CMath.exp(1.i * Math::PI) #=> (-1.0+1.2246467991473532e-16i)
   def exp: (untyped z) -> untyped
 
-  #
-  # Returns the natural logarithm of Complex. If a second argument is given,
-  # it will be the base of logarithm.
-  #
-  #   CMath.log(1 + 4i)     #=> (1.416606672028108+1.3258176636680326i)
-  #   CMath.log(1 + 4i, 10) #=> (0.6152244606891369+0.5757952953408879i)
   def log: (untyped z, ?untyped b) -> untyped
 
-  #
-  # Returns the base 2 logarithm of +z+
-  #
-  #   CMath.log2(-1) => (0.0+4.532360141827194i)
   def log2: (untyped z) -> untyped
 
-  #
-  # Returns the base 10 logarithm of +z+
-  #
-  #   CMath.log10(-1) #=> (0.0+1.3643763538418412i)
   def log10: (untyped z) -> untyped
 
-  #
-  # Returns the non-negative square root of Complex.
-  #
-  #   CMath.sqrt(-1 + 0i) #=> 0.0+1.0i
   def sqrt: (untyped z) -> untyped
 
-  #
-  # Returns the principal value of the cube root of +z+
-  #
-  #   CMath.cbrt(1 + 4i) #=> (1.449461632813119+0.6858152562177092i)
   def cbrt: (untyped z) -> untyped
 
-  #
-  # Returns the sine of +z+, where +z+ is given in radians
-  #
-  #   CMath.sin(1 + 1i) #=> (1.2984575814159773+0.6349639147847361i)
   def sin: (untyped z) -> untyped
 
-  #
-  # Returns the cosine of +z+, where +z+ is given in radians
-  #
-  #   CMath.cos(1 + 1i) #=> (0.8337300251311491-0.9888977057628651i)
   def cos: (untyped z) -> untyped
 
-  #
-  # Returns the tangent of +z+, where +z+ is given in radians
-  #
-  #   CMath.tan(1 + 1i) #=> (0.27175258531951174+1.0839233273386943i)
   def tan: (untyped z) -> untyped
 
-  #
-  # Returns the hyperbolic sine of +z+, where +z+ is given in radians
-  #
-  #   CMath.sinh(1 + 1i) #=> (0.6349639147847361+1.2984575814159773i)
   def sinh: (untyped z) -> untyped
 
-  #
-  # Returns the hyperbolic cosine of +z+, where +z+ is given in radians
-  #
-  #   CMath.cosh(1 + 1i) #=> (0.8337300251311491+0.9888977057628651i)
   def cosh: (untyped z) -> untyped
 
-  #
-  # Returns the hyperbolic tangent of +z+, where +z+ is given in radians
-  #
-  #   CMath.tanh(1 + 1i) #=> (1.0839233273386943+0.27175258531951174i)
   def tanh: (untyped z) -> untyped
 
-  #
-  # Returns the arc sine of +z+
-  #
-  #   CMath.asin(1 + 1i) #=> (0.6662394324925153+1.0612750619050355i)
   def asin: (untyped z) -> untyped
 
-  #
-  # Returns the arc cosine of +z+
-  #
-  #   CMath.acos(1 + 1i) #=> (0.9045568943023813-1.0612750619050357i)
   def acos: (untyped z) -> untyped
 
-  #
-  # Returns the arc tangent of +z+
-  #
-  #   CMath.atan(1 + 1i) #=> (1.0172219678978514+0.4023594781085251i)
   def atan: (untyped z) -> untyped
 
-  #
-  # returns the arc tangent of +y+ divided by +x+ using the signs of +y+ and
-  # +x+ to determine the quadrant
-  #
-  #   CMath.atan2(1 + 1i, 0) #=> (1.5707963267948966+0.0i)
   def atan2: (untyped y, untyped x) -> untyped
 
-  #
-  # returns the inverse hyperbolic sine of +z+
-  #
-  #   CMath.asinh(1 + 1i) #=> (1.0612750619050357+0.6662394324925153i)
   def asinh: (untyped z) -> untyped
 
-  #
-  # returns the inverse hyperbolic cosine of +z+
-  #
-  #   CMath.acosh(1 + 1i) #=> (1.0612750619050357+0.9045568943023813i)
   def acosh: (untyped z) -> untyped
 
-  #
-  # returns the inverse hyperbolic tangent of +z+
-  #
-  #   CMath.atanh(1 + 1i) #=> (0.4023594781085251+1.0172219678978514i)
   def atanh: (untyped z) -> untyped
 
   def handle_no_method_error: () -> untyped

--- a/stdlib/cmath/cmath.rbs
+++ b/stdlib/cmath/cmath.rbs
@@ -2,78 +2,16 @@ module CMath
   include Math
 
   #
-  # Math::E raised to the +z+ power
+  # Returns the arc cosine of +z+
   #
-  #   CMath.exp(1.i * Math::PI) #=> (-1.0+1.2246467991473532e-16i)
-  def exp: (Numeric z) -> Numeric
+  #   CMath.acos(1 + 1i) #=> (0.9045568943023813-1.0612750619050357i)
+  def acos: (Numeric z) -> Numeric
 
   #
-  # Returns the natural logarithm of Complex. If a second argument is given,
-  # it will be the base of logarithm.
+  # returns the inverse hyperbolic cosine of +z+
   #
-  #   CMath.log(1 + 4i)     #=> (1.416606672028108+1.3258176636680326i)
-  #   CMath.log(1 + 4i, 10) #=> (0.6152244606891369+0.5757952953408879i)
-  def log: (Numeric z, ?Numeric b) -> Numeric
-
-  #
-  # Returns the base 2 logarithm of +z+
-  #
-  #   CMath.log2(-1) => (0.0+4.532360141827194i)
-  def log2: (Numeric z) -> Numeric
-
-  #
-  # Returns the base 10 logarithm of +z+
-  #
-  #   CMath.log10(-1) #=> (0.0+1.3643763538418412i)
-  def log10: (Numeric z) -> Numeric
-
-  #
-  # Returns the non-negative square root of Complex.
-  #
-  #   CMath.sqrt(-1 + 0i) #=> 0.0+1.0i
-  def sqrt: (Numeric z) -> Numeric
-
-  #
-  # Returns the principal value of the cube root of +z+
-  #
-  #   CMath.cbrt(1 + 4i) #=> (1.449461632813119+0.6858152562177092i)
-  def cbrt: (Numeric z) -> Numeric
-
-  #
-  # Returns the sine of +z+, where +z+ is given in radians
-  #
-  #   CMath.sin(1 + 1i) #=> (1.2984575814159773+0.6349639147847361i)
-  def sin: (Numeric z) -> Numeric
-
-  #
-  # Returns the cosine of +z+, where +z+ is given in radians
-  #
-  #   CMath.cos(1 + 1i) #=> (0.8337300251311491-0.9888977057628651i)
-  def cos: (Numeric z) -> Numeric
-
-  #
-  # Returns the tangent of +z+, where +z+ is given in radians
-  #
-  #   CMath.tan(1 + 1i) #=> (0.27175258531951174+1.0839233273386943i)
-  def tan: (Numeric z) -> Numeric
-
-  #
-  # Returns the hyperbolic sine of +z+, where +z+ is given in radians
-  #
-  #   CMath.sinh(1 + 1i) #=> (0.6349639147847361+1.2984575814159773i)
-  def sinh: (Numeric z) -> Numeric
-
-  #
-  # Returns the hyperbolic cosine of +z+, where +z+ is given in radians
-  #
-  #   CMath.cosh(1 + 1i) #=> (0.8337300251311491+0.9888977057628651i)
-  def cosh: (Numeric z) -> Numeric
-
-  #
-  # Returns the hyperbolic tangent of +z+, where +z+ is given in radians
-  #
-  #   CMath.tanh(1 + 1i) #=> (1.0839233273386943+0.27175258531951174i)
-  def tanh: (Numeric z) -> Numeric
+  #   CMath.acosh(1 + 1i) #=> (1.0612750619050357+0.9045568943023813i)
+  def acosh: (Numeric z) -> Numeric
 
   #
   # Returns the arc sine of +z+
@@ -82,10 +20,10 @@ module CMath
   def asin: (Numeric z) -> Numeric
 
   #
-  # Returns the arc cosine of +z+
+  # returns the inverse hyperbolic sine of +z+
   #
-  #   CMath.acos(1 + 1i) #=> (0.9045568943023813-1.0612750619050357i)
-  def acos: (Numeric z) -> Numeric
+  #   CMath.asinh(1 + 1i) #=> (1.0612750619050357+0.6662394324925153i)
+  def asinh: (Numeric z) -> Numeric
 
   #
   # Returns the arc tangent of +z+
@@ -101,20 +39,82 @@ module CMath
   def atan2: (Numeric y, Numeric x) -> Numeric
 
   #
-  # returns the inverse hyperbolic sine of +z+
-  #
-  #   CMath.asinh(1 + 1i) #=> (1.0612750619050357+0.6662394324925153i)
-  def asinh: (Numeric z) -> Numeric
-
-  #
-  # returns the inverse hyperbolic cosine of +z+
-  #
-  #   CMath.acosh(1 + 1i) #=> (1.0612750619050357+0.9045568943023813i)
-  def acosh: (Numeric z) -> Numeric
-
-  #
   # returns the inverse hyperbolic tangent of +z+
   #
   #   CMath.atanh(1 + 1i) #=> (0.4023594781085251+1.0172219678978514i)
   def atanh: (Numeric z) -> Numeric
+
+  #
+  # Returns the principal value of the cube root of +z+
+  #
+  #   CMath.cbrt(1 + 4i) #=> (1.449461632813119+0.6858152562177092i)
+  def cbrt: (Numeric z) -> Numeric
+
+  #
+  # Returns the cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cos(1 + 1i) #=> (0.8337300251311491-0.9888977057628651i)
+  def cos: (Numeric z) -> Numeric
+
+  #
+  # Returns the hyperbolic cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cosh(1 + 1i) #=> (0.8337300251311491+0.9888977057628651i)
+  def cosh: (Numeric z) -> Numeric
+
+  #
+  # Math::E raised to the +z+ power
+  #
+  #   CMath.exp(1.i * Math::PI) #=> (-1.0+1.2246467991473532e-16i)
+  def exp: (Numeric z) -> Numeric
+
+  #
+  # Returns the natural logarithm of Complex. If a second argument is given,
+  # it will be the base of logarithm.
+  #
+  #   CMath.log(1 + 4i)     #=> (1.416606672028108+1.3258176636680326i)
+  #   CMath.log(1 + 4i, 10) #=> (0.6152244606891369+0.5757952953408879i)
+  def log: (Numeric z, ?Numeric b) -> Numeric
+
+  #
+  # Returns the base 10 logarithm of +z+
+  #
+  #   CMath.log10(-1) #=> (0.0+1.3643763538418412i)
+  def log10: (Numeric z) -> Numeric
+
+  #
+  # Returns the base 2 logarithm of +z+
+  #
+  #   CMath.log2(-1) => (0.0+4.532360141827194i)
+  def log2: (Numeric z) -> Numeric
+
+  #
+  # Returns the sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sin(1 + 1i) #=> (1.2984575814159773+0.6349639147847361i)
+  def sin: (Numeric z) -> Numeric
+
+  #
+  # Returns the hyperbolic sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sinh(1 + 1i) #=> (0.6349639147847361+1.2984575814159773i)
+  def sinh: (Numeric z) -> Numeric
+
+  #
+  # Returns the non-negative square root of Complex.
+  #
+  #   CMath.sqrt(-1 + 0i) #=> 0.0+1.0i
+  def sqrt: (Numeric z) -> Numeric
+
+  #
+  # Returns the tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tan(1 + 1i) #=> (0.27175258531951174+1.0839233273386943i)
+  def tan: (Numeric z) -> Numeric
+
+  #
+  # Returns the hyperbolic tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tanh(1 + 1i) #=> (1.0839233273386943+0.27175258531951174i)
+  def tanh: (Numeric z) -> Numeric
 end

--- a/stdlib/cmath/cmath.rbs
+++ b/stdlib/cmath/cmath.rbs
@@ -1,45 +1,120 @@
 module CMath
   include Math
 
-  RealMath: untyped
+  #
+  # Math::E raised to the +z+ power
+  #
+  #   CMath.exp(1.i * Math::PI) #=> (-1.0+1.2246467991473532e-16i)
+  def exp: (Numeric z) -> Numeric
 
-  def exp: (untyped z) -> untyped
+  #
+  # Returns the natural logarithm of Complex. If a second argument is given,
+  # it will be the base of logarithm.
+  #
+  #   CMath.log(1 + 4i)     #=> (1.416606672028108+1.3258176636680326i)
+  #   CMath.log(1 + 4i, 10) #=> (0.6152244606891369+0.5757952953408879i)
+  def log: (Numeric z, ?Numeric b) -> Numeric
 
-  def log: (untyped z, ?untyped b) -> untyped
+  #
+  # Returns the base 2 logarithm of +z+
+  #
+  #   CMath.log2(-1) => (0.0+4.532360141827194i)
+  def log2: (Numeric z) -> Numeric
 
-  def log2: (untyped z) -> untyped
+  #
+  # Returns the base 10 logarithm of +z+
+  #
+  #   CMath.log10(-1) #=> (0.0+1.3643763538418412i)
+  def log10: (Numeric z) -> Numeric
 
-  def log10: (untyped z) -> untyped
+  #
+  # Returns the non-negative square root of Complex.
+  #
+  #   CMath.sqrt(-1 + 0i) #=> 0.0+1.0i
+  def sqrt: (Numeric z) -> Numeric
 
-  def sqrt: (untyped z) -> untyped
+  #
+  # Returns the principal value of the cube root of +z+
+  #
+  #   CMath.cbrt(1 + 4i) #=> (1.449461632813119+0.6858152562177092i)
+  def cbrt: (Numeric z) -> Numeric
 
-  def cbrt: (untyped z) -> untyped
+  #
+  # Returns the sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sin(1 + 1i) #=> (1.2984575814159773+0.6349639147847361i)
+  def sin: (Numeric z) -> Numeric
 
-  def sin: (untyped z) -> untyped
+  #
+  # Returns the cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cos(1 + 1i) #=> (0.8337300251311491-0.9888977057628651i)
+  def cos: (Numeric z) -> Numeric
 
-  def cos: (untyped z) -> untyped
+  #
+  # Returns the tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tan(1 + 1i) #=> (0.27175258531951174+1.0839233273386943i)
+  def tan: (Numeric z) -> Numeric
 
-  def tan: (untyped z) -> untyped
+  #
+  # Returns the hyperbolic sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sinh(1 + 1i) #=> (0.6349639147847361+1.2984575814159773i)
+  def sinh: (Numeric z) -> Numeric
 
-  def sinh: (untyped z) -> untyped
+  #
+  # Returns the hyperbolic cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cosh(1 + 1i) #=> (0.8337300251311491+0.9888977057628651i)
+  def cosh: (Numeric z) -> Numeric
 
-  def cosh: (untyped z) -> untyped
+  #
+  # Returns the hyperbolic tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tanh(1 + 1i) #=> (1.0839233273386943+0.27175258531951174i)
+  def tanh: (Numeric z) -> Numeric
 
-  def tanh: (untyped z) -> untyped
+  #
+  # Returns the arc sine of +z+
+  #
+  #   CMath.asin(1 + 1i) #=> (0.6662394324925153+1.0612750619050355i)
+  def asin: (Numeric z) -> Numeric
 
-  def asin: (untyped z) -> untyped
+  #
+  # Returns the arc cosine of +z+
+  #
+  #   CMath.acos(1 + 1i) #=> (0.9045568943023813-1.0612750619050357i)
+  def acos: (Numeric z) -> Numeric
 
-  def acos: (untyped z) -> untyped
+  #
+  # Returns the arc tangent of +z+
+  #
+  #   CMath.atan(1 + 1i) #=> (1.0172219678978514+0.4023594781085251i)
+  def atan: (Numeric z) -> Numeric
 
-  def atan: (untyped z) -> untyped
+  #
+  # returns the arc tangent of +y+ divided by +x+ using the signs of +y+ and
+  # +x+ to determine the quadrant
+  #
+  #   CMath.atan2(1 + 1i, 0) #=> (1.5707963267948966+0.0i)
+  def atan2: (Numeric y, Numeric x) -> Numeric
 
-  def atan2: (untyped y, untyped x) -> untyped
+  #
+  # returns the inverse hyperbolic sine of +z+
+  #
+  #   CMath.asinh(1 + 1i) #=> (1.0612750619050357+0.6662394324925153i)
+  def asinh: (Numeric z) -> Numeric
 
-  def asinh: (untyped z) -> untyped
+  #
+  # returns the inverse hyperbolic cosine of +z+
+  #
+  #   CMath.acosh(1 + 1i) #=> (1.0612750619050357+0.9045568943023813i)
+  def acosh: (Numeric z) -> Numeric
 
-  def acosh: (untyped z) -> untyped
-
-  def atanh: (untyped z) -> untyped
-
-  def handle_no_method_error: () -> untyped
+  #
+  # returns the inverse hyperbolic tangent of +z+
+  #
+  #   CMath.atanh(1 + 1i) #=> (0.4023594781085251+1.0172219678978514i)
+  def atanh: (Numeric z) -> Numeric
 end

--- a/stdlib/cmath/cmath.rbs
+++ b/stdlib/cmath/cmath.rbs
@@ -1,0 +1,124 @@
+module CMath
+  include Math
+
+  RealMath: untyped
+
+  #
+  # Math::E raised to the +z+ power
+  #
+  #   CMath.exp(1.i * Math::PI) #=> (-1.0+1.2246467991473532e-16i)
+  def exp: (untyped z) -> untyped
+
+  #
+  # Returns the natural logarithm of Complex. If a second argument is given,
+  # it will be the base of logarithm.
+  #
+  #   CMath.log(1 + 4i)     #=> (1.416606672028108+1.3258176636680326i)
+  #   CMath.log(1 + 4i, 10) #=> (0.6152244606891369+0.5757952953408879i)
+  def log: (untyped z, ?untyped b) -> untyped
+
+  #
+  # Returns the base 2 logarithm of +z+
+  #
+  #   CMath.log2(-1) => (0.0+4.532360141827194i)
+  def log2: (untyped z) -> untyped
+
+  #
+  # Returns the base 10 logarithm of +z+
+  #
+  #   CMath.log10(-1) #=> (0.0+1.3643763538418412i)
+  def log10: (untyped z) -> untyped
+
+  #
+  # Returns the non-negative square root of Complex.
+  #
+  #   CMath.sqrt(-1 + 0i) #=> 0.0+1.0i
+  def sqrt: (untyped z) -> untyped
+
+  #
+  # Returns the principal value of the cube root of +z+
+  #
+  #   CMath.cbrt(1 + 4i) #=> (1.449461632813119+0.6858152562177092i)
+  def cbrt: (untyped z) -> untyped
+
+  #
+  # Returns the sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sin(1 + 1i) #=> (1.2984575814159773+0.6349639147847361i)
+  def sin: (untyped z) -> untyped
+
+  #
+  # Returns the cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cos(1 + 1i) #=> (0.8337300251311491-0.9888977057628651i)
+  def cos: (untyped z) -> untyped
+
+  #
+  # Returns the tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tan(1 + 1i) #=> (0.27175258531951174+1.0839233273386943i)
+  def tan: (untyped z) -> untyped
+
+  #
+  # Returns the hyperbolic sine of +z+, where +z+ is given in radians
+  #
+  #   CMath.sinh(1 + 1i) #=> (0.6349639147847361+1.2984575814159773i)
+  def sinh: (untyped z) -> untyped
+
+  #
+  # Returns the hyperbolic cosine of +z+, where +z+ is given in radians
+  #
+  #   CMath.cosh(1 + 1i) #=> (0.8337300251311491+0.9888977057628651i)
+  def cosh: (untyped z) -> untyped
+
+  #
+  # Returns the hyperbolic tangent of +z+, where +z+ is given in radians
+  #
+  #   CMath.tanh(1 + 1i) #=> (1.0839233273386943+0.27175258531951174i)
+  def tanh: (untyped z) -> untyped
+
+  #
+  # Returns the arc sine of +z+
+  #
+  #   CMath.asin(1 + 1i) #=> (0.6662394324925153+1.0612750619050355i)
+  def asin: (untyped z) -> untyped
+
+  #
+  # Returns the arc cosine of +z+
+  #
+  #   CMath.acos(1 + 1i) #=> (0.9045568943023813-1.0612750619050357i)
+  def acos: (untyped z) -> untyped
+
+  #
+  # Returns the arc tangent of +z+
+  #
+  #   CMath.atan(1 + 1i) #=> (1.0172219678978514+0.4023594781085251i)
+  def atan: (untyped z) -> untyped
+
+  #
+  # returns the arc tangent of +y+ divided by +x+ using the signs of +y+ and
+  # +x+ to determine the quadrant
+  #
+  #   CMath.atan2(1 + 1i, 0) #=> (1.5707963267948966+0.0i)
+  def atan2: (untyped y, untyped x) -> untyped
+
+  #
+  # returns the inverse hyperbolic sine of +z+
+  #
+  #   CMath.asinh(1 + 1i) #=> (1.0612750619050357+0.6662394324925153i)
+  def asinh: (untyped z) -> untyped
+
+  #
+  # returns the inverse hyperbolic cosine of +z+
+  #
+  #   CMath.acosh(1 + 1i) #=> (1.0612750619050357+0.9045568943023813i)
+  def acosh: (untyped z) -> untyped
+
+  #
+  # returns the inverse hyperbolic tangent of +z+
+  #
+  #   CMath.atanh(1 + 1i) #=> (0.4023594781085251+1.0172219678978514i)
+  def atanh: (untyped z) -> untyped
+
+  def handle_no_method_error: () -> untyped
+end

--- a/test/stdlib/CMath_test.rb
+++ b/test/stdlib/CMath_test.rb
@@ -1,0 +1,105 @@
+require_relative "test_helper"
+
+
+class CMathTest < Minitest::Test
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "::CMath"
+
+
+  def test_acos
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :acos
+  end
+
+  def test_acosh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :acosh
+  end
+
+  def test_asin
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :asin
+  end
+
+  def test_asinh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :asinh
+  end
+
+  def test_atan
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :atan
+  end
+
+  def test_atan2
+    assert_send_type  "(::Numeric y, ::Numeric x) -> ::Numeric",
+                      CMath.new, :atan2
+  end
+
+  def test_atanh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :atanh
+  end
+
+  def test_cbrt
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :cbrt
+  end
+
+  def test_cos
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :cos
+  end
+
+  def test_cosh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :cosh
+  end
+
+  def test_exp
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :exp
+  end
+
+  def test_log
+    assert_send_type  "(::Numeric z, ?::Numeric b) -> ::Numeric",
+                      CMath.new, :log
+  end
+
+  def test_log10
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :log10
+  end
+
+  def test_log2
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :log2
+  end
+
+  def test_sin
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :sin
+  end
+
+  def test_sinh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :sinh
+  end
+
+  def test_sqrt
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :sqrt
+  end
+
+  def test_tan
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :tan
+  end
+
+  def test_tanh
+    assert_send_type  "(::Numeric z) -> ::Numeric",
+                      CMath.new, :tanh
+  end
+end


### PR DESCRIPTION
I am not sure about the location of the `cmath.rbs` file.

Tests are not passing on my machine yet but I don't know what is needed to make them pass:

```
moritz@pink rbs % ruby bin/test_runner.rb test/stdlib/CMath_test.rb
Traceback (most recent call last):
	9: from bin/test_runner.rb:12:in `<main>'
	8: from bin/test_runner.rb:12:in `each'
	7: from bin/test_runner.rb:13:in `block in <main>'
	6: from bin/test_runner.rb:13:in `load'
	5: from test/stdlib/CMath_test.rb:4:in `<top (required)>'
	4: from test/stdlib/CMath_test.rb:8:in `<class:CMathTest>'
	3: from /Users/moritz/Desktop/rbs/test/stdlib/test_helper.rb:155:in `testing'
	2: from /Users/moritz/.rvm/gems/ruby-2.7.0/gems/rbs-0.9.1/lib/rbs/definition_builder.rb:397:in `build_instance'
	1: from /Users/moritz/.rvm/gems/ruby-2.7.0/gems/rbs-0.9.1/lib/rbs/definition_builder.rb:1021:in `try_cache'
/Users/moritz/.rvm/gems/ruby-2.7.0/gems/rbs-0.9.1/lib/rbs/definition_builder.rb:398:in `block in build_instance': Unknown name for build_instance: ::CMath (RuntimeError)
```