### PR TITLE
Debgug print  “No type checker” message

### DIFF
--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -71,7 +71,7 @@ end
 at_exit do
   if $!.nil? || $!.is_a?(SystemExit) && $!.success?
     if tester.targets.empty?
-      logger.warn "No type checker was installed!"
+      logger.debug { "No type checker was installed!" }
     end
   end
 end


### PR DESCRIPTION
The `at_exit` block may be called twice for `RUBYOPT="-rrbs/test/setup" rake test`, one for unit tests and another for `rake`. This is confusing.

This PR is to make it `debug` print to stop printing it by default.