### PR TITLE
Allow overloading from super class methods

### DIFF
--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -45,6 +45,15 @@ module RBS
         def update(type: self.type, member: self.member, defined_in: self.defined_in, implemented_in: self.implemented_in)
           TypeDef.new(type: type, member: member, defined_in: defined_in, implemented_in: implemented_in)
         end
+
+        def overload?
+          case member
+          when AST::Members::MethodDefinition
+            member.overload?
+          else
+            false
+          end
+        end
       end
 
       attr_reader :super_method
@@ -77,6 +86,10 @@ module RBS
 
       def annotations
         @annotations ||= @extra_annotations + defs.flat_map(&:annotations)
+      end
+
+      def members
+        @members ||= defs.map(&:member).uniq
       end
 
       # @deprecated


### PR DESCRIPTION
RBS currently allows adding overloads only to methods defined in _that_ class.

```rbs
class Foo
  def foo: () -> Integer

  def foo: (String) -> String | ...         # OK
end

class Bar < Foo
  def foo: (Integer) -> String | ...        # Error 🚨
end
```

This makes writing signatures which provides a new module/class extending an existing module/class super difficult. One example is `cmath`. We want to write something like:

```
module CMath
  include Math

  def cos: (Complex) -> (Float | Complex)      # Add overload to accept Complex objects
         | ...                                 # While other numeric arguments are allowed as Math
end
```

This PR is to allow this.

* Overloading `...` are allowed for extending super class methods.
* Overloading without _primary_ (non-overloading) method definition is an error.