### PR TITLE
Add `Record` type checker

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -295,7 +295,8 @@ module RBS
           Test.call(val, IS_AP, ::Array) &&
             type.types.map.with_index {|ty, index| value(val[index], ty) }.all?
         when Types::Record
-          Test::call(val, IS_AP, ::Hash)
+          Test::call(val, IS_AP, ::Hash) && 
+            type.fields.map {|key, type| value(val[key], type) }.all?
         when Types::Proc
           Test::call(val, IS_AP, ::Proc)
         else


### PR DESCRIPTION
This PR allows the runtime type checker to also check the types of the key-value pairs in `Record`s similarly to `Tuple`s instead of just checking if the `Record` is a `Hash` or not.