### PR TITLE
Add date/datetime library types

### DIFF
--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -136,7 +136,27 @@
 class Date
   include Comparable
 
-  def initialize: (*untyped) -> untyped
+  # Creates a date object denoting the given calendar date.
+  #
+  # In this class, BCE years are counted astronomically.  Thus, the year before
+  # the year 1 is the year zero, and the year preceding the year zero is the year
+  # -1.  The month and the day of month should be a negative or a positive number
+  # (as a relative month/day from the end of year/month when negative).  They
+  # should not be zero.
+  #
+  # The last argument should be a Julian day number which denotes the day of
+  # calendar reform.  Date::ITALY (2299161=1582-10-15), Date::ENGLAND
+  # (2361222=1752-09-14), Date::GREGORIAN (the proleptic Gregorian calendar) and
+  # Date::JULIAN (the proleptic Julian calendar) can be specified as a day of
+  # calendar reform.
+  #
+  #     Date.new(2001)            #=> #<Date: 2001-01-01 ...>
+  #     Date.new(2001,2,3)        #=> #<Date: 2001-02-03 ...>
+  #     Date.new(2001,2,-1)       #=> #<Date: 2001-02-28 ...>
+  #
+  # See also ::jd.
+  #
+  def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
 
   # Returns a hash of parsed elements.
   #
@@ -953,7 +973,7 @@ class Date
 
   # Returns a DateTime object which denotes self.
   #
-  def to_datetime: () -> untyped
+  def to_datetime: () -> DateTime
 
   # Returns a string in an ISO 8601 format. (This method doesn't use the expanded
   # representations.)

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -447,7 +447,7 @@ class Date
   #     DateTime.jd(0,12) + DateTime.new(2001,2,3).ajd
   #                               #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
   #
-  def +: (Integer | Date | Rational arg0) -> Date
+  def +: (Integer | Date | Rational other) -> Date
 
   # Returns the difference between the two dates if the other is a date object. 
   # If the other is a numeric value, returns a date object pointing `other` days
@@ -462,7 +462,7 @@ class Date
   #     DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
   #                              #=> (1/2)
   #
-  def -: (Integer | Date | Rational arg0) ->Date
+  def -: (Integer | Date | Rational other) ->Date
 
   # Returns a date object pointing `n` months before self. The argument `n` should
   # be a numeric value.
@@ -781,10 +781,6 @@ class Date
   #
   #     Date.new(2001).step(Date.new(2001,-1,-1)).select{|d| d.sunday?}.size
   #                               #=> 52
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     d.step(limit[, step=1])              ->  enumerator
-  #     d.step(limit[, step=1]){|date| ...}  ->  self
   #
   def step: (Date limit, ?Integer step) { (Date) -> untyped } -> nil
           | (Date limit, ?Integer step) -> ::Enumerator[Date, nil]

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -134,8 +134,6 @@
 #     d.strftime('%a %d %b %Y')    #=> "Sun 04 Feb 2001"
 #
 class Date
-  include Comparable
-
   # Creates a date object denoting the given calendar date.
   #
   # In this class, BCE years are counted astronomically.  Thus, the year before
@@ -157,6 +155,9 @@ class Date
   # See also ::jd.
   #
   def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
+  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
+
+  include Comparable
 
   # Returns a hash of parsed elements.
   #
@@ -431,6 +432,8 @@ class Date
   #     Date.xmlschema('2001-02-03')      #=> #<Date: 2001-02-03 ...>
   #
   def self.xmlschema: (String str, ?Integer start) -> Date
+
+  public
 
   # Returns a date object pointing `other` days after self.  The other should be a
   # numeric value.  If the other is a fractional number, assumes its precision is

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -447,7 +447,7 @@ class Date
   #     DateTime.jd(0,12) + DateTime.new(2001,2,3).ajd
   #                               #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
   #
-  def +: (Integer | Date | Rational other) -> Date
+  def +: (Integer | Rational other) -> Date
 
   # Returns the difference between the two dates if the other is a date object. 
   # If the other is a numeric value, returns a date object pointing `other` days
@@ -462,7 +462,8 @@ class Date
   #     DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
   #                              #=> (1/2)
   #
-  def -: (Integer | Date | Rational other) ->Date
+  def -: (Integer | Rational other) -> Date
+       | (Date other) -> Rational
 
   # Returns a date object pointing `n` months before self. The argument `n` should
   # be a numeric value.
@@ -589,16 +590,10 @@ class Date
   #
   def day: () -> Integer
 
-  # Returns the fractional part of the day.
-  #
-  #     DateTime.new(2001,2,3,12).day_fraction    #=> (1/2)
-  #
-  def day_fraction: () -> Rational
-
   # This method is equivalent to step(min, -1){|date| ...}.
   #
-  def downto: (Date min) { (Date) -> untyped } -> nil
-            | (Date min) -> Enumerator[Date, nil]
+  def downto: (Date min) { (Date) -> untyped } -> Date
+            | (Date min) -> Enumerator[Date, Date]
 
   # This method is equivalent to new_start(Date::ENGLAND).
   #
@@ -774,7 +769,7 @@ class Date
   #     Date.new(2001,2,3).start                  #=> 2299161.0
   #     Date.new(2001,2,3,Date::GREGORIAN).start  #=> -Infinity
   #
-  def start: () -> Integer
+  def start: () -> Float
 
   # Iterates evaluation of the given block, which takes a date object. The limit
   # should be a date object.
@@ -782,8 +777,8 @@ class Date
   #     Date.new(2001).step(Date.new(2001,-1,-1)).select{|d| d.sunday?}.size
   #                               #=> 52
   #
-  def step: (Date limit, ?Integer step) { (Date) -> untyped } -> nil
-          | (Date limit, ?Integer step) -> ::Enumerator[Date, nil]
+  def step: (Date limit, ?Integer step) { (Date) -> untyped } -> Date
+          | (Date limit, ?Integer step) -> ::Enumerator[Date, Date]
 
   # Formats date according to the directives in the given format string. The
   # directives begin with a percent (%) character. Any text not listed as a
@@ -992,8 +987,8 @@ class Date
 
   # This method is equivalent to step(max, 1){|date| ...}.
   #
-  def upto: (Date max) { (Date) -> untyped } -> nil
-          | (Date max) -> ::Enumerator[Date, nil]
+  def upto: (Date max) { (Date) -> untyped } -> Date
+          | (Date max) -> ::Enumerator[Date, Date]
 
   # Returns the day of week (0-6, Sunday is zero).
   #

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -161,15 +161,15 @@ class Date
 
   # Returns a hash of parsed elements.
   #
-  def self._httpdate: (String str) -> Hash
+  def self._httpdate: (String str) -> Hash[Symbol, Integer]
 
   # Returns a hash of parsed elements.
   #
-  def self._iso8601: (String str) -> Hash
+  def self._iso8601: (String str) -> Hash[Symbol, Integer]
 
   # Returns a hash of parsed elements.
   #
-  def self._jisx0301: (String str) -> Hash
+  def self._jisx0301: (String str) -> Hash[Symbol, Integer]
 
   # Parses the given representation of date and time, and returns a hash of parsed
   # elements.  This method does not function as a validator.
@@ -179,19 +179,19 @@ class Date
   #
   #     Date._parse('2001-02-03') #=> {:year=>2001, :mon=>2, :mday=>3}
   #
-  def self._parse: (String str, ?bool complete) -> Hash
+  def self._parse: (String str, ?bool complete) -> Hash[Symbol, Integer]
 
   # Returns a hash of parsed elements.
   #
-  def self._rfc2822: (String str) -> Hash
+  def self._rfc2822: (String str) -> Hash[Symbol, Integer | String]
 
   # Returns a hash of parsed elements.
   #
-  def self._rfc3339: (String str) -> Hash
+  def self._rfc3339: (String str) -> Hash[Symbol, Integer | String]
 
   # Returns a hash of parsed elements.
   #
-  def self._rfc822: (String str) -> Hash
+  def self._rfc822: (String str) -> Hash[Symbol, Integer | String]
 
   # Parses the given representation of date and time with the given template, and
   # returns a hash of parsed elements.  _strptime does not support specification
@@ -202,11 +202,11 @@ class Date
   #
   # See also strptime(3) and #strftime.
   #
-  def self._strptime: (String str, ?String format) -> Hash
+  def self._strptime: (String str, ?String format) -> Hash[Symbol, Integer]
 
   # Returns a hash of parsed elements.
   #
-  def self._xmlschema: (String str) -> Hash
+  def self._xmlschema: (String str) -> Hash[Symbol, Integer]
 
   # Creates a date object denoting the given calendar date.
   #
@@ -992,7 +992,7 @@ class Date
 
   # This method is equivalent to step(max, 1){|date| ...}.
   #
-  def upto: (Date max) { (Date) -> untypd } -> nil
+  def upto: (Date max) { (Date) -> untyped } -> nil
           | (Date max) -> ::Enumerator[Date, nil]
 
   # Returns the day of week (0-6, Sunday is zero).

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -1,0 +1,1043 @@
+# date and datetime class - Tadayoshi Funaba 1998-2011
+#
+# 'date' provides two classes: Date and DateTime.
+#
+# ## Terms and Definitions
+#
+# Some terms and definitions are based on ISO 8601 and JIS X 0301.
+#
+# ### Calendar Date
+#
+# The calendar date is a particular day of a calendar year, identified by its
+# ordinal number within a calendar month within that year.
+#
+# In those classes, this is so-called "civil".
+#
+# ### Ordinal Date
+#
+# The ordinal date is a particular day of a calendar year identified by its
+# ordinal number within the year.
+#
+# In those classes, this is so-called "ordinal".
+#
+# ### Week Date
+#
+# The week date is a date identified by calendar week and day numbers.
+#
+# The calendar week is a seven day period within a calendar year, starting on a
+# Monday and identified by its ordinal number within the year; the first
+# calendar week of the year is the one that includes the first Thursday of that
+# year. In the Gregorian calendar, this is equivalent to the week which includes
+# January 4.
+#
+# In those classes, this is so-called "commercial".
+#
+# ### Julian Day Number
+#
+# The Julian day number is in elapsed days since noon (Greenwich Mean Time) on
+# January 1, 4713 BCE (in the Julian calendar).
+#
+# In this document, the astronomical Julian day number is the same as the
+# original Julian day number. And the chronological Julian day number is a
+# variation of the Julian day number. Its days begin at midnight on local time.
+#
+# In this document, when the term "Julian day number" simply appears, it just
+# refers to "chronological Julian day number", not the original.
+#
+# In those classes, those are so-called "ajd" and "jd".
+#
+# ### Modified Julian Day Number
+#
+# The modified Julian day number is in elapsed days since midnight (Coordinated
+# Universal Time) on November 17, 1858 CE (in the Gregorian calendar).
+#
+# In this document, the astronomical modified Julian day number is the same as
+# the original modified Julian day number. And the chronological modified Julian
+# day number is a variation of the modified Julian day number. Its days begin at
+# midnight on local time.
+#
+# In this document, when the term "modified Julian day number" simply appears,
+# it just refers to "chronological modified Julian day number", not the
+# original.
+#
+# In those classes, those are so-called "amjd" and "mjd".
+#
+# ## Date
+#
+# A subclass of Object that includes the Comparable module and easily handles
+# date.
+#
+# A Date object is created with Date::new, Date::jd, Date::ordinal,
+# Date::commercial, Date::parse, Date::strptime, Date::today, Time#to_date, etc.
+#
+#     require 'date'
+#
+#     Date.new(2001,2,3)
+#      #=> #<Date: 2001-02-03 ...>
+#     Date.jd(2451944)
+#      #=> #<Date: 2001-02-03 ...>
+#     Date.ordinal(2001,34)
+#      #=> #<Date: 2001-02-03 ...>
+#     Date.commercial(2001,5,6)
+#      #=> #<Date: 2001-02-03 ...>
+#     Date.parse('2001-02-03')
+#      #=> #<Date: 2001-02-03 ...>
+#     Date.strptime('03-02-2001', '%d-%m-%Y')
+#      #=> #<Date: 2001-02-03 ...>
+#     Time.new(2001,2,3).to_date
+#      #=> #<Date: 2001-02-03 ...>
+#
+# All date objects are immutable; hence cannot modify themselves.
+#
+# The concept of a date object can be represented as a tuple of the day count,
+# the offset and the day of calendar reform.
+#
+# The day count denotes the absolute position of a temporal dimension. The
+# offset is relative adjustment, which determines decoded local time with the
+# day count. The day of calendar reform denotes the start day of the new style.
+# The old style of the West is the Julian calendar which was adopted by Caesar.
+# The new style is the Gregorian calendar, which is the current civil calendar
+# of many countries.
+#
+# The day count is virtually the astronomical Julian day number. The offset in
+# this class is usually zero, and cannot be specified directly.
+#
+# A Date object can be created with an optional argument, the day of calendar
+# reform as a Julian day number, which should be 2298874 to 2426355 or
+# negative/positive infinity. The default value is `Date::ITALY`
+# (2299161=1582-10-15). See also sample/cal.rb.
+#
+#     $ ruby sample/cal.rb -c it 10 1582
+#         October 1582
+#      S  M Tu  W Th  F  S
+#         1  2  3  4 15 16
+#     17 18 19 20 21 22 23
+#     24 25 26 27 28 29 30
+#     31
+#
+#     $ ruby sample/cal.rb -c gb  9 1752
+#        September 1752
+#      S  M Tu  W Th  F  S
+#            1  2 14 15 16
+#     17 18 19 20 21 22 23
+#     24 25 26 27 28 29 30
+#
+# A Date object has various methods. See each reference.
+#
+#     d = Date.parse('3rd Feb 2001')
+#                                  #=> #<Date: 2001-02-03 ...>
+#     d.year                       #=> 2001
+#     d.mon                        #=> 2
+#     d.mday                       #=> 3
+#     d.wday                       #=> 6
+#     d += 1                       #=> #<Date: 2001-02-04 ...>
+#     d.strftime('%a %d %b %Y')    #=> "Sun 04 Feb 2001"
+#
+class Date
+  include Comparable
+
+  def initialize: (*untyped) -> untyped
+
+  # Returns a hash of parsed elements.
+  #
+  def self._httpdate: (String str) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._iso8601: (String str) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._jisx0301: (String str) -> Hash
+
+  # Parses the given representation of date and time, and returns a hash of parsed
+  # elements.  This method does not function as a validator.
+  #
+  # If the optional second argument is true and the detected year is in the range
+  # "00" to "99", considers the year a 2-digit form and makes it full.
+  #
+  #     Date._parse('2001-02-03') #=> {:year=>2001, :mon=>2, :mday=>3}
+  #
+  def self._parse: (String str, ?bool complete) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._rfc2822: (String str) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._rfc3339: (String str) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._rfc822: (String str) -> Hash
+
+  # Parses the given representation of date and time with the given template, and
+  # returns a hash of parsed elements.  _strptime does not support specification
+  # of flags and width unlike strftime.
+  #
+  #     Date._strptime('2001-02-03', '%Y-%m-%d')
+  #                               #=> {:year=>2001, :mon=>2, :mday=>3}
+  #
+  # See also strptime(3) and #strftime.
+  #
+  def self._strptime: (String str, ?String format) -> Hash
+
+  # Returns a hash of parsed elements.
+  #
+  def self._xmlschema: (String str) -> Hash
+
+  # Creates a date object denoting the given calendar date.
+  #
+  # In this class, BCE years are counted astronomically.  Thus, the year before
+  # the year 1 is the year zero, and the year preceding the year zero is the year
+  # -1.  The month and the day of month should be a negative or a positive number
+  # (as a relative month/day from the end of year/month when negative).  They
+  # should not be zero.
+  #
+  # The last argument should be a Julian day number which denotes the day of
+  # calendar reform.  Date::ITALY (2299161=1582-10-15), Date::ENGLAND
+  # (2361222=1752-09-14), Date::GREGORIAN (the proleptic Gregorian calendar) and
+  # Date::JULIAN (the proleptic Julian calendar) can be specified as a day of
+  # calendar reform.
+  #
+  #     Date.new(2001)            #=> #<Date: 2001-01-01 ...>
+  #     Date.new(2001,2,3)        #=> #<Date: 2001-02-03 ...>
+  #     Date.new(2001,2,-1)       #=> #<Date: 2001-02-28 ...>
+  #
+  # See also ::jd.
+  #
+  def self.civil: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
+
+  # Creates a date object denoting the given week date.
+  #
+  # The week and the day of week should be a negative or a positive number (as a
+  # relative week/day from the end of year/week when negative).  They should not
+  # be zero.
+  #
+  #     Date.commercial(2001)     #=> #<Date: 2001-01-01 ...>
+  #     Date.commercial(2002)     #=> #<Date: 2001-12-31 ...>
+  #     Date.commercial(2001,5,6) #=> #<Date: 2001-02-03 ...>
+  #
+  # See also ::jd and ::new.
+  #
+  def self.commercial: (?Integer cwyear, ?Integer cweek, ?Integer cwday, ?Integer start) -> Date
+
+  # Returns true if the given year is a leap year of the proleptic Gregorian
+  # calendar.
+  #
+  #     Date.gregorian_leap?(1900)        #=> false
+  #     Date.gregorian_leap?(2000)        #=> true
+  #
+  def self.gregorian_leap?: (Integer year) -> bool
+
+  # Creates a new Date object by parsing from a string according to some RFC 2616
+  # format.
+  #
+  #     Date.httpdate('Sat, 03 Feb 2001 00:00:00 GMT')
+  #                                               #=> #<Date: 2001-02-03 ...>
+  #
+  def self.httpdate: (String str, ?Integer start) -> Date
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # ISO 8601 formats.
+  #
+  #     Date.iso8601('2001-02-03')        #=> #<Date: 2001-02-03 ...>
+  #     Date.iso8601('20010203')          #=> #<Date: 2001-02-03 ...>
+  #     Date.iso8601('2001-W05-6')        #=> #<Date: 2001-02-03 ...>
+  #
+  def self.iso8601: (String str, ?Integer start) -> Date
+
+  # Creates a date object denoting the given chronological Julian day number.
+  #
+  #     Date.jd(2451944)          #=> #<Date: 2001-02-03 ...>
+  #     Date.jd(2451945)          #=> #<Date: 2001-02-04 ...>
+  #     Date.jd(0)                #=> #<Date: -4712-01-01 ...>
+  #
+  # See also ::new.
+  #
+  def self.jd: (Integer jd, ?Integer start) -> Date
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # JIS X 0301 formats.
+  #
+  #     Date.jisx0301('H13.02.03')                #=> #<Date: 2001-02-03 ...>
+  #
+  # For no-era year, legacy format, Heisei is assumed.
+  #
+  #     Date.jisx0301('13.02.03')                 #=> #<Date: 2001-02-03 ...>
+  #
+  def self.jisx0301: (String str, ?Integer start) -> Date
+
+  # Returns true if the given year is a leap year of the proleptic Julian
+  # calendar.
+  #
+  #     Date.julian_leap?(1900)           #=> true
+  #     Date.julian_leap?(1901)           #=> false
+  #
+  def self.julian_leap?: (Integer year) -> bool
+
+  # Returns true if the given year is a leap year of the proleptic Gregorian
+  # calendar.
+  #
+  #     Date.gregorian_leap?(1900)        #=> false
+  #     Date.gregorian_leap?(2000)        #=> true
+  #
+  def self.leap?: (Integer year) -> bool
+
+  # Creates a date object denoting the given ordinal date.
+  #
+  # The day of year should be a negative or a positive number (as a relative day
+  # from the end of year when negative).  It should not be zero.
+  #
+  #     Date.ordinal(2001)        #=> #<Date: 2001-01-01 ...>
+  #     Date.ordinal(2001,34)     #=> #<Date: 2001-02-03 ...>
+  #     Date.ordinal(2001,-1)     #=> #<Date: 2001-12-31 ...>
+  #
+  # See also ::jd and ::new.
+  #
+  def self.ordinal: (?Integer year, ?Integer yday, ?Integer start) -> Date
+
+  # Parses the given representation of date and time, and creates a date object. 
+  # This method does not function as a validator.
+  #
+  # If the optional second argument is true and the detected year is in the range
+  # "00" to "99", considers the year a 2-digit form and makes it full.
+  #
+  #     Date.parse('2001-02-03')          #=> #<Date: 2001-02-03 ...>
+  #     Date.parse('20010203')            #=> #<Date: 2001-02-03 ...>
+  #     Date.parse('3rd Feb 2001')        #=> #<Date: 2001-02-03 ...>
+  #
+  def self.parse: (String str, ?bool complete, ?Integer start) -> Date
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # RFC 2822 formats.
+  #
+  #     Date.rfc2822('Sat, 3 Feb 2001 00:00:00 +0000')
+  #                                               #=> #<Date: 2001-02-03 ...>
+  #
+  def self.rfc2822: (String str, ?Integer start) -> Date
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # RFC 3339 formats.
+  #
+  #     Date.rfc3339('2001-02-03T04:05:06+07:00') #=> #<Date: 2001-02-03 ...>
+  #
+  def self.rfc3339: (String str, ?Integer start) -> Date
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # RFC 2822 formats.
+  #
+  #     Date.rfc2822('Sat, 3 Feb 2001 00:00:00 +0000')
+  #                                               #=> #<Date: 2001-02-03 ...>
+  #
+  def self.rfc822: (String str, ?Integer start) -> Date
+
+  # Parses the given representation of date and time with the given template, and
+  # creates a date object.  strptime does not support specification of flags and
+  # width unlike strftime.
+  #
+  #     Date.strptime('2001-02-03', '%Y-%m-%d')   #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('03-02-2001', '%d-%m-%Y')   #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('2001-034', '%Y-%j')        #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('2001-W05-6', '%G-W%V-%u')  #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('2001 04 6', '%Y %U %w')    #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('2001 05 6', '%Y %W %u')    #=> #<Date: 2001-02-03 ...>
+  #     Date.strptime('sat3feb01', '%a%d%b%y')    #=> #<Date: 2001-02-03 ...>
+  #
+  # See also strptime(3) and #strftime.
+  #
+  def self.strptime: (String str, ?String format, ?Integer start) -> Date
+
+  # Creates a date object denoting the present day.
+  #
+  #     Date.today   #=> #<Date: 2011-06-11 ...>
+  #
+  def self.today: (?Integer start) -> Date
+
+  # Returns true if the given calendar date is valid, and false if not. Valid in
+  # this context is whether the arguments passed to this method would be accepted
+  # by ::new.
+  #
+  #     Date.valid_date?(2001,2,3)        #=> true
+  #     Date.valid_date?(2001,2,29)       #=> false
+  #     Date.valid_date?(2001,2,-1)       #=> true
+  #
+  # See also ::jd and ::civil.
+  #
+  def self.valid_civil?: (Integer year, Integer month, Integer mday, ?Integer start) -> bool
+
+  # Returns true if the given week date is valid, and false if not.
+  #
+  #     Date.valid_commercial?(2001,5,6)  #=> true
+  #     Date.valid_commercial?(2001,5,8)  #=> false
+  #
+  # See also ::jd and ::commercial.
+  #
+  def self.valid_commercial?: (Integer cwyear, Integer cweek, Integer cwday, ?Integer start) -> bool
+
+  # Returns true if the given calendar date is valid, and false if not. Valid in
+  # this context is whether the arguments passed to this method would be accepted
+  # by ::new.
+  #
+  #     Date.valid_date?(2001,2,3)        #=> true
+  #     Date.valid_date?(2001,2,29)       #=> false
+  #     Date.valid_date?(2001,2,-1)       #=> true
+  #
+  # See also ::jd and ::civil.
+  #
+  def self.valid_date?: (Integer year, Integer month, Integer mday, ?Integer start) -> bool
+
+  # Just returns true.  It's nonsense, but is for symmetry.
+  #
+  #     Date.valid_jd?(2451944)           #=> true
+  #
+  # See also ::jd.
+  #
+  def self.valid_jd?: (Integer jd, ?Integer start) -> bool
+
+  # Returns true if the given ordinal date is valid, and false if not.
+  #
+  #     Date.valid_ordinal?(2001,34)      #=> true
+  #     Date.valid_ordinal?(2001,366)     #=> false
+  #
+  # See also ::jd and ::ordinal.
+  #
+  def self.valid_ordinal?: (Integer year, Integer yday, ?Integer start) -> bool
+
+  # Creates a new Date object by parsing from a string according to some typical
+  # XML Schema formats.
+  #
+  #     Date.xmlschema('2001-02-03')      #=> #<Date: 2001-02-03 ...>
+  #
+  def self.xmlschema: (String str, ?Integer start) -> Date
+
+  # Returns a date object pointing `other` days after self.  The other should be a
+  # numeric value.  If the other is a fractional number, assumes its precision is
+  # at most nanosecond.
+  #
+  #     Date.new(2001,2,3) + 1    #=> #<Date: 2001-02-04 ...>
+  #     DateTime.new(2001,2,3) + Rational(1,2)
+  #                               #=> #<DateTime: 2001-02-03T12:00:00+00:00 ...>
+  #     DateTime.new(2001,2,3) + Rational(-1,2)
+  #                               #=> #<DateTime: 2001-02-02T12:00:00+00:00 ...>
+  #     DateTime.jd(0,12) + DateTime.new(2001,2,3).ajd
+  #                               #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
+  #
+  def +: (Integer | Date | Rational arg0) -> Date
+
+  # Returns the difference between the two dates if the other is a date object. 
+  # If the other is a numeric value, returns a date object pointing `other` days
+  # before self.  If the other is a fractional number, assumes its precision is at
+  # most nanosecond.
+  #
+  #     Date.new(2001,2,3) - 1   #=> #<Date: 2001-02-02 ...>
+  #     DateTime.new(2001,2,3) - Rational(1,2)
+  #                              #=> #<DateTime: 2001-02-02T12:00:00+00:00 ...>
+  #     Date.new(2001,2,3) - Date.new(2001)
+  #                              #=> (33/1)
+  #     DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
+  #                              #=> (1/2)
+  #
+  def -: (Integer | Date | Rational arg0) ->Date
+
+  # Returns a date object pointing `n` months before self. The argument `n` should
+  # be a numeric value.
+  #
+  #     Date.new(2001,2,3)  <<  1   #=> #<Date: 2001-01-03 ...>
+  #     Date.new(2001,2,3)  << -2   #=> #<Date: 2001-04-03 ...>
+  #
+  # When the same day does not exist for the corresponding month, the last day of
+  # the month is used instead:
+  #
+  #     Date.new(2001,3,28) << 1   #=> #<Date: 2001-02-28 ...>
+  #     Date.new(2001,3,31) << 1   #=> #<Date: 2001-02-28 ...>
+  #
+  # This also results in the following, possibly unexpected, behavior:
+  #
+  #     Date.new(2001,3,31) << 2         #=> #<Date: 2001-01-31 ...>
+  #     Date.new(2001,3,31) << 1 << 1    #=> #<Date: 2001-01-28 ...>
+  #
+  #     Date.new(2001,3,31) << 1 << -1   #=> #<Date: 2001-03-28 ...>
+  #
+  def <<: (Integer month) -> Date
+
+  # Compares the two dates and returns -1, zero, 1 or nil.  The other should be a
+  # date object or a numeric value as an astronomical Julian day number.
+  #
+  #     Date.new(2001,2,3) <=> Date.new(2001,2,4)   #=> -1
+  #     Date.new(2001,2,3) <=> Date.new(2001,2,3)   #=> 0
+  #     Date.new(2001,2,3) <=> Date.new(2001,2,2)   #=> 1
+  #     Date.new(2001,2,3) <=> Object.new           #=> nil
+  #     Date.new(2001,2,3) <=> Rational(4903887,2)  #=> 0
+  #
+  # See also Comparable.
+  #
+  def <=>: (Date | Rational | Object other) -> Integer?
+
+  # Returns true if they are the same day.
+  #
+  #     Date.new(2001,2,3) === Date.new(2001,2,3)
+  #                                       #=> true
+  #     Date.new(2001,2,3) === Date.new(2001,2,4)
+  #                                       #=> false
+  #     DateTime.new(2001,2,3) === DateTime.new(2001,2,3,12)
+  #                                       #=> true
+  #     DateTime.new(2001,2,3) === DateTime.new(2001,2,3,0,0,0,'+24:00')
+  #                                       #=> true
+  #     DateTime.new(2001,2,3) === DateTime.new(2001,2,4,0,0,0,'+24:00')
+  #                                       #=> false
+  #
+  def ===: (Date other) -> bool
+
+  # Returns a date object pointing `n` months after self. The argument `n` should
+  # be a numeric value.
+  #
+  #     Date.new(2001,2,3)  >>  1   #=> #<Date: 2001-03-03 ...>
+  #     Date.new(2001,2,3)  >> -2   #=> #<Date: 2000-12-03 ...>
+  #
+  # When the same day does not exist for the corresponding month, the last day of
+  # the month is used instead:
+  #
+  #     Date.new(2001,1,28) >> 1   #=> #<Date: 2001-02-28 ...>
+  #     Date.new(2001,1,31) >> 1   #=> #<Date: 2001-02-28 ...>
+  #
+  # This also results in the following, possibly unexpected, behavior:
+  #
+  #     Date.new(2001,1,31) >> 2         #=> #<Date: 2001-03-31 ...>
+  #     Date.new(2001,1,31) >> 1 >> 1    #=> #<Date: 2001-03-28 ...>
+  #
+  #     Date.new(2001,1,31) >> 1 >> -1   #=> #<Date: 2001-01-28 ...>
+  #
+  def >>: (Integer month) -> Date
+
+  # Returns the astronomical Julian day number.  This is a fractional number,
+  # which is not adjusted by the offset.
+  #
+  #     DateTime.new(2001,2,3,4,5,6,'+7').ajd     #=> (11769328217/4800)
+  #     DateTime.new(2001,2,2,14,5,6,'-7').ajd    #=> (11769328217/4800)
+  #
+  def ajd: () -> Rational
+
+  # Returns the astronomical modified Julian day number.  This is a fractional
+  # number, which is not adjusted by the offset.
+  #
+  #     DateTime.new(2001,2,3,4,5,6,'+7').amjd    #=> (249325817/4800)
+  #     DateTime.new(2001,2,2,14,5,6,'-7').amjd   #=> (249325817/4800)
+  #
+  def amjd: () -> Rational
+
+  # Returns a string in asctime(3) format (but without "n\0" at the end).  This
+  # method is equivalent to strftime('%c').
+  #
+  # See also asctime(3) or ctime(3).
+  #
+  def asctime: () -> String
+
+  # Returns a string in asctime(3) format (but without "n\0" at the end).  This
+  # method is equivalent to strftime('%c').
+  #
+  # See also asctime(3) or ctime(3).
+  #
+  def ctime: () -> String
+
+  # Returns the day of calendar week (1-7, Monday is 1).
+  #
+  #     Date.new(2001,2,3).cwday          #=> 6
+  #
+  def cwday: () -> Integer
+
+  # Returns the calendar week number (1-53).
+  #
+  #     Date.new(2001,2,3).cweek          #=> 5
+  #
+  def cweek: () -> Integer
+
+  # Returns the calendar week based year.
+  #
+  #     Date.new(2001,2,3).cwyear         #=> 2001
+  #     Date.new(2000,1,1).cwyear         #=> 1999
+  #
+  def cwyear: () -> Integer
+
+  # Returns the day of the month (1-31).
+  #
+  #     Date.new(2001,2,3).mday           #=> 3
+  #
+  def day: () -> Integer
+
+  # Returns the fractional part of the day.
+  #
+  #     DateTime.new(2001,2,3,12).day_fraction    #=> (1/2)
+  #
+  def day_fraction: () -> Rational
+
+  # This method is equivalent to step(min, -1){|date| ...}.
+  #
+  def downto: (Date min) { (Date) -> untyped } -> nil
+            | (Date min) -> Enumerator[Date, nil]
+
+  # This method is equivalent to new_start(Date::ENGLAND).
+  #
+  def england: () -> Date
+
+  # Returns true if the date is Friday.
+  #
+  def friday?: () -> bool
+
+  # This method is equivalent to new_start(Date::GREGORIAN).
+  #
+  def gregorian: () -> Date
+
+  # Returns true if the date is on or after the day of calendar reform.
+  #
+  #     Date.new(1582,10,15).gregorian?          #=> true
+  #     (Date.new(1582,10,15) - 1).gregorian?    #=> false
+  #
+  def gregorian?: () -> bool
+
+  # This method is equivalent to strftime('%a, %d %b %Y %T GMT'). See also RFC
+  # 2616.
+  #
+  def httpdate: () -> String
+
+  # Returns the value as a string for inspection.
+  #
+  #     Date.new(2001,2,3).inspect
+  #               #=> "#<Date: 2001-02-03>"
+  #     DateTime.new(2001,2,3,4,5,6,'-7').inspect
+  #               #=> "#<DateTime: 2001-02-03T04:05:06-07:00>"
+  #
+  def inspect: () -> String
+
+  # This method is equivalent to strftime('%F').
+  #
+  def iso8601: () -> String
+
+  # This method is equivalent to new_start(Date::ITALY).
+  #
+  def italy: () -> Date
+
+  # Returns the Julian day number.  This is a whole number, which is adjusted by
+  # the offset as the local time.
+  #
+  #     DateTime.new(2001,2,3,4,5,6,'+7').jd      #=> 2451944
+  #     DateTime.new(2001,2,3,4,5,6,'-7').jd      #=> 2451944
+  #
+  def jd: () -> Integer
+
+  # Returns a string in a JIS X 0301 format.
+  #
+  #     Date.new(2001,2,3).jisx0301       #=> "H13.02.03"
+  #
+  def jisx0301: () -> String
+
+  # This method is equivalent to new_start(Date::JULIAN).
+  #
+  def julian: () -> Date
+
+  # Returns true if the date is before the day of calendar reform.
+  #
+  #     Date.new(1582,10,15).julian?             #=> false
+  #     (Date.new(1582,10,15) - 1).julian?       #=> true
+  #
+  def julian?: () -> bool
+
+  # Returns the Lilian day number.  This is a whole number, which is adjusted by
+  # the offset as the local time.
+  #
+  #     Date.new(2001,2,3).ld            #=> 152784
+  #
+  def ld: () -> Integer
+
+  # Returns true if the year is a leap year.
+  #
+  #     Date.new(2000).leap?      #=> true
+  #     Date.new(2001).leap?      #=> false
+  #
+  def leap?: () -> bool
+
+  # Returns the day of the month (1-31).
+  #
+  #     Date.new(2001,2,3).mday           #=> 3
+  #
+  def mday: () -> Integer
+
+  # Returns the modified Julian day number.  This is a whole number, which is
+  # adjusted by the offset as the local time.
+  #
+  #     DateTime.new(2001,2,3,4,5,6,'+7').mjd     #=> 51943
+  #     DateTime.new(2001,2,3,4,5,6,'-7').mjd     #=> 51943
+  #
+  def mjd: () -> Integer
+
+  # Returns the month (1-12).
+  #
+  #     Date.new(2001,2,3).mon            #=> 2
+  #
+  def mon: () -> Integer
+
+  # Returns true if the date is Monday.
+  #
+  def monday?: () -> bool
+
+  # Returns the month (1-12).
+  #
+  #     Date.new(2001,2,3).mon            #=> 2
+  #
+  def month: () -> Integer
+
+  # Duplicates self and resets its day of calendar reform.
+  #
+  #     d = Date.new(1582,10,15)
+  #     d.new_start(Date::JULIAN)         #=> #<Date: 1582-10-05 ...>
+  #
+  def new_start: (?Integer start) -> Date
+
+  # Returns a date object denoting the following day.
+  #
+  def next: () -> Date
+
+  # This method is equivalent to d + n.
+  #
+  def next_day: (?Integer day) -> Date
+
+  # This method is equivalent to d >> n.
+  #
+  def next_month: (?Integer month) -> Date
+
+  # This method is equivalent to d >> (n * 12).
+  #
+  #     Date.new(2001,2,3).next_year      #=> #<Date: 2002-02-03 ...>
+  #     Date.new(2008,2,29).next_year     #=> #<Date: 2009-02-28 ...>
+  #     Date.new(2008,2,29).next_year(4)  #=> #<Date: 2012-02-29 ...>
+  #
+  def next_year: (?Integer year) -> Date
+
+  # This method is equivalent to d - n.
+  #
+  def prev_day: (?Integer day) -> Date
+
+  # This method is equivalent to d << n.
+  #
+  def prev_month: (?Integer month) -> Date
+
+  # This method is equivalent to d << (n * 12).
+  #
+  #     Date.new(2001,2,3).prev_year      #=> #<Date: 2000-02-03 ...>
+  #     Date.new(2008,2,29).prev_year     #=> #<Date: 2007-02-28 ...>
+  #     Date.new(2008,2,29).prev_year(4)  #=> #<Date: 2004-02-29 ...>
+  #
+  def prev_year: (?Integer year) -> Date
+
+  # This method is equivalent to strftime('%a, %-d %b %Y %T %z').
+  #
+  def rfc2822: () -> String
+
+  # This method is equivalent to strftime('%FT%T%:z').
+  #
+  def rfc3339: () -> String
+
+  # This method is equivalent to strftime('%a, %-d %b %Y %T %z').
+  #
+  def rfc822: () -> String
+
+  # Returns true if the date is Saturday.
+  #
+  def saturday?: () -> bool
+
+  # Returns the Julian day number denoting the day of calendar reform.
+  #
+  #     Date.new(2001,2,3).start                  #=> 2299161.0
+  #     Date.new(2001,2,3,Date::GREGORIAN).start  #=> -Infinity
+  #
+  def start: () -> Integer
+
+  # Iterates evaluation of the given block, which takes a date object. The limit
+  # should be a date object.
+  #
+  #     Date.new(2001).step(Date.new(2001,-1,-1)).select{|d| d.sunday?}.size
+  #                               #=> 52
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     d.step(limit[, step=1])              ->  enumerator
+  #     d.step(limit[, step=1]){|date| ...}  ->  self
+  #
+  def step: (Date limit, ?Integer step) { (Date) -> untyped } -> nil
+          | (Date limit, ?Integer step) -> ::Enumerator[Date, nil]
+
+  # Formats date according to the directives in the given format string. The
+  # directives begin with a percent (%) character. Any text not listed as a
+  # directive will be passed through to the output string.
+  #
+  # A directive consists of a percent (%) character, zero or more flags, an
+  # optional minimum field width, an optional modifier, and a conversion specifier
+  # as follows.
+  #
+  #     %<flags><width><modifier><conversion>
+  #
+  # Flags:
+  #     -  don't pad a numerical output.
+  #     _  use spaces for padding.
+  #     0  use zeros for padding.
+  #     ^  upcase the result string.
+  #     #  change case.
+  #
+  # The minimum field width specifies the minimum width.
+  #
+  # The modifiers are "E", "O", ":", "::" and ":::". "E" and "O" are ignored.  No
+  # effect to result currently.
+  #
+  # Format directives:
+  #
+  #     Date (Year, Month, Day):
+  #       %Y - Year with century (can be negative, 4 digits at least)
+  #               -0001, 0000, 1995, 2009, 14292, etc.
+  #       %C - year / 100 (round down.  20 in 2009)
+  #       %y - year % 100 (00..99)
+  #
+  #       %m - Month of the year, zero-padded (01..12)
+  #               %_m  blank-padded ( 1..12)
+  #               %-m  no-padded (1..12)
+  #       %B - The full month name (``January'')
+  #               %^B  uppercased (``JANUARY'')
+  #       %b - The abbreviated month name (``Jan'')
+  #               %^b  uppercased (``JAN'')
+  #       %h - Equivalent to %b
+  #
+  #       %d - Day of the month, zero-padded (01..31)
+  #               %-d  no-padded (1..31)
+  #       %e - Day of the month, blank-padded ( 1..31)
+  #
+  #       %j - Day of the year (001..366)
+  #
+  #     Time (Hour, Minute, Second, Subsecond):
+  #       %H - Hour of the day, 24-hour clock, zero-padded (00..23)
+  #       %k - Hour of the day, 24-hour clock, blank-padded ( 0..23)
+  #       %I - Hour of the day, 12-hour clock, zero-padded (01..12)
+  #       %l - Hour of the day, 12-hour clock, blank-padded ( 1..12)
+  #       %P - Meridian indicator, lowercase (``am'' or ``pm'')
+  #       %p - Meridian indicator, uppercase (``AM'' or ``PM'')
+  #
+  #       %M - Minute of the hour (00..59)
+  #
+  #       %S - Second of the minute (00..60)
+  #
+  #       %L - Millisecond of the second (000..999)
+  #       %N - Fractional seconds digits, default is 9 digits (nanosecond)
+  #               %3N  millisecond (3 digits)   %15N femtosecond (15 digits)
+  #               %6N  microsecond (6 digits)   %18N attosecond  (18 digits)
+  #               %9N  nanosecond  (9 digits)   %21N zeptosecond (21 digits)
+  #               %12N picosecond (12 digits)   %24N yoctosecond (24 digits)
+  #
+  #     Time zone:
+  #       %z - Time zone as hour and minute offset from UTC (e.g. +0900)
+  #               %:z - hour and minute offset from UTC with a colon (e.g. +09:00)
+  #               %::z - hour, minute and second offset from UTC (e.g. +09:00:00)
+  #               %:::z - hour, minute and second offset from UTC
+  #                                                 (e.g. +09, +09:30, +09:30:30)
+  #       %Z - Equivalent to %:z (e.g. +09:00)
+  #
+  #     Weekday:
+  #       %A - The full weekday name (``Sunday'')
+  #               %^A  uppercased (``SUNDAY'')
+  #       %a - The abbreviated name (``Sun'')
+  #               %^a  uppercased (``SUN'')
+  #       %u - Day of the week (Monday is 1, 1..7)
+  #       %w - Day of the week (Sunday is 0, 0..6)
+  #
+  #     ISO 8601 week-based year and week number:
+  #     The week 1 of YYYY starts with a Monday and includes YYYY-01-04.
+  #     The days in the year before the first week are in the last week of
+  #     the previous year.
+  #       %G - The week-based year
+  #       %g - The last 2 digits of the week-based year (00..99)
+  #       %V - Week number of the week-based year (01..53)
+  #
+  #     Week number:
+  #     The week 1 of YYYY starts with a Sunday or Monday (according to %U
+  #     or %W).  The days in the year before the first week are in week 0.
+  #       %U - Week number of the year.  The week starts with Sunday.  (00..53)
+  #       %W - Week number of the year.  The week starts with Monday.  (00..53)
+  #
+  #     Seconds since the Unix Epoch:
+  #       %s - Number of seconds since 1970-01-01 00:00:00 UTC.
+  #       %Q - Number of milliseconds since 1970-01-01 00:00:00 UTC.
+  #
+  #     Literal string:
+  #       %n - Newline character (\n)
+  #       %t - Tab character (\t)
+  #       %% - Literal ``%'' character
+  #
+  #     Combination:
+  #       %c - date and time (%a %b %e %T %Y)
+  #       %D - Date (%m/%d/%y)
+  #       %F - The ISO 8601 date format (%Y-%m-%d)
+  #       %v - VMS date (%e-%b-%Y)
+  #       %x - Same as %D
+  #       %X - Same as %T
+  #       %r - 12-hour time (%I:%M:%S %p)
+  #       %R - 24-hour time (%H:%M)
+  #       %T - 24-hour time (%H:%M:%S)
+  #       %+ - date(1) (%a %b %e %H:%M:%S %Z %Y)
+  #
+  # This method is similar to the strftime() function defined in ISO C and POSIX.
+  # Several directives (%a, %A, %b, %B, %c, %p, %r, %x, %X, %E*, %O* and %Z) are
+  # locale dependent in the function. However, this method is locale independent.
+  # So, the result may differ even if the same format string is used in other
+  # systems such as C. It is good practice to avoid %x and %X because there are
+  # corresponding locale independent representations, %D and %T.
+  #
+  # Examples:
+  #
+  #     d = DateTime.new(2007,11,19,8,37,48,"-06:00")
+  #                               #=> #<DateTime: 2007-11-19T08:37:48-0600 ...>
+  #     d.strftime("Printed on %m/%d/%Y")   #=> "Printed on 11/19/2007"
+  #     d.strftime("at %I:%M%p")            #=> "at 08:37AM"
+  #
+  # Various ISO 8601 formats:
+  #     %Y%m%d           => 20071119                  Calendar date (basic)
+  #     %F               => 2007-11-19                Calendar date (extended)
+  #     %Y-%m            => 2007-11                   Calendar date, reduced accuracy, specific month
+  #     %Y               => 2007                      Calendar date, reduced accuracy, specific year
+  #     %C               => 20                        Calendar date, reduced accuracy, specific century
+  #     %Y%j             => 2007323                   Ordinal date (basic)
+  #     %Y-%j            => 2007-323                  Ordinal date (extended)
+  #     %GW%V%u          => 2007W471                  Week date (basic)
+  #     %G-W%V-%u        => 2007-W47-1                Week date (extended)
+  #     %GW%V            => 2007W47                   Week date, reduced accuracy, specific week (basic)
+  #     %G-W%V           => 2007-W47                  Week date, reduced accuracy, specific week (extended)
+  #     %H%M%S           => 083748                    Local time (basic)
+  #     %T               => 08:37:48                  Local time (extended)
+  #     %H%M             => 0837                      Local time, reduced accuracy, specific minute (basic)
+  #     %H:%M            => 08:37                     Local time, reduced accuracy, specific minute (extended)
+  #     %H               => 08                        Local time, reduced accuracy, specific hour
+  #     %H%M%S,%L        => 083748,000                Local time with decimal fraction, comma as decimal sign (basic)
+  #     %T,%L            => 08:37:48,000              Local time with decimal fraction, comma as decimal sign (extended)
+  #     %H%M%S.%L        => 083748.000                Local time with decimal fraction, full stop as decimal sign (basic)
+  #     %T.%L            => 08:37:48.000              Local time with decimal fraction, full stop as decimal sign (extended)
+  #     %H%M%S%z         => 083748-0600               Local time and the difference from UTC (basic)
+  #     %T%:z            => 08:37:48-06:00            Local time and the difference from UTC (extended)
+  #     %Y%m%dT%H%M%S%z  => 20071119T083748-0600      Date and time of day for calendar date (basic)
+  #     %FT%T%:z         => 2007-11-19T08:37:48-06:00 Date and time of day for calendar date (extended)
+  #     %Y%jT%H%M%S%z    => 2007323T083748-0600       Date and time of day for ordinal date (basic)
+  #     %Y-%jT%T%:z      => 2007-323T08:37:48-06:00   Date and time of day for ordinal date (extended)
+  #     %GW%V%uT%H%M%S%z => 2007W471T083748-0600      Date and time of day for week date (basic)
+  #     %G-W%V-%uT%T%:z  => 2007-W47-1T08:37:48-06:00 Date and time of day for week date (extended)
+  #     %Y%m%dT%H%M      => 20071119T0837             Calendar date and local time (basic)
+  #     %FT%R            => 2007-11-19T08:37          Calendar date and local time (extended)
+  #     %Y%jT%H%MZ       => 2007323T0837Z             Ordinal date and UTC of day (basic)
+  #     %Y-%jT%RZ        => 2007-323T08:37Z           Ordinal date and UTC of day (extended)
+  #     %GW%V%uT%H%M%z   => 2007W471T0837-0600        Week date and local time and difference from UTC (basic)
+  #     %G-W%V-%uT%R%:z  => 2007-W47-1T08:37-06:00    Week date and local time and difference from UTC (extended)
+  #
+  # See also strftime(3) and ::strptime.
+  #
+  def strftime: (?String format) -> String
+
+  # Returns a date object denoting the following day.
+  #
+  def succ: () -> Date
+
+  # Returns true if the date is Sunday.
+  #
+  def sunday?: () -> bool
+
+  # Returns true if the date is Thursday.
+  #
+  def thursday?: () -> bool
+
+  # Returns self.
+  #
+  def to_date: () -> Date
+
+  # Returns a DateTime object which denotes self.
+  #
+  def to_datetime: () -> untyped
+
+  # Returns a string in an ISO 8601 format. (This method doesn't use the expanded
+  # representations.)
+  #
+  #     Date.new(2001,2,3).to_s  #=> "2001-02-03"
+  #
+  def to_s: () -> String
+
+  # Returns a Time object which denotes self. If self is a julian date, convert it
+  # to a gregorian date before converting it to Time.
+  #
+  def to_time: () -> Time
+
+  # Returns true if the date is Tuesday.
+  #
+  def tuesday?: () -> bool
+
+  # This method is equivalent to step(max, 1){|date| ...}.
+  #
+  def upto: (Date max) { (Date) -> untypd } -> nil
+          | (Date max) -> ::Enumerator[Date, nil]
+
+  # Returns the day of week (0-6, Sunday is zero).
+  #
+  #     Date.new(2001,2,3).wday           #=> 6
+  #
+  def wday: () -> Integer
+
+  # Returns true if the date is Wednesday.
+  #
+  def wednesday?: () -> bool
+
+  # This method is equivalent to strftime('%F').
+  #
+  def xmlschema: () -> String
+
+  # Returns the day of the year (1-366).
+  #
+  #     Date.new(2001,2,3).yday           #=> 34
+  #
+  def yday: () -> Integer
+
+  # Returns the year.
+  #
+  #     Date.new(2001,2,3).year           #=> 2001
+  #     (Date.new(1,1,1) - 1).year        #=> 0
+  #
+  def year: () -> Integer
+end
+
+# An array of strings of abbreviated day names in English.  The first is "Sun".
+#
+Date::ABBR_DAYNAMES: Array[String]
+
+# An array of strings of abbreviated month names in English.  The first element
+# is nil.
+#
+Date::ABBR_MONTHNAMES: Array[String?]
+
+# An array of strings of the full names of days of the week in English. The
+# first is "Sunday".
+#
+Date::DAYNAMES: Array[String]
+
+# The Julian day number of the day of calendar reform for England and her
+# colonies.
+#
+Date::ENGLAND: Integer
+
+# The Julian day number of the day of calendar reform for the proleptic
+# Gregorian calendar.
+#
+Date::GREGORIAN: Integer
+
+# The Julian day number of the day of calendar reform for Italy and some
+# catholic countries.
+#
+Date::ITALY: Integer
+
+# The Julian day number of the day of calendar reform for the proleptic Julian
+# calendar.
+#
+Date::JULIAN: Integer
+
+# An array of strings of full month names in English.  The first element is nil.
+#
+Date::MONTHNAMES: Array[String?]

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -154,8 +154,7 @@ class Date
   #
   # See also ::jd.
   #
-  def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
-  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> Date
+  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer start) -> void
 
   include Comparable
 

--- a/stdlib/date/date_time.rbs
+++ b/stdlib/date/date_time.rbs
@@ -145,7 +145,7 @@ class DateTime < Date
   #
   # See also strptime(3) and #strftime.
   #
-  def self._strptime: (String str, ?String format) -> Hash
+  def self._strptime: (String str, ?String format) -> Hash[Symbol, Integer | String]
 
   # Creates a DateTime object denoting the given calendar date.
   #

--- a/stdlib/date/date_time.rbs
+++ b/stdlib/date/date_time.rbs
@@ -136,8 +136,7 @@ class DateTime < Date
   #     DateTime.new(2001,-11,-26,-20,-55,-54,'+7')
   #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
   #
-  def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
-  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> void
 
   # Parses the given representation of date and time with the given template, and
   # returns a hash of parsed elements.  _strptime does not support specification

--- a/stdlib/date/date_time.rbs
+++ b/stdlib/date/date_time.rbs
@@ -1,0 +1,582 @@
+# ## DateTime
+#
+# A subclass of Date that easily handles date, hour, minute, second, and offset.
+#
+# DateTime does not consider any leap seconds, does not track any summer time
+# rules.
+#
+# A DateTime object is created with DateTime::new, DateTime::jd,
+# DateTime::ordinal, DateTime::commercial, DateTime::parse, DateTime::strptime,
+# DateTime::now, Time#to_datetime, etc.
+#
+#     require 'date'
+#
+#     DateTime.new(2001,2,3,4,5,6)
+#                         #=> #<DateTime: 2001-02-03T04:05:06+00:00 ...>
+#
+# The last element of day, hour, minute, or second can be a fractional number.
+# The fractional number's precision is assumed at most nanosecond.
+#
+#     DateTime.new(2001,2,3.5)
+#                         #=> #<DateTime: 2001-02-03T12:00:00+00:00 ...>
+#
+# An optional argument, the offset, indicates the difference between the local
+# time and UTC. For example, `Rational(3,24)` represents ahead of 3 hours of
+# UTC, `Rational(-5,24)` represents behind of 5 hours of UTC. The offset should
+# be -1 to +1, and its precision is assumed at most second. The default value is
+# zero (equals to UTC).
+#
+#     DateTime.new(2001,2,3,4,5,6,Rational(3,24))
+#                         #=> #<DateTime: 2001-02-03T04:05:06+03:00 ...>
+#
+# The offset also accepts string form:
+#
+#     DateTime.new(2001,2,3,4,5,6,'+03:00')
+#                         #=> #<DateTime: 2001-02-03T04:05:06+03:00 ...>
+#
+# An optional argument, the day of calendar reform (`start`), denotes a Julian
+# day number, which should be 2298874 to 2426355 or negative/positive infinity.
+# The default value is `Date::ITALY` (2299161=1582-10-15).
+#
+# A DateTime object has various methods. See each reference.
+#
+#     d = DateTime.parse('3rd Feb 2001 04:05:06+03:30')
+#                         #=> #<DateTime: 2001-02-03T04:05:06+03:30 ...>
+#     d.hour              #=> 4
+#     d.min               #=> 5
+#     d.sec               #=> 6
+#     d.offset            #=> (7/48)
+#     d.zone              #=> "+03:30"
+#     d += Rational('1.5')
+#                         #=> #<DateTime: 2001-02-04%16:05:06+03:30 ...>
+#     d = d.new_offset('+09:00')
+#                         #=> #<DateTime: 2001-02-04%21:35:06+09:00 ...>
+#     d.strftime('%I:%M:%S %p')
+#                         #=> "09:35:06 PM"
+#     d > DateTime.new(1999)
+#                         #=> true
+#
+# ### When should you use DateTime and when should you use Time?
+#
+# It's a common misconception that [William
+# Shakespeare](http://en.wikipedia.org/wiki/William_Shakespeare) and [Miguel de
+# Cervantes](http://en.wikipedia.org/wiki/Miguel_de_Cervantes) died on the same
+# day in history - so much so that UNESCO named April 23 as [World Book Day
+# because of this fact](http://en.wikipedia.org/wiki/World_Book_Day). However,
+# because England hadn't yet adopted the [Gregorian Calendar
+# Reform](http://en.wikipedia.org/wiki/Gregorian_calendar#Gregorian_reform) (and
+# wouldn't until
+# [1752](http://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750)) their
+# deaths are actually 10 days apart. Since Ruby's Time class implements a
+# [proleptic Gregorian
+# calendar](http://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar) and has
+# no concept of calendar reform there's no way to express this with Time
+# objects. This is where DateTime steps in:
+#
+#     shakespeare = DateTime.iso8601('1616-04-23', Date::ENGLAND)
+#      #=> Tue, 23 Apr 1616 00:00:00 +0000
+#     cervantes = DateTime.iso8601('1616-04-23', Date::ITALY)
+#      #=> Sat, 23 Apr 1616 00:00:00 +0000
+#
+# Already you can see something is weird - the days of the week are different.
+# Taking this further:
+#
+#     cervantes == shakespeare
+#      #=> false
+#     (shakespeare - cervantes).to_i
+#      #=> 10
+#
+# This shows that in fact they died 10 days apart (in reality 11 days since
+# Cervantes died a day earlier but was buried on the 23rd). We can see the
+# actual date of Shakespeare's death by using the #gregorian method to convert
+# it:
+#
+#     shakespeare.gregorian
+#      #=> Tue, 03 May 1616 00:00:00 +0000
+#
+# So there's an argument that all the celebrations that take place on the 23rd
+# April in Stratford-upon-Avon are actually the wrong date since England is now
+# using the Gregorian calendar. You can see why when we transition across the
+# reform date boundary:
+#
+#     # start off with the anniversary of Shakespeare's birth in 1751
+#     shakespeare = DateTime.iso8601('1751-04-23', Date::ENGLAND)
+#      #=> Tue, 23 Apr 1751 00:00:00 +0000
+#
+#     # add 366 days since 1752 is a leap year and April 23 is after February 29
+#     shakespeare + 366
+#      #=> Thu, 23 Apr 1752 00:00:00 +0000
+#
+#     # add another 365 days to take us to the anniversary in 1753
+#     shakespeare + 366 + 365
+#      #=> Fri, 04 May 1753 00:00:00 +0000
+#
+# As you can see, if we're accurately tracking the number of [solar
+# years](http://en.wikipedia.org/wiki/Tropical_year) since Shakespeare's
+# birthday then the correct anniversary date would be the 4th May and not the
+# 23rd April.
+#
+# So when should you use DateTime in Ruby and when should you use Time? Almost
+# certainly you'll want to use Time since your app is probably dealing with
+# current dates and times. However, if you need to deal with dates and times in
+# a historical context you'll want to use DateTime to avoid making the same
+# mistakes as UNESCO. If you also have to deal with timezones then best of luck
+# - just bear in mind that you'll probably be dealing with [local solar
+# times](http://en.wikipedia.org/wiki/Solar_time), since it wasn't until the
+# 19th century that the introduction of the railways necessitated the need for
+# [Standard Time](http://en.wikipedia.org/wiki/Standard_time#Great_Britain) and
+# eventually timezones.
+#
+class DateTime < Date
+  public
+
+  # Creates a DateTime object denoting the given calendar date.
+  #
+  #     DateTime.new(2001,2,3)    #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
+  #     DateTime.new(2001,2,3,4,5,6,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.new(2001,-11,-26,-20,-55,-54,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+
+  # Parses the given representation of date and time with the given template, and
+  # returns a hash of parsed elements.  _strptime does not support specification
+  # of flags and width unlike strftime.
+  #
+  # See also strptime(3) and #strftime.
+  #
+  def self._strptime: (String str, ?String format) -> Hash
+
+  # Creates a DateTime object denoting the given calendar date.
+  #
+  #     DateTime.new(2001,2,3)    #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
+  #     DateTime.new(2001,2,3,4,5,6,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.new(2001,-11,-26,-20,-55,-54,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.civil: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+
+  # Creates a DateTime object denoting the given week date.
+  #
+  #     DateTime.commercial(2001) #=> #<DateTime: 2001-01-01T00:00:00+00:00 ...>
+  #     DateTime.commercial(2002) #=> #<DateTime: 2001-12-31T00:00:00+00:00 ...>
+  #     DateTime.commercial(2001,5,6,4,5,6,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.commercial: (?Integer cwyear, ?Integer cweek, ?Integer cwday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some RFC
+  # 2616 format.
+  #
+  #     DateTime.httpdate('Sat, 03 Feb 2001 04:05:06 GMT')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+00:00 ...>
+  #
+  def self.httpdate: (String str, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical ISO 8601 formats.
+  #
+  #     DateTime.iso8601('2001-02-03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.iso8601('20010203T040506+0700')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.iso8601('2001-W05-6T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.iso8601: (String str, ?Integer start) -> DateTime
+
+  # Creates a DateTime object denoting the given chronological Julian day number.
+  #
+  #     DateTime.jd(2451944)      #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
+  #     DateTime.jd(2451945)      #=> #<DateTime: 2001-02-04T00:00:00+00:00 ...>
+  #     DateTime.jd(Rational('0.5'))
+  #                               #=> #<DateTime: -4712-01-01T12:00:00+00:00 ...>
+  #
+  def self.jd: (?Integer jd, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical JIS X 0301 formats.
+  #
+  #     DateTime.jisx0301('H13.02.03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  # For no-era year, legacy format, Heisei is assumed.
+  #
+  #     DateTime.jisx0301('13.02.03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.jisx0301: (String str, ?Integer start) -> DateTime
+
+  # Creates a DateTime object denoting the present time.
+  #
+  #     DateTime.now              #=> #<DateTime: 2011-06-11T21:20:44+09:00 ...>
+  #
+  def self.now: (?Integer start) -> DateTime
+
+  # Creates a DateTime object denoting the given ordinal date.
+  #
+  #     DateTime.ordinal(2001,34) #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
+  #     DateTime.ordinal(2001,34,4,5,6,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.ordinal(2001,-332,-20,-55,-54,'+7')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.ordinal: (?Integer year, ?Integer yday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+
+  # Parses the given representation of date and time, and creates a DateTime
+  # object.  This method does not function as a validator.
+  #
+  # If the optional second argument is true and the detected year is in the range
+  # "00" to "99", makes it full.
+  #
+  #     DateTime.parse('2001-02-03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.parse('20010203T040506+0700')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.parse('3rd Feb 2001 04:05:06 PM')
+  #                               #=> #<DateTime: 2001-02-03T16:05:06+00:00 ...>
+  #
+  def self.parse: (String str, ?bool complete, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical RFC 2822 formats.
+  #
+  #     DateTime.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700')
+  #                              #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.rfc2822: (String str, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical RFC 3339 formats.
+  #
+  #     DateTime.rfc3339('2001-02-03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.rfc3339: (String str, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical RFC 2822 formats.
+  #
+  #     DateTime.rfc2822('Sat, 3 Feb 2001 04:05:06 +0700')
+  #                              #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.rfc822: (String str, ?Integer start) -> DateTime
+
+  # Parses the given representation of date and time with the given template, and
+  # creates a DateTime object.  strptime does not support specification of flags
+  # and width unlike strftime.
+  #
+  #     DateTime.strptime('2001-02-03T04:05:06+07:00', '%Y-%m-%dT%H:%M:%S%z')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.strptime('03-02-2001 04:05:06 PM', '%d-%m-%Y %I:%M:%S %p')
+  #                               #=> #<DateTime: 2001-02-03T16:05:06+00:00 ...>
+  #     DateTime.strptime('2001-W05-6T04:05:06+07:00', '%G-W%V-%uT%H:%M:%S%z')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.strptime('2001 04 6 04 05 06 +7', '%Y %U %w %H %M %S %z')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.strptime('2001 05 6 04 05 06 +7', '%Y %W %u %H %M %S %z')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #     DateTime.strptime('-1', '%s')
+  #                               #=> #<DateTime: 1969-12-31T23:59:59+00:00 ...>
+  #     DateTime.strptime('-1000', '%Q')
+  #                               #=> #<DateTime: 1969-12-31T23:59:59+00:00 ...>
+  #     DateTime.strptime('sat3feb014pm+7', '%a%d%b%y%H%p%z')
+  #                               #=> #<DateTime: 2001-02-03T16:00:00+07:00 ...>
+  #
+  # See also strptime(3) and #strftime.
+  #
+  def self.strptime: (String str, ?String format, ?Integer start) -> DateTime
+
+  # Creates a new DateTime object by parsing from a string according to some
+  # typical XML Schema formats.
+  #
+  #     DateTime.xmlschema('2001-02-03T04:05:06+07:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
+  #
+  def self.xmlschema: (String str, ?Integer start) -> DateTime
+
+  # Returns the hour (0-23).
+  #
+  #     DateTime.new(2001,2,3,4,5,6).hour         #=> 4
+  #
+  def hour: () -> Integer
+
+  # This method is equivalent to strftime('%FT%T%:z'). The optional argument `n`
+  # is the number of digits for fractional seconds.
+  #
+  #     DateTime.parse('2001-02-03T04:05:06.123456789+07:00').iso8601(9)
+  #                               #=> "2001-02-03T04:05:06.123456789+07:00"
+  #
+  def iso8601: (?Integer n) -> String
+
+  # Returns a string in a JIS X 0301 format. The optional argument `n` is the
+  # number of digits for fractional seconds.
+  #
+  #     DateTime.parse('2001-02-03T04:05:06.123456789+07:00').jisx0301(9)
+  #                               #=> "H13.02.03T04:05:06.123456789+07:00"
+  #
+  def jisx0301: (?Integer n) -> String
+
+  # Returns the minute (0-59).
+  #
+  #     DateTime.new(2001,2,3,4,5,6).min          #=> 5
+  #
+  def min: () -> Integer
+
+  # Returns the minute (0-59).
+  #
+  #     DateTime.new(2001,2,3,4,5,6).min          #=> 5
+  #
+  def minute: () -> Integer
+
+  # Duplicates self and resets its offset.
+  #
+  #     d = DateTime.new(2001,2,3,4,5,6,'-02:00')
+  #                               #=> #<DateTime: 2001-02-03T04:05:06-02:00 ...>
+  #     d.new_offset('+09:00')    #=> #<DateTime: 2001-02-03T15:05:06+09:00 ...>
+  #
+  def new_offset: (?String offset) -> DateTime
+
+  # Returns the offset.
+  #
+  #     DateTime.parse('04pm+0730').offset        #=> (5/16)
+  #
+  def offset: () -> Rational
+
+  # This method is equivalent to strftime('%FT%T%:z'). The optional argument `n`
+  # is the number of digits for fractional seconds.
+  #
+  #     DateTime.parse('2001-02-03T04:05:06.123456789+07:00').rfc3339(9)
+  #                               #=> "2001-02-03T04:05:06.123456789+07:00"
+  #
+  def rfc3339: (?Integer n) -> String
+
+  # Returns the second (0-59).
+  #
+  #     DateTime.new(2001,2,3,4,5,6).sec          #=> 6
+  #
+  def sec: () -> Integer
+
+  # Returns the fractional part of the second.
+  #
+  #     DateTime.new(2001,2,3,4,5,6.5).sec_fraction       #=> (1/2)
+  #
+  def sec_fraction: () -> Rational
+
+  # Returns the second (0-59).
+  #
+  #     DateTime.new(2001,2,3,4,5,6).sec          #=> 6
+  #
+  def second: () -> Integer
+
+  # Returns the fractional part of the second.
+  #
+  #     DateTime.new(2001,2,3,4,5,6.5).sec_fraction       #=> (1/2)
+  #
+  def second_fraction: () -> Rational
+
+  # Formats date according to the directives in the given format string. The
+  # directives begin with a percent (%) character. Any text not listed as a
+  # directive will be passed through to the output string.
+  #
+  # A directive consists of a percent (%) character, zero or more flags, an
+  # optional minimum field width, an optional modifier, and a conversion specifier
+  # as follows.
+  #
+  #     %<flags><width><modifier><conversion>
+  #
+  # Flags:
+  #     -  don't pad a numerical output.
+  #     _  use spaces for padding.
+  #     0  use zeros for padding.
+  #     ^  upcase the result string.
+  #     #  change case.
+  #     :  use colons for %z.
+  #
+  # The minimum field width specifies the minimum width.
+  #
+  # The modifiers are "E" and "O". They are ignored.
+  #
+  # Format directives:
+  #
+  #     Date (Year, Month, Day):
+  #       %Y - Year with century (can be negative, 4 digits at least)
+  #               -0001, 0000, 1995, 2009, 14292, etc.
+  #       %C - year / 100 (round down.  20 in 2009)
+  #       %y - year % 100 (00..99)
+  #
+  #       %m - Month of the year, zero-padded (01..12)
+  #               %_m  blank-padded ( 1..12)
+  #               %-m  no-padded (1..12)
+  #       %B - The full month name (``January'')
+  #               %^B  uppercased (``JANUARY'')
+  #       %b - The abbreviated month name (``Jan'')
+  #               %^b  uppercased (``JAN'')
+  #       %h - Equivalent to %b
+  #
+  #       %d - Day of the month, zero-padded (01..31)
+  #               %-d  no-padded (1..31)
+  #       %e - Day of the month, blank-padded ( 1..31)
+  #
+  #       %j - Day of the year (001..366)
+  #
+  #     Time (Hour, Minute, Second, Subsecond):
+  #       %H - Hour of the day, 24-hour clock, zero-padded (00..23)
+  #       %k - Hour of the day, 24-hour clock, blank-padded ( 0..23)
+  #       %I - Hour of the day, 12-hour clock, zero-padded (01..12)
+  #       %l - Hour of the day, 12-hour clock, blank-padded ( 1..12)
+  #       %P - Meridian indicator, lowercase (``am'' or ``pm'')
+  #       %p - Meridian indicator, uppercase (``AM'' or ``PM'')
+  #
+  #       %M - Minute of the hour (00..59)
+  #
+  #       %S - Second of the minute (00..60)
+  #
+  #       %L - Millisecond of the second (000..999)
+  #       %N - Fractional seconds digits, default is 9 digits (nanosecond)
+  #               %3N  millisecond (3 digits)   %15N femtosecond (15 digits)
+  #               %6N  microsecond (6 digits)   %18N attosecond  (18 digits)
+  #               %9N  nanosecond  (9 digits)   %21N zeptosecond (21 digits)
+  #               %12N picosecond (12 digits)   %24N yoctosecond (24 digits)
+  #
+  #     Time zone:
+  #       %z - Time zone as hour and minute offset from UTC (e.g. +0900)
+  #               %:z - hour and minute offset from UTC with a colon (e.g. +09:00)
+  #               %::z - hour, minute and second offset from UTC (e.g. +09:00:00)
+  #               %:::z - hour, minute and second offset from UTC
+  #                                                 (e.g. +09, +09:30, +09:30:30)
+  #       %Z - Equivalent to %:z (e.g. +09:00)
+  #
+  #     Weekday:
+  #       %A - The full weekday name (``Sunday'')
+  #               %^A  uppercased (``SUNDAY'')
+  #       %a - The abbreviated name (``Sun'')
+  #               %^a  uppercased (``SUN'')
+  #       %u - Day of the week (Monday is 1, 1..7)
+  #       %w - Day of the week (Sunday is 0, 0..6)
+  #
+  #     ISO 8601 week-based year and week number:
+  #     The week 1 of YYYY starts with a Monday and includes YYYY-01-04.
+  #     The days in the year before the first week are in the last week of
+  #     the previous year.
+  #       %G - The week-based year
+  #       %g - The last 2 digits of the week-based year (00..99)
+  #       %V - Week number of the week-based year (01..53)
+  #
+  #     Week number:
+  #     The week 1 of YYYY starts with a Sunday or Monday (according to %U
+  #     or %W).  The days in the year before the first week are in week 0.
+  #       %U - Week number of the year.  The week starts with Sunday.  (00..53)
+  #       %W - Week number of the year.  The week starts with Monday.  (00..53)
+  #
+  #     Seconds since the Unix Epoch:
+  #       %s - Number of seconds since 1970-01-01 00:00:00 UTC.
+  #       %Q - Number of milliseconds since 1970-01-01 00:00:00 UTC.
+  #
+  #     Literal string:
+  #       %n - Newline character (\n)
+  #       %t - Tab character (\t)
+  #       %% - Literal ``%'' character
+  #
+  #     Combination:
+  #       %c - date and time (%a %b %e %T %Y)
+  #       %D - Date (%m/%d/%y)
+  #       %F - The ISO 8601 date format (%Y-%m-%d)
+  #       %v - VMS date (%e-%b-%Y)
+  #       %x - Same as %D
+  #       %X - Same as %T
+  #       %r - 12-hour time (%I:%M:%S %p)
+  #       %R - 24-hour time (%H:%M)
+  #       %T - 24-hour time (%H:%M:%S)
+  #       %+ - date(1) (%a %b %e %H:%M:%S %Z %Y)
+  #
+  # This method is similar to the strftime() function defined in ISO C and POSIX.
+  # Several directives (%a, %A, %b, %B, %c, %p, %r, %x, %X, %E*, %O* and %Z) are
+  # locale dependent in the function. However, this method is locale independent.
+  # So, the result may differ even if the same format string is used in other
+  # systems such as C. It is good practice to avoid %x and %X because there are
+  # corresponding locale independent representations, %D and %T.
+  #
+  # Examples:
+  #
+  #     d = DateTime.new(2007,11,19,8,37,48,"-06:00")
+  #                               #=> #<DateTime: 2007-11-19T08:37:48-0600 ...>
+  #     d.strftime("Printed on %m/%d/%Y")   #=> "Printed on 11/19/2007"
+  #     d.strftime("at %I:%M%p")            #=> "at 08:37AM"
+  #
+  # Various ISO 8601 formats:
+  #     %Y%m%d           => 20071119                  Calendar date (basic)
+  #     %F               => 2007-11-19                Calendar date (extended)
+  #     %Y-%m            => 2007-11                   Calendar date, reduced accuracy, specific month
+  #     %Y               => 2007                      Calendar date, reduced accuracy, specific year
+  #     %C               => 20                        Calendar date, reduced accuracy, specific century
+  #     %Y%j             => 2007323                   Ordinal date (basic)
+  #     %Y-%j            => 2007-323                  Ordinal date (extended)
+  #     %GW%V%u          => 2007W471                  Week date (basic)
+  #     %G-W%V-%u        => 2007-W47-1                Week date (extended)
+  #     %GW%V            => 2007W47                   Week date, reduced accuracy, specific week (basic)
+  #     %G-W%V           => 2007-W47                  Week date, reduced accuracy, specific week (extended)
+  #     %H%M%S           => 083748                    Local time (basic)
+  #     %T               => 08:37:48                  Local time (extended)
+  #     %H%M             => 0837                      Local time, reduced accuracy, specific minute (basic)
+  #     %H:%M            => 08:37                     Local time, reduced accuracy, specific minute (extended)
+  #     %H               => 08                        Local time, reduced accuracy, specific hour
+  #     %H%M%S,%L        => 083748,000                Local time with decimal fraction, comma as decimal sign (basic)
+  #     %T,%L            => 08:37:48,000              Local time with decimal fraction, comma as decimal sign (extended)
+  #     %H%M%S.%L        => 083748.000                Local time with decimal fraction, full stop as decimal sign (basic)
+  #     %T.%L            => 08:37:48.000              Local time with decimal fraction, full stop as decimal sign (extended)
+  #     %H%M%S%z         => 083748-0600               Local time and the difference from UTC (basic)
+  #     %T%:z            => 08:37:48-06:00            Local time and the difference from UTC (extended)
+  #     %Y%m%dT%H%M%S%z  => 20071119T083748-0600      Date and time of day for calendar date (basic)
+  #     %FT%T%:z         => 2007-11-19T08:37:48-06:00 Date and time of day for calendar date (extended)
+  #     %Y%jT%H%M%S%z    => 2007323T083748-0600       Date and time of day for ordinal date (basic)
+  #     %Y-%jT%T%:z      => 2007-323T08:37:48-06:00   Date and time of day for ordinal date (extended)
+  #     %GW%V%uT%H%M%S%z => 2007W471T083748-0600      Date and time of day for week date (basic)
+  #     %G-W%V-%uT%T%:z  => 2007-W47-1T08:37:48-06:00 Date and time of day for week date (extended)
+  #     %Y%m%dT%H%M      => 20071119T0837             Calendar date and local time (basic)
+  #     %FT%R            => 2007-11-19T08:37          Calendar date and local time (extended)
+  #     %Y%jT%H%MZ       => 2007323T0837Z             Ordinal date and UTC of day (basic)
+  #     %Y-%jT%RZ        => 2007-323T08:37Z           Ordinal date and UTC of day (extended)
+  #     %GW%V%uT%H%M%z   => 2007W471T0837-0600        Week date and local time and difference from UTC (basic)
+  #     %G-W%V-%uT%R%:z  => 2007-W47-1T08:37-06:00    Week date and local time and difference from UTC (extended)
+  #
+  # See also strftime(3) and ::strptime.
+  #
+  def strftime: (?String format) -> String
+
+  # Returns a Date object which denotes self.
+  #
+  def to_date: () -> Date
+
+  # Returns self.
+  #
+  def to_datetime: () -> DateTime
+
+  # Returns a string in an ISO 8601 format. (This method doesn't use the expanded
+  # representations.)
+  #
+  #     DateTime.new(2001,2,3,4,5,6,'-7').to_s
+  #                              #=> "2001-02-03T04:05:06-07:00"
+  #
+  def to_s: () -> String
+
+  # Returns a Time object which denotes self.
+  #
+  def to_time: () -> Time
+
+  # This method is equivalent to strftime('%FT%T%:z'). The optional argument `n`
+  # is the number of digits for fractional seconds.
+  #
+  #     DateTime.parse('2001-02-03T04:05:06.123456789+07:00').iso8601(9)
+  #                               #=> "2001-02-03T04:05:06.123456789+07:00"
+  #
+  def xmlschema: (?Integer n) -> String
+
+  # Returns the timezone.
+  #
+  #     DateTime.parse('04pm+0730').zone          #=> "+07:30"
+  #
+  def zone: () -> String
+end

--- a/stdlib/date/date_time.rbs
+++ b/stdlib/date/date_time.rbs
@@ -128,8 +128,6 @@
 # eventually timezones.
 #
 class DateTime < Date
-  public
-
   # Creates a DateTime object denoting the given calendar date.
   #
   #     DateTime.new(2001,2,3)    #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
@@ -139,6 +137,7 @@ class DateTime < Date
   #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
   #
   def self.new: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
+  def initialize: (?Integer year, ?Integer month, ?Integer mday, ?Integer hour, ?Integer minute, ?Integer second, ?Integer offset, ?Integer start) -> DateTime
 
   # Parses the given representation of date and time with the given template, and
   # returns a hash of parsed elements.  _strptime does not support specification
@@ -296,6 +295,8 @@ class DateTime < Date
   #                               #=> #<DateTime: 2001-02-03T04:05:06+07:00 ...>
   #
   def self.xmlschema: (String str, ?Integer start) -> DateTime
+
+  public
 
   # Returns the hour (0-23).
   #

--- a/test/stdlib/DateTime_test.rb
+++ b/test/stdlib/DateTime_test.rb
@@ -1,0 +1,192 @@
+require_relative "test_helper"
+
+class DateTimeSingletonTest < Minitest::Test
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "singleton(::DateTime)"
+
+
+  def test_new
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+                      DateTime, :new
+  end
+
+  def test__strptime
+    assert_send_type  "(::String str, ?::String format) -> ::Hash",
+                      DateTime, :_strptime
+  end
+
+  def test_civil
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+                      DateTime, :civil
+  end
+
+  def test_commercial
+    assert_send_type  "(?::Integer cwyear, ?::Integer cweek, ?::Integer cwday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+                      DateTime, :commercial
+  end
+
+  def test_httpdate
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :httpdate
+  end
+
+  def test_iso8601
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :iso8601
+  end
+
+  def test_jd
+    assert_send_type  "(?::Integer jd, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+                      DateTime, :jd
+  end
+
+  def test_jisx0301
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :jisx0301
+  end
+
+  def test_ordinal
+    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+                      DateTime, :ordinal
+  end
+
+  def test_parse
+    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::DateTime",
+                      DateTime, :parse
+  end
+
+  def test_rfc2822
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :rfc2822
+  end
+
+  def test_rfc3339
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :rfc3339
+  end
+
+  def test_rfc822
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :rfc822
+  end
+
+  def test_strptime
+    assert_send_type  "(::String str, ?::String format, ?::Integer start) -> ::DateTime",
+                      DateTime, :strptime
+  end
+
+  def test_xmlschema
+    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
+                      DateTime, :xmlschema
+  end
+
+  def test_now
+    assert_send_type  "(?::Integer start) -> ::DateTime",
+                      DateTime, :now
+  end
+end
+
+class DateTimeTest < Minitest::Test
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "::DateTime"
+
+
+  def test_to_s
+    assert_send_type  "() -> ::String",
+                      DateTime.new, :to_s
+  end
+
+  def test_iso8601
+    assert_send_type  "(?::Integer n) -> ::String",
+                      DateTime.new, :iso8601
+  end
+
+  def test_jisx0301
+    assert_send_type  "(?::Integer n) -> ::String",
+                      DateTime.new, :jisx0301
+  end
+
+  def test_rfc3339
+    assert_send_type  "(?::Integer n) -> ::String",
+                      DateTime.new, :rfc3339
+  end
+
+  def test_strftime
+    assert_send_type  "(?::String format) -> ::String",
+                      DateTime.new, :strftime
+  end
+
+  def test_to_date
+    assert_send_type  "() -> ::Date",
+                      DateTime.new, :to_date
+  end
+
+  def test_to_datetime
+    assert_send_type  "() -> ::DateTime",
+                      DateTime.new, :to_datetime
+  end
+
+  def test_to_time
+    assert_send_type  "() -> ::Time",
+                      DateTime.new, :to_time
+  end
+
+  def test_xmlschema
+    assert_send_type  "(?::Integer n) -> ::String",
+                      DateTime.new, :xmlschema
+  end
+
+  def test_hour
+    assert_send_type  "() -> ::Integer",
+                      DateTime.new, :hour
+  end
+
+  def test_min
+    assert_send_type  "() -> ::Integer",
+                      DateTime.new, :min
+  end
+
+  def test_minute
+    assert_send_type  "() -> ::Integer",
+                      DateTime.new, :minute
+  end
+
+  def test_new_offset
+    assert_send_type  "(?::String offset) -> ::DateTime",
+                      DateTime.new, :new_offset
+  end
+
+  def test_offset
+    assert_send_type  "() -> ::Rational",
+                      DateTime.new, :offset
+  end
+
+  def test_sec
+    assert_send_type  "() -> ::Integer",
+                      DateTime.new, :sec
+  end
+
+  def test_sec_fraction
+    assert_send_type  "() -> ::Rational",
+                      DateTime.new, :sec_fraction
+  end
+
+  def test_second
+    assert_send_type  "() -> ::Integer",
+                      DateTime.new, :second
+  end
+
+  def test_second_fraction
+    assert_send_type  "() -> ::Rational",
+                      DateTime.new, :second_fraction
+  end
+
+  def test_zone
+    assert_send_type  "() -> ::String",
+                      DateTime.new, :zone
+  end
+end

--- a/test/stdlib/DateTime_test.rb
+++ b/test/stdlib/DateTime_test.rb
@@ -1,99 +1,198 @@
 require_relative "test_helper"
+require "date"
 
 class DateTimeSingletonTest < Minitest::Test
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  library "date"
   testing "singleton(::DateTime)"
 
-
   def test_new
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :new
+    assert_send_type  "(::Integer year) -> ::DateTime",
+                      DateTime, :new, 2020
+    assert_send_type  "(::Integer year, ::Integer month) -> ::DateTime",
+                      DateTime, :new, 2020, 8
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15, 2, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15, 2, 2, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15, 2, 2, 2, 1
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset, ::Integer start) -> ::DateTime",
+                      DateTime, :new, 2020, 8, 15, 2, 2, 2, 1, Date::ITALY
   end
 
   def test__strptime
-    assert_send_type  "(::String str, ?::String format) -> ::Hash",
-                      DateTime, :_strptime
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer | String]",
+                      DateTime, :_strptime, "2020-08-15T00:00:00Z"
+    assert_send_type  "(::String str, ::String format) -> ::Hash[Symbol, Integer | String]",
+                      DateTime, :_strptime, "2020-08-15T00:00:00Z", "%Y-%M-%d"
   end
 
   def test_civil
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :civil
+    assert_send_type  "(::Integer year) -> ::DateTime",
+                      DateTime, :civil, 2020
+    assert_send_type  "(::Integer year, ::Integer month) -> ::DateTime",
+                      DateTime, :civil, 2020, 8
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15, 2, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15, 2, 2, 2
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15, 2, 2, 2, 1
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset, ::Integer start) -> ::DateTime",
+                      DateTime, :civil, 2020, 8, 15, 2, 2, 2, 1, Date::ITALY
   end
 
   def test_commercial
-    assert_send_type  "(?::Integer cwyear, ?::Integer cweek, ?::Integer cwday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :commercial
+    assert_send_type  "(::Integer cwyear) -> ::DateTime",
+                      DateTime, :commercial, 2020
+    assert_send_type  "(::Integer cwyear, ::Integer cweek) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ::Integer hour) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1, 2
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ::Integer hour, ::Integer minute) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1, 2, 2
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ::Integer hour, ::Integer minute, ::Integer second) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1, 2, 2, 2
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1, 2, 2, 2, 3
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset, ::Integer start) -> ::DateTime",
+                      DateTime, :commercial, 2020, 1, 1, 2, 2, 2, 3, Date::ITALY
   end
 
   def test_httpdate
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :httpdate
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :httpdate, "Sat Aug 15 00:00:00 2020"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :httpdate, "Sat Aug 15 00:00:00 2020", Date::ITALY
   end
 
   def test_iso8601
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :iso8601
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :iso8601, "2020-08-15T00:00:00+0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :iso8601, "2020-08-15T00:00:00+0900", Date::ITALY
   end
 
   def test_jd
-    assert_send_type  "(?::Integer jd, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :jd
+    assert_send_type  "(::Integer jd) -> ::DateTime",
+                      DateTime, :jd, 2020
+    assert_send_type  "(::Integer jd, ::Integer hour) -> ::DateTime",
+                      DateTime, :jd, 2020, 1
+    assert_send_type  "(::Integer jd, ::Integer hour, ::Integer minute) -> ::DateTime",
+                      DateTime, :jd, 2020, 1, 1
+    assert_send_type  "(::Integer jd, ::Integer hour, ::Integer minute, ::Integer second) -> ::DateTime",
+                      DateTime, :jd, 2020, 1, 1, 1
+    assert_send_type  "(::Integer jd, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset) -> ::DateTime",
+                      DateTime, :jd, 2020, 1, 1, 1, 2
+    assert_send_type  "(::Integer jd, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset, ::Integer start) -> ::DateTime",
+                      DateTime, :jd, 2020, 1, 1, 1, 2, Date::ITALY
   end
 
   def test_jisx0301
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :jisx0301
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :jisx0301, "2020-08-15T00:00:00+0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :jisx0301, "2020-08-15T00:00:00+0900", Date::ITALY
   end
 
   def test_ordinal
-    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer hour, ?::Integer minute, ?::Integer second, ?::Integer offset, ?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :ordinal
+    assert_send_type  "(::Integer year) -> ::DateTime",
+                      DateTime, :ordinal, 2020
+    assert_send_type  "(::Integer year, ::Integer yday) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer hour) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1, 2
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer hour, ::Integer minute) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1, 2, 2
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer hour, ::Integer minute, ::Integer second) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1, 2, 2, 2
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1, 2, 2, 2, 3
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer hour, ::Integer minute, ::Integer second, ::Integer offset, ::Integer start) -> ::DateTime",
+                      DateTime, :ordinal, 2020, 1, 2, 2, 2, 3, Date::ITALY
   end
 
   def test_parse
-    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::DateTime",
-                      DateTime, :parse
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :parse, "2020-08-15T00:00:00+0900"
+    assert_send_type  "(::String str, bool complete) -> ::DateTime",
+                      DateTime, :parse, "2020-08-15T00:00:00+0900", true
+    assert_send_type  "(::String str, bool complete, ::Integer start) -> ::DateTime",
+                      DateTime, :parse, "2020-08-15T00:00:00+0900", true, Date::ITALY
   end
 
   def test_rfc2822
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :rfc2822
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :rfc2822, "Sat, 15 Aug 2020 00:00:00 +0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :rfc2822, "Sat, 15 Aug 2020 00:00:00 +0900", Date::ITALY
   end
 
   def test_rfc3339
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :rfc3339
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :rfc3339, "2020-08-15T00:00:00+09:00"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :rfc3339, "2020-08-15T00:00:00+09:00", Date::ITALY
   end
 
   def test_rfc822
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :rfc822
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :rfc822, "Sat, 15 Aug 2020 00:00:00 +0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :rfc822, "Sat, 15 Aug 2020 00:00:00 +0900", Date::ITALY
   end
 
   def test_strptime
-    assert_send_type  "(::String str, ?::String format, ?::Integer start) -> ::DateTime",
-                      DateTime, :strptime
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :strptime, "2020-08-15T00:00:00+09:00"
+    assert_send_type  "(::String str, ::String format) -> ::DateTime",
+                      DateTime, :strptime, "2020-08-15T00:00:00+09:00", "%Y-%M-%d"
+    assert_send_type  "(::String str, ::String format, ::Integer start) -> ::DateTime",
+                      DateTime, :strptime, "2020-08-15T00:00:00+09:00", "%Y-%M-%d", Date::ITALY
   end
 
   def test_xmlschema
-    assert_send_type  "(::String str, ?::Integer start) -> ::DateTime",
-                      DateTime, :xmlschema
+    assert_send_type  "(::String str) -> ::DateTime",
+                      DateTime, :xmlschema, "2020-08-15T00:00:00+09:00"
+    assert_send_type  "(::String str, ::Integer start) -> ::DateTime",
+                      DateTime, :xmlschema, "2020-08-15T00:00:00+09:00", Date::ITALY
   end
 
   def test_now
-    assert_send_type  "(?::Integer start) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime, :now
+    assert_send_type  "(::Integer start) -> ::DateTime",
+                      DateTime, :now, Date::ITALY
   end
 end
 
 class DateTimeTest < Minitest::Test
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  library "date"
   testing "::DateTime"
-
 
   def test_to_s
     assert_send_type  "() -> ::String",
@@ -101,23 +200,31 @@ class DateTimeTest < Minitest::Test
   end
 
   def test_iso8601
-    assert_send_type  "(?::Integer n) -> ::String",
+    assert_send_type  "() -> ::String",
                       DateTime.new, :iso8601
+    assert_send_type  "(::Integer n) -> ::String",
+                      DateTime.new, :iso8601, 1
   end
 
   def test_jisx0301
-    assert_send_type  "(?::Integer n) -> ::String",
+    assert_send_type  "() -> ::String",
                       DateTime.new, :jisx0301
+    assert_send_type  "(::Integer n) -> ::String",
+                      DateTime.new, :jisx0301, 1
   end
 
   def test_rfc3339
-    assert_send_type  "(?::Integer n) -> ::String",
+    assert_send_type  "() -> ::String",
                       DateTime.new, :rfc3339
+    assert_send_type  "(::Integer n) -> ::String",
+                      DateTime.new, :rfc3339, 1
   end
 
   def test_strftime
-    assert_send_type  "(?::String format) -> ::String",
+    assert_send_type  "() -> ::String",
                       DateTime.new, :strftime
+    assert_send_type  "(::String format) -> ::String",
+                      DateTime.new, :strftime, "%Y-%M-%d"
   end
 
   def test_to_date
@@ -136,8 +243,10 @@ class DateTimeTest < Minitest::Test
   end
 
   def test_xmlschema
-    assert_send_type  "(?::Integer n) -> ::String",
+    assert_send_type  "() -> ::String",
                       DateTime.new, :xmlschema
+    assert_send_type  "(::Integer n) -> ::String",
+                      DateTime.new, :xmlschema, 1
   end
 
   def test_hour
@@ -156,8 +265,10 @@ class DateTimeTest < Minitest::Test
   end
 
   def test_new_offset
-    assert_send_type  "(?::String offset) -> ::DateTime",
+    assert_send_type  "() -> ::DateTime",
                       DateTime.new, :new_offset
+    assert_send_type  "(::String offset) -> ::DateTime",
+                      DateTime.new, :new_offset, "+09:00"
   end
 
   def test_offset

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -1,135 +1,161 @@
 require_relative "test_helper"
+require "date"
 
 class DateSingletonTest < Minitest::Test
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  library "date"
   testing "singleton(::Date)"
-
 
   def test_new
     assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
                       Date, :new
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :new, 2020
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :new, 2020, 8
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :new, 2020, 8, 15
   end
 
   def test__httpdate
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_httpdate
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
+                      Date, :_httpdate, "Sat Aug 15 00:00:00 2020"
   end
 
   def test__iso8601
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_iso8601
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
+                      Date, :_iso8601, "2020-08-15"
   end
 
   def test__jisx0301
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_jisx0301
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
+                      Date, :_jisx0301, "2020-08-15"
   end
 
   def test__parse
-    assert_send_type  "(::String str, ?bool complete) -> ::Hash",
-                      Date, :_parse
+    assert_send_type  "(::String str, ?bool complete) -> ::Hash[Symbol, Integer]",
+                      Date, :_parse, "2020-08-15"
+    assert_send_type  "(::String str, ?bool complete) -> ::Hash[Symbol, Integer]",
+                      Date, :_parse, "2020-08-15", true
   end
 
   def test__rfc2822
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_rfc2822
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer | String]",
+                      Date, :_rfc2822, "Sat Aug 15 2020 00:00:00 +09:00"
   end
 
   def test__rfc3339
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_rfc3339
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer | String]",
+                      Date, :_rfc3339, "2020-08-15T00:00:00+09:00"
   end
 
   def test__rfc822
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_rfc822
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer | String]",
+                      Date, :_rfc822, "Sat Aug 15 2020 00:00:00 +09:00"
   end
 
   def test__strptime
-    assert_send_type  "(::String str, ?::String format) -> ::Hash",
-                      Date, :_strptime
+    assert_send_type  "(::String str, ?::String format) -> ::Hash[Symbol, Integer]",
+                      Date, :_strptime, "2020-08-15"
   end
 
   def test__xmlschema
-    assert_send_type  "(::String str) -> ::Hash",
-                      Date, :_xmlschema
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
+                      Date, :_xmlschema, "2020-08-15"
   end
 
   def test_civil
     assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
                       Date, :civil
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :civil, 2020
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :civil, 2020, 8
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :civil, 2020, 8, 15
   end
 
   def test_commercial
-    assert_send_type  "(?::Integer cwyear, ?::Integer cweek, ?::Integer cwday, ?::Integer start) -> ::Date",
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
                       Date, :commercial
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :commercial, 2020
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :commercial, 2020, 1
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :commercial, 2020, 1, 1
   end
 
   def test_gregorian_leap?
     assert_send_type  "(::Integer year) -> bool",
-                      Date, :gregorian_leap?
+                      Date, :gregorian_leap?, 2020
   end
 
   def test_httpdate
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :httpdate
+                      Date, :httpdate, "Sat Aug 15 00:00:00 2020"
   end
 
   def test_iso8601
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :iso8601
+                      Date, :iso8601, "2020-08-15"
   end
 
   def test_jd
     assert_send_type  "(::Integer jd, ?::Integer start) -> ::Date",
-                      Date, :jd
+                      Date, :jd, 2020
   end
 
   def test_jisx0301
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :jisx0301
+                      Date, :jisx0301, "2020-08-15"
   end
 
   def test_julian_leap?
     assert_send_type  "(::Integer year) -> bool",
-                      Date, :julian_leap?
+                      Date, :julian_leap?, 2020
   end
 
   def test_leap?
     assert_send_type  "(::Integer year) -> bool",
-                      Date, :leap?
+                      Date, :leap?, 2020
   end
 
   def test_ordinal
     assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
                       Date, :ordinal
+    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+                      Date, :ordinal, 2020
+    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+                      Date, :ordinal, 2020, 1
   end
 
   def test_parse
     assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::Date",
-                      Date, :parse
+                      Date, :parse, "2020-08-15"
+    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::Date",
+                      Date, :parse, "2020-08-15", true
   end
 
   def test_rfc2822
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :rfc2822
+                      Date, :rfc2822, "Sat, 15 Aug 2020 00:00:00 +0900"
   end
 
   def test_rfc3339
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :rfc3339
+                      Date, :rfc3339, "2020-08-15T00:00:00+09:00"
   end
 
   def test_rfc822
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :rfc822
+                      Date, :rfc822, "Sat, 15 Aug 2020 00:00:00 +0900"
   end
 
   def test_strptime
     assert_send_type  "(::String str, ?::String format, ?::Integer start) -> ::Date",
-                      Date, :strptime
+                      Date, :strptime, "2020-08-15"
   end
 
   def test_today
@@ -139,85 +165,79 @@ class DateSingletonTest < Minitest::Test
 
   def test_valid_civil?
     assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
-                      Date, :valid_civil?
+                      Date, :valid_civil?, 2020, 8, 15
   end
 
   def test_valid_commercial?
     assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ?::Integer start) -> bool",
-                      Date, :valid_commercial?
+                      Date, :valid_commercial?, 2020, 1, 1
   end
 
   def test_valid_date?
     assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
-                      Date, :valid_date?
+                      Date, :valid_date?, 2020, 8, 15
   end
 
   def test_valid_jd?
     assert_send_type  "(::Integer jd, ?::Integer start) -> bool",
-                      Date, :valid_jd?
+                      Date, :valid_jd?, 2020
   end
 
   def test_valid_ordinal?
     assert_send_type  "(::Integer year, ::Integer yday, ?::Integer start) -> bool",
-                      Date, :valid_ordinal?
+                      Date, :valid_ordinal?, 2020, 1
   end
 
   def test_xmlschema
     assert_send_type  "(::String str, ?::Integer start) -> ::Date",
-                      Date, :xmlschema
+                      Date, :xmlschema, "2020-08-15"
   end
 end
 
 class DateTest < Minitest::Test
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  library "date"
   testing "::Date"
-
-
-  def test_initialize
-    assert_send_type  "(*untyped) -> untyped",
-                      Date.new, :initialize
-  end
 
   def test_spaceship
     assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
-                      Date.new, :<=>
+                      Date.new, :<=>, Date.new(2020, 8, 15)
+    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+                      Date.new, :<=>, Rational(1, 2)
+    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+                      Date.new, :<=>, {}
   end
 
   def test_triple_equal
     assert_send_type  "(::Date other) -> bool",
-                      Date.new, :===
-  end
-
-  def test_inspect
-    assert_send_type  "() -> ::String",
-                      Date.new, :inspect
-  end
-
-  def test_to_s
-    assert_send_type  "() -> ::String",
-                      Date.new, :to_s
+                      Date.new, :===, Date.new
   end
 
   def test_plus
-    assert_send_type  "(::Integer | ::Date | ::Rational arg0) -> ::Date",
-                      Date.new, :+
+    assert_send_type  "(::Integer | ::Date | ::Rational other) -> ::Date",
+                      Date.new, :+, 1
+    assert_send_type  "(::Integer | ::Date | ::Rational other) -> ::Date",
+                      Date.new, :+, Rational(1, 2)
   end
 
   def test_minus
-    assert_send_type  "(::Integer | ::Date | ::Rational arg0) -> ::Date",
-                      Date.new, :-
+    assert_send_type  "(::Integer | ::Rational other) -> ::Date",
+                      Date.new, :-, 1
+    assert_send_type  "(::Integer | ::Rational other) -> ::Date",
+                      Date.new, :-, Rational(1, 2)
+    assert_send_type  "(::Date other) -> ::Rational",
+                      Date.new, :-, Date.new
   end
 
   def test_left_shift
     assert_send_type  "(::Integer month) -> ::Date",
-                      Date.new, :<<
+                      Date.new, :<<, 1
   end
 
   def test_right_shift
     assert_send_type  "(::Integer month) -> ::Date",
-                      Date.new, :>>
+                      Date.new, :>>, 1
   end
 
   def test_ajd
@@ -260,16 +280,11 @@ class DateTest < Minitest::Test
                       Date.new, :day
   end
 
-  def test_day_fraction
-    assert_send_type  "() -> ::Rational",
-                      Date.new, :day_fraction
-  end
-
   def test_downto
-    assert_send_type  "(::Date min) { (::Date) -> untyped } -> nil",
-                      Date.new, :downto
-    assert_send_type  "(::Date min) -> ::Enumerator[::Date, nil]",
-                      Date.new, :downto
+    assert_send_type  "(::Date min) { (::Date) -> untyped } -> ::Date",
+                      Date.new, :downto, Date.new do end
+    assert_send_type  "(::Date min) -> ::Enumerator[::Date, ::Date]",
+                      Date.new, :downto, Date.new
   end
 
   def test_england
@@ -295,6 +310,11 @@ class DateTest < Minitest::Test
   def test_httpdate
     assert_send_type  "() -> ::String",
                       Date.new, :httpdate
+  end
+
+  def test_inspect
+    assert_send_type  "() -> ::String",
+                      Date.new, :inspect
   end
 
   def test_iso8601
@@ -375,31 +395,43 @@ class DateTest < Minitest::Test
   def test_next_day
     assert_send_type  "(?::Integer day) -> ::Date",
                       Date.new, :next_day
+    assert_send_type  "(?::Integer day) -> ::Date",
+                      Date.new, :next_day, 1
   end
 
   def test_next_month
     assert_send_type  "(?::Integer month) -> ::Date",
                       Date.new, :next_month
+    assert_send_type  "(?::Integer month) -> ::Date",
+                      Date.new, :next_month, 1
   end
 
   def test_next_year
     assert_send_type  "(?::Integer year) -> ::Date",
                       Date.new, :next_year
+    assert_send_type  "(?::Integer year) -> ::Date",
+                      Date.new, :next_year, 1
   end
 
   def test_prev_day
     assert_send_type  "(?::Integer day) -> ::Date",
                       Date.new, :prev_day
+    assert_send_type  "(?::Integer day) -> ::Date",
+                      Date.new, :prev_day, 1
   end
 
   def test_prev_month
     assert_send_type  "(?::Integer month) -> ::Date",
                       Date.new, :prev_month
+    assert_send_type  "(?::Integer month) -> ::Date",
+                      Date.new, :prev_month, 1
   end
 
   def test_prev_year
     assert_send_type  "(?::Integer year) -> ::Date",
                       Date.new, :prev_year
+    assert_send_type  "(?::Integer year) -> ::Date",
+                      Date.new, :prev_year, 1
   end
 
   def test_rfc2822
@@ -423,20 +455,22 @@ class DateTest < Minitest::Test
   end
 
   def test_start
-    assert_send_type  "() -> ::Integer",
+    assert_send_type  "() -> ::Float",
                       Date.new, :start
   end
 
   def test_step
-    assert_send_type  "(::Date limit, ?::Integer step) { (::Date) -> untyped } -> nil",
-                      Date.new, :step
-    assert_send_type  "(::Date limit, ?::Integer step) -> ::Enumerator[::Date, nil]",
-                      Date.new, :step
+    assert_send_type  "(::Date limit, ?::Integer step) { (::Date) -> untyped } -> Date",
+                      Date.new, :step, Date.new do end
+    assert_send_type  "(::Date limit, ?::Integer step) -> ::Enumerator[::Date, ::Date]",
+                      Date.new, :step, Date.new
   end
 
   def test_strftime
     assert_send_type  "(?::String format) -> ::String",
                       Date.new, :strftime
+    assert_send_type  "(?::String format) -> ::String",
+                      Date.new, :strftime, "%Y-%M"
   end
 
   def test_succ
@@ -464,6 +498,11 @@ class DateTest < Minitest::Test
                       Date.new, :to_datetime
   end
 
+  def test_to_s
+    assert_send_type  "() -> ::String",
+                      Date.new, :to_s
+  end
+
   def test_to_time
     assert_send_type  "() -> ::Time",
                       Date.new, :to_time
@@ -475,10 +514,10 @@ class DateTest < Minitest::Test
   end
 
   def test_upto
-    assert_send_type  "(::Date max) { (::Date) -> untypd } -> nil",
-                      Date.new, :upto
-    assert_send_type  "(::Date max) -> ::Enumerator[::Date, nil]",
-                      Date.new, :upto
+    assert_send_type  "(::Date max) { (::Date) -> untyped } -> Date",
+                      Date.new, :upto, Date.new do end
+    assert_send_type  "(::Date max) -> ::Enumerator[::Date, ::Date]",
+                      Date.new, :upto, Date.new
   end
 
   def test_wday

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -1,0 +1,503 @@
+require_relative "test_helper"
+
+class DateSingletonTest < Minitest::Test
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "singleton(::Date)"
+
+
+  def test__httpdate
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_httpdate
+  end
+
+  def test__iso8601
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_iso8601
+  end
+
+  def test__jisx0301
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_jisx0301
+  end
+
+  def test__parse
+    assert_send_type  "(::String str, ?bool complete) -> ::Hash",
+                      Date, :_parse
+  end
+
+  def test__rfc2822
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_rfc2822
+  end
+
+  def test__rfc3339
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_rfc3339
+  end
+
+  def test__rfc822
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_rfc822
+  end
+
+  def test__strptime
+    assert_send_type  "(::String str, ?::String format) -> ::Hash",
+                      Date, :_strptime
+  end
+
+  def test__xmlschema
+    assert_send_type  "(::String str) -> ::Hash",
+                      Date, :_xmlschema
+  end
+
+  def test_civil
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :civil
+  end
+
+  def test_commercial
+    assert_send_type  "(?::Integer cwyear, ?::Integer cweek, ?::Integer cwday, ?::Integer start) -> ::Date",
+                      Date, :commercial
+  end
+
+  def test_gregorian_leap?
+    assert_send_type  "(::Integer year) -> bool",
+                      Date, :gregorian_leap?
+  end
+
+  def test_httpdate
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :httpdate
+  end
+
+  def test_iso8601
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :iso8601
+  end
+
+  def test_jd
+    assert_send_type  "(::Integer jd, ?::Integer start) -> ::Date",
+                      Date, :jd
+  end
+
+  def test_jisx0301
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :jisx0301
+  end
+
+  def test_julian_leap?
+    assert_send_type  "(::Integer year) -> bool",
+                      Date, :julian_leap?
+  end
+
+  def test_leap?
+    assert_send_type  "(::Integer year) -> bool",
+                      Date, :leap?
+  end
+
+  def test_ordinal
+    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+                      Date, :ordinal
+  end
+
+  def test_parse
+    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::Date",
+                      Date, :parse
+  end
+
+  def test_rfc2822
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :rfc2822
+  end
+
+  def test_rfc3339
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :rfc3339
+  end
+
+  def test_rfc822
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :rfc822
+  end
+
+  def test_strptime
+    assert_send_type  "(::String str, ?::String format, ?::Integer start) -> ::Date",
+                      Date, :strptime
+  end
+
+  def test_today
+    assert_send_type  "(?::Integer start) -> ::Date",
+                      Date, :today
+  end
+
+  def test_valid_civil?
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
+                      Date, :valid_civil?
+  end
+
+  def test_valid_commercial?
+    assert_send_type  "(::Integer cwyear, ::Integer cweek, ::Integer cwday, ?::Integer start) -> bool",
+                      Date, :valid_commercial?
+  end
+
+  def test_valid_date?
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
+                      Date, :valid_date?
+  end
+
+  def test_valid_jd?
+    assert_send_type  "(::Integer jd, ?::Integer start) -> bool",
+                      Date, :valid_jd?
+  end
+
+  def test_valid_ordinal?
+    assert_send_type  "(::Integer year, ::Integer yday, ?::Integer start) -> bool",
+                      Date, :valid_ordinal?
+  end
+
+  def test_xmlschema
+    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+                      Date, :xmlschema
+  end
+end
+
+class DateTest < Minitest::Test
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "::Date"
+
+
+  def test_initialize
+    assert_send_type  "(*untyped) -> untyped",
+                      Date.new, :initialize
+  end
+
+  def test_spaceship
+    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+                      Date.new, :<=>
+  end
+
+  def test_triple_equal
+    assert_send_type  "(::Date other) -> bool",
+                      Date.new, :===
+  end
+
+  def test_inspect
+    assert_send_type  "() -> ::String",
+                      Date.new, :inspect
+  end
+
+  def test_to_s
+    assert_send_type  "() -> ::String",
+                      Date.new, :to_s
+  end
+
+  def test_plus
+    assert_send_type  "(::Integer | ::Date | ::Rational arg0) -> ::Date",
+                      Date.new, :+
+  end
+
+  def test_minus
+    assert_send_type  "(::Integer | ::Date | ::Rational arg0) -> ::Date",
+                      Date.new, :-
+  end
+
+  def test_left_shift
+    assert_send_type  "(::Integer month) -> ::Date",
+                      Date.new, :<<
+  end
+
+  def test_right_shift
+    assert_send_type  "(::Integer month) -> ::Date",
+                      Date.new, :>>
+  end
+
+  def test_ajd
+    assert_send_type  "() -> ::Rational",
+                      Date.new, :ajd
+  end
+
+  def test_amjd
+    assert_send_type  "() -> ::Rational",
+                      Date.new, :amjd
+  end
+
+  def test_asctime
+    assert_send_type  "() -> ::String",
+                      Date.new, :asctime
+  end
+
+  def test_ctime
+    assert_send_type  "() -> ::String",
+                      Date.new, :ctime
+  end
+
+  def test_cwday
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :cwday
+  end
+
+  def test_cweek
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :cweek
+  end
+
+  def test_cwyear
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :cwyear
+  end
+
+  def test_day
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :day
+  end
+
+  def test_day_fraction
+    assert_send_type  "() -> ::Rational",
+                      Date.new, :day_fraction
+  end
+
+  def test_downto
+    assert_send_type  "(::Date min) { (::Date) -> untyped } -> nil",
+                      Date.new, :downto
+    assert_send_type  "(::Date min) -> ::Enumerator[::Date, nil]",
+                      Date.new, :downto
+  end
+
+  def test_england
+    assert_send_type  "() -> ::Date",
+                      Date.new, :england
+  end
+
+  def test_friday?
+    assert_send_type  "() -> bool",
+                      Date.new, :friday?
+  end
+
+  def test_gregorian
+    assert_send_type  "() -> ::Date",
+                      Date.new, :gregorian
+  end
+
+  def test_gregorian?
+    assert_send_type  "() -> bool",
+                      Date.new, :gregorian?
+  end
+
+  def test_httpdate
+    assert_send_type  "() -> ::String",
+                      Date.new, :httpdate
+  end
+
+  def test_iso8601
+    assert_send_type  "() -> ::String",
+                      Date.new, :iso8601
+  end
+
+  def test_italy
+    assert_send_type  "() -> ::Date",
+                      Date.new, :italy
+  end
+
+  def test_jd
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :jd
+  end
+
+  def test_jisx0301
+    assert_send_type  "() -> ::String",
+                      Date.new, :jisx0301
+  end
+
+  def test_julian
+    assert_send_type  "() -> ::Date",
+                      Date.new, :julian
+  end
+
+  def test_julian?
+    assert_send_type  "() -> bool",
+                      Date.new, :julian?
+  end
+
+  def test_ld
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :ld
+  end
+
+  def test_leap?
+    assert_send_type  "() -> bool",
+                      Date.new, :leap?
+  end
+
+  def test_mday
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :mday
+  end
+
+  def test_mjd
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :mjd
+  end
+
+  def test_mon
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :mon
+  end
+
+  def test_monday?
+    assert_send_type  "() -> bool",
+                      Date.new, :monday?
+  end
+
+  def test_month
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :month
+  end
+
+  def test_new_start
+    assert_send_type  "(?::Integer start) -> ::Date",
+                      Date.new, :new_start
+  end
+
+  def test_next
+    assert_send_type  "() -> ::Date",
+                      Date.new, :next
+  end
+
+  def test_next_day
+    assert_send_type  "(?::Integer day) -> ::Date",
+                      Date.new, :next_day
+  end
+
+  def test_next_month
+    assert_send_type  "(?::Integer month) -> ::Date",
+                      Date.new, :next_month
+  end
+
+  def test_next_year
+    assert_send_type  "(?::Integer year) -> ::Date",
+                      Date.new, :next_year
+  end
+
+  def test_prev_day
+    assert_send_type  "(?::Integer day) -> ::Date",
+                      Date.new, :prev_day
+  end
+
+  def test_prev_month
+    assert_send_type  "(?::Integer month) -> ::Date",
+                      Date.new, :prev_month
+  end
+
+  def test_prev_year
+    assert_send_type  "(?::Integer year) -> ::Date",
+                      Date.new, :prev_year
+  end
+
+  def test_rfc2822
+    assert_send_type  "() -> ::String",
+                      Date.new, :rfc2822
+  end
+
+  def test_rfc3339
+    assert_send_type  "() -> ::String",
+                      Date.new, :rfc3339
+  end
+
+  def test_rfc822
+    assert_send_type  "() -> ::String",
+                      Date.new, :rfc822
+  end
+
+  def test_saturday?
+    assert_send_type  "() -> bool",
+                      Date.new, :saturday?
+  end
+
+  def test_start
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :start
+  end
+
+  def test_step
+    assert_send_type  "(::Date limit, ?::Integer step) { (::Date) -> untyped } -> nil",
+                      Date.new, :step
+    assert_send_type  "(::Date limit, ?::Integer step) -> ::Enumerator[::Date, nil]",
+                      Date.new, :step
+  end
+
+  def test_strftime
+    assert_send_type  "(?::String format) -> ::String",
+                      Date.new, :strftime
+  end
+
+  def test_succ
+    assert_send_type  "() -> ::Date",
+                      Date.new, :succ
+  end
+
+  def test_sunday?
+    assert_send_type  "() -> bool",
+                      Date.new, :sunday?
+  end
+
+  def test_thursday?
+    assert_send_type  "() -> bool",
+                      Date.new, :thursday?
+  end
+
+  def test_to_date
+    assert_send_type  "() -> ::Date",
+                      Date.new, :to_date
+  end
+
+  def test_to_datetime
+    assert_send_type  "() -> untyped",
+                      Date.new, :to_datetime
+  end
+
+  def test_to_time
+    assert_send_type  "() -> ::Time",
+                      Date.new, :to_time
+  end
+
+  def test_tuesday?
+    assert_send_type  "() -> bool",
+                      Date.new, :tuesday?
+  end
+
+  def test_upto
+    assert_send_type  "(::Date max) { (::Date) -> untypd } -> nil",
+                      Date.new, :upto
+    assert_send_type  "(::Date max) -> ::Enumerator[::Date, nil]",
+                      Date.new, :upto
+  end
+
+  def test_wday
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :wday
+  end
+
+  def test_wednesday?
+    assert_send_type  "() -> bool",
+                      Date.new, :wednesday?
+  end
+
+  def test_xmlschema
+    assert_send_type  "() -> ::String",
+                      Date.new, :xmlschema
+  end
+
+  def test_yday
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :yday
+  end
+
+  def test_year
+    assert_send_type  "() -> ::Integer",
+                      Date.new, :year
+  end
+end

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -8,14 +8,16 @@ class DateSingletonTest < Minitest::Test
   testing "singleton(::Date)"
 
   def test_new
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date, :new
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date, :new, 2020
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month) -> ::Date",
                       Date, :new, 2020, 8
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> ::Date",
                       Date, :new, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer start) -> ::Date",
+                      Date, :new, 2020, 8, 15, Date::ITALY
   end
 
   def test__httpdate
@@ -34,9 +36,9 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test__parse
-    assert_send_type  "(::String str, ?bool complete) -> ::Hash[Symbol, Integer]",
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
                       Date, :_parse, "2020-08-15"
-    assert_send_type  "(::String str, ?bool complete) -> ::Hash[Symbol, Integer]",
+    assert_send_type  "(::String str, bool complete) -> ::Hash[Symbol, Integer]",
                       Date, :_parse, "2020-08-15", true
   end
 
@@ -56,8 +58,10 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test__strptime
-    assert_send_type  "(::String str, ?::String format) -> ::Hash[Symbol, Integer]",
+    assert_send_type  "(::String str) -> ::Hash[Symbol, Integer]",
                       Date, :_strptime, "2020-08-15"
+    assert_send_type  "(::String str, ::String format) -> ::Hash[Symbol, Integer]",
+                      Date, :_strptime, "2020-08-15", "%Y-%M-%d"
   end
 
   def test__xmlschema
@@ -66,25 +70,29 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test_civil
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date, :civil
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date, :civil, 2020
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month) -> ::Date",
                       Date, :civil, 2020, 8
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> ::Date",
                       Date, :civil, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer start) -> ::Date",
+                      Date, :civil, 2020, 8, 15, Date::ITALY
   end
 
   def test_commercial
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date, :commercial
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date, :commercial, 2020
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month) -> ::Date",
                       Date, :commercial, 2020, 1
-    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> ::Date",
                       Date, :commercial, 2020, 1, 1
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer start) -> ::Date",
+                      Date, :commercial, 2020, 1, 1, Date::ITALY
   end
 
   def test_gregorian_leap?
@@ -93,23 +101,31 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test_httpdate
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :httpdate, "Sat Aug 15 00:00:00 2020"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :httpdate, "Sat Aug 15 00:00:00 2020", Date::ITALY
   end
 
   def test_iso8601
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :iso8601, "2020-08-15"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :iso8601, "2020-08-15", Date::ITALY
   end
 
   def test_jd
-    assert_send_type  "(::Integer jd, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer jd) -> ::Date",
                       Date, :jd, 2020
+    assert_send_type  "(::Integer jd, ::Integer start) -> ::Date",
+                      Date, :jd, 2020, Date::ITALY
   end
 
   def test_jisx0301
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :jisx0301, "2020-08-15"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :jisx0301, "2020-08-15", Date::ITALY
   end
 
   def test_julian_leap?
@@ -123,49 +139,67 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test_ordinal
-    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date, :ordinal
-    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date, :ordinal, 2020
-    assert_send_type  "(?::Integer year, ?::Integer yday, ?::Integer start) -> ::Date",
+    assert_send_type  "(::Integer year, ::Integer yday) -> ::Date",
                       Date, :ordinal, 2020, 1
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer start) -> ::Date",
+                      Date, :ordinal, 2020, 1, Date::ITALY
   end
 
   def test_parse
-    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :parse, "2020-08-15"
-    assert_send_type  "(::String str, ?bool complete, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str, bool complete) -> ::Date",
                       Date, :parse, "2020-08-15", true
+    assert_send_type  "(::String str, bool complete, ::Integer start) -> ::Date",
+                      Date, :parse, "2020-08-15", true, Date::ITALY
   end
 
   def test_rfc2822
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :rfc2822, "Sat, 15 Aug 2020 00:00:00 +0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :rfc2822, "Sat, 15 Aug 2020 00:00:00 +0900", Date::ITALY
   end
 
   def test_rfc3339
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :rfc3339, "2020-08-15T00:00:00+09:00"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :rfc3339, "2020-08-15T00:00:00+09:00", Date::ITALY
   end
 
   def test_rfc822
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :rfc822, "Sat, 15 Aug 2020 00:00:00 +0900"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :rfc822, "Sat, 15 Aug 2020 00:00:00 +0900", Date::ITALY
   end
 
   def test_strptime
-    assert_send_type  "(::String str, ?::String format, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :strptime, "2020-08-15"
+    assert_send_type  "(::String str, ::String format) -> ::Date",
+                      Date, :strptime, "2020-08-15", "%Y-%M-%d"
+    assert_send_type  "(::String str, ::String format, ::Integer start) -> ::Date",
+                      Date, :strptime, "2020-08-15", "%Y-%M-%d", Date::ITALY
   end
 
   def test_today
-    assert_send_type  "(?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date, :today
+    assert_send_type  "(::Integer start) -> ::Date",
+                      Date, :today, Date::ITALY
   end
 
   def test_valid_civil?
-    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> bool",
                       Date, :valid_civil?, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer start) -> bool",
+                      Date, :valid_civil?, 2020, 8, 15, Date::ITALY
   end
 
   def test_valid_commercial?
@@ -174,23 +208,31 @@ class DateSingletonTest < Minitest::Test
   end
 
   def test_valid_date?
-    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ?::Integer start) -> bool",
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday) -> bool",
                       Date, :valid_date?, 2020, 8, 15
+    assert_send_type  "(::Integer year, ::Integer month, ::Integer mday, ::Integer start) -> bool",
+                      Date, :valid_date?, 2020, 8, 15, Date::ITALY
   end
 
   def test_valid_jd?
-    assert_send_type  "(::Integer jd, ?::Integer start) -> bool",
+    assert_send_type  "(::Integer jd) -> bool",
                       Date, :valid_jd?, 2020
+    assert_send_type  "(::Integer jd, ::Integer start) -> bool",
+                      Date, :valid_jd?, 2020, Date::ITALY
   end
 
   def test_valid_ordinal?
-    assert_send_type  "(::Integer year, ::Integer yday, ?::Integer start) -> bool",
+    assert_send_type  "(::Integer year, ::Integer yday) -> bool",
                       Date, :valid_ordinal?, 2020, 1
+    assert_send_type  "(::Integer year, ::Integer yday, ::Integer start) -> bool",
+                      Date, :valid_ordinal?, 2020, 1, Date::ITALY
   end
 
   def test_xmlschema
-    assert_send_type  "(::String str, ?::Integer start) -> ::Date",
+    assert_send_type  "(::String str) -> ::Date",
                       Date, :xmlschema, "2020-08-15"
+    assert_send_type  "(::String str, ::Integer start) -> ::Date",
+                      Date, :xmlschema, "2020-08-15", Date::ITALY
   end
 end
 
@@ -201,11 +243,11 @@ class DateTest < Minitest::Test
   testing "::Date"
 
   def test_spaceship
-    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+    assert_send_type  "(::Date other) -> ::Integer",
                       Date.new, :<=>, Date.new(2020, 8, 15)
-    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+    assert_send_type  "(::Rational other) -> ::Integer",
                       Date.new, :<=>, Rational(1, 2)
-    assert_send_type  "(::Date | ::Rational | ::Object other) -> ::Integer?",
+    assert_send_type  "(::Object other) -> ::Integer?",
                       Date.new, :<=>, {}
   end
 
@@ -215,16 +257,16 @@ class DateTest < Minitest::Test
   end
 
   def test_plus
-    assert_send_type  "(::Integer | ::Date | ::Rational other) -> ::Date",
+    assert_send_type  "(::Integer other) -> ::Date",
                       Date.new, :+, 1
-    assert_send_type  "(::Integer | ::Date | ::Rational other) -> ::Date",
+    assert_send_type  "(::Rational other) -> ::Date",
                       Date.new, :+, Rational(1, 2)
   end
 
   def test_minus
-    assert_send_type  "(::Integer | ::Rational other) -> ::Date",
+    assert_send_type  "(::Integer) -> ::Date",
                       Date.new, :-, 1
-    assert_send_type  "(::Integer | ::Rational other) -> ::Date",
+    assert_send_type  "(::Rational other) -> ::Date",
                       Date.new, :-, Rational(1, 2)
     assert_send_type  "(::Date other) -> ::Rational",
                       Date.new, :-, Date.new
@@ -383,8 +425,10 @@ class DateTest < Minitest::Test
   end
 
   def test_new_start
-    assert_send_type  "(?::Integer start) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :new_start
+    assert_send_type  "(::Integer start) -> ::Date",
+                      Date.new, :new_start, Date::ITALY
   end
 
   def test_next
@@ -393,44 +437,44 @@ class DateTest < Minitest::Test
   end
 
   def test_next_day
-    assert_send_type  "(?::Integer day) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :next_day
-    assert_send_type  "(?::Integer day) -> ::Date",
+    assert_send_type  "(::Integer day) -> ::Date",
                       Date.new, :next_day, 1
   end
 
   def test_next_month
-    assert_send_type  "(?::Integer month) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :next_month
-    assert_send_type  "(?::Integer month) -> ::Date",
+    assert_send_type  "(::Integer month) -> ::Date",
                       Date.new, :next_month, 1
   end
 
   def test_next_year
-    assert_send_type  "(?::Integer year) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :next_year
-    assert_send_type  "(?::Integer year) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date.new, :next_year, 1
   end
 
   def test_prev_day
-    assert_send_type  "(?::Integer day) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :prev_day
-    assert_send_type  "(?::Integer day) -> ::Date",
+    assert_send_type  "(::Integer day) -> ::Date",
                       Date.new, :prev_day, 1
   end
 
   def test_prev_month
-    assert_send_type  "(?::Integer month) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :prev_month
-    assert_send_type  "(?::Integer month) -> ::Date",
+    assert_send_type  "(::Integer month) -> ::Date",
                       Date.new, :prev_month, 1
   end
 
   def test_prev_year
-    assert_send_type  "(?::Integer year) -> ::Date",
+    assert_send_type  "() -> ::Date",
                       Date.new, :prev_year
-    assert_send_type  "(?::Integer year) -> ::Date",
+    assert_send_type  "(::Integer year) -> ::Date",
                       Date.new, :prev_year, 1
   end
 
@@ -460,16 +504,20 @@ class DateTest < Minitest::Test
   end
 
   def test_step
-    assert_send_type  "(::Date limit, ?::Integer step) { (::Date) -> untyped } -> Date",
+    assert_send_type  "(::Date limit) { (::Date) -> untyped } -> Date",
                       Date.new, :step, Date.new do end
-    assert_send_type  "(::Date limit, ?::Integer step) -> ::Enumerator[::Date, ::Date]",
+    assert_send_type  "(::Date limit, ::Integer step) { (::Date) -> untyped } -> Date",
+                      Date.new, :step, Date.new, 1 do end
+    assert_send_type  "(::Date limit) -> ::Enumerator[::Date, ::Date]",
                       Date.new, :step, Date.new
+    assert_send_type  "(::Date limit, ::Integer step) -> ::Enumerator[::Date, ::Date]",
+                      Date.new, :step, Date.new, 1
   end
 
   def test_strftime
-    assert_send_type  "(?::String format) -> ::String",
+    assert_send_type  "() -> ::String",
                       Date.new, :strftime
-    assert_send_type  "(?::String format) -> ::String",
+    assert_send_type  "(::String format) -> ::String",
                       Date.new, :strftime, "%Y-%M"
   end
 

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -7,6 +7,11 @@ class DateSingletonTest < Minitest::Test
   testing "singleton(::Date)"
 
 
+  def test_new
+    assert_send_type  "(?::Integer year, ?::Integer month, ?::Integer mday, ?::Integer start) -> ::Date",
+                      Date, :new
+  end
+
   def test__httpdate
     assert_send_type  "(::String str) -> ::Hash",
                       Date, :_httpdate


### PR DESCRIPTION
Add signatures of Date class and DateTime class.
This PR is based on [the contributon guide](https://github.com/ruby/rbs/blob/master/docs/CONTRIBUTING.md).