### PR TITLE
_parameter_ typo fix

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -212,7 +212,7 @@ _method-type_ ::= `(` _parameters_ `) ->` _type_                                
 
 _parameters_ ::= _required-positionals_ _optional-positionals_ _rest-positional_ _trailing-positionals_ _keywords_
 
-_paramater_ ::= _type_ _var-name_                                  # Parameter with var name
+_parameter_ ::= _type_ _var-name_                                  # Parameter with var name
               | _type_                                             # Parameter without var name
 _required-positionals_ ::= _parameter_ `,` ...
 _optional-positionals_ ::= `?` _parameter_ `,` ...


### PR DESCRIPTION
Dearest Reviewer,

This is a a typo fix.  While I am here I have a question about _parameter_. Why would a parameter include a var-name if it was not in the name parameter format `(x: Int)`? 

```
  def bar: (untyped `type`, void: untyped `void`) -> untyped
```
In this test what does `type` do? https://github.com/ruby/rbs/blob/master/test/rbs/signature_parsing_test.rb#L786

I am mostly reading the syntax document. Is there another document I should be reading for reference? 

Thanks for your time,

Dictated but not reviewed,
Becker