### PR TITLE
Environment loader api

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -75,33 +75,33 @@ module RBS
       self.class.gem_sig_path(name, version)
     end
 
-    def each_signature(path = nil, immediate: true, &block)
+    def each_signature(path, immediate: true, &block)
       if block_given?
-        if path
-          case
-          when path.file?
-            if path.extname == ".rbs" || immediate
-              yield path
-            end
-          when path.directory?
-            path.children.each do |child|
-              each_signature child, immediate: false, &block
-            end
+        case
+        when path.file?
+          if path.extname == ".rbs" || immediate
+            yield path
           end
-        else
-          paths.each do |path|
-            case path
-            when Pathname
-              each_signature path, immediate: immediate, &block
-            when LibraryPath
-              each_signature path.path, immediate: immediate, &block
-            when GemPath
-              each_signature path.path, immediate: immediate, &block
-            end
+        when path.directory?
+          path.children.each do |child|
+            each_signature child, immediate: false, &block
           end
         end
       else
         enum_for :each_signature, path, immediate: immediate
+      end
+    end
+
+    def each_library_path
+      paths.each do |path|
+        case path
+        when Pathname
+          yield path, path
+        when LibraryPath
+          yield path, path.path
+        when GemPath
+          yield path, path.path
+        end
       end
     end
 
@@ -119,18 +119,21 @@ module RBS
         signature_files = []
 
         unless no_builtin?
-          signature_files.push(*each_signature(stdlib_root + "builtin"))
+          each_signature(stdlib_root + "builtin") do |path|
+            signature_files << [:stdlib, path]
+          end
         end
 
-        each_signature do |path|
-          signature_files.push path
+        each_library_path do |library_path, pathname|
+          each_signature(pathname) do |path|
+            signature_files << [library_path, path]
+          end
         end
 
-        signature_files.each do |file|
-          buffer = Buffer.new(name: file.to_s, content: file.read)
-          env.buffers.push(buffer)
+        signature_files.each do |lib_path, file_path|
+          buffer = Buffer.new(name: file_path.to_s, content: file_path.read)
           Parser.parse_signature(buffer).each do |decl|
-            yield decl, path
+            yield decl, buffer, file_path, lib_path
           end
         end
       else
@@ -139,9 +142,15 @@ module RBS
     end
 
     def load(env:)
-      each_decl do |decl|
+      loadeds = []
+
+      each_decl do |decl, buffer, file_path, lib_path|
+        env.buffers.push(buffer)
         env << decl
+        loadeds << [decl, file_path, lib_path]
       end
+
+      loadeds
     end
   end
 end


### PR DESCRIPTION
This PR is to add some missing APIs to `EnvironmentLoader` to help writing tools which incrementally load `.rbs` files.

* `#each_decl` loads `.rbs` files and yields the declarations, buffer, `Pathname` to the `.rbs`, and _library path_ where the `.rbs` is loaded from.
* `#load(env:)` returns an array of declarations loaded by the call.