### PR TITLE
[docs] Add comments to sytnax doc

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -529,3 +529,16 @@ You can declare a global variable.
 $LOAD_PATH: Array[String]
 ```
 
+### Comments
+
+You can write single line comments. Comments must be on their own line. Comments can lead with whitespace.
+
+```
+# This if interface Foo
+# Usage of Foo is bar
+interface _Foo
+  # New foo is a method
+  # it will return foo.
+  def new: () -> Foo
+end
+```


### PR DESCRIPTION
Dearest Reviewer,

I was shocked to see comments in rbs files only because it was not listed in the syntax file. I assumed that post line comments are not allowed. I am unsure if that is a correct statement.  I also assumed that heredocs/docstring/<<- and =begin/=end docs are not supported. 

Please let me know if I am incorrect in these assumptions and I will update the diff.

Thank you for work and time on this project,

Dictated but not reviewed,
Becker