### PR TITLE
Add Double API to RBS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 # Development dependencies
 gem "rake"
 gem "minitest"
+gem "rspec"
 gem "racc"
 gem "rubocop"
 gem "rubocop-rubycw"

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -760,6 +760,7 @@ Examples:
     def run_test(args, options)
       targets = []
       sample_size = nil
+      double_suite = nil
 
       (opts = OptionParser.new do |opts|
         opts.banner = <<EOB
@@ -787,13 +788,13 @@ EOB
         exit 1
       end
 
-      env_hash = {
-        'RBS_TEST_OPT' => test_opt(options),
-        'RBS_TEST_TARGET' => (targets.join(',') unless targets.empty?),
-        'RBS_TEST_SAMPLE_SIZE' => sample_size,
-        'RBS_TEST_LOGLEVEL' => RBS.logger_level,
-        'RUBYOPT' => "#{ENV['RUBYOPT']} -rrbs/test/setup"
-      }
+    env_hash = {
+      'RBS_TEST_OPT' => test_opt(options),
+      'RBS_TEST_TARGET' => (targets_string unless targets_string.empty?),
+      'RBS_TEST_SAMPLE_SIZE' => sample_size,
+      'RBS_TEST_LOGLEVEL' => RBS.logger_level
+      'RUBYOPT' => "#{ENV['RUBYOPT']} -rrbs/test/setup"
+    }
 
       system(env_hash, *args)
       $?

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -758,6 +758,7 @@ Examples:
     end
 
     def run_test(args, options)
+      unchecked_classes = []
       targets = []
       sample_size = nil
       double_suite = nil
@@ -781,6 +782,15 @@ EOB
         opts.on("--sample-size SAMPLE_SIZE", "Sets the sample size") do |size|
           sample_size = size
         end
+
+        opts.on("--unchecked-class UNCHECKED_CLASS", "Sets the class that would not be checked") do |unchecked_class|
+          unchecked_classes << unchecked_class
+        end
+
+        opts.on("--double-suite DOUBLE_SUITE", "Sets the double suite in use (currently supported: rspec | minitest)") do |suite|
+          double_suite = suite
+        end
+
       end).order!(args)
 
       if args.length.zero?
@@ -788,13 +798,15 @@ EOB
         exit 1
       end
 
-    env_hash = {
-      'RBS_TEST_OPT' => test_opt(options),
-      'RBS_TEST_TARGET' => (targets_string unless targets_string.empty?),
-      'RBS_TEST_SAMPLE_SIZE' => sample_size,
-      'RBS_TEST_LOGLEVEL' => RBS.logger_level
-      'RUBYOPT' => "#{ENV['RUBYOPT']} -rrbs/test/setup"
-    }
+      env_hash = {
+        'RUBYOPT' => "#{ENV['RUBYOPT']} -rrbs/test/setup",
+        'RBS_TEST_OPT' => test_opt(options),
+        'RBS_TEST_LOGLEVEL' => RBS.logger_level,
+        'RBS_TEST_SAMPLE_SIZE' => sample_size,
+        'RBS_TEST_DOUBLE_SUITE' => double_suite,
+        'RBS_TEST_UNCHECKED_CLASSES' => (unchecked_classes.join(',') unless unchecked_classes.empty?),
+        'RBS_TEST_TARGET' => (targets.join(',') unless targets.empty?)
+      }
 
       system(env_hash, *args)
       $?

--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -13,8 +13,8 @@ begin
   skips = (ENV['RBS_TEST_SKIP'] || '').split(',').map! { |e| e.strip }
   RBS.logger_level = (ENV["RBS_TEST_LOGLEVEL"] || "info")
   sample_size = get_sample_size(ENV['RBS_TEST_SAMPLE_SIZE'] || '')
-  double_class = ENV['RBS_TEST_DOUBLE_CLASS'] || to_double_class(ENV['RBS_TEST_DOUBLE_SUITE'])
-
+  double_class = to_double_class(ENV['RBS_TEST_DOUBLE_SUITE'])
+  unchecked_classes = (ENV['RBS_TEST_UNCHECKED_CLASSES'] || '').split(',').map! { |unchecked_class| unchecked_class.strip }.push(*double_class)
 rescue InvalidSampleSizeError => exception
   RBS.logger.error exception.message
   exit 1
@@ -27,8 +27,8 @@ if filter.empty?
   STDERR.puts "  [OPTIONAL] RBS_TEST_OPT: options for signatures (`-r` for libraries or `-I` for signatures)"
   STDERR.puts "  [OPTIONAL] RBS_TEST_LOGLEVEL: one of debug|info|warn|error|fatal (defaults to info)"
   STDERR.puts "  [OPTIONAL] RBS_TEST_SAMPLE_SIZE: sets the amount of values in a collection to be type-checked (Set to `ALL` to type check all the values)"
-  STDERR.puts "  [OPTIONAL] RBS_TEST_DOUBLE_SUITE: sets the double suite in use (currently supported"
-  STDERR.puts "  [OPTIONAL] RBS_TEST_DOUBLE_CLASS: sets the double suite in use"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_DOUBLE_SUITE: sets the double suite in use (currently supported: minitest | rspec)"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_UNCHECKED_CLASSES: sets the classes that would not be checked"
   exit 1
 end
 
@@ -64,7 +64,7 @@ TracePoint.trace :end do |tp|
     if filter.any? {|f| match(to_absolute_typename(f).to_s, class_name.to_s) } && skips.none? {|f| match(f, class_name.to_s) }
       if env.class_decls.key?(class_name)
         logger.info "Setting up hooks for #{class_name}"
-        tester.install!(tp.self, sample_size: sample_size, double_suite: double_class)
+        tester.install!(tp.self, sample_size: sample_size, unchecked_classes: unchecked_classes)
       end
     end
   end

--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -13,6 +13,8 @@ begin
   skips = (ENV['RBS_TEST_SKIP'] || '').split(',').map! { |e| e.strip }
   RBS.logger_level = (ENV["RBS_TEST_LOGLEVEL"] || "info")
   sample_size = get_sample_size(ENV['RBS_TEST_SAMPLE_SIZE'] || '')
+  double_class = ENV['RBS_TEST_DOUBLE_CLASS'] || to_double_class(ENV['RBS_TEST_DOUBLE_SUITE'])
+
 rescue InvalidSampleSizeError => exception
   RBS.logger.error exception.message
   exit 1
@@ -25,6 +27,8 @@ if filter.empty?
   STDERR.puts "  [OPTIONAL] RBS_TEST_OPT: options for signatures (`-r` for libraries or `-I` for signatures)"
   STDERR.puts "  [OPTIONAL] RBS_TEST_LOGLEVEL: one of debug|info|warn|error|fatal (defaults to info)"
   STDERR.puts "  [OPTIONAL] RBS_TEST_SAMPLE_SIZE: sets the amount of values in a collection to be type-checked (Set to `ALL` to type check all the values)"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_DOUBLE_SUITE: sets the double suite in use (currently supported"
+  STDERR.puts "  [OPTIONAL] RBS_TEST_DOUBLE_CLASS: sets the double suite in use"
   exit 1
 end
 
@@ -60,7 +64,7 @@ TracePoint.trace :end do |tp|
     if filter.any? {|f| match(to_absolute_typename(f).to_s, class_name.to_s) } && skips.none? {|f| match(f, class_name.to_s) }
       if env.class_decls.key?(class_name)
         logger.info "Setting up hooks for #{class_name}"
-        tester.install!(tp.self, sample_size: sample_size)
+        tester.install!(tp.self, sample_size: sample_size, double_suite: double_class)
       end
     end
   end

--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -24,6 +24,24 @@ module RBS
           int_size
         end
       end
+
+      def to_double_class(double_suite)
+        return nil unless double_suite
+
+        double_class = ENV['RBS_TEST_DOUBLE_CLASS']
+        RBS.logger.warn "Both the double class #{double_class} and double suite (#{double_suite}) are set!" if double_class == double_suite
+
+        case double_suite.downcase.strip
+        when 'rspec'
+          '::RSpec::Mocks::Double'
+        when 'minitest'
+          '::Minitest::Mock'        
+        else
+          RBS.logger.warn "Unknown test suite - defaults to nil"
+          nil
+        end
+      end
+
     end
   end
 end

--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -28,14 +28,11 @@ module RBS
       def to_double_class(double_suite)
         return nil unless double_suite
 
-        double_class = ENV['RBS_TEST_DOUBLE_CLASS']
-        RBS.logger.warn "Both the double class #{double_class} and double suite (#{double_suite}) are set!" if double_class == double_suite
-
         case double_suite.downcase.strip
         when 'rspec'
-          '::RSpec::Mocks::Double'
+          ['::RSpec::Mocks::Double']
         when 'minitest'
-          '::Minitest::Mock'        
+          ['::Minitest::Mock'] 
         else
           RBS.logger.warn "Unknown test suite - defaults to nil"
           nil

--- a/lib/rbs/test/tester.rb
+++ b/lib/rbs/test/tester.rb
@@ -37,7 +37,7 @@ module RBS
         end
       end
 
-      def install!(klass, sample_size:, double_suite:)
+      def install!(klass, sample_size:, unchecked_classes:)
         RBS.logger.info { "Installing runtime type checker in #{klass}..." }
 
         type_name = factory.type_name(klass.name).absolute!
@@ -45,7 +45,7 @@ module RBS
         builder.build_instance(type_name).tap do |definition|
           instance_key = new_key(type_name, "InstanceChecker")
           tester, set = instance_testers[klass] ||= [
-            MethodCallTester.new(klass, builder, definition, kind: :instance, sample_size: sample_size, double_suite: double_suite),
+            MethodCallTester.new(klass, builder, definition, kind: :instance, sample_size: sample_size, unchecked_classes: unchecked_classes),
             Set[]
           ]
           Observer.register(instance_key, tester)
@@ -68,7 +68,7 @@ module RBS
         builder.build_singleton(type_name).tap do |definition|
           singleton_key = new_key(type_name, "SingletonChecker")
           tester, set = singleton_testers[klass] ||= [
-            MethodCallTester.new(klass.singleton_class, builder, definition, kind: :singleton, sample_size: sample_size, double_suite: double_suite),
+            MethodCallTester.new(klass.singleton_class, builder, definition, kind: :singleton, sample_size: sample_size, unchecked_classes: unchecked_classes),
             Set[]
           ]
           Observer.register(singleton_key, tester)
@@ -111,15 +111,15 @@ module RBS
         attr_reader :builder
         attr_reader :kind
         attr_reader :sample_size
-        attr_reader :double_suite
+        attr_reader :unchecked_classes
 
-        def initialize(self_class, builder, definition, kind:, sample_size:, double_suite:)
+        def initialize(self_class, builder, definition, kind:, sample_size:, unchecked_classes:)
           @self_class = self_class
           @definition = definition
           @builder = builder
           @kind = kind
           @sample_size = sample_size
-          @double_suite = double_suite
+          @unchecked_classes = unchecked_classes
         end
 
         def env
@@ -127,7 +127,7 @@ module RBS
         end
 
         def check
-          @check ||= TypeCheck.new(self_class: self_class, builder: builder, sample_size: sample_size, double_suite: double_suite)
+          @check ||= TypeCheck.new(self_class: self_class, builder: builder, sample_size: sample_size, unchecked_classes: unchecked_classes)
         end
 
         def format_method_name(name)

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -4,15 +4,17 @@ module RBS
       attr_reader :self_class
       attr_reader :builder
       attr_reader :sample_size
+      attr_reader :double_suite
 
       attr_reader :const_cache
 
       DEFAULT_SAMPLE_SIZE = 100
 
-      def initialize(self_class:, builder:, sample_size:)
+      def initialize(self_class:, builder:, sample_size:, double_suite:)
         @self_class = self_class
         @builder = builder
         @sample_size = sample_size
+        @double_suite = double_suite
         @const_cache = {}
       end
 
@@ -203,7 +205,16 @@ module RBS
         const_cache[type_name] ||= Object.const_get(type_name.to_s)
       end
 
+      def is_double?(value)
+        double_suite && Test.call(value, IS_AP, Object.const_get(double_suite))
+      end
+
       def value(val, type)
+        if is_double?(val)
+          RBS.logger.info("A double (#{val.inspect}) is detected!")
+          return true 
+        end
+
         case type
         when Types::Bases::Any
           true

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -4,17 +4,17 @@ module RBS
       attr_reader :self_class
       attr_reader :builder
       attr_reader :sample_size
-      attr_reader :double_suite
+      attr_reader :unchecked_classes
 
       attr_reader :const_cache
 
       DEFAULT_SAMPLE_SIZE = 100
 
-      def initialize(self_class:, builder:, sample_size:, double_suite:)
+      def initialize(self_class:, builder:, sample_size:, unchecked_classes:)
         @self_class = self_class
         @builder = builder
         @sample_size = sample_size
-        @double_suite = double_suite
+        @unchecked_classes = unchecked_classes.uniq
         @const_cache = {}
       end
 
@@ -206,7 +206,7 @@ module RBS
       end
 
       def is_double?(value)
-        double_suite && Test.call(value, IS_AP, Object.const_get(double_suite))
+        unchecked_classes.any? { |unchecked_class| Test.call(value, IS_AP, Object.const_get(unchecked_class))}
       end
 
       def value(val, type)

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -25,5 +25,15 @@ class SetupHelperTest < Minitest::Test
       get_sample_size(invalid_value)
     end    
   end
+
+  def test_to_double_class
+    assert '::RSpec::Mocks::Double', to_double_class('rspec')
+    assert '::Minitest::Mock', to_double_class('rspec')
+    assert_nil to_double_class('rr')
+    assert_nil to_double_class('foo')
+    assert_nil to_double_class('bar')
+    assert_nil to_double_class('mocha')
+    assert_nil to_double_class(nil)
+  end
 end
 

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -3,6 +3,7 @@ require "rbs/test"
 
 class SetupHelperTest < Minitest::Test
   include RBS::Test::SetupHelper
+  include TestHelper
 
   def test_get_valid_sample_size
     assert_equal 100, get_sample_size("100")
@@ -29,11 +30,14 @@ class SetupHelperTest < Minitest::Test
   def test_to_double_class
     assert '::RSpec::Mocks::Double', to_double_class('rspec')
     assert '::Minitest::Mock', to_double_class('rspec')
-    assert_nil to_double_class('rr')
-    assert_nil to_double_class('foo')
-    assert_nil to_double_class('bar')
-    assert_nil to_double_class('mocha')
-    assert_nil to_double_class(nil)
+
+    silence_warnings do
+      assert_nil to_double_class('rr')
+      assert_nil to_double_class('foo')
+      assert_nil to_double_class('bar')
+      assert_nil to_double_class('mocha')
+      assert_nil to_double_class(nil)
+    end
   end
 end
 

--- a/test/rbs/test/tester_test.rb
+++ b/test/rbs/test/tester_test.rb
@@ -24,7 +24,7 @@ EOF
         builder = RBS::DefinitionBuilder.new(env: env)
         definition = builder.build_instance(type_name("::Hello"))
 
-        checker = RBS::Test::Tester::MethodCallTester.new(Object, builder, definition, kind: :instance, sample_size: 100, double_suite: nil)
+        checker = RBS::Test::Tester::MethodCallTester.new(Object, builder, definition, kind: :instance, sample_size: 100, unchecked_classes: [])
 
         # No type error detected
         checker.call(

--- a/test/rbs/test/tester_test.rb
+++ b/test/rbs/test/tester_test.rb
@@ -24,7 +24,7 @@ EOF
         builder = RBS::DefinitionBuilder.new(env: env)
         definition = builder.build_instance(type_name("::Hello"))
 
-        checker = RBS::Test::Tester::MethodCallTester.new(Object, builder, definition, kind: :instance, sample_size: 100)
+        checker = RBS::Test::Tester::MethodCallTester.new(Object, builder, definition, kind: :instance, sample_size: 100, double_suite: nil)
 
         # No type error detected
         checker.call(

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -34,7 +34,7 @@ EOF
           self_class: Integer,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: nil
+          unchecked_classes: []
         )
 
         assert typecheck.value(3, parse_type("::foo"))
@@ -66,7 +66,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, unchecked_classes: [])
 
         assert typecheck.value([], parse_type("::Array[::Integer]"))
         assert typecheck.value([1], parse_type("::Array[::Integer]"))
@@ -83,7 +83,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, unchecked_classes: [])
 
         assert typecheck.value({}, parse_type("::Hash[::Integer, ::String]"))
         assert typecheck.value(Array.new(100) {|i| [i, i.to_s] }.to_h, parse_type("::Hash[::Integer, ::String]"))
@@ -98,7 +98,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, unchecked_classes: [])
 
         assert typecheck.value([1,2,3].each, parse_type("Enumerator[Integer, Array[Integer]]"))
         assert typecheck.value(Array.new(400, 3).each, parse_type("Enumerator[Integer, Array[Integer]]"))
@@ -136,7 +136,7 @@ EOF
           self_class: Object,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: nil
+          unchecked_classes: []
         )
 
         parse_method_type("(Integer) -> String").tap do |method_type|
@@ -196,7 +196,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, unchecked_classes: [])
 
         assert typecheck.value({foo: 'foo', bar: 0, baz: :baz }, parse_type("{:foo => String, :bar => Integer, :baz => Symbol}"))
         assert typecheck.value({foo: 'foo', bar: 0, baz: :baz }, parse_type("{foo: String, bar: Integer, baz: Symbol}"))
@@ -229,7 +229,7 @@ EOF
           self_class: Object,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: nil
+          unchecked_classes: []
         )
 
         parse_method_type("(Integer) -> String").tap do |method_type|
@@ -370,21 +370,21 @@ EOF
           self_class: Integer,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: 'Minitest::Mock'
+          unchecked_classes: ['Minitest::Mock']
         )
 
         rspec_typecheck = Test::TypeCheck.new(
           self_class: Integer,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: 'RSpec::Mocks::Double'
+          unchecked_classes: ['RSpec::Mocks::Double']
         )
 
         no_mock_typecheck = Test::TypeCheck.new(
           self_class: Integer,
           builder: DefinitionBuilder.new(env: env),
           sample_size: 100,
-          double_suite: nil
+          unchecked_classes: []
         )
 
         minitest_mock = ::Minitest::Mock.new
@@ -424,7 +424,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Object, builder: builder, sample_size: 100, double_suite: nil)
+        typecheck = Test::TypeCheck.new(self_class: Object, builder: builder, sample_size: 100, unchecked_classes: [])
 
         builder.build_instance(type_name("::Foo")).tap do |foo|
           typecheck.overloaded_call(

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -2,8 +2,11 @@ require "test_helper"
 
 require "rbs/test"
 require "logger"
+require "rspec/mocks/standalone"
 
 return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+
+RSPEC_MOCK = double('foo')
 
 class RBS::Test::TypeCheckTest < Minitest::Test
   include TestHelper
@@ -30,7 +33,8 @@ EOF
         typecheck = Test::TypeCheck.new(
           self_class: Integer,
           builder: DefinitionBuilder.new(env: env),
-          sample_size: 100
+          sample_size: 100,
+          double_suite: nil
         )
 
         assert typecheck.value(3, parse_type("::foo"))
@@ -62,7 +66,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
 
         assert typecheck.value([], parse_type("::Array[::Integer]"))
         assert typecheck.value([1], parse_type("::Array[::Integer]"))
@@ -79,7 +83,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
 
         assert typecheck.value({}, parse_type("::Hash[::Integer, ::String]"))
         assert typecheck.value(Array.new(100) {|i| [i, i.to_s] }.to_h, parse_type("::Hash[::Integer, ::String]"))
@@ -94,7 +98,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
 
         assert typecheck.value([1,2,3].each, parse_type("Enumerator[Integer, Array[Integer]]"))
         assert typecheck.value(Array.new(400, 3).each, parse_type("Enumerator[Integer, Array[Integer]]"))
@@ -131,7 +135,8 @@ EOF
         typecheck = Test::TypeCheck.new(
           self_class: Object,
           builder: DefinitionBuilder.new(env: env),
-          sample_size: 100
+          sample_size: 100,
+          double_suite: nil
         )
 
         parse_method_type("(Integer) -> String").tap do |method_type|
@@ -191,7 +196,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100)
+        typecheck = Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: 100, double_suite: nil)
 
         assert typecheck.value({foo: 'foo', bar: 0, baz: :baz }, parse_type("{:foo => String, :bar => Integer, :baz => Symbol}"))
         assert typecheck.value({foo: 'foo', bar: 0, baz: :baz }, parse_type("{foo: String, bar: Integer, baz: Symbol}"))
@@ -223,7 +228,8 @@ EOF
         typecheck = Test::TypeCheck.new(
           self_class: Object,
           builder: DefinitionBuilder.new(env: env),
-          sample_size: 100
+          sample_size: 100,
+          double_suite: nil
         )
 
         parse_method_type("(Integer) -> String").tap do |method_type|
@@ -357,6 +363,54 @@ EOF
     end
   end
 
+  def test_is_double
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        minitest_typecheck = Test::TypeCheck.new(
+          self_class: Integer,
+          builder: DefinitionBuilder.new(env: env),
+          sample_size: 100,
+          double_suite: 'Minitest::Mock'
+        )
+
+        rspec_typecheck = Test::TypeCheck.new(
+          self_class: Integer,
+          builder: DefinitionBuilder.new(env: env),
+          sample_size: 100,
+          double_suite: 'RSpec::Mocks::Double'
+        )
+
+        no_mock_typecheck = Test::TypeCheck.new(
+          self_class: Integer,
+          builder: DefinitionBuilder.new(env: env),
+          sample_size: 100,
+          double_suite: nil
+        )
+
+        minitest_mock = ::Minitest::Mock.new
+        rspec_mock = RSPEC_MOCK
+
+        assert minitest_typecheck.is_double? minitest_mock
+        assert rspec_typecheck.is_double? rspec_mock
+
+        refute minitest_typecheck.is_double? rspec_mock
+        refute rspec_typecheck.is_double? minitest_mock
+
+        refute minitest_typecheck.is_double? 1
+        refute minitest_typecheck.is_double? 'hi'
+        refute minitest_typecheck.is_double? nil
+
+        refute rspec_typecheck.is_double? 1
+        refute rspec_typecheck.is_double? 'hi'
+        refute rspec_typecheck.is_double? nil
+
+        refute no_mock_typecheck.is_double? minitest_mock
+        refute no_mock_typecheck.is_double? minitest_mock
+
+      end
+    end
+  end
+
   def test_type_overload
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
@@ -370,7 +424,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        typecheck = Test::TypeCheck.new(self_class: Object, builder: builder, sample_size: 100)
+        typecheck = Test::TypeCheck.new(self_class: Object, builder: builder, sample_size: 100, double_suite: nil)
 
         builder.build_instance(type_name("::Foo")).tap do |foo|
           typecheck.overloaded_call(

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -234,7 +234,7 @@ module TypeAssertions
            method_type
          end
 
-    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, double_suite: nil)
+    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, unchecked_classes: [])
     errors = typecheck.method_call(method, mt, trace.last, errors: [])
 
     assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.last.inspect}"
@@ -285,7 +285,7 @@ module TypeAssertions
                           end,
                    type: mt.type.with_return_type(RBS::Types::Bases::Any.new(location: nil)))
 
-    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, double_suite: nil)
+    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, unchecked_classes: [])
     errors = typecheck.method_call(method, mt, trace.last, errors: [])
 
     assert_operator exception, :is_a?, ::Exception

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -234,7 +234,7 @@ module TypeAssertions
            method_type
          end
 
-    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100)
+    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, double_suite: nil)
     errors = typecheck.method_call(method, mt, trace.last, errors: [])
 
     assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.last.inspect}"
@@ -285,7 +285,7 @@ module TypeAssertions
                           end,
                    type: mt.type.with_return_type(RBS::Types::Bases::Any.new(location: nil)))
 
-    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100)
+    typecheck = RBS::Test::TypeCheck.new(self_class: receiver.class, builder: builder, sample_size: 100, double_suite: nil)
     errors = typecheck.method_call(method, mt, trace.last, errors: [])
 
     assert_operator exception, :is_a?, ::Exception

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -158,7 +158,7 @@ SIG
   end
 
   def assert_sampling_check(builder, sample_size, array)
-    checker = RBS::Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: sample_size)
+    checker = RBS::Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: sample_size, double_suite: nil)
     
     sample = checker.each_sample(array).to_a
     

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -158,7 +158,7 @@ SIG
   end
 
   def assert_sampling_check(builder, sample_size, array)
-    checker = RBS::Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: sample_size, double_suite: nil)
+    checker = RBS::Test::TypeCheck.new(self_class: Integer, builder: builder, sample_size: sample_size, unchecked_classes: [])
     
     sample = checker.each_sample(array).to_a
     


### PR DESCRIPTION
As of now, there are some issues with doubles for RBS. In order to mitigate those issues, the Double API was made so that users can declare the double suite they are using and ignore unwanted classes. 