### PR TITLE
Add incompatible doc

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -316,6 +316,7 @@ You can write `self.` or `self?.` before the name of the method to specify the k
 def to_s: () -> String                        # Defines a instance method
 def self.new: () -> AnObject                  # Defines singleton method
 def self?.sqrt: (Numeric) -> Numeric          # self? is for `module_function`s
+incompatible def to_s: () -> String           # Defines a method incompatbile with super. More here https://github.com/ruby/rbs/pull/10
 ```
 
 The method type can be connected with `|`s to define an overloaded method.


### PR DESCRIPTION
Dearest Reviewer,

I was reading over the hash.rbs file and found incompatible. I found the pull request that adds it. I think I understand its use case. If there 
is a better example or more detail to add here please let me know.

I would like to update the ebnf format but I am unsure what an optional string syntax would be.
```
_method-member_ ::= [`incompatible`] `def` _method-name_ `:` _method-types_            # Instance method
                  | [`incompatible`] `def self.` _method-name_ `:` _method-types_      # Singleton method
                  | [`incompatible`] `def self?.` _method-name_ `:` _method-types_     # Singleton and instance method
```
If this is the correct format I can add it in as well.

Thank you for your time and work on this project.
Dictated but not reviewed.
Becker