### PR TITLE
Delete incompatible method attribute

### DIFF
--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -11,17 +11,15 @@ module RBS
         attr_reader :annotations
         attr_reader :location
         attr_reader :comment
-        attr_reader :attributes
         attr_reader :overload
 
-        def initialize(name:, kind:, types:, annotations:, location:, comment:, attributes:, overload:)
+        def initialize(name:, kind:, types:, annotations:, location:, comment:, overload:)
           @name = name
           @kind = kind
           @types = types
           @annotations = annotations
           @location = location
           @comment = comment
-          @attributes = attributes
           @overload = overload
         end
 
@@ -30,14 +28,13 @@ module RBS
             other.name == name &&
             other.kind == kind &&
             other.types == types &&
-            other.attributes == attributes &&
             other.overload == overload
         end
 
         alias eql? ==
 
         def hash
-          self.class.hash ^ name.hash ^ kind.hash ^ types.hash ^ attributes.hash ^ overload.hash
+          self.class.hash ^ name.hash ^ kind.hash ^ types.hash ^ overload.hash
         end
 
         def instance?
@@ -52,7 +49,7 @@ module RBS
           overload
         end
 
-        def update(name: self.name, kind: self.kind, types: self.types, annotations: self.annotations, location: self.location, comment: self.comment, attributes: self.attributes, overload: self.overload)
+        def update(name: self.name, kind: self.kind, types: self.types, annotations: self.annotations, location: self.location, comment: self.comment, overload: self.overload)
           self.class.new(
             name: name,
             kind: kind,
@@ -60,7 +57,6 @@ module RBS
             annotations: annotations,
             location: location,
             comment: comment,
-            attributes: attributes,
             overload: overload
           )
         end
@@ -73,7 +69,6 @@ module RBS
             annotations: annotations,
             location: location,
             comment: comment,
-            attributes: attributes,
             overload: overload
           }.to_json(*a)
         end

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -92,11 +92,6 @@ module RBS
         @members ||= defs.map(&:member).uniq
       end
 
-      # @deprecated
-      def attributes
-        []
-      end
-
       def public?
         @accessibility == :public
       end

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -325,7 +325,6 @@ module RBS
           comment: member.comment,
           overload: member.overload?,
           annotations: member.annotations,
-          attributes: member.attributes,
           location: member.location
         )
       when AST::Members::AttrAccessor

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -458,16 +458,14 @@ rule
           types: val[6],
           annotations: val[0],
           location: location,
-          comment: leading_comment(val[0].first&.location || val[1].first&.location || val[2]&.location || val[3].location),
-          attributes: val[1].map(&:value),
+          comment: leading_comment(val[0].first&.location || val[2]&.location || val[3].location),
           overload: overload || !!val[2]
         )
       }
 
   attributes:
-      { result = [] }
     | attributes kINCOMPATIBLE {
-        result = val[0].push(val[1])
+        RBS.logger.warn "`incompatible` method attribute is deprecated and ignored."
       }
 
   method_kind:

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -130,7 +130,6 @@ module RBS
               types: types,
               kind: kind,
               comment: comments[node.first_lineno - 1],
-              attributes: [],
               overload: false
             )
 

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -173,7 +173,6 @@ module RBS
               types: types,
               kind: :singleton,
               comment: comment,
-              attributes: [],
               overload: false
             )
           end
@@ -194,7 +193,6 @@ module RBS
               types: types,
               kind: :instance,
               comment: comment,
-              attributes: [],
               overload: false
             )
           end

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -154,7 +154,6 @@ module RBS
                 location: nil,
                 comment: method.comments[0],
                 annotations: method.annotations,
-                attributes: method.attributes,
                 overload: false
               )
               return
@@ -193,7 +192,6 @@ module RBS
                 location: nil,
                 comment: nil,
                 annotations: [],
-                attributes: [],
                 overload: false
               )
             end
@@ -227,7 +225,6 @@ module RBS
                   location: nil,
                   comment: nil,
                   annotations: [],
-                  attributes: [],
                   overload: false
                 )
               end
@@ -262,7 +259,6 @@ module RBS
                   location: nil,
                   comment: nil,
                   annotations: [],
-                  attributes: [],
                   overload: false
                 )
               end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -250,8 +250,7 @@ module RBS
 
       string = ""
 
-      attrs = member.attributes.empty? ? "" : member.attributes.join(" ") + " "
-      prefix = "#{attrs}def #{name}:"
+      prefix = "def #{name}:"
       padding = " " * (prefix.size-1)
 
       string << prefix

--- a/stdlib/builtin/hash.rbs
+++ b/stdlib/builtin/hash.rbs
@@ -1016,7 +1016,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h["d"]           #=> "Go Fish: d"
   #     h.keys           #=> ["c", "d"]
   #
-  incompatible def initialize: () -> void
+  def initialize: () -> void
                              | (untyped default) -> void
                              | [A, B] () { (Hash[A, B] hash, A key) -> B } -> void
 

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -446,6 +446,7 @@ end
   end
 
   def test_incompatible_method_definition
+    # `incompatible` is ignored with warning message.
     Parser.parse_signature(<<~SIG).yield_self do |decls|
       class Foo
         incompatible def foo: () -> Integer
@@ -457,9 +458,6 @@ end
         assert_instance_of Declarations::Class, decl
 
         assert_instance_of Members::MethodDefinition, decl.members[0]
-        decl.members[0].yield_self do |m|
-          assert_equal [:incompatible], m.attributes
-        end
       end
     end
   end

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -114,21 +114,6 @@ end
     SIG
   end
 
-  def test_attributes
-    assert_writer <<-SIG
-class Foo
-  def initialize: () -> void
-
-  incompatible def foo: () -> String
-                      | () -> nil
-end
-
-class Bar
-  def self.new: (String) -> Bar
-end
-    SIG
-  end
-
   def test_variance
     assert_writer <<-SIG
 class Foo[out A, unchecked B, in C] < Bar[A, C, B]


### PR DESCRIPTION
RBS does not check any compatibility of a method between the child class and parent class.

* Related to https://github.com/ruby/rbs/pull/382