### PR TITLE
Define .new method using #initialize from modules

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -882,7 +882,7 @@ module RBS
           end
 
           unless definition.methods.key?(:new)
-            instance = build_one_instance(type_name)
+            instance = build_instance(type_name)
             initialize = instance.methods[:initialize]
 
             if initialize


### PR DESCRIPTION
This is to allow defining `#initialize` in included modules.