### PR TITLE
Remove unused code

### DIFF
--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -435,14 +435,6 @@ rule
   method_member:
       annotations attributes overload kDEF method_kind def_name method_types {
         location = val[3].location + val[6].last.location
-        types = val[6].map do |type|
-          case type
-          when LocatedValue
-            type.value
-          else
-            type
-          end
-        end
 
         last_type = val[6].last
         if last_type.is_a?(LocatedValue) && last_type.value == :dot3


### PR DESCRIPTION
It emits a warning with `$VERBOSE = true`:

```
parser.y:438: warning: assigned but unused variable - types
```