### PR TITLE
Remove needless output while `rake test`

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1,3 +1,4 @@
+require "open3"
 require "optparse"
 require "shellwords"
 
@@ -808,8 +809,10 @@ EOB
         'RBS_TEST_TARGET' => (targets.join(',') unless targets.empty?)
       }
 
-      system(env_hash, *args)
-      $?
+      out, err, status = Open3.capture3(env_hash, *args)
+      stdout.print(out)
+      stderr.print(err)
+      status
     end
   end
 end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -447,17 +447,19 @@ end
 
   def test_incompatible_method_definition
     # `incompatible` is ignored with warning message.
-    Parser.parse_signature(<<~SIG).yield_self do |decls|
+    silence_warnings do
+      Parser.parse_signature(<<~SIG).yield_self do |decls|
       class Foo
         incompatible def foo: () -> Integer
       end
      SIG
-      assert_equal 1, decls.size
+        assert_equal 1, decls.size
 
-      decls[0].yield_self do |decl|
-        assert_instance_of Declarations::Class, decl
+        decls[0].yield_self do |decl|
+          assert_instance_of Declarations::Class, decl
 
-        assert_instance_of Members::MethodDefinition, decl.members[0]
+          assert_instance_of Members::MethodDefinition, decl.members[0]
+        end
       end
     end
   end
@@ -1041,14 +1043,16 @@ EOF
   end
 
   def test_overload_def_deprecated
-    Parser.parse_signature(<<EOF).yield_self do |decls|
+    silence_warnings do
+      Parser.parse_signature(<<EOF).yield_self do |decls|
 module Steep
   overload def to_s: (Integer) -> String
 end
 EOF
-      decls[0].members[0].tap do |member|
-        assert_instance_of Members::MethodDefinition, member
-        assert_operator member, :overload?
+        decls[0].members[0].tap do |member|
+          assert_instance_of Members::MethodDefinition, member
+          assert_operator member, :overload?
+        end
       end
     end
   end

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -112,6 +112,7 @@ class TestClass
   end
 end
 RUBY
+    assert_match "No type checker was installed!", output
   end
 
   def test_open_decls

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -132,7 +132,7 @@ class Hello
 end
 RBS
 
-    assert_match /TypeError: \[Hello#world\]/, output
+    assert_match(/TypeError: \[Hello#world\]/, output)
   end
 
   def test_minitest


### PR DESCRIPTION
`rake test` prints needless and redundant strings currently. This PR tries to remove all of them.

Before:

```
$ bundle exec rake test 
/home/tadashi/git/rbs/test/rbs/test/runtime_test_test.rb:108: warning: assigned but unused variable - output
/home/tadashi/git/rbs/test/rbs/test/runtime_test_test.rb:134: warning: ambiguous first argument; put parentheses or a space even after `/' operator

# Running tests with run options --seed 1919:

.......................W, [2020-09-16T11:20:23.082667 #513922]  WARN -- rbs: `incompatible` method attribute is deprecated and ignored.
......W, [2020-09-16T11:20:23.084430 #513922]  WARN -- rbs: `overload def` syntax is deprecated. Use `...` syntax instead.
......................................................................................BSDL	      COPYING  Gemfile.lock  Rakefile	bin   exe	     lib	  schema  stdlib  test
CHANGELOG.md  Gemfile  README.md     Steepfile	docs  goodcheck.yml  rbs.gemspec  sig	  steep   vendor
ruby 2.7.1p118 (2020-08-07 revision e9e4f8430a) [x86_64-linux]
rbs 0.12.1
D, [2020-09-16T11:20:37.225065 #513984] DEBUG -- : No type checker was installed!
rake build            # Build rbs-0.12.1.gem into the pkg directory
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake install          # Build and install rbs-0.12.1.gem into system gems
rake install:local    # Build and install rbs-0.12.1.gem into system gems without network access
rake release[remote]  # Create tag v0.12.1 and build and push rbs-0.12.1.gem to rubygems.org
rake test             # Run tests
D, [2020-09-16T11:20:37.819015 #513986] DEBUG -- : No type checker was installed!
Traceback (most recent call last):
	12: from /home/tadashi/git/rbs/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `<main>'
	11: from /home/tadashi/git/rbs/vendor/bundle/ruby/2.7.0/bin/rbs:23:in `load'
	10: from /home/tadashi/git/rbs/exe/rbs:5:in `<top (required)>'
	 9: from /home/tadashi/git/rbs/exe/rbs:5:in `require'
	 8: from /home/tadashi/git/rbs/lib/rbs/cli.rb:4:in `<top (required)>'
	 7: from /home/tadashi/git/rbs/lib/rbs/cli.rb:5:in `<module:RBS>'
	 6: from /home/tadashi/git/rbs/lib/rbs/test/setup.rb:64:in `block in <top (required)>'
	 5: from /home/tadashi/git/rbs/lib/rbs/test/setup.rb:64:in `any?'
	 4: from /home/tadashi/git/rbs/lib/rbs/test/setup.rb:64:in `block (2 levels) in <top (required)>'
	 3: from /home/tadashi/git/rbs/lib/rbs/test/setup.rb:53:in `to_absolute_typename'
	 2: from /home/tadashi/git/rbs/lib/rbs/factory.rb:8:in `type_name'
	 1: from /home/tadashi/git/rbs/lib/rbs/factory.rb:8:in `new'
/home/tadashi/git/rbs/lib/rbs/type_name.rb:19:in `initialize': unhandled exception
..........................................................................................................................

Finished tests in 25.143859s, 9.4258 tests/s, 196.9069 assertions/s.


237 tests, 4951 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
$ bundle exec rake test 

# Running tests with run options --seed 27346:

.............................................................................................................................................................................................................................................

Finished tests in 25.253236s, 9.3849 tests/s, 196.1333 assertions/s.


237 tests, 4953 assertions, 0 failures, 0 errors, 0 skips
```

Because these are almost cosmetic changes for developers of RBS itself, there is no hurry to merge of course.