### PR TITLE
Fix VarianceCalculator exception when passing too many type arguments

### DIFF
--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -120,7 +120,7 @@ module RBS
 
         type.args.each.with_index do |ty, i|
           var = type_params.params[i]
-          case var.variance
+          case var&.variance
           when :invariant
             type(ty, result: result, context: :invariant)
           when :covariant

--- a/test/rbs/variance_calculator_test.rb
+++ b/test/rbs/variance_calculator_test.rb
@@ -46,6 +46,10 @@ EOF
         calculator.in_method_type(method_type: parse_method_type("(A&B) -> void", variables: Set[:A, :B]), variables: [:A, :B]).tap do |result|
           assert_equal({ A: :contravariant, B: :contravariant }, result.result)
         end
+
+        calculator.in_method_type(method_type: parse_method_type("() -> ::Foo[A, B, C, D]", variables: Set[:A, :B, :C, :D]), variables: [:A, :B, :C, :D]).tap do |result|
+          assert_equal({ A: :covariant, B: :contravariant, C: :invariant, D: :unused }, result.result)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #401.

This uses safe traversal so that running the variance calculator when too many type arguments are passed doesn't throw an exception. The variance of that type parameter instead gets left as `:unused`.

Please let me know if there's anything else I need to add to this PR! Thanks for all your work on RBS, I'm really enjoying getting familiar with it :)