### PR TITLE
fix: typo in the paths inline documentation

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -488,7 +488,7 @@ Show paths to directories where the RBS files are loaded from.
 Examples:
 
   $ rbs paths
-  $ tbs -r set paths
+  $ rbs -r set paths
 EOU
       end.parse!(args)
 


### PR DESCRIPTION
Corrects what appears to be a typo in the `rbs paths` inline documentation.