### PR TITLE
`Fiber.yield` is not allowed on transferred fiber

### DIFF
--- a/test/stdlib/Fiber_test.rb
+++ b/test/stdlib/Fiber_test.rb
@@ -101,14 +101,13 @@ class FiberExtTest < Minitest::Test
   end
 
   def test_transfer
-    f = Fiber.new do
-      loop { Fiber.yield }
-    end
-
+    f = Fiber.new{}
     assert_send_type '() -> untyped',
                      f, :transfer
+    f = Fiber.new{}
     assert_send_type '(untyped) -> untyped',
                      f, :transfer, 1
+    f = Fiber.new{}
     assert_send_type '(untyped, untyped) -> untyped',
                      f, :transfer, 1, 'foo'
   end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/17221 will change the behavior of Fiber#transfer,
so that `Fiber#transfer`'s usage should be changed.

(1) Transferred fiber can not `Fiber.yield` 
(2) `Fiber.yield` should be used with `Fiber#resume`