### PR TITLE
Run validation silently

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,11 +25,11 @@ task :test_doc => :parser do
 end
 
 task :validate => :parser do
-  sh "#{ruby} #{rbs} validate"
+  sh "#{ruby} #{rbs} validate --silent"
 
   FileList["stdlib/*"].each do |path|
     next if path =~ %r{stdlib/builtin}
-    sh "#{ruby} #{rbs} -r#{File.basename(path)} validate"
+    sh "#{ruby} #{rbs} -r#{File.basename(path)} validate --silent"
   end
 end
 

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -384,6 +384,11 @@ Examples:
 
   $ rbs validate
 EOU
+
+        opts.on("--silent") do
+          require "stringio"
+          @stdout = StringIO.new
+        end
       end.parse!(args)
 
       loader = EnvironmentLoader.new()
@@ -544,7 +549,7 @@ EOU
 Usage: rbs prototype runtime [options...] [pattern...]
 
 Generate RBS prototype based on runtime introspection.
-It loads Ruby code specified in [options] and generates RBS prototypes for classes matches to [pattern]. 
+It loads Ruby code specified in [options] and generates RBS prototypes for classes matches to [pattern].
 
 Examples:
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -133,6 +133,12 @@ singleton(::BasicObject)
   def test_validate
     with_cli do |cli|
       cli.run(%w(-r set validate))
+      assert_match /Validating/, stdout.string
+    end
+
+    with_cli do |cli|
+      cli.run(%w(validate --silent))
+      assert_equal "", stdout.string
     end
 
     with_cli do |cli|


### PR DESCRIPTION
Validation with `--silent` skips printing all messages.