### PR TITLE
Fix variance validation

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -814,8 +814,7 @@ module RBS
 
       methods.each do |name, method|
         method.method_types.each do |method_type|
-          case method_type
-          when MethodType
+          unless name == :initialize
             result = calculator.in_method_type(method_type: method_type, variables: param_names)
 
             validate_params_with type_params, result: result do |param|

--- a/stdlib/builtin/range.rbs
+++ b/stdlib/builtin/range.rbs
@@ -87,10 +87,8 @@
 # r.to_a                     #=> [xxx, xxxx, xxxxx, xxxxxx]
 # r.member?(Xs.new(5))       #=> true
 # ```
-class Range[Elem] < Object
+class Range[out Elem] < Object
   include Enumerable[Elem, Range[Elem]]
-
-  def self.new: [U] (U from, U to, ?bool exclude_end) -> ::Range[U]
 
   def ==: (untyped obj) -> bool
 
@@ -146,7 +144,7 @@ class Range[Elem] < Object
 
   def `include?`: (untyped obj) -> bool
 
-  def initialize: (Elem _begin, Elem _end, ?bool exclude_end) -> void
+  def initialize: (Elem from, Elem to, ?bool exclude_end) -> void
 
   # Convert this range object to a printable form (using `inspect` to
   # convert the begin and end objects).

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1594,4 +1594,20 @@ end
       end
     end
   end
+
+  def test_definition_variance_initialize
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class Hello[out T]
+  def get: () -> T
+
+  def initialize: (T value) -> void
+end
+      EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+        builder.build_instance(type_name("::Hello"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR is to make `Range[T]` covariant.

Adding `out` annotation to `Range` class definition didn't work because `#initialize` contains the parameter in _in_ (_contravariant_) position. However, `#initialize` is a constructor, and checking the variance for the method doesn't make sense.

So, skipping `#initialize` during variance validation would be a good option. 🎉 
