### PR TITLE
Fix trailing whitespace

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         container_tag:
-        - master-nightly-bionic 
+        - master-nightly-bionic
         - 2.6.5-bionic
         - 2.7.0-bionic
         job:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ rbs method Object then
 
 ## Library
 
-There are two important concepts, _environment_ and _definition_. 
+There are two important concepts, _environment_ and _definition_.
 
 An _environment_ is a dictionary that keeps track of all declarations. What is the declaration associated with `String` class? An _environment_ will give you the answer.
 
@@ -107,7 +107,7 @@ instance = builder.build_instance(string)
 
 # Print the types of `gsub` method:
 puts instance.methods[:gsub].method_types.join("\n")
-# Ouputs => 
+# Ouputs =>
 #  (::Regexp | ::string pattern, ::string replacement) -> ::String
 #  (::Regexp | ::string pattern, ::Hash[::String, ::String] hash) -> ::String
 #  (::Regexp | ::string pattern) { (::String match) -> ::_ToS } -> ::String

--- a/bin/annotate-with-rdoc
+++ b/bin/annotate-with-rdoc
@@ -14,7 +14,7 @@ def format_comment(comment)
   out = RDoc::Markup::Document.new
   out << comment
   formatter = RDoc::Markup::ToMarkdown.new
-  out.accept(formatter)
+  out.accept(formatter).lines.map(&:rstrip).join("\n")
 end
 
 def comment_for_constant(decl, stores:)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,6 +17,7 @@
     - Use `rbs prototype runtime --merge CLASS_NAME` command to generate the missing method definitions.
     - Committing the auto generated signatures is recommended.
 5. Annotate with RDoc.
+    - You'll need RDoc installed. Rvm users should use `rvm docs generate` first.
     - Use `bin/annotate-with-rdoc stdlib/path/to/signature.rbs` to annotate the RBS files.
     - Committing the generated annotations is recommended.
 6. Fix method types and comments.

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -6,12 +6,12 @@ rules:
       - "stdlib/**/*.rbs"
     fail:
       - |
-        # arglists 💪👽🚨 << Delete this section   
-        #    File.absolute_path?(file_name)  ->  true or false    
+        # arglists 💪👽🚨 << Delete this section
+        #    File.absolute_path?(file_name)  ->  true or false
         #
 
   - id: rbs.no_arg
-    pattern: 
+    pattern:
       regexp: arg\d+
     message: |
       Stop using parameter names like `arg0` or `arg1`
@@ -23,7 +23,7 @@ rules:
       - Documents (comments) may contain that pattern.
     glob:
       - "stdlib/**/*.rbs"
-    fail: 
+    fail:
       - "def `send`: (String | Symbol arg0, *untyped arg1) -> untyped"
     pass:
       - "def `send`: (String | Symbol, *untyped) -> untyped"

--- a/lib/rbs/ast/comment.rb
+++ b/lib/rbs/ast/comment.rb
@@ -23,7 +23,7 @@ module RBS
         { string: string, location: location }.to_json(*a)
       end
 
-      def concat(string:, location:)  
+      def concat(string:, location:)
         @string.concat string
 
         if loc = @location

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -40,7 +40,7 @@ module RBS
           if s = super_class
             yield s
           end
-          
+
           self_types&.each(&block)
           included_modules&.each(&block)
           prepended_modules&.each(&block)
@@ -303,7 +303,7 @@ module RBS
             mod_ancestors = instance_ancestors(name, building_ancestors: building_ancestors)
             ancestors.unshift(*mod_ancestors.apply(arg_types, location: entry.primary.decl.location))
           end
-        end  
+        end
       end
 
       ancestors.unshift(self_ancestor)
@@ -316,7 +316,7 @@ module RBS
             mod_ancestors = instance_ancestors(name, building_ancestors: building_ancestors)
             ancestors.unshift(*mod_ancestors.apply(arg_types, location: entry.primary.decl.location))
           end
-        end  
+        end
       end
 
       building_ancestors.pop

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -13,7 +13,7 @@ module RBS
       def context
         @context ||= begin
                        (outer + [decl]).each.with_object([Namespace.root]) do |decl, array|
-                         first = array.first or raise 
+                         first = array.first or raise
                          array.unshift(first + decl.name.to_namespace)
                        end
                      end

--- a/lib/rbs/namespace.rb
+++ b/lib/rbs/namespace.rb
@@ -100,7 +100,7 @@ module RBS
 
         until current.empty?
           yield current
-          current = _ = current.parent 
+          current = _ = current.parent
         end
 
         yield current

--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -3,15 +3,15 @@ module RBS
     module SetupHelper
       class InvalidSampleSizeError < StandardError
         attr_reader :string
-        
+
         def initialize(string)
           @string = string
           super("Sample size should be a positive integer: `#{string}`")
         end
       end
-      
+
       DEFAULT_SAMPLE_SIZE = 100
-      
+
       def get_sample_size(string)
         case string
         when ""
@@ -32,7 +32,7 @@ module RBS
         when 'rspec'
           ['::RSpec::Mocks::Double']
         when 'minitest'
-          ['::Minitest::Mock'] 
+          ['::Minitest::Mock']
         else
           RBS.logger.warn "Unknown test suite - defaults to nil"
           nil

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -212,7 +212,7 @@ module RBS
       def value(val, type)
         if is_double?(val)
           RBS.logger.info("A double (#{val.inspect}) is detected!")
-          return true 
+          return true
         end
 
         case type
@@ -306,7 +306,7 @@ module RBS
           Test.call(val, IS_AP, ::Array) &&
             type.types.map.with_index {|ty, index| value(val[index], ty) }.all?
         when Types::Record
-          Test::call(val, IS_AP, ::Hash) && 
+          Test::call(val, IS_AP, ::Hash) &&
             type.fields.map {|key, type| value(val[key], type) }.all?
         when Types::Proc
           Test::call(val, IS_AP, ::Proc)

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -23,7 +23,7 @@ module RBS
     def ==(other)
       other.is_a?(self.class) && other.namespace == namespace && other.name == name
     end
-    
+
     alias eql? ==
 
     def hash

--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -135,7 +135,7 @@ module RBS
                   when :contravariant
                     :covariant
                   else
-                    raise                    
+                    raise
                   end
             type(ty, result: result, context: con)
           end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -305,7 +305,7 @@ module RBS
       if prev_loc && decl_loc
         prev_end_line = prev_loc.end_line
         start_line = decl_loc.start_line
-  
+
         if start_line - prev_end_line > 1
           puts
         end

--- a/sig/constant.rbs
+++ b/sig/constant.rbs
@@ -11,9 +11,9 @@ module RBS
     attr_reader entry: constant_entry
 
     def initialize: (name: TypeName, type: Types::t, entry: constant_entry) -> void
-                  
+
     def ==: (untyped other) -> bool
-          
+
     alias eql? ==
 
     def hash: () -> Integer

--- a/sig/constant_table.rbs
+++ b/sig/constant_table.rbs
@@ -6,25 +6,25 @@ module RBS
     attr_reader env(): Environment
 
     def initialize: (builder: DefinitionBuilder) -> void
-                  
+
     def absolute_type: (Types::t, context: Array[Namespace]) -> Types::t
-                     
+
     def absolute_type_name: (TypeName, context: Array[Namespace], location: Location?) -> TypeName
-                          
+
     def name_to_constant: (TypeName) -> Constant?
-                        
+
     def split_name: (TypeName) -> Array[Symbol]
-                  
+
     def resolve_constant_reference: (TypeName name, context: Array[Namespace]) -> Constant?
-                                  
+
     def resolve_constant_reference_context: (Symbol, context: Array[Namespace]) -> Constant?
-                                          
+
     def resolve_constant_reference_inherit: (Symbol, scopes: Array[Namespace], ?no_object: bool) -> Constant?
-                                          
+
     def constant_scopes: (TypeName) -> Array[Namespace]
-                       
+
     def constant_scopes_module: (TypeName, scopes: Array[Namespace]) -> Array[Namespace]
-                       
+
     def constant_scopes0: (TypeName, ?scopes: Array[Namespace]) -> Array[Namespace]
   end
 end

--- a/sig/declarations.rbs
+++ b/sig/declarations.rbs
@@ -2,7 +2,7 @@ module RBS
   module AST
     module Declarations
       type t = Class | Module | Interface | Constant | Global | Alias
-      
+
       class Base
       end
 

--- a/sig/definition.rbs
+++ b/sig/definition.rbs
@@ -28,7 +28,7 @@ module RBS
         def annotations: () -> Array[AST::Annotation]
 
         def update: (?type: MethodType, ?member: method_member, ?defined_in: TypeName?, ?implemented_in: TypeName?) -> TypeDef
-        
+
         def overload?: () -> bool
       end
 

--- a/sig/namespace.rbs
+++ b/sig/namespace.rbs
@@ -1,6 +1,6 @@
 module RBS
   # Namespace instance represents a _prefix of module names_.
-  # 
+  #
   #    vvvvvvvvvvvvvv  TypeName
   #    RBS::Namespace
   #    ^^^^^           Namespace
@@ -44,7 +44,7 @@ module RBS
     # If `other` is an absolute namespace, it returns `other`.
     #
     #   Namespace("Foo::") + Namespace("::Bar::")  # =>  ::Bar::
-    # 
+    #
     def +: (Namespace other) -> Namespace
 
     # Add one path component to self.
@@ -62,7 +62,7 @@ module RBS
 
     # Returns true if self is absolute namespace.
     def absolute?: () -> bool
-    
+
     # Returns true if self is relative namespace.
     def relative?: () -> bool
 

--- a/sig/substitution.rbs
+++ b/sig/substitution.rbs
@@ -1,6 +1,6 @@
 module RBS
   # Substitution from type variables to types.
-  # 
+  #
   # The substitution construction is in _destructive_ manner.
   #
   #    sub = Substitution.new
@@ -25,7 +25,7 @@ module RBS
     # Utility method to construct a substitution.
     # Raises an error when `variables.size != types.size`.
     # `instance_type` defaults to `nil`.
-    # 
+    #
     # Yields types in `types` and the block value is used if block is given.
     #
     def self.build: (Array[Symbol] variables, Array[Types::t] types, ?instance_type: Types::t?) ?{ (Types::t) -> Types::t } -> instance

--- a/sig/typename.rbs
+++ b/sig/typename.rbs
@@ -1,6 +1,6 @@
 module RBS
   # TypeName represents name of types in RBS.
-  # 
+  #
   # TypeNames are one of the three kind, class, alias, and interface.
   # *class* type names corresponds to Ruby classes and modules.
   # There are no corresponding Ruby value to *alias* and *interface* type names.

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -154,7 +154,7 @@ module RBS
 
       include NoFreeVariables
       include NoSubst
-      include EmptyEachType      
+      include EmptyEachType
     end
 
     module Application

--- a/sig/writer.rbs
+++ b/sig/writer.rbs
@@ -4,37 +4,37 @@ module RBS
     attr_reader indentation: Array[String]
 
     def initialize: (out: IO) -> void
-                  
+
     def indent: (?Integer size) { () -> void } -> void
-              
+
     def prefix: () -> String
-              
+
     def puts: (?String) -> void
-            
+
     def write_annotation: (Array[AST::Annotation]) -> void
-                        
+
     def write_comment: (AST::Comment?) -> void
-                     
+
     def write: (Array[AST::Declarations::t]) -> void
-             
+
     def write_decl: (AST::Declarations::t) -> void
-                  
+
     def write_member: (AST::Declarations::Module::member) -> void
-                  
+
     def name_and_params: (TypeName, AST::Declarations::ModuleTypeParams) -> String?
-                       
+
     def name_and_args: (TypeName, Array[Types::t]) -> String?
-                     
+
     def method_name: (Symbol) -> String
-                   
+
     def write_def: (AST::Members::MethodDefinition) -> void
-                 
+
     def attribute: (:reader | :writer | :accessor, AST::Members::Attribute) -> void
-                 
+
     interface _Located
       def location: () -> Location?
     end
-                 
+
     def preserve_empty_line: (_Located?, _Located) -> void
   end
 end

--- a/stdlib/benchmark/benchmark.rbs
+++ b/stdlib/benchmark/benchmark.rbs
@@ -53,9 +53,9 @@
 #     times:    1.000000   0.000000   1.000000 (  1.003611)
 #     upto:     1.030000   0.000000   1.030000 (  1.028098)
 #
-# *   The times for some benchmarks depend on the order in which items are run. 
+# *   The times for some benchmarks depend on the order in which items are run.
 #     These differences are due to the cost of memory allocation and garbage
-#     collection. To avoid these discrepancies, the #bmbm method is provided. 
+#     collection. To avoid these discrepancies, the #bmbm method is provided.
 #     For example, to compare ways to sort an array of floats:
 #
 #         require 'benchmark'

--- a/stdlib/builtin/basic_object.rbs
+++ b/stdlib/builtin/basic_object.rbs
@@ -1,108 +1,108 @@
 # BasicObject is the parent class of all classes in Ruby.  It's an explicit
 # blank class.
-# 
+#
 # BasicObject can be used for creating object hierarchies independent of Ruby's
 # object hierarchy, proxy objects like the Delegator class, or other uses where
 # namespace pollution from Ruby's methods and classes must be avoided.
-# 
+#
 # To avoid polluting BasicObject for other users an appropriately named subclass
 # of BasicObject should be created instead of directly modifying BasicObject:
-# 
+#
 #     class MyObjectSystem < BasicObject
 #     end
-# 
+#
 # BasicObject does not include Kernel (for methods like `puts`) and BasicObject
 # is outside of the namespace of the standard library so common classes will not
 # be found without using a full class path.
-# 
+#
 # A variety of strategies can be used to provide useful portions of the standard
 # library to subclasses of BasicObject.  A subclass could `include Kernel` to
 # obtain `puts`, `exit`, etc.  A custom Kernel-like module could be created and
 # included or delegation can be used via #method_missing:
-# 
+#
 #     class MyObjectSystem < BasicObject
 #       DELEGATE = [:puts, :p]
-# 
+#
 #       def method_missing(name, *args, &block)
 #         super unless DELEGATE.include? name
 #         ::Kernel.send(name, *args, &block)
 #       end
-# 
+#
 #       def respond_to_missing?(name, include_private = false)
 #         DELEGATE.include?(name) or super
 #       end
 #     end
-# 
+#
 # Access to classes and modules from the Ruby standard library can be obtained
 # in a BasicObject subclass by referencing the desired constant from the root
 # like `::File` or `::Enumerator`. Like #method_missing, #const_missing can be
 # used to delegate constant lookup to `Object`:
-# 
+#
 #     class MyObjectSystem < BasicObject
 #       def self.const_missing(name)
 #         ::Object.const_get(name)
 #       end
 #     end
-# 
+#
 class BasicObject
   # Boolean negate.
-  # 
+  #
   def !: () -> bool
 
   # Returns true if two objects are not-equal, otherwise false.
-  # 
+  #
   def !=: (untyped other) -> bool
 
   # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
   # `other` are the same object. Typically, this method is overridden in
   # descendant classes to provide class-specific meaning.
-  # 
+  #
   # Unlike `==`, the `equal?` method should never be overridden by subclasses as
   # it is used to determine object identity (that is, `a.equal?(b)` if and only if
   # `a` is the same object as `b`):
-  # 
+  #
   #     obj = "a"
   #     other = obj.dup
-  # 
+  #
   #     obj == other      #=> true
   #     obj.equal? other  #=> false
   #     obj.equal? obj    #=> true
-  # 
+  #
   # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
   # key.  This is used by Hash to test members for equality.  For objects of class
   # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
   # tradition by aliasing `eql?` to their overridden `==` method, but there are
   # exceptions.  `Numeric` types, for example, perform type conversion across
   # `==`, but not across `eql?`, so:
-  # 
+  #
   #     1 == 1.0     #=> true
   #     1.eql? 1.0   #=> false
-  # 
+  #
   def ==: (untyped other) -> bool
 
   # Returns an integer identifier for `obj`.
-  # 
+  #
   # The same number will be returned on all calls to `object_id` for a given
   # object, and no two active objects will share an id.
-  # 
+  #
   # Note: that some objects of builtin classes are reused for optimization. This
   # is the case for immediate values and frozen string literals.
-  # 
+  #
   # Immediate values are not passed by reference but are passed by value: `nil`,
   # `true`, `false`, Fixnums, Symbols, and some Floats.
-  # 
+  #
   #     Object.new.object_id  == Object.new.object_id  # => false
   #     (21 * 2).object_id    == (21 * 2).object_id    # => true
   #     "hello".object_id     == "hello".object_id     # => false
   #     "hi".freeze.object_id == "hi".freeze.object_id # => true
-  # 
+  #
   def __id__: () -> Integer
 
   # Invokes the method identified by *symbol*, passing it any arguments specified.
   # You can use `__send__` if the name `send` clashes with an existing method in
   # *obj*. When the method is identified by a string, the string is converted to a
   # symbol.
-  # 
+  #
   #     class Klass
   #       def hello(*args)
   #         "Hello " + args.join(' ')
@@ -110,48 +110,48 @@ class BasicObject
   #     end
   #     k = Klass.new
   #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
-  # 
+  #
   def __send__: (String | Symbol arg0, *untyped args) -> untyped
 
   # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
   # `other` are the same object. Typically, this method is overridden in
   # descendant classes to provide class-specific meaning.
-  # 
+  #
   # Unlike `==`, the `equal?` method should never be overridden by subclasses as
   # it is used to determine object identity (that is, `a.equal?(b)` if and only if
   # `a` is the same object as `b`):
-  # 
+  #
   #     obj = "a"
   #     other = obj.dup
-  # 
+  #
   #     obj == other      #=> true
   #     obj.equal? other  #=> false
   #     obj.equal? obj    #=> true
-  # 
+  #
   # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
   # key.  This is used by Hash to test members for equality.  For objects of class
   # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
   # tradition by aliasing `eql?` to their overridden `==` method, but there are
   # exceptions.  `Numeric` types, for example, perform type conversion across
   # `==`, but not across `eql?`, so:
-  # 
+  #
   #     1 == 1.0     #=> true
   #     1.eql? 1.0   #=> false
-  # 
+  #
   def equal?: (untyped other) -> bool
 
   # Evaluates a string containing Ruby source code, or the given block, within the
   # context of the receiver (*obj*). In order to set the context, the variable
   # `self` is set to *obj* while the code is executing, giving the code access to
   # *obj*'s instance variables and private methods.
-  # 
+  #
   # When `instance_eval` is given a block, *obj* is also passed in as the block's
   # only argument.
-  # 
+  #
   # When `instance_eval` is given a `String`, the optional second and third
   # parameters supply a filename and starting line number that are used when
   # reporting compilation errors.
-  # 
+  #
   #     class KlassWithSecret
   #       def initialize
   #         @secret = 99
@@ -165,7 +165,7 @@ class BasicObject
   #     k.instance_eval { @secret }          #=> 99
   #     k.instance_eval { the_secret }       #=> "Ssssh! The secret is 99."
   #     k.instance_eval {|obj| obj == self } #=> true
-  # 
+  #
   def instance_eval: (String, ?String filename, ?Integer lineno) -> untyped
                    | [U] () { (self) -> U } -> U
 
@@ -173,7 +173,7 @@ class BasicObject
   # to set the context, the variable `self` is set to *obj* while the code is
   # executing, giving the code access to *obj*'s instance variables.  Arguments
   # are passed as block parameters.
-  # 
+  #
   #     class KlassWithSecret
   #       def initialize
   #         @secret = 99
@@ -181,11 +181,11 @@ class BasicObject
   #     end
   #     k = KlassWithSecret.new
   #     k.instance_exec(5) {|x| @secret+x }   #=> 104
-  # 
+  #
   def instance_exec: [U, V] (*V args) { (*V args) -> U } -> U
 
   # Not documented
-  # 
+  #
   def initialize: () -> void
 
   private
@@ -199,7 +199,7 @@ class BasicObject
   # method. The example below creates a class `Roman`, which responds to methods
   # with names consisting of roman numerals, returning the corresponding integer
   # values.
-  # 
+  #
   #     class Roman
   #       def roman_to_int(str)
   #         # ...
@@ -209,16 +209,16 @@ class BasicObject
   #         roman_to_int(str)
   #       end
   #     end
-  # 
+  #
   #     r = Roman.new
   #     r.iv      #=> 4
   #     r.xxiii   #=> 23
   #     r.mm      #=> 2000
-  # 
+  #
   def method_missing: (Symbol, *untyped) -> untyped
 
   # Invoked as a callback whenever a singleton method is added to the receiver.
-  # 
+  #
   #     module Chatty
   #       def Chatty.singleton_method_added(id)
   #         puts "Adding #{id.id2name}"
@@ -227,18 +227,18 @@ class BasicObject
   #       def two()          end
   #       def Chatty.three() end
   #     end
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     Adding singleton_method_added
   #     Adding one
   #     Adding three
-  # 
+  #
   def singleton_method_added: (Symbol) -> void
 
   # Invoked as a callback whenever a singleton method is removed from the
   # receiver.
-  # 
+  #
   #     module Chatty
   #       def Chatty.singleton_method_removed(id)
   #         puts "Removing #{id.id2name}"
@@ -251,17 +251,17 @@ class BasicObject
   #         remove_method :one
   #       end
   #     end
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     Removing three
   #     Removing one
-  # 
+  #
   def singleton_method_removed: (Symbol) -> void
 
   # Invoked as a callback whenever a singleton method is undefined in the
   # receiver.
-  # 
+  #
   #     module Chatty
   #       def Chatty.singleton_method_undefined(id)
   #         puts "Undefining #{id.id2name}"
@@ -271,10 +271,10 @@ class BasicObject
   #          undef_method(:one)
   #       end
   #     end
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     Undefining one
-  # 
+  #
   def singleton_method_undefined: (Symbol) -> void
 end

--- a/stdlib/builtin/binding.rbs
+++ b/stdlib/builtin/binding.rbs
@@ -4,10 +4,10 @@
 # in this context are all retained. Binding objects can be created using
 # Kernel#binding, and are made available to the callback of
 # Kernel#set_trace_func and instances of TracePoint.
-# 
+#
 # These binding objects can be passed as the second argument of the Kernel#eval
 # method, establishing an environment for the evaluation.
-# 
+#
 #     class Demo
 #       def initialize(n)
 #         @secret = n
@@ -16,39 +16,39 @@
 #         binding
 #       end
 #     end
-# 
+#
 #     k1 = Demo.new(99)
 #     b1 = k1.get_binding
 #     k2 = Demo.new(-3)
 #     b2 = k2.get_binding
-# 
+#
 #     eval("@secret", b1)   #=> 99
 #     eval("@secret", b2)   #=> -3
 #     eval("@secret")       #=> nil
-# 
+#
 # Binding objects have no class-specific methods.
-# 
+#
 class Binding
   public
 
   # Evaluates the Ruby expression(s) in *string*, in the *binding*'s context.  If
   # the optional *filename* and *lineno* parameters are present, they will be used
   # when reporting syntax errors.
-  # 
+  #
   #     def get_binding(param)
   #       binding
   #     end
   #     b = get_binding("hello")
   #     b.eval("param")   #=> "hello"
-  # 
+  #
   def eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
 
   # Opens an IRB session where `binding.irb` is called which allows for
   # interactive debugging. You can call any methods or variables available in the
   # current scope, and mutate state if you need to.
-  # 
+  #
   # Given a Ruby file called `potato.rb` containing the following code:
-  # 
+  #
   #     class Potato
   #       def initialize
   #         @cooked = false
@@ -56,16 +56,16 @@ class Binding
   #         puts "Cooked potato: #{@cooked}"
   #       end
   #     end
-  # 
+  #
   #     Potato.new
-  # 
+  #
   # Running `ruby potato.rb` will open an IRB session where `binding.irb` is
   # called, and you will see the following:
-  # 
+  #
   #     $ ruby potato.rb
-  # 
+  #
   #     From: potato.rb @ line 4 :
-  # 
+  #
   #         1: class Potato
   #         2:   def initialize
   #         3:     @cooked = false
@@ -75,12 +75,12 @@ class Binding
   #         7: end
   #         8:
   #         9: Potato.new
-  # 
+  #
   #     irb(#<Potato:0x00007feea1916670>):001:0>
-  # 
+  #
   # You can type any valid Ruby code and it will be evaluated in the current
   # context. This allows you to debug without having to run your code repeatedly:
-  # 
+  #
   #     irb(#<Potato:0x00007feea1916670>):001:0> @cooked
   #     => false
   #     irb(#<Potato:0x00007feea1916670>):002:0> self.class
@@ -89,89 +89,89 @@ class Binding
   #     => ".../2.5.1/lib/ruby/2.5.0/irb/workspace.rb:85:in `eval'"
   #     irb(#<Potato:0x00007feea1916670>):004:0> @cooked = true
   #     => true
-  # 
+  #
   # You can exit the IRB session with the `exit` command. Note that exiting will
   # resume execution where `binding.irb` had paused it, as you can see from the
   # output printed to standard output in this example:
-  # 
+  #
   #     irb(#<Potato:0x00007feea1916670>):005:0> exit
   #     Cooked potato: true
-  # 
+  #
   # See IRB@IRB+Usage for more information.
-  # 
+  #
   def irb: () -> void
 
   # Returns `true` if a local variable `symbol` exists.
-  # 
+  #
   #     def foo
   #       a = 1
   #       binding.local_variable_defined?(:a) #=> true
   #       binding.local_variable_defined?(:b) #=> false
   #     end
-  # 
+  #
   # This method is the short version of the following code:
-  # 
+  #
   #     binding.eval("defined?(#{symbol}) == 'local-variable'")
-  # 
+  #
   def local_variable_defined?: (String | Symbol symbol) -> bool
 
   # Returns the value of the local variable `symbol`.
-  # 
+  #
   #     def foo
   #       a = 1
   #       binding.local_variable_get(:a) #=> 1
   #       binding.local_variable_get(:b) #=> NameError
   #     end
-  # 
+  #
   # This method is the short version of the following code:
-  # 
+  #
   #     binding.eval("#{symbol}")
-  # 
+  #
   def local_variable_get: (String | Symbol symbol) -> untyped
 
   # Set local variable named `symbol` as `obj`.
-  # 
+  #
   #     def foo
   #       a = 1
   #       bind = binding
   #       bind.local_variable_set(:a, 2) # set existing local variable `a'
   #       bind.local_variable_set(:b, 3) # create new local variable `b'
   #                                      # `b' exists only in binding
-  # 
+  #
   #       p bind.local_variable_get(:a)  #=> 2
   #       p bind.local_variable_get(:b)  #=> 3
   #       p a                            #=> 2
   #       p b                            #=> NameError
   #     end
-  # 
+  #
   # This method behaves similarly to the following code:
-  # 
+  #
   #     binding.eval("#{symbol} = #{obj}")
-  # 
+  #
   # if `obj` can be dumped in Ruby code.
-  # 
+  #
   def local_variable_set: [U] (String | Symbol symbol, U obj) -> U
 
   # Returns the names of the binding's local variables as symbols.
-  # 
+  #
   #     def foo
   #       a = 1
   #       2.times do |n|
   #         binding.local_variables #=> [:a, :n]
   #       end
   #     end
-  # 
+  #
   # This method is the short version of the following code:
-  # 
+  #
   #     binding.eval("local_variables")
-  # 
+  #
   def local_variables: () -> Array[Symbol]
 
   # Returns the bound receiver of the binding object.
-  # 
+  #
   def receiver: () -> untyped
 
   # Returns the Ruby source filename and line number of the binding object.
-  # 
+  #
   def source_location: () -> [ String, Integer ]
 end

--- a/stdlib/builtin/class.rbs
+++ b/stdlib/builtin/class.rbs
@@ -1,18 +1,18 @@
 # Extends any Class to include *json_creatable?* method.
 # Classes in Ruby are first-class objects---each is an instance of class Class.
-# 
+#
 # Typically, you create a new class by using:
-# 
+#
 #     class Name
 #      # some code describing the class behavior
 #     end
-# 
+#
 # When a new class is created, an object of type Class is initialized and
 # assigned to a global constant (Name in this case).
-# 
+#
 # When `Name.new` is called to create a new object, the #new method in Class is
 # run by default. This can be demonstrated by overriding #new in Class:
-# 
+#
 #     class Class
 #       alias old_new new
 #       def new(*args)
@@ -20,16 +20,16 @@
 #         old_new(*args)
 #       end
 #     end
-# 
+#
 #     class Name
 #     end
-# 
+#
 #     n = Name.new
-# 
+#
 # *produces:*
-# 
+#
 #     Creating a new Name
-# 
+#
 # Classes, modules, and objects are interrelated. In the diagram that follows,
 # the vertical arrows represent inheritance, and the parentheses metaclasses.
 # All metaclasses are instances of the class `Class'.
@@ -51,15 +51,15 @@
 #                  |       +---+         |        +----+
 #                  |                     |
 #     obj--->OtherClass---------->(OtherClass)-----------...
-# 
+#
 class Class < Module
   # Creates a new anonymous (unnamed) class with the given superclass (or Object
   # if no parameter is given). You can give a class a name by assigning the class
   # object to a constant.
-  # 
+  #
   # If a block is given, it is passed the class object, and the block is evaluated
   # in the context of this class like #class_eval.
-  # 
+  #
   #     fred = Class.new do
   #       def meth1
   #         "hello"
@@ -68,78 +68,78 @@ class Class < Module
   #         "bye"
   #       end
   #     end
-  # 
+  #
   #     a = fred.new     #=> #<#<Class:0x100381890>:0x100376b98>
   #     a.meth1          #=> "hello"
   #     a.meth2          #=> "bye"
-  # 
+  #
   # Assign the class to a constant (name starting uppercase) if you want to treat
   # it like a regular class.
-  # 
+  #
   def initialize: (?Class superclass) ?{ (Class newclass) -> void } -> void
 
   # Allocates space for a new object of *class*'s class and does not call
   # initialize on the new instance. The returned object must be an instance of
   # *class*.
-  # 
+  #
   #     klass = Class.new do
   #       def initialize(*args)
   #         @initialized = true
   #       end
-  # 
+  #
   #       def initialized?
   #         @initialized || false
   #       end
   #     end
-  # 
+  #
   #     klass.allocate.initialized? #=> false
-  # 
+  #
   def allocate: () -> untyped
 
   # Callback invoked whenever a subclass of the current class is created.
-  # 
+  #
   # Example:
-  # 
+  #
   #     class Foo
   #       def self.inherited(subclass)
   #         puts "New subclass: #{subclass}"
   #       end
   #     end
-  # 
+  #
   #     class Bar < Foo
   #     end
-  # 
+  #
   #     class Baz < Bar
   #     end
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     New subclass: Bar
   #     New subclass: Baz
-  # 
+  #
   def inherited: (Class arg0) -> untyped
 
   # Calls #allocate to create a new object of *class*'s class, then invokes that
   # object's #initialize method, passing it *args*.  This is the method that ends
   # up getting called whenever an object is constructed using `.new`.
-  # 
+  #
   def new: () -> untyped
 
   # Returns the superclass of *class*, or `nil`.
-  # 
+  #
   #     File.superclass          #=> IO
   #     IO.superclass            #=> Object
   #     Object.superclass        #=> BasicObject
   #     class Foo; end
   #     class Bar < Foo; end
   #     Bar.superclass           #=> Foo
-  # 
+  #
   # Returns nil when the given class does not have a parent class:
-  # 
+  #
   #     BasicObject.superclass   #=> nil
-  # 
+  #
   # # arglists
   #     class.superclass -> a_super_class or nil
-  # 
+  #
   def `superclass`: () -> Class?
 end

--- a/stdlib/builtin/complex.rbs
+++ b/stdlib/builtin/complex.rbs
@@ -1,110 +1,110 @@
 # A complex number can be represented as a paired real number with imaginary
 # unit; a+bi.  Where a is real part, b is imaginary part and i is imaginary
 # unit.  Real a equals complex a+0i mathematically.
-# 
+#
 # Complex object can be created as literal, and also by using Kernel#Complex,
 # Complex::rect, Complex::polar or to_c method.
-# 
+#
 #     2+1i                 #=> (2+1i)
 #     Complex(1)           #=> (1+0i)
 #     Complex(2, 3)        #=> (2+3i)
 #     Complex.polar(2, 3)  #=> (-1.9799849932008908+0.2822400161197344i)
 #     3.to_c               #=> (3+0i)
-# 
+#
 # You can also create complex object from floating-point numbers or strings.
-# 
+#
 #     Complex(0.3)         #=> (0.3+0i)
 #     Complex('0.3-0.5i')  #=> (0.3-0.5i)
 #     Complex('2/3+3/4i')  #=> ((2/3)+(3/4)*i)
 #     Complex('1@2')       #=> (-0.4161468365471424+0.9092974268256817i)
-# 
+#
 #     0.3.to_c             #=> (0.3+0i)
 #     '0.3-0.5i'.to_c      #=> (0.3-0.5i)
 #     '2/3+3/4i'.to_c      #=> ((2/3)+(3/4)*i)
 #     '1@2'.to_c           #=> (-0.4161468365471424+0.9092974268256817i)
-# 
+#
 # A complex object is either an exact or an inexact number.
-# 
+#
 #     Complex(1, 1) / 2    #=> ((1/2)+(1/2)*i)
 #     Complex(1, 1) / 2.0  #=> (0.5+0.5i)
-# 
+#
 class Complex < Numeric
   # Returns a complex object which denotes the given polar form.
-  # 
+  #
   #     Complex.polar(3, 0)            #=> (3.0+0.0i)
   #     Complex.polar(3, Math::PI/2)   #=> (1.836909530733566e-16+3.0i)
   #     Complex.polar(3, Math::PI)     #=> (-3.0+3.673819061467132e-16i)
   #     Complex.polar(3, -Math::PI/2)  #=> (1.836909530733566e-16-3.0i)
-  # 
+  #
   def self.polar: (Numeric, ?Numeric) -> Complex
 
   # Returns a complex object which denotes the given rectangular form.
-  # 
+  #
   #     Complex.rectangular(1, 2)  #=> (1+2i)
-  # 
+  #
   def self.rect: (Numeric, ?Numeric) -> Complex
 
   # Returns a complex object which denotes the given rectangular form.
-  # 
+  #
   #     Complex.rectangular(1, 2)  #=> (1+2i)
-  # 
+  #
   alias self.rectangular self.rect
 
   public
 
   # Performs multiplication.
-  # 
+  #
   #     Complex(2, 3)  * Complex(2, 3)   #=> (-5+12i)
   #     Complex(900)   * Complex(1)      #=> (900+0i)
   #     Complex(-2, 9) * Complex(-9, 2)  #=> (0-85i)
   #     Complex(9, 8)  * 4               #=> (36+32i)
   #     Complex(20, 9) * 9.8             #=> (196.0+88.2i)
-  # 
+  #
   def *: (Numeric) -> Complex
 
   # Performs exponentiation.
-  # 
+  #
   #     Complex('i') ** 2              #=> (-1+0i)
   #     Complex(-8) ** Rational(1, 3)  #=> (1.0000000000000002+1.7320508075688772i)
-  # 
+  #
   def **: (Numeric) -> Complex
 
   # Performs addition.
-  # 
+  #
   #     Complex(2, 3)  + Complex(2, 3)   #=> (4+6i)
   #     Complex(900)   + Complex(1)      #=> (901+0i)
   #     Complex(-2, 9) + Complex(-9, 2)  #=> (-11+11i)
   #     Complex(9, 8)  + 4               #=> (13+8i)
   #     Complex(20, 9) + 9.8             #=> (29.8+9i)
-  # 
+  #
   def +: (Numeric) -> Complex
 
   def +@: () -> Complex
 
   # Performs subtraction.
-  # 
+  #
   #     Complex(2, 3)  - Complex(2, 3)   #=> (0+0i)
   #     Complex(900)   - Complex(1)      #=> (899+0i)
   #     Complex(-2, 9) - Complex(-9, 2)  #=> (7+7i)
   #     Complex(9, 8)  - 4               #=> (5+8i)
   #     Complex(20, 9) - 9.8             #=> (10.2+9i)
-  # 
+  #
   def -: (Numeric) -> Complex
 
   # Returns negation of the value.
-  # 
+  #
   #     -Complex(1, 2)  #=> (-1-2i)
-  # 
+  #
   def -@: () -> Complex
 
   # Performs division.
-  # 
+  #
   #     Complex(2, 3)  / Complex(2, 3)   #=> ((1/1)+(0/1)*i)
   #     Complex(900)   / Complex(1)      #=> ((900/1)+(0/1)*i)
   #     Complex(-2, 9) / Complex(-9, 2)  #=> ((36/85)-(77/85)*i)
   #     Complex(9, 8)  / 4               #=> ((9/4)+(2/1)*i)
   #     Complex(20, 9) / 9.8             #=> (2.0408163265306123+0.9183673469387754i)
-  # 
+  #
   def /: (Numeric) -> Complex
 
   def <: (Numeric) -> bot
@@ -114,23 +114,23 @@ class Complex < Numeric
   # If `cmp`'s imaginary part is zero, and `object` is also a real number (or a
   # Complex number where the imaginary part is zero), compare the real part of
   # `cmp` to object.  Otherwise, return nil.
-  # 
+  #
   #     Complex(2, 3)  <=> Complex(2, 3)   #=> nil
   #     Complex(2, 3)  <=> 1               #=> nil
   #     Complex(2)     <=> 1               #=> 1
   #     Complex(2)     <=> 2               #=> 0
   #     Complex(2)     <=> 3               #=> -1
-  # 
+  #
   def <=>: (Numeric) -> Integer?
 
   # Returns true if cmp equals object numerically.
-  # 
+  #
   #     Complex(2, 3)  == Complex(2, 3)   #=> true
   #     Complex(5)     == 5               #=> true
   #     Complex(0)     == 0.0             #=> true
   #     Complex('1/3') == 0.33            #=> false
   #     Complex('1/2') == '1/2'           #=> false
-  # 
+  #
   def ==: (untyped) -> bool
 
   def >: (Numeric) -> bot
@@ -138,29 +138,29 @@ class Complex < Numeric
   def >=: (Numeric) -> bot
 
   # Returns the absolute part of its polar form.
-  # 
+  #
   #     Complex(-1).abs         #=> 1
   #     Complex(3.0, -4.0).abs  #=> 5.0
-  # 
+  #
   def abs: () -> Numeric
 
   # Returns square of the absolute value.
-  # 
+  #
   #     Complex(-1).abs2         #=> 1
   #     Complex(3.0, -4.0).abs2  #=> 25.0
-  # 
+  #
   def abs2: () -> Numeric
 
   # Returns the angle part of its polar form.
-  # 
+  #
   #     Complex.polar(3, Math::PI/2).arg  #=> 1.5707963267948966
-  # 
+  #
   def angle: () -> Float
 
   # Returns the angle part of its polar form.
-  # 
+  #
   #     Complex.polar(3, Math::PI/2).arg  #=> 1.5707963267948966
-  # 
+  #
   alias arg angle
 
   def ceil: (*untyped) -> bot
@@ -170,21 +170,21 @@ class Complex < Numeric
   def coerce: (Numeric) -> [ Complex, Complex ]
 
   # Returns the complex conjugate.
-  # 
+  #
   #     Complex(1, 2).conjugate  #=> (1-2i)
-  # 
+  #
   def conj: () -> Complex
 
   # Returns the complex conjugate.
-  # 
+  #
   #     Complex(1, 2).conjugate  #=> (1-2i)
-  # 
+  #
   def conjugate: () -> Complex
 
   # Returns the denominator (lcm of both denominator - real and imag).
-  # 
+  #
   # See numerator.
-  # 
+  #
   def denominator: () -> Integer
 
   def div: (Numeric) -> bot
@@ -196,14 +196,14 @@ class Complex < Numeric
   def eql?: (untyped) -> bool
 
   # Performs division as each part is a float, never returns a float.
-  # 
+  #
   #     Complex(11, 22).fdiv(3)  #=> (3.6666666666666665+7.333333333333333i)
-  # 
+  #
   def fdiv: (Numeric) -> Complex
 
   # Returns `true` if `cmp`'s real and imaginary parts are both finite numbers,
   # otherwise returns `false`.
-  # 
+  #
   def finite?: () -> bool
 
   def floor: (?Integer) -> bot
@@ -213,46 +213,46 @@ class Complex < Numeric
   def i: () -> bot
 
   # Returns the imaginary part.
-  # 
+  #
   #     Complex(7).imaginary      #=> 0
   #     Complex(9, -4).imaginary  #=> -4
-  # 
+  #
   def imag: () -> Numeric
 
   # Returns the imaginary part.
-  # 
+  #
   #     Complex(7).imaginary      #=> 0
   #     Complex(9, -4).imaginary  #=> -4
-  # 
+  #
   def imaginary: () -> Numeric
 
   # Returns `1` if `cmp`'s real or imaginary part is an infinite number, otherwise
   # returns `nil`.
-  # 
+  #
   #     For example:
-  # 
+  #
   #        (1+1i).infinite?                   #=> nil
   #        (Float::INFINITY + 1i).infinite?   #=> 1
-  # 
+  #
   def infinite?: () -> Integer?
 
   # Returns the value as a string for inspection.
-  # 
+  #
   #     Complex(2).inspect                       #=> "(2+0i)"
   #     Complex('-8/6').inspect                  #=> "((-4/3)+0i)"
   #     Complex('1/2i').inspect                  #=> "(0+(1/2)*i)"
   #     Complex(0, Float::INFINITY).inspect      #=> "(0+Infinity*i)"
   #     Complex(Float::NAN, Float::NAN).inspect  #=> "(NaN+NaN*i)"
-  # 
+  #
   def inspect: () -> String
 
   def integer?: () -> bool
 
   # Returns the absolute part of its polar form.
-  # 
+  #
   #     Complex(-1).abs         #=> 1
   #     Complex(3.0, -4.0).abs  #=> 5.0
-  # 
+  #
   alias magnitude abs
 
   def modulo: (Numeric) -> bot
@@ -262,78 +262,78 @@ class Complex < Numeric
   def nonzero?: () -> self?
 
   # Returns the numerator.
-  # 
+  #
   #         1   2       3+4i  <-  numerator
   #         - + -i  ->  ----
   #         2   3        6    <-  denominator
-  # 
+  #
   #     c = Complex('1/2+2/3i')  #=> ((1/2)+(2/3)*i)
   #     n = c.numerator          #=> (3+4i)
   #     d = c.denominator        #=> 6
   #     n / d                    #=> ((1/2)+(2/3)*i)
   #     Complex(Rational(n.real, d), Rational(n.imag, d))
   #                              #=> ((1/2)+(2/3)*i)
-  # 
+  #
   # See denominator.
-  # 
+  #
   def numerator: () -> Complex
 
   # Returns the angle part of its polar form.
-  # 
+  #
   #     Complex.polar(3, Math::PI/2).arg  #=> 1.5707963267948966
-  # 
+  #
   alias phase angle
 
   # Returns an array; [cmp.abs, cmp.arg].
-  # 
+  #
   #     Complex(1, 2).polar  #=> [2.23606797749979, 1.1071487177940904]
-  # 
+  #
   def polar: () -> [Numeric, Float]
 
   def positive?: () -> bot
 
   # Performs division.
-  # 
+  #
   #     Complex(2, 3)  / Complex(2, 3)   #=> ((1/1)+(0/1)*i)
   #     Complex(900)   / Complex(1)      #=> ((900/1)+(0/1)*i)
   #     Complex(-2, 9) / Complex(-9, 2)  #=> ((36/85)-(77/85)*i)
   #     Complex(9, 8)  / 4               #=> ((9/4)+(2/1)*i)
   #     Complex(20, 9) / 9.8             #=> (2.0408163265306123+0.9183673469387754i)
-  # 
+  #
   def quo: (Numeric) -> Complex
 
   # Returns the value as a rational if possible (the imaginary part should be
   # exactly zero).
-  # 
+  #
   #     Complex(1.0/3, 0).rationalize  #=> (1/3)
   #     Complex(1, 0.0).rationalize    # RangeError
   #     Complex(1, 2).rationalize      # RangeError
-  # 
+  #
   # See to_r.
-  # 
+  #
   def rationalize: (?Numeric eps) -> Rational
 
   # Returns the real part.
-  # 
+  #
   #     Complex(7).real      #=> 7
   #     Complex(9, -4).real  #=> 9
-  # 
+  #
   def real: () -> Numeric
 
   # Returns false, even if the complex number has no imaginary part.
-  # 
+  #
   def real?: () -> false
 
   # Returns an array; [cmp.real, cmp.imag].
-  # 
+  #
   #     Complex(1, 2).rectangular  #=> [1, 2]
-  # 
+  #
   def rect: () -> [Numeric, Numeric]
 
   # Returns an array; [cmp.real, cmp.imag].
-  # 
+  #
   #     Complex(1, 2).rectangular  #=> [1, 2]
-  # 
+  #
   alias rectangular rect
 
   def reminder: (Numeric) -> bot
@@ -343,51 +343,51 @@ class Complex < Numeric
   def step: (*untyped) ?{ (*untyped) -> untyped } -> bot
 
   # Returns self.
-  # 
+  #
   #     Complex(2).to_c      #=> (2+0i)
   #     Complex(-8, 6).to_c  #=> (-8+6i)
-  # 
+  #
   def to_c: () -> Complex
 
   # Returns the value as a float if possible (the imaginary part should be exactly
   # zero).
-  # 
+  #
   #     Complex(1, 0).to_f    #=> 1.0
   #     Complex(1, 0.0).to_f  # RangeError
   #     Complex(1, 2).to_f    # RangeError
-  # 
+  #
   def to_f: () -> Float
 
   # Returns the value as an integer if possible (the imaginary part should be
   # exactly zero).
-  # 
+  #
   #     Complex(1, 0).to_i    #=> 1
   #     Complex(1, 0.0).to_i  # RangeError
   #     Complex(1, 2).to_i    # RangeError
-  # 
+  #
   def to_i: () -> Integer
 
   alias to_int to_i
 
   # Returns the value as a rational if possible (the imaginary part should be
   # exactly zero).
-  # 
+  #
   #     Complex(1, 0).to_r    #=> (1/1)
   #     Complex(1, 0.0).to_r  # RangeError
   #     Complex(1, 2).to_r    # RangeError
-  # 
+  #
   # See rationalize.
-  # 
+  #
   def to_r: () -> Rational
 
   # Returns the value as a string.
-  # 
+  #
   #     Complex(2).to_s                       #=> "2+0i"
   #     Complex('-8/6').to_s                  #=> "-4/3+0i"
   #     Complex('1/2i').to_s                  #=> "0+1/2i"
   #     Complex(0, Float::INFINITY).to_s      #=> "0+Infinity*i"
   #     Complex(Float::NAN, Float::NAN).to_s  #=> "NaN+NaN*i"
-  # 
+  #
   def to_s: () -> String
 
   def truncate: (?Integer) -> bot
@@ -396,5 +396,5 @@ class Complex < Numeric
 end
 
 # The imaginary unit.
-# 
+#
 Complex::I: Complex

--- a/stdlib/builtin/encoding.rbs
+++ b/stdlib/builtin/encoding.rbs
@@ -1,6 +1,6 @@
 class Encoding < Object
   # Returns the hash of available encoding alias and original encoding name.
-  # 
+  #
   #     Encoding.aliases
   #     #=> {"BINARY"=>"ASCII-8BIT", "ASCII"=>"US-ASCII", "ANSI_X3.4-1986"=>"US-ASCII",
   #           "SJIS"=>"Shift_JIS", "eucJP"=>"EUC-JP", "CP932"=>"Windows-31J"}
@@ -9,35 +9,35 @@ class Encoding < Object
   def self.compatible?: (untyped obj1, untyped obj2) -> Encoding?
 
   # Returns default external encoding.
-  # 
+  #
   # The default external encoding is used by default for strings created
   # from the following locations:
-  # 
+  #
   #   - CSV
-  # 
+  #
   #   - [File](https://ruby-doc.org/core-2.6.3/File.html) data read from
   #     disk
-  # 
+  #
   #   - SDBM
-  # 
+  #
   #   - StringIO
-  # 
+  #
   #   - Zlib::GzipReader
-  # 
+  #
   #   - Zlib::GzipWriter
-  # 
+  #
   #   - [String\#inspect](https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect)
-  # 
+  #
   #   - [Regexp\#inspect](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect)
-  # 
+  #
   # While strings created from these locations will have this encoding, the
   # encoding may not be valid. Be sure to check
   # [String\#valid\_encoding?](https://ruby-doc.org/core-2.6.3/String.html#method-i-valid_encoding-3F)
   # .
-  # 
+  #
   # [File](https://ruby-doc.org/core-2.6.3/File.html) data written to disk
   # will be transcoded to the default external encoding when written.
-  # 
+  #
   # The default external encoding is initialized by the locale or -E option.
   def self.default_external: () -> Encoding
 
@@ -47,43 +47,43 @@ class Encoding < Object
   # Returns default internal encoding. Strings will be transcoded to the
   # default internal encoding in the following places if the default
   # internal encoding is not nil:
-  # 
+  #
   #   - CSV
-  # 
+  #
   #   - Etc.sysconfdir and Etc.systmpdir
-  # 
+  #
   #   - [File](https://ruby-doc.org/core-2.6.3/File.html) data read from
   #     disk
-  # 
+  #
   #   - [File](https://ruby-doc.org/core-2.6.3/File.html) names from
   #     [Dir](https://ruby-doc.org/core-2.6.3/Dir.html)
-  # 
+  #
   #   - [Integer\#chr](https://ruby-doc.org/core-2.6.3/Integer.html#method-i-chr)
-  # 
+  #
   #   - [String\#inspect](https://ruby-doc.org/core-2.6.3/String.html#method-i-inspect)
   #     and
   #     [Regexp\#inspect](https://ruby-doc.org/core-2.6.3/Regexp.html#method-i-inspect)
-  # 
+  #
   #   - Strings returned from Readline
-  # 
+  #
   #   - Strings returned from SDBM
-  # 
+  #
   #   - [Time\#zone](https://ruby-doc.org/core-2.6.3/Time.html#method-i-zone)
-  # 
+  #
   #   - Values from [ENV](https://ruby-doc.org/core-2.6.3/ENV.html)
-  # 
+  #
   #   - Values in ARGV including $PROGRAM\_NAME
-  # 
+  #
   # Additionally
   # [String\#encode](https://ruby-doc.org/core-2.6.3/String.html#method-i-encode)
   # and
   # [String\#encode\!](https://ruby-doc.org/core-2.6.3/String.html#method-i-encode-21)
   # use the default internal encoding if no encoding is given.
-  # 
+  #
   # The locale encoding (\_\_ENCODING\_\_), not
   # [::default\_internal](Encoding.downloaded.ruby_doc#method-c-default_internal)
   # , is used as the encoding of created strings.
-  # 
+  #
   # [::default\_internal](Encoding.downloaded.ruby_doc#method-c-default_internal)
   # is initialized by the source file's internal\_encoding or -E option.
   def self.default_internal: () -> Encoding?
@@ -97,7 +97,7 @@ class Encoding < Object
   def self.list: () -> ::Array[Encoding]
 
   # Returns the list of available encoding names.
-  # 
+  #
   #     Encoding.name_list
   #     #=> ["US-ASCII", "ASCII-8BIT", "UTF-8",
   #           "ISO-8859-1", "Shift_JIS", "EUC-JP",
@@ -106,7 +106,7 @@ class Encoding < Object
   def self.name_list: () -> ::Array[String]
 
   # Returns whether ASCII-compatible or not.
-  # 
+  #
   # ```ruby
   # Encoding::UTF_8.ascii_compatible?     #=> true
   # Encoding::UTF_16BE.ascii_compatible?  #=> false
@@ -116,7 +116,7 @@ class Encoding < Object
   # Returns true for dummy encodings. A dummy encoding is an encoding for
   # which character handling is not properly implemented. It is used for
   # stateful encodings.
-  # 
+  #
   # ```ruby
   # Encoding::ISO_2022_JP.dummy?       #=> true
   # Encoding::UTF_8.dummy?             #=> false
@@ -126,14 +126,14 @@ class Encoding < Object
   def inspect: () -> String
 
   # Returns the name of the encoding.
-  # 
+  #
   # ```ruby
   # Encoding::UTF_8.name      #=> "UTF-8"
   # ```
   def name: () -> String
 
   # Returns the list of name and aliases of the encoding.
-  # 
+  #
   # ```ruby
   # Encoding::WINDOWS_31J.names  #=> ["Windows-31J", "CP932", "csWindows31J"]
   # ```
@@ -142,7 +142,7 @@ class Encoding < Object
   def replicate: (String name) -> Encoding
 
   # Returns the name of the encoding.
-  # 
+  #
   # ```ruby
   # Encoding::UTF_8.name      #=> "UTF-8"
   # ```

--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -11,10 +11,10 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # block is not given, Ruby adds an implicit block of `{ |obj| obj }` which
   # will cause [all?](Enumerable.downloaded.ruby_doc#method-i-all-3F) to
   # return `true` when none of the collection members are `false` or `nil` .
-  # 
+  #
   # If instead a pattern is supplied, the method returns whether `pattern
   # === element` for every collection member.
-  # 
+  #
   #     %w[ant bear cat].all? { |word| word.length >= 3 } #=> true
   #     %w[ant bear cat].all? { |word| word.length >= 4 } #=> false
   #     %w[ant bear cat].all?(/t/)                        #=> false
@@ -30,10 +30,10 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # |obj| obj }` that will cause
   # [any?](Enumerable.downloaded.ruby_doc#method-i-any-3F) to return `true`
   # if at least one of the collection members is not `false` or `nil` .
-  # 
+  #
   # If instead a pattern is supplied, the method returns whether `pattern
   # === element` for any collection member.
-  # 
+  #
   # ```ruby
   # %w[ant bear cat].any? { |word| word.length >= 3 } #=> true
   # %w[ant bear cat].any? { |word| word.length >= 4 } #=> true
@@ -54,7 +54,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # argument is given, the number of items in `enum` that are equal to
   # `item` are counted. If a block is given, it counts the number of
   # elements yielding a true value.
-  # 
+  #
   # ```ruby
   # ary = [1, 2, 4, 2]
   # ary.count               #=> 4
@@ -86,11 +86,11 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
                       | [U] (U arg0) -> ::Enumerator[[ Elem, U ], Return]
 
   # Returns an array containing the items in *enum* .
-  # 
+  #
   # ```ruby
   # (1..7).to_a                       #=> [1, 2, 3, 4, 5, 6, 7]
   # { 'a'=>1, 'b'=>2, 'c'=>3 }.to_a   #=> [["a", 1], ["b", 2], ["c", 3]]
-  # 
+  #
   # require 'prime'
   # Prime.entries 10                  #=> [2, 3, 5, 7]
   # ```
@@ -109,7 +109,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # Returns the first element, or the first `n` elements, of the enumerable.
   # If the enumerable is empty, the first form returns `nil`, and the
   # second form returns an empty array.
-  # 
+  #
   # ```ruby
   # %w[foo bar baz].first     #=> "foo"
   # %w[foo bar baz].first(2)  #=> ["foo", "bar"]
@@ -139,16 +139,16 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # Returns the object in *enum* with the maximum value. The first form
   # assumes all objects implement `Comparable` ; the second uses the block
   # to return *a \<=\> b* .
-  # 
+  #
   # ```ruby
   # a = %w(albatross dog horse)
   # a.max                                   #=> "horse"
   # a.max { |a, b| a.length <=> b.length }  #=> "albatross"
   # ```
-  # 
+  #
   # If the `n` argument is given, maximum `n` elements are returned as an
   # array, sorted in descending order.
-  # 
+  #
   # ```ruby
   # a = %w[albatross dog horse]
   # a.max(2)                                  #=> ["horse", "dog"]
@@ -168,16 +168,16 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # Returns the object in *enum* with the minimum value. The first form
   # assumes all objects implement `Comparable` ; the second uses the block
   # to return *a \<=\> b* .
-  # 
+  #
   # ```ruby
   # a = %w(albatross dog horse)
   # a.min                                   #=> "albatross"
   # a.min { |a, b| a.length <=> b.length }  #=> "dog"
   # ```
-  # 
+  #
   # If the `n` argument is given, minimum `n` elements are returned as a
   # sorted array.
-  # 
+  #
   # ```ruby
   # a = %w[albatross dog horse]
   # a.min(2)                                  #=> ["albatross", "dog"]
@@ -197,7 +197,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # Returns a two element array which contains the minimum and the maximum
   # value in the enumerable. The first form assumes all objects implement
   # `Comparable` ; the second uses the block to return *a \<=\> b* .
-  # 
+  #
   # ```ruby
   # a = %w(albatross dog horse)
   # a.minmax                                  #=> ["albatross", "horse"]
@@ -213,10 +213,10 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # returns `true` if the block never returns `true` for all elements. If
   # the block is not given, `none?` will return `true` only if none of the
   # collection members is true.
-  # 
+  #
   # If instead a pattern is supplied, the method returns whether `pattern
   # === element` for none of the collection members.
-  # 
+  #
   # ```ruby
   # %w{ant bear cat}.none? { |word| word.length == 5 } #=> true
   # %w{ant bear cat}.none? { |word| word.length >= 4 } #=> false
@@ -234,10 +234,10 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # returns `true` if the block returns `true` exactly once. If the block is
   # not given, `one?` will return `true` only if exactly one of the
   # collection members is true.
-  # 
+  #
   # If instead a pattern is supplied, the method returns whether `pattern
   # === element` for exactly one collection member.
-  # 
+  #
   # ```ruby
   # %w{ant bear cat}.one? { |word| word.length == 4 }  #=> true
   # %w{ant bear cat}.one? { |word| word.length > 4 }   #=> false
@@ -261,22 +261,22 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
                   | () -> ::Enumerator[Elem, Return]
 
   # Returns an array containing the items in *enum* sorted.
-  # 
+  #
   # Comparisons for the sort will be done using the items’ own `<=>`
   # operator or using an optional code block.
-  # 
+  #
   # The block must implement a comparison between `a` and `b` and return an
   # integer less than 0 when `b` follows `a`, `0` when `a` and `b` are
   # equivalent, or an integer greater than 0 when `a` follows `b` .
-  # 
+  #
   # The result is not guaranteed to be stable. When the comparison of two
   # elements returns `0`, the order of the elements is unpredictable.
-  # 
+  #
   # ```ruby
   # %w(rhea kea flea).sort           #=> ["flea", "kea", "rhea"]
   # (1..10).sort { |a, b| b <=> a }  #=> [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
   # ```
-  # 
+  #
   # See also [\#sort\_by](Enumerable.downloaded.ruby_doc#method-i-sort_by).
   # It implements a Schwartzian transform which is useful when key
   # computation or comparison is expensive.
@@ -294,13 +294,13 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # Implemented in C++
   # Returns the result of interpreting *enum* as a list of `[key, value]`
   # pairs.
-  # 
+  #
   #     %i[hello world].each_with_index.to_h
   #       # => {:hello => 0, :world => 1}
-  # 
+  #
   # If a block is given, the results of the block on each element of the
   # enum will be used as pairs.
-  # 
+  #
   # ```ruby
   # (1..5).to_h {|x| [x, x ** 2]}
   #   #=> {1=>1, 2=>4, 3=>9, 4=>16, 5=>25}
@@ -324,11 +324,11 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   alias reduce inject
 
   # Returns an array containing the items in *enum* .
-  # 
+  #
   # ```ruby
   # (1..7).to_a                       #=> [1, 2, 3, 4, 5, 6, 7]
   # { 'a'=>1, 'b'=>2, 'c'=>3 }.to_a   #=> [["a", 1], ["b", 2], ["c", 3]]
-  # 
+  #
   # require 'prime'
   # Prime.entries 10                  #=> [2, 3, 5, 7]
   # ```
@@ -342,10 +342,10 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [\#drop\_while](Enumerable.downloaded.ruby_doc#method-i-drop_while)
   # enumerate values only on an as-needed basis. However, if a block is
   # given to zip, values are enumerated immediately.
-  # 
-  # 
+  #
+  #
   # The following program finds pythagorean triples:
-  # 
+  #
   # ```ruby
   # def pythagorean_triples
   #   (1..Float::INFINITY).lazy.flat_map {|z|

--- a/stdlib/builtin/enumerator.rbs
+++ b/stdlib/builtin/enumerator.rbs
@@ -1,59 +1,59 @@
 # A class which allows both internal and external iteration.
-# 
+#
 # An [Enumerator](Enumerator) can be created by the
 # following methods.
-# 
+#
 #   - Kernel\#to\_enum
-# 
+#
 #   - Kernel\#enum\_for
-# 
+#
 #   - [::new](Enumerator#method-c-new)
-# 
+#
 # Most methods have two forms: a block form where the contents are
 # evaluated for each item in the enumeration, and a non-block form which
 # returns a new [Enumerator](Enumerator) wrapping the
 # iteration.
-# 
+#
 # ```ruby
 # enumerator = %w(one two three).each
 # puts enumerator.class # => Enumerator
-# 
+#
 # enumerator.each_with_object("foo") do |item, obj|
 #   puts "#{obj}: #{item}"
 # end
-# 
+#
 # # foo: one
 # # foo: two
 # # foo: three
-# 
+#
 # enum_with_obj = enumerator.each_with_object("foo")
 # puts enum_with_obj.class # => Enumerator
-# 
+#
 # enum_with_obj.each do |item, obj|
 #   puts "#{obj}: #{item}"
 # end
-# 
+#
 # # foo: one
 # # foo: two
 # # foo: three
 # ```
-# 
+#
 # This allows you to chain Enumerators together. For example, you can map
 # a list's elements to strings containing the index and the element as a
 # string via:
-# 
+#
 # ```ruby
 # puts %w[foo bar baz].map.with_index { |w, i| "#{i}:#{w}" }
 # # => ["0:foo", "1:bar", "2:baz"]
 # ```
-# 
+#
 # An [Enumerator](Enumerator) can also be used as an
 # external iterator. For example,
 # [\#next](Enumerator#method-i-next) returns the next
 # value of the iterator or raises
 # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html) if
 # the [Enumerator](Enumerator) is at the end.
-# 
+#
 # ```ruby
 # e = [1,2,3].each   # returns an enumerator object.
 # puts e.next   # => 1
@@ -61,9 +61,9 @@
 # puts e.next   # => 3
 # puts e.next   # raises StopIteration
 # ```
-# 
+#
 # You can use this to implement an internal iterator as follows:
-# 
+#
 # ```ruby
 # def ext_each(e)
 #   while true
@@ -76,20 +76,20 @@
 #     e.feed y
 #   end
 # end
-# 
+#
 # o = Object.new
-# 
+#
 # def o.each
 #   puts yield
 #   puts yield(1)
 #   puts yield(1, 2)
 #   3
 # end
-# 
+#
 # # use o.each as an internal iterator directly.
 # puts o.each {|*x| puts x; [:b, *x] }
 # # => [], [:b], [1], [:b, 1], [1, 2], [:b, 1, 2], 3
-# 
+#
 # # convert o.each to an external iterator for
 # # implementing an internal iterator.
 # puts ext_each(o.to_enum) {|*x| puts x; [:b, *x] }
@@ -112,8 +112,8 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # position forward. When the position reached at the end,
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html) is
   # raised.
-  # 
-  # 
+  #
+  #
   # ```ruby
   # a = [1,2,3]
   # e = a.to_enum
@@ -122,7 +122,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # p e.next   #=> 3
   # p e.next   #raises StopIteration
   # ```
-  # 
+  #
   # Note that enumeration sequence by `next` does not affect other
   # non-external enumeration methods, unless the underlying iteration
   # methods itself has side-effect, e.g.
@@ -134,10 +134,10 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # internal position forward. When the position reached at the end,
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html) is
   # raised.
-  # 
+  #
   # This method can be used to distinguish `yield` and `yield nil` .
-  # 
-  # 
+  #
+  #
   # ```ruby
   # o = Object.new
   # def o.each
@@ -159,7 +159,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # p e.next
   # p e.next
   # p e.next
-  # 
+  #
   # ## yield args       next_values      next
   # #  yield            []               nil
   # #  yield 1          [1]              1
@@ -167,7 +167,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # #  yield nil        [nil]            nil
   # #  yield [1, 2]     [[1, 2]]         [1, 2]
   # ```
-  # 
+  #
   # Note that `next_values` does not affect other non-external enumeration
   # methods unless underlying iteration method itself has side-effect, e.g.
   # [IO\#each\_line](https://ruby-doc.org/core-2.6.3/IO.html#method-i-each_line)
@@ -178,8 +178,8 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # position forward. If the position is already at the end,
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html) is
   # raised.
-  # 
-  # 
+  #
+  #
   # ```ruby
   # a = [1,2,3]
   # e = a.to_enum
@@ -199,8 +199,8 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # already at the end,
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html) is
   # raised.
-  # 
-  # 
+  #
+  #
   # ```ruby
   # o = Object.new
   # def o.each
@@ -221,13 +221,13 @@ class Enumerator[unchecked out Elem, out Return] < Object
   def peek_values: () -> ::Array[Elem]
 
   # Rewinds the enumeration sequence to the beginning.
-  # 
+  #
   # If the enclosed object responds to a “rewind” method, it is called.
   def rewind: () -> self
 
   # Returns the size of the enumerator, or `nil` if it can’t be calculated
   # lazily.
-  # 
+  #
   # ```ruby
   # (1..100).to_a.permutation(4).size # => 94109400
   # loop.size # => Float::INFINITY

--- a/stdlib/builtin/errors.rbs
+++ b/stdlib/builtin/errors.rbs
@@ -20,7 +20,7 @@
 class ArgumentError < StandardError
 end
 
-# The exception class which will be raised when pushing into a closed Queue. 
+# The exception class which will be raised when pushing into a closed Queue.
 # See Queue#close and SizedQueue#close.
 #
 class ClosedQueueError < StopIteration

--- a/stdlib/builtin/exception.rbs
+++ b/stdlib/builtin/exception.rbs
@@ -9,19 +9,19 @@
 # information like
 # [NameError\#name](https://ruby-doc.org/core-2.6.3/NameError.html#method-i-name)
 # .
-# 
+#
 # Programs may make subclasses of
 # [Exception](Exception), typically of
 # [StandardError](https://ruby-doc.org/core-2.6.3/StandardError.html) or
 # [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html), to
 # provide custom classes and add additional information. See the subclass
 # list below for defaults for `raise` and `rescue` .
-# 
+#
 # When an exception has been raised but not yet handled (in `rescue`,
 # `ensure`, `at_exit` and `END` blocks) the global variable `$!` will
 # contain the current exception and `$@` contains the current exception’s
 # backtrace.
-# 
+#
 # It is recommended that a library should have one subclass of
 # [StandardError](https://ruby-doc.org/core-2.6.3/StandardError.html) or
 # [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html) and
@@ -29,97 +29,97 @@
 # rescue a generic exception type to catch all exceptions the library may
 # raise even if future versions of the library add new exception
 # subclasses.
-# 
+#
 # For example:
-# 
+#
 # ```ruby
 # class MyLibrary
 #   class Error < RuntimeError
 #   end
-# 
+#
 #   class WidgetError < Error
 #   end
-# 
+#
 #   class FrobError < Error
 #   end
-# 
+#
 # end
 # ```
-# 
+#
 # To handle both WidgetError and FrobError the library user can rescue
 # MyLibrary::Error.
-# 
+#
 # The built-in subclasses of [Exception](Exception)
 # are:
-# 
+#
 #   - [NoMemoryError](https://ruby-doc.org/core-2.6.3/NoMemoryError.html)
-# 
+#
 #   - [ScriptError](https://ruby-doc.org/core-2.6.3/ScriptError.html)
-# 
+#
 #       - [LoadError](https://ruby-doc.org/core-2.6.3/LoadError.html)
-# 
+#
 #       - [NotImplementedError](https://ruby-doc.org/core-2.6.3/NotImplementedError.html)
-# 
+#
 #       - [SyntaxError](https://ruby-doc.org/core-2.6.3/SyntaxError.html)
-# 
+#
 #   - [SecurityError](https://ruby-doc.org/core-2.6.3/SecurityError.html)
-# 
+#
 #   - [SignalException](https://ruby-doc.org/core-2.6.3/SignalException.html)
-# 
+#
 #       - [Interrupt](https://ruby-doc.org/core-2.6.3/Interrupt.html)
-# 
+#
 #   - [StandardError](https://ruby-doc.org/core-2.6.3/StandardError.html)
 #     -- default for `rescue`
-# 
+#
 #       - [ArgumentError](https://ruby-doc.org/core-2.6.3/ArgumentError.html)
-# 
+#
 #           - [UncaughtThrowError](https://ruby-doc.org/core-2.6.3/UncaughtThrowError.html)
-# 
+#
 #       - [EncodingError](https://ruby-doc.org/core-2.6.3/EncodingError.html)
-# 
+#
 #       - [FiberError](https://ruby-doc.org/core-2.6.3/FiberError.html)
-# 
+#
 #       - [IOError](https://ruby-doc.org/core-2.6.3/IOError.html)
-# 
+#
 #           - [EOFError](https://ruby-doc.org/core-2.6.3/EOFError.html)
-# 
+#
 #       - [IndexError](https://ruby-doc.org/core-2.6.3/IndexError.html)
-# 
+#
 #           - [KeyError](https://ruby-doc.org/core-2.6.3/KeyError.html)
-# 
+#
 #           - [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html)
-# 
+#
 #       - [LocalJumpError](https://ruby-doc.org/core-2.6.3/LocalJumpError.html)
-# 
+#
 #       - [NameError](https://ruby-doc.org/core-2.6.3/NameError.html)
-# 
+#
 #           - [NoMethodError](https://ruby-doc.org/core-2.6.3/NoMethodError.html)
-# 
+#
 #       - [RangeError](https://ruby-doc.org/core-2.6.3/RangeError.html)
-# 
+#
 #           - [FloatDomainError](https://ruby-doc.org/core-2.6.3/FloatDomainError.html)
-# 
+#
 #       - [RegexpError](https://ruby-doc.org/core-2.6.3/RegexpError.html)
-# 
+#
 #       - [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html)
 #         -- default for `raise`
-# 
+#
 #           - [FrozenError](https://ruby-doc.org/core-2.6.3/FrozenError.html)
-# 
+#
 #       - [SystemCallError](https://ruby-doc.org/core-2.6.3/SystemCallError.html)
-# 
+#
 #           - Errno::\*
-# 
+#
 #       - [ThreadError](https://ruby-doc.org/core-2.6.3/ThreadError.html)
-# 
+#
 #       - [TypeError](https://ruby-doc.org/core-2.6.3/TypeError.html)
-# 
+#
 #       - [ZeroDivisionError](https://ruby-doc.org/core-2.6.3/ZeroDivisionError.html)
-# 
+#
 #   - [SystemExit](https://ruby-doc.org/core-2.6.3/SystemExit.html)
-# 
+#
 #   - [SystemStackError](https://ruby-doc.org/core-2.6.3/SystemStackError.html)
-# 
+#
 #   - fatal – impossible to rescue
 class Exception < Object
   def self.to_tty?: () -> bool
@@ -131,25 +131,25 @@ class Exception < Object
   # Returns any backtrace associated with the exception. The backtrace is an
   # array of strings, each containing either “filename:lineNo: in \`method”‘
   # or “filename:lineNo.”
-  # 
+  #
   # ```ruby
   # def a
   #   raise "boom"
   # end
-  # 
+  #
   # def b
   #   a()
   # end
-  # 
+  #
   # begin
   #   b()
   # rescue => detail
   #   print detail.backtrace.join("\n")
   # end
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     prog.rb:2:in `a'
   #     prog.rb:6:in `b'
   #     prog.rb:10
@@ -161,7 +161,7 @@ class Exception < Object
   # the backtrace is an array of
   # [Thread::Backtrace::Location](https://ruby-doc.org/core-2.6.3/Thread/Backtrace/Location.html)
   # .
-  # 
+  #
   # Now, this method is not affected by
   # [\#set\_backtrace](Exception.downloaded.ruby_doc#method-i-set_backtrace)
   # .

--- a/stdlib/builtin/false_class.rbs
+++ b/stdlib/builtin/false_class.rbs
@@ -1,7 +1,7 @@
 # The global value `false` is the only instance of class FalseClass and
 # represents a logically false value in boolean expressions. The class provides
 # operators allowing `false` to participate correctly in logical expressions.
-# 
+#
 class FalseClass
   public
 
@@ -9,19 +9,19 @@ class FalseClass
 
   # And---Returns `false`. *obj* is always evaluated as it is the argument to a
   # method call---there is no short-circuit evaluation in this case.
-  # 
+  #
   def &: (untyped obj) -> bool
 
   # Case Equality -- For class Object, effectively the same as calling `#==`, but
   # typically overridden by descendants to provide meaningful semantics in `case`
   # statements.
-  # 
+  #
   def ===: (false) -> true
          | (untyped obj) -> bool
 
   # Exclusive Or---If *obj* is `nil` or `false`, returns `false`; otherwise,
   # returns `true`.
-  # 
+  #
   def ^: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool
@@ -29,11 +29,11 @@ class FalseClass
   alias inspect to_s
 
   # The string representation of `false` is "false".
-  # 
+  #
   def to_s: () -> "false"
 
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
-  # 
+  #
   def |: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool

--- a/stdlib/builtin/fiber.rbs
+++ b/stdlib/builtin/fiber.rbs
@@ -3,59 +3,59 @@
 # that can be paused and resumed, much like threads. The main difference
 # is that they are never preempted and that the scheduling must be done by
 # the programmer and not the VM.
-# 
+#
 # As opposed to other stackless light weight concurrency models, each
 # fiber comes with a stack. This enables the fiber to be paused from
 # deeply nested function calls within the fiber block. See the ruby(1)
 # manpage to configure the size of the fiber stack(s).
-# 
+#
 # When a fiber is created it will not run automatically. Rather it must be
 # explicitly asked to run using the `Fiber#resume` method. The code
 # running inside the fiber can give up control by calling `Fiber.yield` in
 # which case it yields control back to caller (the caller of the
 # `Fiber#resume` ).
-# 
+#
 # Upon yielding or termination the [Fiber](Fiber)
 # returns the value of the last executed expression
-# 
+#
 # For instance:
-# 
+#
 # ```ruby
 # fiber = Fiber.new do
 #   Fiber.yield 1
 #   2
 # end
-# 
+#
 # puts fiber.resume
 # puts fiber.resume
 # puts fiber.resume
 # ```
-# 
+#
 # *produces*
-# 
+#
 #     1
 #     2
 #     FiberError: dead fiber called
-# 
+#
 # The `Fiber#resume` method accepts an arbitrary number of parameters, if
 # it is the first call to `resume` then they will be passed as block
 # arguments. Otherwise they will be the return value of the call to
 # `Fiber.yield`
-# 
+#
 # Example:
-# 
+#
 # ```ruby
 # fiber = Fiber.new do |first|
 #   second = Fiber.yield first + 2
 # end
-# 
+#
 # puts fiber.resume 10
 # puts fiber.resume 14
 # puts fiber.resume 18
 # ```
-# 
+#
 # *produces*
-# 
+#
 #     12
 #     14
 #     FiberError: dead fiber called

--- a/stdlib/builtin/fiber_error.rbs
+++ b/stdlib/builtin/fiber_error.rbs
@@ -2,7 +2,7 @@
 # [Fiber](https://ruby-doc.org/core-2.6.3/Fiber.html), in particular when
 # attempting to call/resume a dead fiber, attempting to yield from the
 # root fiber, or calling a fiber across threads.
-# 
+#
 # ```ruby
 # fiber = Fiber.new{}
 # fiber.resume #=> nil

--- a/stdlib/builtin/float.rbs
+++ b/stdlib/builtin/float.rbs
@@ -1,158 +1,158 @@
 # Float objects represent inexact real numbers using the native architecture's
 # double-precision floating point representation.
-# 
+#
 # Floating point has a different arithmetic and is an inexact number. So you
 # should know its esoteric system. See following:
-# 
+#
 # *   http://docs.sun.com/source/806-3568/ncg_goldberg.html
 # *   https://github.com/rdp/ruby_tutorials_core/wiki/Ruby-Talk-FAQ#floats_impre
 #     cise
 # *   http://en.wikipedia.org/wiki/Floating_point#Accuracy_problems
-# 
-# 
+#
+#
 class Float < Numeric
   public
 
   # Returns the modulo after division of `float` by `other`.
-  # 
+  #
   #     6543.21.modulo(137)      #=> 104.21000000000004
   #     6543.21.modulo(137.24)   #=> 92.92999999999961
-  # 
+  #
   def %: (Integer) -> Float
        | (Float) -> Float
        | (Rational) -> Float
        | (Numeric) -> Numeric
 
   # Returns a new Float which is the product of `float` and `other`.
-  # 
+  #
   def *: (Complex) -> Complex
        | (Numeric) -> Float
 
   # Raises `float` to the power of `other`.
-  # 
+  #
   #     2.0**3   #=> 8.0
-  # 
+  #
   def **: (Complex) -> Complex
         | (Numeric) -> Float
 
   # Returns a new Float which is the sum of `float` and `other`.
-  # 
+  #
   def +: (Complex) -> Complex
        | (Numeric) -> Float
 
   def +@: () -> Float
 
   # Returns a new Float which is the difference of `float` and `other`.
-  # 
+  #
   def -: (Complex) -> Complex
        | (Numeric) -> Float
 
   # Returns `float`, negated.
-  # 
+  #
   def -@: () -> Float
 
   # Returns a new Float which is the result of dividing `float` by `other`.
-  # 
+  #
   def /: (Complex) -> Complex
        | (Numeric) -> Float
 
   # Returns `true` if `float` is less than `real`.
-  # 
+  #
   # The result of `NaN < NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def <: (Numeric) -> bool
 
   # Returns `true` if `float` is less than or equal to `real`.
-  # 
+  #
   # The result of `NaN <= NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def <=: (Numeric) -> bool
 
   # Returns -1, 0, or +1 depending on whether `float` is less than, equal to, or
   # greater than `real`. This is the basis for the tests in the Comparable module.
-  # 
+  #
   # The result of `NaN <=> NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   # `nil` is returned if the two values are incomparable.
-  # 
+  #
   def <=>: (Numeric) -> Integer?
 
   # Returns `true` only if `obj` has the same value as `float`. Contrast this with
   # Float#eql?, which requires `obj` to be a Float.
-  # 
+  #
   #     1.0 == 1   #=> true
-  # 
+  #
   # The result of `NaN == NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def ==: (untyped) -> bool
 
   # Returns `true` only if `obj` has the same value as `float`. Contrast this with
   # Float#eql?, which requires `obj` to be a Float.
-  # 
+  #
   #     1.0 == 1   #=> true
-  # 
+  #
   # The result of `NaN == NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def ===: (untyped) -> bool
 
   # Returns `true` if `float` is greater than `real`.
-  # 
+  #
   # The result of `NaN > NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def >: (Numeric) -> bool
 
   # Returns `true` if `float` is greater than or equal to `real`.
-  # 
+  #
   # The result of `NaN >= NaN` is undefined, so an implementation-dependent value
   # is returned.
-  # 
+  #
   def >=: (Numeric) -> bool
 
   # Returns the absolute value of `float`.
-  # 
+  #
   #     (-34.56).abs   #=> 34.56
   #     -34.56.abs     #=> 34.56
   #     34.56.abs      #=> 34.56
-  # 
+  #
   # Float#magnitude is an alias for Float#abs.
-  # 
+  #
   def abs: () -> Float
 
   def abs2: () -> Float
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   def angle: () -> (Integer | Float)
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   alias arg angle
 
   # Returns the smallest number greater than or equal to `float` with a precision
   # of `ndigits` decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a floating point number when `ndigits` is positive, otherwise returns
   # an integer.
-  # 
+  #
   #     1.2.ceil      #=> 2
   #     2.0.ceil      #=> 2
   #     (-1.2).ceil   #=> -1
   #     (-2.0).ceil   #=> -2
-  # 
+  #
   #     1.234567.ceil(2)   #=> 1.24
   #     1.234567.ceil(3)   #=> 1.235
   #     1.234567.ceil(4)   #=> 1.2346
   #     1.234567.ceil(5)   #=> 1.23457
-  # 
+  #
   #     34567.89.ceil(-5)  #=> 100000
   #     34567.89.ceil(-4)  #=> 40000
   #     34567.89.ceil(-3)  #=> 35000
@@ -162,24 +162,24 @@ class Float < Numeric
   #     34567.89.ceil(1)   #=> 34567.9
   #     34567.89.ceil(2)   #=> 34567.89
   #     34567.89.ceil(3)   #=> 34567.89
-  # 
+  #
   # Note that the limited precision of floating point arithmetic might lead to
   # surprising results:
-  # 
+  #
   #     (2.1 / 0.7).ceil  #=> 4 (!)
-  # 
+  #
   def ceil: () -> Integer
           | (int digits) -> (Integer | Float)
 
   def clone: (?freeze: bool) -> self
 
   # Returns an array with both `numeric` and `float` represented as Float objects.
-  # 
+  #
   # This is achieved by converting `numeric` to a Float.
-  # 
+  #
   #     1.2.coerce(3)       #=> [3.0, 1.2]
   #     2.5.coerce(1.1)     #=> [1.1, 2.5]
-  # 
+  #
   def coerce: (Numeric) -> [Numeric, Numeric]
 
   def conj: () -> Float
@@ -187,61 +187,61 @@ class Float < Numeric
   def conjugate: () -> Float
 
   # Returns the denominator (always positive).  The result is machine dependent.
-  # 
+  #
   # See also Float#numerator.
-  # 
+  #
   def denominator: () -> Integer
 
   def div: (Numeric) -> Integer
 
   # See Numeric#divmod.
-  # 
+  #
   #     42.0.divmod(6)   #=> [7, 0.0]
   #     42.0.divmod(5)   #=> [8, 2.0]
-  # 
+  #
   def divmod: (Numeric) -> [Numeric, Numeric]
 
   def dup: () -> self
 
   # Returns `true` only if `obj` is a Float with the same value as `float`.
   # Contrast this with Float#==, which performs type conversions.
-  # 
+  #
   #     1.0.eql?(1)   #=> false
-  # 
+  #
   # The result of `NaN.eql?(NaN)` is undefined, so an implementation-dependent
   # value is returned.
-  # 
+  #
   def eql?: (untyped) -> bool
 
   # Returns `float / numeric`, same as Float#/.
-  # 
+  #
   def fdiv: (Complex) -> Complex
           | (Numeric) -> Float
 
   # Returns `true` if `float` is a valid IEEE floating point number, i.e. it is
   # not infinite and Float#nan? is `false`.
-  # 
+  #
   def finite?: () -> bool
 
   # Returns the largest number less than or equal to `float` with a precision of
   # `ndigits` decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a floating point number when `ndigits` is positive, otherwise returns
   # an integer.
-  # 
+  #
   #     1.2.floor      #=> 1
   #     2.0.floor      #=> 2
   #     (-1.2).floor   #=> -2
   #     (-2.0).floor   #=> -2
-  # 
+  #
   #     1.234567.floor(2)   #=> 1.23
   #     1.234567.floor(3)   #=> 1.234
   #     1.234567.floor(4)   #=> 1.2345
   #     1.234567.floor(5)   #=> 1.23456
-  # 
+  #
   #     34567.89.floor(-5)  #=> 0
   #     34567.89.floor(-4)  #=> 30000
   #     34567.89.floor(-3)  #=> 34000
@@ -251,19 +251,19 @@ class Float < Numeric
   #     34567.89.floor(1)   #=> 34567.8
   #     34567.89.floor(2)   #=> 34567.89
   #     34567.89.floor(3)   #=> 34567.89
-  # 
+  #
   # Note that the limited precision of floating point arithmetic might lead to
   # surprising results:
-  # 
+  #
   #     (0.3 / 0.1).floor  #=> 2 (!)
-  # 
+  #
   def floor: () -> Integer
            | (int digits) -> (Integer | Numeric)
 
   # Returns a hash code for this float.
-  # 
+  #
   # See also Object#hash.
-  # 
+  #
   def hash: () -> Integer
 
   def i: () -> Complex
@@ -274,11 +274,11 @@ class Float < Numeric
 
   # Returns `nil`, -1, or 1 depending on whether the value is finite, `-Infinity`,
   # or `+Infinity`.
-  # 
+  #
   #     (0.0).infinite?        #=> nil
   #     (-1.0/0.0).infinite?   #=> -1
   #     (+1.0/0.0).infinite?   #=> 1
-  # 
+  #
   def infinite?: () -> Integer?
 
   alias inspect to_s
@@ -286,51 +286,51 @@ class Float < Numeric
   def integer?: () -> bool
 
   # Returns the absolute value of `float`.
-  # 
+  #
   #     (-34.56).abs   #=> 34.56
   #     -34.56.abs     #=> 34.56
   #     34.56.abs      #=> 34.56
-  # 
+  #
   # Float#magnitude is an alias for Float#abs.
-  # 
+  #
   alias magnitude abs
 
   # Returns the modulo after division of `float` by `other`.
-  # 
+  #
   #     6543.21.modulo(137)      #=> 104.21000000000004
   #     6543.21.modulo(137.24)   #=> 92.92999999999961
-  # 
+  #
   def modulo: (Numeric) -> Float
 
   # Returns `true` if `float` is an invalid IEEE floating point number.
-  # 
+  #
   #     a = -1.0      #=> -1.0
   #     a.nan?        #=> false
   #     a = 0.0/0.0   #=> NaN
   #     a.nan?        #=> true
-  # 
+  #
   def nan?: () -> bool
 
   # Returns `true` if `float` is less than 0.
-  # 
+  #
   def negative?: () -> bool
 
   # Returns the next representable floating point number.
-  # 
+  #
   # Float::MAX.next_float and Float::INFINITY.next_float is Float::INFINITY.
-  # 
+  #
   # Float::NAN.next_float is Float::NAN.
-  # 
+  #
   # For example:
-  # 
+  #
   #     0.01.next_float    #=> 0.010000000000000002
   #     1.0.next_float     #=> 1.0000000000000002
   #     100.0.next_float   #=> 100.00000000000001
-  # 
+  #
   #     0.01.next_float - 0.01     #=> 1.734723475976807e-18
   #     1.0.next_float - 1.0       #=> 2.220446049250313e-16
   #     100.0.next_float - 100.0   #=> 1.4210854715202004e-14
-  # 
+  #
   #     f = 0.01; 20.times { printf "%-20a %s\n", f, f.to_s; f = f.next_float }
   #     #=> 0x1.47ae147ae147bp-7 0.01
   #     #   0x1.47ae147ae147cp-7 0.010000000000000002
@@ -352,7 +352,7 @@ class Float < Numeric
   #     #   0x1.47ae147ae148cp-7 0.01000000000000003
   #     #   0x1.47ae147ae148dp-7 0.010000000000000031
   #     #   0x1.47ae147ae148ep-7 0.010000000000000033
-  # 
+  #
   #     f = 0.0
   #     100.times { f += 0.1 }
   #     f                           #=> 9.99999999999998       # should be 10.0 in the ideal world.
@@ -362,48 +362,48 @@ class Float < Numeric
   #     (10-f)/(10*Float::EPSILON)  #=> 8.8                    # approximation of the above.
   #     "%a" % 10                   #=> "0x1.4p+3"
   #     "%a" % f                    #=> "0x1.3fffffffffff5p+3" # the last hex digit is 5.  16 - 5 = 11 ulp.
-  # 
+  #
   def next_float: () -> Float
 
   def nonzero?: () -> self?
 
   # Returns the numerator.  The result is machine dependent.
-  # 
+  #
   #     n = 0.3.numerator    #=> 5404319552844595
   #     d = 0.3.denominator  #=> 18014398509481984
   #     n.fdiv(d)            #=> 0.3
-  # 
+  #
   # See also Float#denominator.
-  # 
+  #
   def numerator: () -> Integer
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   alias phase angle
 
   def polar: () -> [ Float, Integer | Float ]
 
   # Returns `true` if `float` is greater than 0.
-  # 
+  #
   def positive?: () -> bool
 
   # Returns the previous representable floating point number.
-  # 
+  #
   # (-Float::MAX).prev_float and (-Float::INFINITY).prev_float is
   # -Float::INFINITY.
-  # 
+  #
   # Float::NAN.prev_float is Float::NAN.
-  # 
+  #
   # For example:
-  # 
+  #
   #     0.01.prev_float    #=> 0.009999999999999998
   #     1.0.prev_float     #=> 0.9999999999999999
   #     100.0.prev_float   #=> 99.99999999999999
-  # 
+  #
   #     0.01 - 0.01.prev_float     #=> 1.734723475976807e-18
   #     1.0 - 1.0.prev_float       #=> 1.1102230246251565e-16
   #     100.0 - 100.0.prev_float   #=> 1.4210854715202004e-14
-  # 
+  #
   #     f = 0.01; 20.times { printf "%-20a %s\n", f, f.to_s; f = f.prev_float }
   #     #=> 0x1.47ae147ae147bp-7 0.01
   #     #   0x1.47ae147ae147ap-7 0.009999999999999998
@@ -425,24 +425,24 @@ class Float < Numeric
   #     #   0x1.47ae147ae146ap-7 0.00999999999999997
   #     #   0x1.47ae147ae1469p-7 0.009999999999999969
   #     #   0x1.47ae147ae1468p-7 0.009999999999999967
-  # 
+  #
   def prev_float: () -> Float
 
   # Returns `float / numeric`, same as Float#/.
-  # 
+  #
   def quo: (Complex) -> Complex
          | (Numeric) -> Float
 
   # Returns a simpler approximation of the value (flt-|eps| <= result <=
   # flt+|eps|).  If the optional argument `eps` is not given, it will be chosen
   # automatically.
-  # 
+  #
   #     0.3.rationalize          #=> (3/10)
   #     1.333.rationalize        #=> (1333/1000)
   #     1.333.rationalize(0.01)  #=> (4/3)
-  # 
+  #
   # See also Float#to_r.
-  # 
+  #
   def rationalize: (?Numeric eps) -> Rational
 
   def real: () -> Float
@@ -457,23 +457,23 @@ class Float < Numeric
 
   # Returns `float` rounded to the nearest value with a precision of `ndigits`
   # decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a floating point number when `ndigits` is positive, otherwise returns
   # an integer.
-  # 
+  #
   #     1.4.round      #=> 1
   #     1.5.round      #=> 2
   #     1.6.round      #=> 2
   #     (-1.5).round   #=> -2
-  # 
+  #
   #     1.234567.round(2)   #=> 1.23
   #     1.234567.round(3)   #=> 1.235
   #     1.234567.round(4)   #=> 1.2346
   #     1.234567.round(5)   #=> 1.23457
-  # 
+  #
   #     34567.89.round(-5)  #=> 0
   #     34567.89.round(-4)  #=> 30000
   #     34567.89.round(-3)  #=> 35000
@@ -483,15 +483,15 @@ class Float < Numeric
   #     34567.89.round(1)   #=> 34567.9
   #     34567.89.round(2)   #=> 34567.89
   #     34567.89.round(3)   #=> 34567.89
-  # 
+  #
   # If the optional `half` keyword argument is given, numbers that are half-way
   # between two possible rounded values will be rounded according to the specified
   # tie-breaking `mode`:
-  # 
+  #
   # *   `:up` or `nil`: round half away from zero (default)
   # *   `:down`: round half toward zero
   # *   `:even`: round half toward the nearest even number
-  # 
+  #
   #         2.5.round(half: :up)      #=> 3
   #         2.5.round(half: :down)    #=> 2
   #         2.5.round(half: :even)    #=> 2
@@ -501,7 +501,7 @@ class Float < Numeric
   #         (-2.5).round(half: :up)   #=> -3
   #         (-2.5).round(half: :down) #=> -2
   #         (-2.5).round(half: :even) #=> -2
-  # 
+  #
   def round: (?half: :up | :down | :even) -> Integer
            | (int digits, ?half: :up | :down | :even) -> (Integer | Float)
 
@@ -513,174 +513,174 @@ class Float < Numeric
   def to_c: () -> Complex
 
   # Since `float` is already a Float, returns `self`.
-  # 
+  #
   def to_f: () -> Float
 
   # Returns the `float` truncated to an Integer.
-  # 
+  #
   #     1.2.to_i      #=> 1
   #     (-1.2).to_i   #=> -1
-  # 
+  #
   # Note that the limited precision of floating point arithmetic might lead to
   # surprising results:
-  # 
+  #
   #     (0.3 / 0.1).to_i  #=> 2 (!)
-  # 
+  #
   # #to_int is an alias for #to_i.
-  # 
+  #
   def to_i: () -> Integer
 
   # Returns the `float` truncated to an Integer.
-  # 
+  #
   #     1.2.to_i      #=> 1
   #     (-1.2).to_i   #=> -1
-  # 
+  #
   # Note that the limited precision of floating point arithmetic might lead to
   # surprising results:
-  # 
+  #
   #     (0.3 / 0.1).to_i  #=> 2 (!)
-  # 
+  #
   # #to_int is an alias for #to_i.
-  # 
+  #
   alias to_int to_i
 
   # Returns the value as a rational.
-  # 
+  #
   #     2.0.to_r    #=> (2/1)
   #     2.5.to_r    #=> (5/2)
   #     -0.75.to_r  #=> (-3/4)
   #     0.0.to_r    #=> (0/1)
   #     0.3.to_r    #=> (5404319552844595/18014398509481984)
-  # 
+  #
   # NOTE: 0.3.to_r isn't the same as "0.3".to_r.  The latter is equivalent to
   # "3/10".to_r, but the former isn't so.
-  # 
+  #
   #     0.3.to_r   == 3/10r  #=> false
   #     "0.3".to_r == 3/10r  #=> true
-  # 
+  #
   # See also Float#rationalize.
-  # 
+  #
   def to_r: () -> Rational
 
   # Returns a string containing a representation of `self`. As well as a fixed or
   # exponential form of the `float`, the call may return `NaN`, `Infinity`, and
   # `-Infinity`.
-  # 
+  #
   def to_s: () -> String
 
   # Returns `float` truncated (toward zero) to a precision of `ndigits` decimal
   # digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a floating point number when `ndigits` is positive, otherwise returns
   # an integer.
-  # 
+  #
   #     2.8.truncate           #=> 2
   #     (-2.8).truncate        #=> -2
   #     1.234567.truncate(2)   #=> 1.23
   #     34567.89.truncate(-2)  #=> 34500
-  # 
+  #
   # Note that the limited precision of floating point arithmetic might lead to
   # surprising results:
-  # 
+  #
   #     (0.3 / 0.1).truncate  #=> 2 (!)
-  # 
+  #
   def truncate: () -> Integer
               | (Integer ndigits) -> (Integer | Float)
 
   # Returns `true` if `float` is 0.0.
-  # 
+  #
   def zero?: () -> bool
 end
 
 # The minimum number of significant decimal digits in a double-precision
 # floating point.
-# 
+#
 # Usually defaults to 15.
-# 
+#
 Float::DIG: Integer
 
 # The difference between 1 and the smallest double-precision floating point
 # number greater than 1.
-# 
+#
 # Usually defaults to 2.2204460492503131e-16.
-# 
+#
 Float::EPSILON: Float
 
 # An expression representing positive infinity.
-# 
+#
 Float::INFINITY: Float
 
 # The number of base digits for the `double` data type.
-# 
+#
 # Usually defaults to 53.
-# 
+#
 Float::MANT_DIG: Integer
 
 # The largest possible integer in a double-precision floating point number.
-# 
+#
 # Usually defaults to 1.7976931348623157e+308.
-# 
+#
 Float::MAX: Float
 
 # The largest positive exponent in a double-precision floating point where 10
 # raised to this power minus 1.
-# 
+#
 # Usually defaults to 308.
-# 
+#
 Float::MAX_10_EXP: Integer
 
 # The largest possible exponent value in a double-precision floating point.
-# 
+#
 # Usually defaults to 1024.
-# 
+#
 Float::MAX_EXP: Integer
 
 # The smallest positive normalized number in a double-precision floating point.
-# 
+#
 # Usually defaults to 2.2250738585072014e-308.
-# 
+#
 # If the platform supports denormalized numbers, there are numbers between zero
 # and Float::MIN. 0.0.next_float returns the smallest positive floating point
 # number including denormalized numbers.
-# 
+#
 Float::MIN: Float
 
 # The smallest negative exponent in a double-precision floating point where 10
 # raised to this power minus 1.
-# 
+#
 # Usually defaults to -307.
-# 
+#
 Float::MIN_10_EXP: Integer
 
 # The smallest possible exponent value in a double-precision floating point.
-# 
+#
 # Usually defaults to -1021.
-# 
+#
 Float::MIN_EXP: Integer
 
 # An expression representing a value which is "not a number".
-# 
+#
 Float::NAN: Float
 
 # The base of the floating point, or number of unique digits used to represent
 # the number.
-# 
+#
 # Usually defaults to 2 on most systems, which would represent a base-10
 # decimal.
-# 
+#
 Float::RADIX: Integer
 
 # Deprecated, do not use.
-# 
+#
 # Represents the rounding mode for floating point addition at the start time.
-# 
+#
 # Usually defaults to 1, rounding to the nearest number.
-# 
+#
 # Other modes include:
-# 
+#
 # -1
 # :   Indeterminable
 # 0
@@ -691,6 +691,6 @@ Float::RADIX: Integer
 # :   Rounding towards positive infinity
 # 3
 # :   Rounding towards negative infinity
-# 
-# 
+#
+#
 Float::ROUNDS: Integer

--- a/stdlib/builtin/gc.rbs
+++ b/stdlib/builtin/gc.rbs
@@ -221,7 +221,7 @@ module GC::Profiler
   # `:HEAP_LIVE_OBJECTS`
   # `:HEAP_FREE_OBJECTS`
   # `:HAVE_FINALIZE`
-  # :   
+  # :
   #
   def self.raw_data: () -> ::Array[::Hash[Symbol, untyped]]
 

--- a/stdlib/builtin/io.rbs
+++ b/stdlib/builtin/io.rbs
@@ -2,7 +2,7 @@
 # output in Ruby. An I/O stream may be *duplexed* (that is,
 # bidirectional), and so may use more than one native operating system
 # stream.
-# 
+#
 # Many of the examples in this section use the
 # [File](https://ruby-doc.org/core-2.6.3/File.html) class, the only
 # standard subclass of [IO](IO). The two classes are
@@ -10,47 +10,47 @@
 # [File](https://ruby-doc.org/core-2.6.3/File.html) class, the Socket
 # library subclasses from [IO](IO) (such as TCPSocket
 # or UDPSocket).
-# 
+#
 # The
 # [Kernel\#open](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-open)
 # method can create an [IO](IO) (or
 # [File](https://ruby-doc.org/core-2.6.3/File.html) ) object for these
 # types of arguments:
-# 
+#
 #   - A plain string represents a filename suitable for the underlying
 #     operating system.
-# 
+#
 #   - A string starting with `"|"` indicates a subprocess. The remainder
 #     of the string following the `"|"` is invoked as a process with
 #     appropriate input/output channels connected to it.
-# 
+#
 #   - A string equal to `"|-"` will create another Ruby instance as a
 #     subprocess.
-# 
+#
 # The [IO](IO) may be opened with different file modes
 # (read-only, write-only) and encodings for proper conversion. See
 # [::new](IO#method-c-new) for these options. See
 # [Kernel\#open](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-open)
 # for details of the various command formats described above.
-# 
+#
 # [::popen](IO#method-c-popen), the Open3 library, or
 # Process\#spawn may also be used to communicate with subprocesses through
 # an [IO](IO).
-# 
+#
 # Ruby will convert pathnames between different operating system
 # conventions if possible. For instance, on a Windows system the filename
 # `"/gumby/ruby/test.rb"` will be opened as `"\gumby\ruby\test.rb"` . When
 # specifying a Windows-style filename in a Ruby string, remember to escape
 # the backslashes:
-# 
+#
 # ```ruby
 # "C:\\gumby\\ruby\\test.rb"
 # ```
-# 
+#
 # Our examples here will use the Unix-style forward slashes;
 # File::ALT\_SEPARATOR can be used to get the platform-specific separator
 # character.
-# 
+#
 # The global constant [ARGF](https://ruby-doc.org/core-2.6.3/ARGF.html)
 # (also accessible as `$<` ) provides an IO-like stream which allows
 # access to all files mentioned on the command line (or STDIN if no files
@@ -59,44 +59,44 @@
 # and its alias
 # [ARGF\#filename](https://ruby-doc.org/core-2.6.3/ARGF.html#method-i-filename)
 # are provided to access the name of the file currently being read.
-# 
-# 
+#
+#
 # The io/console extension provides methods for interacting with the
 # console. The console can be accessed from IO.console or the standard
 # input/output/error [IO](IO) objects.
-# 
+#
 # Requiring io/console adds the following methods:
-# 
+#
 #   - IO::console
-# 
+#
 #   - IO\#raw
-# 
+#
 #   - IO\#raw\!
-# 
+#
 #   - IO\#cooked
-# 
+#
 #   - IO\#cooked\!
-# 
+#
 #   - IO\#getch
-# 
+#
 #   - IO\#echo=
-# 
+#
 #   - IO\#echo?
-# 
+#
 #   - IO\#noecho
-# 
+#
 #   - IO\#winsize
-# 
+#
 #   - IO\#winsize=
-# 
+#
 #   - IO\#iflush
-# 
+#
 #   - IO\#ioflush
-# 
+#
 #   - IO\#oflush
-# 
+#
 # Example:
-# 
+#
 # ```ruby
 # require 'io/console'
 # rows, columns = $stdout.winsize
@@ -119,11 +119,11 @@ class IO < Object
 
   # Puts *ios* into binary mode. Once a stream is in binary mode, it cannot
   # be reset to nonbinary mode.
-  # 
+  #
   #   - newline conversion disabled
-  # 
+  #
   #   - encoding conversion disabled
-  # 
+  #
   #   - content is treated as ASCII-8BIT
   def binmode: () -> self
 
@@ -134,9 +134,9 @@ class IO < Object
   # stream is unavailable for any further data operations; an `IOError` is
   # raised if such an attempt is made. I/O streams are automatically closed
   # when they are claimed by the garbage collector.
-  # 
+  #
   # If *ios* is opened by `IO.popen`, `close` sets `$?` .
-  # 
+  #
   # Calling this method on closed [IO](IO.downloaded.ruby_doc) object is
   # just ignored since Ruby 2.3.
   def close: () -> NilClass
@@ -144,7 +144,7 @@ class IO < Object
   def close_on_exec=: (bool arg0) -> bool
 
   # Returns `true` if *ios* will be closed on exec.
-  # 
+  #
   # ```ruby
   # f = open("/dev/null")
   # f.close_on_exec?                 #=> false
@@ -158,18 +158,18 @@ class IO < Object
   # Closes the read end of a duplex I/O stream (i.e., one that contains both
   # a read and a write stream, such as a pipe). Will raise an `IOError` if
   # the stream is not duplexed.
-  # 
+  #
   # ```ruby
   # f = IO.popen("/bin/sh","r+")
   # f.close_read
   # f.readlines
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     prog.rb:3:in `readlines': not opened for reading (IOError)
   #      from prog.rb:3
-  # 
+  #
   # Calling this method on closed [IO](IO.downloaded.ruby_doc) object is
   # just ignored since Ruby 2.3.
   def close_read: () -> NilClass
@@ -177,26 +177,26 @@ class IO < Object
   # Closes the write end of a duplex I/O stream (i.e., one that contains
   # both a read and a write stream, such as a pipe). Will raise an `IOError`
   # if the stream is not duplexed.
-  # 
+  #
   # ```ruby
   # f = IO.popen("/bin/sh","r+")
   # f.close_write
   # f.print "nowhere"
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     prog.rb:3:in `write': not opened for writing (IOError)
   #      from prog.rb:3:in `print'
   #      from prog.rb:3
-  # 
+  #
   # Calling this method on closed [IO](IO.downloaded.ruby_doc) object is
   # just ignored since Ruby 2.3.
   def close_write: () -> NilClass
 
   # Returns `true` if *ios* is completely closed (for duplex streams, both
   # reader and writer), `false` otherwise.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.close         #=> nil
@@ -224,29 +224,29 @@ class IO < Object
   # Returns true if *ios* is at end of file that means there are no more
   # data to read. The stream must be opened for reading or an `IOError` will
   # be raised.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # dummy = f.readlines
   # f.eof   #=> true
   # ```
-  # 
+  #
   # If *ios* is a stream such as pipe or socket, `IO#eof?` blocks until the
   # other end sends some data or closes it.
-  # 
+  #
   # ```ruby
   # r, w = IO.pipe
   # Thread.new { sleep 1; w.close }
   # r.eof?  #=> true after 1 second blocking
-  # 
+  #
   # r, w = IO.pipe
   # Thread.new { sleep 1; w.puts "a" }
   # r.eof?  #=> false after 1 second blocking
-  # 
+  #
   # r, w = IO.pipe
   # r.eof?  # blocks forever
   # ```
-  # 
+  #
   # Note that `IO#eof?` reads data to the input byte buffer. So `IO#sysread`
   # may not behave as you intend with `IO#eof?`, unless you call
   # `IO#rewind` first (which is not available for some streams).
@@ -255,35 +255,35 @@ class IO < Object
   def fcntl: (Integer integer_cmd, String | Integer arg) -> Integer
 
   # Immediately writes all buffered data in *ios* to disk.
-  # 
+  #
   # If the underlying operating system does not support *fdatasync(2)* ,
   # `IO#fsync` is called instead (which might raise a `NotImplementedError`
   # ).
   def fdatasync: () -> Integer?
 
   # Returns an integer representing the numeric file descriptor for *ios* .
-  # 
+  #
   # ```ruby
   # $stdin.fileno    #=> 0
   # $stdout.fileno   #=> 1
   # ```
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [to\_i](IO.downloaded.ruby_doc#method-i-to_i)
   def fileno: () -> Integer
 
   # Flushes any buffered data within *ios* to the underlying operating
   # system (note that this is Ruby internal buffering only; the OS may
   # buffer the data as well).
-  # 
+  #
   # ```ruby
   # $stdout.print "no newline"
   # $stdout.flush
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   # ```ruby
   # no newline
   # ```
@@ -293,14 +293,14 @@ class IO < Object
   # differs from using `IO#sync=` . The latter ensures that data is flushed
   # from Ruby’s buffers, but does not guarantee that the underlying
   # operating system actually writes it to disk.
-  # 
+  #
   # `NotImplementedError` is raised if the underlying operating system does
   # not support *fsync(2)* .
   def fsync: () -> Integer?
 
   # Gets the next 8-bit byte (0..255) from *ios* . Returns `nil` if called
   # at end of file.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.getbyte   #=> 84
@@ -310,7 +310,7 @@ class IO < Object
 
   # Reads a one-character string from *ios* . Returns `nil` if called at end
   # of file.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.getc   #=> "h"
@@ -334,7 +334,7 @@ class IO < Object
 
   # Returns `true` if *ios* is associated with a terminal device (tty),
   # `false` otherwise.
-  # 
+  #
   # ```ruby
   # File.new("testfile").isatty   #=> false
   # File.new("/dev/tty").isatty   #=> true
@@ -347,14 +347,14 @@ class IO < Object
   # number of newlines encountered. The two values will differ if
   # [gets](IO.downloaded.ruby_doc#method-i-gets) is called with a separator
   # other than newline.
-  # 
+  #
   # Methods that use `$/` like [each](IO.downloaded.ruby_doc#method-i-each)
   # , [lines](IO.downloaded.ruby_doc#method-i-lines) and
   # [readline](IO.downloaded.ruby_doc#method-i-readline) will also increment
   # `lineno` .
-  # 
+  #
   # See also the `$.` variable.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.lineno   #=> 0
@@ -369,7 +369,7 @@ class IO < Object
 
   # Returns the process ID of a child process associated with *ios* . This
   # will be set by `IO.popen` .
-  # 
+  #
   # ```ruby
   # pipe = IO.popen("-")
   # if pipe
@@ -378,15 +378,15 @@ class IO < Object
   #   $stderr.puts "In child, pid is #{$$}"
   # end
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     In child, pid is 26209
   #     In parent, child pid is 26209
   def pid: () -> Integer
 
   # Returns the current offset (in bytes) of *ios* .
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.pos    #=> 0
@@ -416,7 +416,7 @@ class IO < Object
 
   # Reads a one-character string from *ios* . Raises an `EOFError` on end of
   # file.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.readchar   #=> "h"
@@ -435,7 +435,7 @@ class IO < Object
             | (String other_IO_or_path, ?String mode_str) -> IO
 
   # Positions *ios* to the beginning of input, resetting `lineno` to zero.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.readline   #=> "This is line one\n"
@@ -443,7 +443,7 @@ class IO < Object
   # f.lineno     #=> 0
   # f.readline   #=> "This is line one\n"
   # ```
-  # 
+  #
   # Note that it cannot be used with streams such as pipes, ttys, and
   # sockets.
   def rewind: () -> Integer
@@ -454,7 +454,7 @@ class IO < Object
                   | (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc) -> self
 
   # Returns status information for *ios* as an object of type `File::Stat` .
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # s = f.stat
@@ -467,7 +467,7 @@ class IO < Object
   # Returns the current “sync mode” of *ios* . When sync mode is true, all
   # output is immediately flushed to the underlying operating system and is
   # not buffered by Ruby internally. See also `IO#fsync` .
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.sync   #=> false
@@ -483,7 +483,7 @@ class IO < Object
   def syswrite: (_ToS arg0) -> Integer
 
   # Returns the current offset (in bytes) of *ios* .
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # f.pos    #=> 0
@@ -497,7 +497,7 @@ class IO < Object
 
   # Returns `true` if *ios* is associated with a terminal device (tty),
   # `false` otherwise.
-  # 
+  #
   # ```ruby
   # File.new("testfile").isatty   #=> false
   # File.new("/dev/tty").isatty   #=> true
@@ -547,29 +547,29 @@ class IO < Object
   # Returns true if *ios* is at end of file that means there are no more
   # data to read. The stream must be opened for reading or an `IOError` will
   # be raised.
-  # 
+  #
   # ```ruby
   # f = File.new("testfile")
   # dummy = f.readlines
   # f.eof   #=> true
   # ```
-  # 
+  #
   # If *ios* is a stream such as pipe or socket, `IO#eof?` blocks until the
   # other end sends some data or closes it.
-  # 
+  #
   # ```ruby
   # r, w = IO.pipe
   # Thread.new { sleep 1; w.close }
   # r.eof?  #=> true after 1 second blocking
-  # 
+  #
   # r, w = IO.pipe
   # Thread.new { sleep 1; w.puts "a" }
   # r.eof?  #=> false after 1 second blocking
-  # 
+  #
   # r, w = IO.pipe
   # r.eof?  # blocks forever
   # ```
-  # 
+  #
   # Note that `IO#eof?` reads data to the input byte buffer. So `IO#sysread`
   # may not behave as you intend with `IO#eof?`, unless you call
   # `IO#rewind` first (which is not available for some streams).

--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -1,18 +1,18 @@
 # The [Kernel](Kernel) module is included by class
 # [Object](https://ruby-doc.org/core-2.6.3/Object.html), so its methods
 # are available in every Ruby object.
-# 
+#
 # The [Kernel](Kernel) instance methods are documented
 # in class [Object](https://ruby-doc.org/core-2.6.3/Object.html) while the
 # module methods are documented here. These methods are called without a
 # receiver and thus can be called in functional form:
-# 
+#
 # ```ruby
 # sprintf "%.1f", 1.234 #=> "1.2"
 # ```
 module Kernel
   private
-  
+
   def caller: (?Integer start_or_range, ?Integer length) -> ::Array[String]?
             | (?::Range[Integer] start_or_range) -> ::Array[String]?
             | () -> ::Array[String]
@@ -24,13 +24,13 @@ module Kernel
            | () { (Object tag) -> untyped } -> untyped
 
   # In a perfect world this should be:
-  # 
+  #
   #   returns(T.class_of(T.self_type))
-  # 
+  #
   # but that doesn't work (yet). Even making it:
-  # 
+  #
   #   returns(Class)
-  # 
+  #
   # is very surprising since users expect their methods to be present.
   # So we settle for untyped.
   def `class`: () -> untyped
@@ -42,7 +42,7 @@ module Kernel
 
   # Returns `true` if `yield` would execute a block in the current context.
   # The `iterator?` form is mildly deprecated.
-  # 
+  #
   # ```ruby
   # def try
   #   if block_given?
@@ -59,7 +59,7 @@ module Kernel
   alias block_given? iterator?
 
   # Returns the names of the current local variables.
-  # 
+  #
   # ```ruby
   # fred = 1
   # for i in 1..10
@@ -102,12 +102,12 @@ module Kernel
   # collect the termination statuses of its children or use `Process.detach`
   # to register disinterest in their status; otherwise, the operating system
   # may accumulate zombie processes.
-  # 
+  #
   # The thread calling fork is the only thread in the created child process.
   # fork doesn’t copy other threads.
-  # 
+  #
   # If fork is not usable, Process.respond\_to?(:fork) returns false.
-  # 
+  #
   # Note that fork(2) is not available on some platforms like Windows and
   # NetBSD 4. Therefore you should use spawn() instead of fork().
   def fork: () -> Integer?
@@ -179,16 +179,16 @@ module Kernel
 
   # Returns `arg` as an [Array](https://ruby-doc.org/core-2.6.3/Array.html)
   # .
-  # 
+  #
   # First tries to call `to_ary` on `arg`, then `to_a` . If `arg` does not
   # respond to `to_ary` or `to_a`, returns an
   # [Array](https://ruby-doc.org/core-2.6.3/Array.html) of length 1
   # containing `arg` .
-  # 
+  #
   # If `to_ary` or `to_a` returns something other than an
   # [Array](https://ruby-doc.org/core-2.6.3/Array.html), raises a
   # `TypeError` .
-  # 
+  #
   # ```ruby
   # Array(["a", "b"])  #=> ["a", "b"]
   # Array(1..5)        #=> [1, 2, 3, 4, 5]
@@ -245,7 +245,7 @@ module Kernel
   # at the point of call. This object can be used when calling `eval` to
   # execute the evaluated command in this environment. See also the
   # description of class `Binding` .
-  # 
+  #
   # ```ruby
   # def get_binding(param)
   #   binding
@@ -260,7 +260,7 @@ module Kernel
   # to return a status code to the invoking environment. `true` and `FALSE`
   # of *status* means success and failure respectively. The interpretation
   # of other integer values are system dependent.
-  # 
+  #
   # ```ruby
   # begin
   #   exit
@@ -270,25 +270,25 @@ module Kernel
   # end
   # puts "after begin block"
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     rescued a SystemExit exception
   #     after begin block
-  # 
+  #
   # Just prior to termination, Ruby executes any `at_exit` functions (see
   # Kernel::at\_exit) and runs any object finalizers (see
   # [ObjectSpace.define\_finalizer](https://ruby-doc.org/core-2.6.3/ObjectSpace.html#method-c-define_finalizer)
   # ).
-  # 
+  #
   # ```ruby
   # at_exit { puts "at_exit function" }
   # ObjectSpace.define_finalizer("string",  proc { puts "in finalizer" })
   # exit
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     at_exit function
   #     in finalizer
   def exit: () -> bot
@@ -325,7 +325,7 @@ module Kernel
   def gets: (?String arg0, ?Integer arg1) -> String?
 
   # Returns an array of the names of global variables.
-  # 
+  #
   # ```ruby
   # global_variables.grep /std/   #=> [:$stdin, :$stdout, :$stderr]
   # ```
@@ -334,9 +334,9 @@ module Kernel
   def load: (String filename, ?bool arg0) -> bool
 
   # Repeatedly executes the block.
-  # 
+  #
   # If no block is given, an enumerator is returned instead.
-  # 
+  #
   # ```ruby
   # loop do
   #   print "Input: "
@@ -345,18 +345,18 @@ module Kernel
   #   # ...
   # end
   # ```
-  # 
+  #
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html)
   # raised in the block breaks the loop. In this case, loop returns the
   # "result" value stored in the exception.
-  # 
+  #
   # ```ruby
   # enum = Enumerator.new { |y|
   #   y << "one"
   #   y << "two"
   #   :ok
   # }
-  # 
+  #
   # result = loop {
   #   puts enum.next
   # } #=> :ok
@@ -372,16 +372,16 @@ module Kernel
   # the output record separator ( `$\` ) is not `nil`, it will be appended
   # to the output. If no arguments are given, prints `$_` . Objects that
   # aren’t strings will be converted by calling their `to_s` method.
-  # 
+  #
   # ```ruby
   # print "cat", [1,2,3], 99, "\n"
   # $, = ", "
   # $\ = "\n"
   # print "cat", [1,2,3], 99
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     cat12399
   #     cat, 1, 2, 3, 99
   def print: (*Kernel args) -> nil
@@ -408,35 +408,35 @@ module Kernel
   # If called without an argument, or if `max.to_i.abs == 0`, rand returns
   # a pseudo-random floating point number between 0.0 and 1.0, including 0.0
   # and excluding 1.0.
-  # 
+  #
   # ```ruby
   # rand        #=> 0.2725926052826416
   # ```
-  # 
+  #
   # When `max.abs` is greater than or equal to 1, `rand` returns a
   # pseudo-random integer greater than or equal to 0 and less than
   # `max.to_i.abs` .
-  # 
+  #
   # ```ruby
   # rand(100)   #=> 12
   # ```
-  # 
+  #
   # When `max` is a [Range](https://ruby-doc.org/core-2.6.3/Range.html),
   # `rand` returns a random number where range.member?(number) == true.
-  # 
+  #
   # Negative or floating point values for `max` are allowed, but may give
   # surprising results.
-  # 
+  #
   # ```ruby
   # rand(-100) # => 87
   # rand(-0.5) # => 0.8130921818028143
   # rand(1.9)  # equivalent to rand(1), which is always 0
   # ```
-  # 
+  #
   # [\#srand](Kernel.downloaded.ruby_doc#method-i-srand) may be used to
   # ensure that sequences of random numbers are reproducible between
   # different runs of a program.
-  # 
+  #
   # See also
   # [Random\#rand](https://ruby-doc.org/core-2.6.3/Random.html#method-i-rand)
   # .
@@ -468,109 +468,109 @@ module Kernel
 
   # Replaces the current process by running the given external *command* ,
   # which can take one of the following forms:
-  # 
+  #
   #   - `exec(commandline)`
   #     command line string which is passed to the standard shell
-  # 
+  #
   #   - `exec(cmdname, arg1, ...)`
   #     command name and one or more arguments (no shell)
-  # 
+  #
   #   - `exec([cmdname, argv0], arg1, ...)`
   #     command name, [argv](https://ruby-doc.org/core-2.6.3/0) and zero or
   #     more arguments (no shell)
-  # 
+  #
   # In the first form, the string is taken as a command line that is subject
   # to shell expansion before being executed.
-  # 
+  #
   # The standard shell always means `"/bin/sh"` on Unix-like systems, same
   # as `ENV["RUBYSHELL"]` (or `ENV["COMSPEC"]` on Windows NT series), and
   # similar.
-  # 
+  #
   # If the string from the first form ( `exec("command")` ) follows these
   # simple rules:
-  # 
+  #
   #   - no meta characters
-  # 
+  #
   #   - no shell reserved word and no special built-in
-  # 
+  #
   #   - Ruby invokes the command directly without shell
-  # 
+  #
   # You can force shell invocation by adding “;” to the string (because “;”
   # is a meta character).
-  # 
+  #
   # Note that this behavior is observable by pid obtained (return value of
   # spawn() and
   # [IO\#pid](https://ruby-doc.org/core-2.6.3/IO.html#method-i-pid) for
   # [IO.popen](https://ruby-doc.org/core-2.6.3/IO.html#method-c-popen) ) is
   # the pid of the invoked command, not shell.
-  # 
+  #
   # In the second form ( `exec("command1", "arg1", ...)` ), the first is
   # taken as a command name and the rest are passed as parameters to command
   # with no shell expansion.
-  # 
+  #
   # In the third form ( `exec(["command", "argv0"], "arg1", ...)` ),
   # starting a two-element array at the beginning of the command, the first
   # element is the command to be executed, and the second argument is used
   # as the `argv[0]` value, which may show up in process listings.
-  # 
+  #
   # In order to execute the command, one of the `exec(2)` system calls are
   # used, so the running command may inherit some of the environment of the
   # original program (including open file descriptors).
-  # 
+  #
   # This behavior is modified by the given `env` and `options` parameters.
   # See ::spawn for details.
-  # 
+  #
   # If the command fails to execute (typically `Errno::ENOENT` when it was
   # not found) a
   # [SystemCallError](https://ruby-doc.org/core-2.6.3/SystemCallError.html)
   # exception is raised.
-  # 
+  #
   # This method modifies process attributes according to given `options`
   # before `exec(2)` system call. See ::spawn for more details about the
   # given `options` .
-  # 
+  #
   # The modified attributes may be retained when `exec(2)` system call
   # fails.
-  # 
+  #
   # For example, hard resource limits are not restorable.
-  # 
+  #
   # Consider to create a child process using ::spawn or
   # [\#system](Kernel.downloaded.ruby_doc#method-i-system) if this is not
   # acceptable.
-  # 
+  #
   # ```ruby
   # exec "echo *"       # echoes list of files in current directory
   # # never get here
-  # 
+  #
   # exec "echo", "*"    # echoes an asterisk
   # # never get here
   # ```
   def exec: (*String args) -> bot
 
   # Executes *command…* in a subshell. *command…* is one of following forms.
-  # 
+  #
   #     commandline                 : command line string which is passed to the standard shell
   #     cmdname, arg1, ...          : command name and one or more arguments (no shell)
   #     [cmdname, argv0], arg1, ... : command name, argv[0] and zero or more arguments (no shell)
-  # 
+  #
   # system returns `true` if the command gives zero exit status, `false` for
   # non zero exit status. Returns `nil` if command execution fails. An error
   # status is available in `$?` . The arguments are processed in the same
   # way as for `Kernel.spawn` .
-  # 
+  #
   # The hash arguments, env and options, are same as `exec` and `spawn` .
   # See `Kernel.spawn` for details.
-  # 
+  #
   # ```ruby
   # system("echo *")
   # system("echo", "*")
   # ```
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     config.h main.rb
   #     *
-  # 
+  #
   # See `Kernel.exec` for the standard shell.
   def system: (*String args) -> (NilClass | FalseClass | TrueClass)
 end

--- a/stdlib/builtin/match_data.rbs
+++ b/stdlib/builtin/match_data.rbs
@@ -95,7 +95,7 @@ class MatchData
   #     f3    #=> "113"
   #     f4    #=> "8"
   #
-  def captures: () -> ::Array[String?] 
+  def captures: () -> ::Array[String?]
 
   # Returns the offset of the character immediately following the end of the *n*th
   # element of the match array in the string. *n* can be a string or symbol to

--- a/stdlib/builtin/method.rbs
+++ b/stdlib/builtin/method.rbs
@@ -4,7 +4,7 @@ class Method < Object
 
   # Invokes the *meth* with the specified arguments, returning the method’s
   # return value.
-  # 
+  #
   # ```ruby
   # m = 12.method("+")
   # m.call(3)    #=> 15
@@ -15,12 +15,12 @@ class Method < Object
   # Returns a proc that is the composition of this method and the given *g*
   # . The returned proc takes a variable number of arguments, calls *g* with
   # them then calls this method with the result.
-  # 
+  #
   # ```ruby
   # def f(x)
   #   x * x
   # end
-  # 
+  #
   # f = self.method(:f)
   # g = proc {|x| x + x }
   # p (f << g).call(2) #=> 16
@@ -30,10 +30,10 @@ class Method < Object
   # Invokes the method with `obj` as the parameter like
   # [call](Method.downloaded.ruby_doc#method-i-call). This allows a method
   # object to be the target of a `when` clause in a case statement.
-  # 
+  #
   # ```ruby
   # require 'prime'
-  # 
+  #
   # case 1373
   # when Prime.method(:prime?)
   #   # ...
@@ -44,12 +44,12 @@ class Method < Object
   # Returns a proc that is the composition of this method and the given *g*
   # . The returned proc takes a variable number of arguments, calls *g* with
   # them then calls this method with the result.
-  # 
+  #
   # ```ruby
   # def f(x)
   #   x * x
   # end
-  # 
+  #
   # f = self.method(:f)
   # g = proc {|x| x + x }
   # p (f >> g).call(2) #=> 8
@@ -58,7 +58,7 @@ class Method < Object
 
   # Invokes the *meth* with the specified arguments, returning the method’s
   # return value.
-  # 
+  #
   # ```ruby
   # m = 12.method("+")
   # m.call(3)    #=> 15
@@ -74,7 +74,7 @@ class Method < Object
   # argument being mandatory if any keyword argument is mandatory. For
   # methods written in C, returns -1 if the call takes a variable number of
   # arguments.
-  # 
+  #
   #     class C
   #       def one;    end
   #       def two(a); end
@@ -98,7 +98,7 @@ class Method < Object
   #     c.method(:eight).arity   #=> 1
   #     c.method(:nine).arity    #=> 1
   #     c.method(:ten).arity     #=> -2
-  # 
+  #
   #     "cat".method(:size).arity      #=> 0
   #     "cat".method(:replace).arity   #=> 1
   #     "cat".method(:squeeze).arity   #=> -1
@@ -106,14 +106,14 @@ class Method < Object
   def arity: () -> Integer
 
   # Returns a clone of this method.
-  # 
+  #
   # ```ruby
   # class A
   #   def foo
   #     return "bar"
   #   end
   # end
-  # 
+  #
   # m = A.new.method(:foo)
   # m.call # => "bar"
   # n = m.clone.call # => "bar"
@@ -126,7 +126,7 @@ class Method < Object
   def name: () -> Symbol
 
   # Returns the original name of the method.
-  # 
+  #
   # ```ruby
   # class C
   #   def foo; end
@@ -137,24 +137,24 @@ class Method < Object
   def original_name: () -> Symbol
 
   # Returns the class or module that defines the method. See also receiver.
-  # 
+  #
   # ```ruby
   # (1..3).method(:map).owner #=> Enumerable
   # ```
   def owner: () -> (Class | Module)
 
   # Returns the parameter information of this method.
-  # 
+  #
   # ```ruby
   # def foo(bar); end
   # method(:foo).parameters #=> [[:req, :bar]]
-  # 
+  #
   # def foo(bar, baz, bat, &blk); end
   # method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:req, :bat], [:block, :blk]]
-  # 
+  #
   # def foo(bar, *args); end
   # method(:foo).parameters #=> [[:req, :bar], [:rest, :args]]
-  # 
+  #
   # def foo(bar, baz, *args, &blk); end
   # method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:rest, :args], [:block, :blk]]
   # ```
@@ -164,7 +164,7 @@ class Method < Object
   ]
 
   # Returns the bound receiver of the method object.
-  # 
+  #
   # ```ruby
   # (1..3).method(:map).receiver # => 1..3
   # ```

--- a/stdlib/builtin/nil_class.rbs
+++ b/stdlib/builtin/nil_class.rbs
@@ -1,81 +1,81 @@
 # The class of the singleton object `nil`.
-# 
+#
 class NilClass
   public
 
   # And---Returns `false`. *obj* is always evaluated as it is the argument to a
   # method call---there is no short-circuit evaluation in this case.
-  # 
+  #
   def &: (untyped obj) -> bool
 
   # Case Equality -- For class Object, effectively the same as calling `#==`, but
   # typically overridden by descendants to provide meaningful semantics in `case`
   # statements.
-  # 
+  #
   def ===: (nil) -> true
          | (untyped obj) -> bool
 
   # Dummy pattern matching -- always returns nil.
-  # 
+  #
   def =~: (untyped obj) -> nil
 
   # Exclusive Or---If *obj* is `nil` or `false`, returns `false`; otherwise,
   # returns `true`.
-  # 
+  #
   def ^: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool
 
   # Always returns the string "nil".
-  # 
+  #
   def inspect: () -> "nil"
 
   # Only the object *nil* responds `true` to `nil?`.
-  # 
+  #
   def nil?: () -> bool
 
   # Returns zero as a rational.  The optional argument `eps` is always ignored.
-  # 
+  #
   def rationalize: (?untyped eps) -> Rational
 
   # Always returns an empty array.
-  # 
+  #
   #     nil.to_a   #=> []
-  # 
+  #
   def to_a: () -> [ ]
 
   # Returns zero as a complex.
-  # 
+  #
   def to_c: () -> Complex
 
   # Always returns zero.
-  # 
+  #
   #     nil.to_f   #=> 0.0
-  # 
+  #
   def to_f: () -> Float
 
   # Always returns an empty hash.
-  # 
+  #
   #     nil.to_h   #=> {}
-  # 
+  #
   def to_h: () -> ::Hash[untyped, untyped]
 
   # Always returns zero.
-  # 
+  #
   #     nil.to_i   #=> 0
-  # 
+  #
   def to_i: () -> 0
 
   # Returns zero as a rational.
-  # 
+  #
   def to_r: () -> Rational
 
   # Always returns the empty string.
-  # 
+  #
   def to_s: () -> ""
 
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
-  # 
+  #
   def |: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool

--- a/stdlib/builtin/numeric.rbs
+++ b/stdlib/builtin/numeric.rbs
@@ -1,176 +1,176 @@
 # Numeric is the class from which all higher-level numeric classes should
 # inherit.
-# 
+#
 # Numeric allows instantiation of heap-allocated objects. Other core numeric
 # classes such as Integer are implemented as immediates, which means that each
 # Integer is a single immutable object which is always passed by value.
-# 
+#
 #     a = 1
 #     1.object_id == a.object_id   #=> true
-# 
+#
 # There can only ever be one instance of the integer `1`, for example. Ruby
 # ensures this by preventing instantiation. If duplication is attempted, the
 # same instance is returned.
-# 
+#
 #     Integer.new(1)                   #=> NoMethodError: undefined method `new' for Integer:Class
 #     1.dup                            #=> 1
 #     1.object_id == 1.dup.object_id   #=> true
-# 
+#
 # For this reason, Numeric should be used when defining other numeric classes.
-# 
+#
 # Classes which inherit from Numeric must implement `coerce`, which returns a
 # two-member Array containing an object that has been coerced into an instance
 # of the new class and `self` (see #coerce).
-# 
+#
 # Inheriting classes should also implement arithmetic operator methods (`+`,
 # `-`, `*` and `/`) and the `<=>` operator (see Comparable). These methods may
 # rely on `coerce` to ensure interoperability with instances of other numeric
 # classes.
-# 
+#
 #     class Tally < Numeric
 #       def initialize(string)
 #         @string = string
 #       end
-# 
+#
 #       def to_s
 #         @string
 #       end
-# 
+#
 #       def to_i
 #         @string.size
 #       end
-# 
+#
 #       def coerce(other)
 #         [self.class.new('|' * other.to_i), self]
 #       end
-# 
+#
 #       def <=>(other)
 #         to_i <=> other.to_i
 #       end
-# 
+#
 #       def +(other)
 #         self.class.new('|' * (to_i + other.to_i))
 #       end
-# 
+#
 #       def -(other)
 #         self.class.new('|' * (to_i - other.to_i))
 #       end
-# 
+#
 #       def *(other)
 #         self.class.new('|' * (to_i * other.to_i))
 #       end
-# 
+#
 #       def /(other)
 #         self.class.new('|' * (to_i / other.to_i))
 #       end
 #     end
-# 
+#
 #     tally = Tally.new('||')
 #     puts tally * 2            #=> "||||"
 #     puts tally > 1            #=> true
-# 
+#
 class Numeric
   include Comparable
 
   public
 
   # `x.modulo(y)` means `x-y*(x/y).floor`.
-  # 
+  #
   # Equivalent to `num.divmod(numeric)[1]`.
-  # 
+  #
   # See Numeric#divmod.
-  # 
+  #
   def %: (Numeric) -> Numeric
 
   # Unary Plus---Returns the receiver.
-  # 
+  #
   def +@: () -> Numeric
 
   # Unary Minus---Returns the receiver, negated.
-  # 
+  #
   def -@: () -> Numeric
 
   # Returns zero if `number` equals `other`, otherwise returns `nil`.
-  # 
+  #
   def <=>: (Numeric other) -> Integer
 
   # Returns the absolute value of `num`.
-  # 
+  #
   #     12.abs         #=> 12
   #     (-34.56).abs   #=> 34.56
   #     -34.56.abs     #=> 34.56
-  # 
+  #
   # Numeric#magnitude is an alias for Numeric#abs.
-  # 
+  #
   def abs: () -> Numeric
 
   # Returns square of self.
-  # 
+  #
   def abs2: () -> Numeric
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   def angle: () -> Numeric
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   alias arg angle
 
   # Returns the smallest number greater than or equal to `num` with a precision of
   # `ndigits` decimal digits (default: 0).
-  # 
+  #
   # Numeric implements this by converting its value to a Float and invoking
   # Float#ceil.
-  # 
+  #
   def ceil: () -> Integer
           | (Integer digits) -> (Integer | Numeric)
 
   # If `numeric` is the same type as `num`, returns an array `[numeric, num]`.
   # Otherwise, returns an array with both `numeric` and `num` represented as Float
   # objects.
-  # 
+  #
   # This coercion mechanism is used by Ruby to handle mixed-type numeric
   # operations: it is intended to find a compatible common type between the two
   # operands of the operator.
-  # 
+  #
   #     1.coerce(2.5)   #=> [2.5, 1.0]
   #     1.2.coerce(3)   #=> [3.0, 1.2]
   #     1.coerce(2)     #=> [2, 1]
-  # 
+  #
   def coerce: (Numeric) -> [ Numeric, Numeric ]
 
   # Returns self.
-  # 
+  #
   def conj: () -> Numeric
 
   # Returns self.
-  # 
+  #
   def conjugate: () -> Numeric
 
   # Returns the denominator (always positive).
-  # 
+  #
   def denominator: () -> Integer
 
   # Uses `/` to perform division, then converts the result to an integer. Numeric
   # does not define the `/` operator; this is left to subclasses.
-  # 
+  #
   # Equivalent to `num.divmod(numeric)[0]`.
-  # 
+  #
   # See Numeric#divmod.
-  # 
+  #
   def div: (Numeric) -> Integer
 
   # Returns an array containing the quotient and modulus obtained by dividing
   # `num` by `numeric`.
-  # 
+  #
   # If `q, r = x.divmod(y)`, then
-  # 
+  #
   #     q = floor(x/y)
   #     x = q*y + r
-  # 
+  #
   # The quotient is rounded toward negative infinity, as shown in the following
   # table:
-  # 
+  #
   #      a    |  b  |  a.divmod(b)  |   a/b   | a.modulo(b) | a.remainder(b)
   #     ------+-----+---------------+---------+-------------+---------------
   #      13   |  4  |   3,    1     |   3     |    1        |     1
@@ -188,222 +188,222 @@ class Numeric
   #     -11.5 |  4  |  -3,    0.5   |  -2.875 |    0.5      |    -3.5
   #     ------+-----+---------------+---------+-------------+---------------
   #     -11.5 | -4  |   2,   -3.5   |   2.875 |   -3.5      |    -3.5
-  # 
+  #
   # Examples
-  # 
+  #
   #     11.divmod(3)        #=> [3, 2]
   #     11.divmod(-3)       #=> [-4, -1]
   #     11.divmod(3.5)      #=> [3, 0.5]
   #     (-11).divmod(3.5)   #=> [-4, 3.0]
   #     11.5.divmod(3.5)    #=> [3, 1.0]
-  # 
+  #
   def divmod: (Numeric) -> [ Numeric, Numeric ]
 
   # Returns `true` if `num` and `numeric` are the same type and have equal values.
   #  Contrast this with Numeric#==, which performs type conversions.
-  # 
+  #
   #     1 == 1.0        #=> true
   #     1.eql?(1.0)     #=> false
   #     1.0.eql?(1.0)   #=> true
-  # 
+  #
   def eql?: (untyped) -> bool
 
   # Returns float division.
-  # 
+  #
   def fdiv: (Numeric) -> Numeric
 
   # Returns `true` if `num` is a finite number, otherwise returns `false`.
-  # 
+  #
   def finite?: () -> bool
 
   # Returns the largest number less than or equal to `num` with a precision of
   # `ndigits` decimal digits (default: 0).
-  # 
+  #
   # Numeric implements this by converting its value to a Float and invoking
   # Float#floor.
-  # 
+  #
   def floor: () -> Integer
            | (Integer digits) -> Numeric
 
   # Returns the corresponding imaginary number. Not available for complex numbers.
-  # 
+  #
   #     -42.i  #=> (0-42i)
   #     2.0.i  #=> (0+2.0i)
-  # 
+  #
   def i: () -> Complex
 
   # Returns zero.
-  # 
+  #
   def imag: () -> Numeric
 
   # Returns zero.
-  # 
+  #
   def imaginary: () -> Numeric
 
   # Returns `nil`, -1, or 1 depending on whether the value is finite, `-Infinity`,
   # or `+Infinity`.
-  # 
+  #
   def infinite?: () -> Integer?
 
   # Returns `true` if `num` is an Integer.
-  # 
+  #
   #     1.0.integer?   #=> false
   #     1.integer?     #=> true
-  # 
+  #
   def integer?: () -> bool
 
   # Returns the absolute value of `num`.
-  # 
+  #
   #     12.abs         #=> 12
   #     (-34.56).abs   #=> 34.56
   #     -34.56.abs     #=> 34.56
-  # 
+  #
   # Numeric#magnitude is an alias for Numeric#abs.
-  # 
+  #
   alias magnitude abs
 
   # `x.modulo(y)` means `x-y*(x/y).floor`.
-  # 
+  #
   # Equivalent to `num.divmod(numeric)[1]`.
-  # 
+  #
   # See Numeric#divmod.
-  # 
+  #
   def modulo: (Numeric) -> Numeric
 
   # Returns `true` if `num` is less than 0.
-  # 
+  #
   def negative?: () -> bool
 
   # Returns `self` if `num` is not zero, `nil` otherwise.
-  # 
+  #
   # This behavior is useful when chaining comparisons:
-  # 
+  #
   #     a = %w( z Bb bB bb BB a aA Aa AA A )
   #     b = a.sort {|a,b| (a.downcase <=> b.downcase).nonzero? || a <=> b }
   #     b   #=> ["A", "a", "AA", "Aa", "aA", "BB", "Bb", "bB", "bb", "z"]
-  # 
+  #
   def nonzero?: () -> self?
 
   # Returns the numerator.
-  # 
+  #
   def numerator: () -> Numeric
 
   # Returns 0 if the value is positive, pi otherwise.
-  # 
+  #
   alias phase angle
 
   # Returns an array; [num.abs, num.arg].
-  # 
+  #
   def polar: () -> [ Numeric, Numeric ]
 
   # Returns `true` if `num` is greater than 0.
-  # 
+  #
   def positive?: () -> bool
 
   # Returns the most exact division (rational for integers, float for floats).
-  # 
+  #
   def quo: (Numeric) -> Numeric
 
   # Returns self.
-  # 
+  #
   def real: () -> Numeric
 
   # Returns `true` if `num` is a real number (i.e. not Complex).
-  # 
+  #
   def real?: () -> bool
 
   # Returns an array; [num, 0].
-  # 
+  #
   def rect: () -> [ Numeric, Numeric ]
 
   # Returns an array; [num, 0].
-  # 
+  #
   alias rectangular rect
 
   # `x.remainder(y)` means `x-y*(x/y).truncate`.
-  # 
+  #
   # See Numeric#divmod.
-  # 
+  #
   def remainder: (Numeric) -> Numeric
 
   # Returns `num` rounded to the nearest value with a precision of `ndigits`
   # decimal digits (default: 0).
-  # 
+  #
   # Numeric implements this by converting its value to a Float and invoking
   # Float#round.
-  # 
+  #
   def round: () -> Integer
            | (Integer digits) -> Numeric
 
   # Invokes the given block with the sequence of numbers starting at `num`,
   # incremented by `step` (defaulted to `1`) on each call.
-  # 
+  #
   # The loop finishes when the value to be passed to the block is greater than
   # `limit` (if `step` is positive) or less than `limit` (if `step` is negative),
   # where `limit` is defaulted to infinity.
-  # 
+  #
   # In the recommended keyword argument style, either or both of `step` and
   # `limit` (default infinity) can be omitted.  In the fixed position argument
   # style, zero as a step (i.e. `num.step(limit, 0)`) is not allowed for
   # historical compatibility reasons.
-  # 
+  #
   # If all the arguments are integers, the loop operates using an integer counter.
-  # 
+  #
   # If any of the arguments are floating point numbers, all are converted to
   # floats, and the loop is executed *floor(n + n*Float::EPSILON) + 1* times,
   # where *n = (limit - num)/step*.
-  # 
+  #
   # Otherwise, the loop starts at `num`, uses either the less-than (`<`) or
   # greater-than (`>`) operator to compare the counter against `limit`, and
   # increments itself using the `+` operator.
-  # 
+  #
   # If no block is given, an Enumerator is returned instead. Especially, the
   # enumerator is an Enumerator::ArithmeticSequence if both `limit` and `step` are
   # kind of Numeric or `nil`.
-  # 
+  #
   # For example:
-  # 
+  #
   #     p 1.step.take(4)
   #     p 10.step(by: -1).take(4)
   #     3.step(to: 5) {|i| print i, " " }
   #     1.step(10, 2) {|i| print i, " " }
   #     Math::E.step(to: Math::PI, by: 0.2) {|f| print f, " " }
-  # 
+  #
   # Will produce:
-  # 
+  #
   #     [1, 2, 3, 4]
   #     [10, 9, 8, 7]
   #     3 4 5
   #     1 3 5 7 9
   #     2.718281828459045 2.9182818284590453 3.118281828459045
-  # 
+  #
   def step: (?Numeric limit, ?Numeric step) { (Numeric) -> void } -> self
           | (?Numeric limit, ?Numeric step) -> Enumerator[Numeric, self]
           | (?by: Numeric, ?to: Numeric) { (Numeric) -> void } -> self
           | (?by: Numeric, ?to: Numeric) -> Enumerator[Numeric, self]
 
   # Returns the value as a complex.
-  # 
+  #
   def to_c: () -> Complex
 
   # Invokes the child class's `to_i` method to convert `num` to an integer.
-  # 
+  #
   #     1.0.class          #=> Float
   #     1.0.to_int.class   #=> Integer
   #     1.0.to_i.class     #=> Integer
-  # 
+  #
   def to_int: () -> Integer
 
   # Returns `num` truncated (toward zero) to a precision of `ndigits` decimal
   # digits (default: 0).
-  # 
+  #
   # Numeric implements this by converting its value to a Float and invoking
   # Float#truncate.
-  # 
+  #
   def truncate: () -> Integer
               | (Integer ndigits) -> (Integer | Numeric)
 
   # Returns `true` if `num` has a zero value.
-  # 
+  #
   def zero?: () -> bool
 end

--- a/stdlib/builtin/object.rbs
+++ b/stdlib/builtin/object.rbs
@@ -1,68 +1,68 @@
 # Object is the default root of all Ruby objects.  Object inherits from
 # BasicObject which allows creating alternate object hierarchies.  Methods on
 # Object are available to all classes unless explicitly overridden.
-# 
+#
 # Object mixes in the Kernel module, making the built-in kernel functions
 # globally accessible.  Although the instance methods of Object are defined by
 # the Kernel module, we have chosen to document them here for clarity.
-# 
+#
 # When referencing constants in classes inheriting from Object you do not need
 # to use the full namespace.  For example, referencing `File` inside `YourClass`
 # will find the top-level File class.
-# 
+#
 # In the descriptions of Object's methods, the parameter *symbol* refers to a
 # symbol, which is either a quoted string or a Symbol (such as `:name`).
-# 
+#
 class Object < BasicObject
   include Kernel
 
   # Returns true if two objects do not match (using the *=~* method), otherwise
   # false.
-  # 
+  #
   def !~: (untyped) -> bool
 
   # Returns 0 if `obj` and `other` are the same object or `obj == other`,
   # otherwise nil.
-  # 
+  #
   # The `<=>` is used by various methods to compare objects, for example
   # Enumerable#sort, Enumerable#max etc.
-  # 
+  #
   # Your implementation of `<=>` should return one of the following values: -1, 0,
   # 1 or nil. -1 means self is smaller than other. 0 means self is equal to other.
   # 1 means self is bigger than other. Nil means the two values could not be
   # compared.
-  # 
+  #
   # When you define `<=>`, you can include Comparable to gain the methods `<=`,
   # `<`, `==`, `>=`, `>` and `between?`.
-  # 
+  #
   def <=>: (untyped) -> Integer?
 
   # Case Equality -- For class Object, effectively the same as calling `#==`, but
   # typically overridden by descendants to provide meaningful semantics in `case`
   # statements.
-  # 
+  #
   def ===: (untyped) -> bool
 
   # This method is deprecated.
-  # 
+  #
   # This is not only unuseful but also troublesome because it may hide a type
   # error.
-  # 
+  #
   def =~: (untyped) -> bool
 
   # Returns the class of *obj*. This method must always be called with an explicit
   # receiver, as `class` is also a reserved word in Ruby.
-  # 
+  #
   #     1.class      #=> Integer
   #     self.class   #=> Object
-  # 
+  #
   def `class`: () -> untyped
 
   # Produces a shallow copy of *obj*---the instance variables of *obj* are copied,
   # but not the objects they reference. `clone` copies the frozen (unless :freeze
   # keyword argument is given with a false value) and tainted state of *obj*. See
   # also the discussion under `Object#dup`.
-  # 
+  #
   #     class Klass
   #        attr_accessor :str
   #     end
@@ -72,16 +72,16 @@ class Object < BasicObject
   #     s2.str[1,4] = "i"   #=> "i"
   #     s1.inspect          #=> "#<Klass:0x401b3a38 @str=\"Hi\">"
   #     s2.inspect          #=> "#<Klass:0x401b3998 @str=\"Hi\">"
-  # 
+  #
   # This method may have class-specific behavior.  If so, that behavior will be
   # documented under the #`initialize_copy` method of the class.
-  # 
+  #
   def clone: (?freeze: bool) -> self
 
   # Defines a singleton method in the receiver. The *method* parameter can be a
   # `Proc`, a `Method` or an `UnboundMethod` object. If a block is specified, it
   # is used as the method body.
-  # 
+  #
   #     class A
   #       class << self
   #         def class_name
@@ -93,95 +93,95 @@ class Object < BasicObject
   #       "I am: #{class_name}"
   #     end
   #     A.who_am_i   # ==> "I am: A"
-  # 
+  #
   #     guy = "Bob"
   #     guy.define_singleton_method(:hello) { "#{self}: Hello there!" }
   #     guy.hello    #=>  "Bob: Hello there!"
-  # 
+  #
   def define_singleton_method: (Symbol, Method | UnboundMethod) -> Symbol
                              | (Symbol) { (*untyped) -> untyped } -> Symbol
 
   # Prints *obj* on the given port (default `$>`). Equivalent to:
-  # 
+  #
   #     def display(port=$>)
   #       port.write self
   #       nil
   #     end
-  # 
+  #
   # For example:
-  # 
+  #
   #     1.display
   #     "cat".display
   #     [ 4, 5, 6 ].display
   #     puts
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     1cat[4, 5, 6]
-  # 
+  #
   def display: (?_Writeable port) -> void
 
   # Produces a shallow copy of *obj*---the instance variables of *obj* are copied,
   # but not the objects they reference. `dup` copies the tainted state of *obj*.
-  # 
+  #
   # This method may have class-specific behavior.  If so, that behavior will be
   # documented under the #`initialize_copy` method of the class.
-  # 
+  #
   # ### on dup vs clone
-  # 
+  #
   # In general, `clone` and `dup` may have different semantics in descendant
   # classes. While `clone` is used to duplicate an object, including its internal
   # state, `dup` typically uses the class of the descendant object to create the
   # new instance.
-  # 
+  #
   # When using #dup, any modules that the object has been extended with will not
   # be copied.
-  # 
+  #
   #     class Klass
   #       attr_accessor :str
   #     end
-  # 
+  #
   #     module Foo
   #       def foo; 'foo'; end
   #     end
-  # 
+  #
   #     s1 = Klass.new #=> #<Klass:0x401b3a38>
   #     s1.extend(Foo) #=> #<Klass:0x401b3a38>
   #     s1.foo #=> "foo"
-  # 
+  #
   #     s2 = s1.clone #=> #<Klass:0x401b3a38>
   #     s2.foo #=> "foo"
-  # 
+  #
   #     s3 = s1.dup #=> #<Klass:0x401b3a38>
   #     s3.foo #=> NoMethodError: undefined method `foo' for #<Klass:0x401b3a38>
-  # 
+  #
   def dup: () -> self
 
   # Creates a new Enumerator which will enumerate by calling `method` on `obj`,
   # passing `args` if any.
-  # 
+  #
   # If a block is given, it will be used to calculate the size of the enumerator
   # without the need to iterate it (see Enumerator#size).
-  # 
+  #
   # ### Examples
-  # 
+  #
   #     str = "xyz"
-  # 
+  #
   #     enum = str.enum_for(:each_byte)
   #     enum.each { |b| puts b }
   #     # => 120
   #     # => 121
   #     # => 122
-  # 
+  #
   #     # protect an array from being modified by some_method
   #     a = [1, 2, 3]
   #     some_method(a.to_enum)
-  # 
+  #
   # It is typical to call to_enum when defining methods for a generic Enumerable,
   # in case no block is passed.
-  # 
+  #
   # Here is such an example, with parameter passing and a sizing block:
-  # 
+  #
   #     module Enumerable
   #       # a generic method to repeat the values of any enumerable
   #       def repeat(n)
@@ -197,42 +197,42 @@ class Object < BasicObject
   #         end
   #       end
   #     end
-  # 
+  #
   #     %i[hello world].repeat(2) { |w| puts w }
   #       # => Prints 'hello', 'hello', 'world', 'world'
   #     enum = (1..14).repeat(3)
   #       # => returns an Enumerator when called without a block
   #     enum.first(4) # => [1, 1, 1, 2]
   #     enum.size # => 42
-  # 
+  #
   def enum_for: (Symbol method, *untyped args) ?{ (*untyped args) -> Integer } -> Enumerator[untyped, untyped]
               | (*untyped args) ?{ (*untyped args) -> Integer } -> Enumerator[untyped, untyped]
 
   # Creates a new Enumerator which will enumerate by calling `method` on `obj`,
   # passing `args` if any.
-  # 
+  #
   # If a block is given, it will be used to calculate the size of the enumerator
   # without the need to iterate it (see Enumerator#size).
-  # 
+  #
   # ### Examples
-  # 
+  #
   #     str = "xyz"
-  # 
+  #
   #     enum = str.enum_for(:each_byte)
   #     enum.each { |b| puts b }
   #     # => 120
   #     # => 121
   #     # => 122
-  # 
+  #
   #     # protect an array from being modified by some_method
   #     a = [1, 2, 3]
   #     some_method(a.to_enum)
-  # 
+  #
   # It is typical to call to_enum when defining methods for a generic Enumerable,
   # in case no block is passed.
-  # 
+  #
   # Here is such an example, with parameter passing and a sizing block:
-  # 
+  #
   #     module Enumerable
   #       # a generic method to repeat the values of any enumerable
   #       def repeat(n)
@@ -248,89 +248,89 @@ class Object < BasicObject
   #         end
   #       end
   #     end
-  # 
+  #
   #     %i[hello world].repeat(2) { |w| puts w }
   #       # => Prints 'hello', 'hello', 'world', 'world'
   #     enum = (1..14).repeat(3)
   #       # => returns an Enumerator when called without a block
   #     enum.first(4) # => [1, 1, 1, 2]
   #     enum.size # => 42
-  # 
+  #
   alias to_enum enum_for
 
   # Equality --- At the `Object` level, `==` returns `true` only if `obj` and
   # `other` are the same object. Typically, this method is overridden in
   # descendant classes to provide class-specific meaning.
-  # 
+  #
   # Unlike `==`, the `equal?` method should never be overridden by subclasses as
   # it is used to determine object identity (that is, `a.equal?(b)` if and only if
   # `a` is the same object as `b`):
-  # 
+  #
   #     obj = "a"
   #     other = obj.dup
-  # 
+  #
   #     obj == other      #=> true
   #     obj.equal? other  #=> false
   #     obj.equal? obj    #=> true
-  # 
+  #
   # The `eql?` method returns `true` if `obj` and `other` refer to the same hash
   # key.  This is used by Hash to test members for equality.  For objects of class
   # `Object`, `eql?` is synonymous with `==`.  Subclasses normally continue this
   # tradition by aliasing `eql?` to their overridden `==` method, but there are
   # exceptions.  `Numeric` types, for example, perform type conversion across
   # `==`, but not across `eql?`, so:
-  # 
+  #
   #     1 == 1.0     #=> true
   #     1.eql? 1.0   #=> false
-  # 
+  #
   def eql?: (untyped) -> bool
 
   # Adds to *obj* the instance methods from each module given as a parameter.
-  # 
+  #
   #     module Mod
   #       def hello
   #         "Hello from Mod.\n"
   #       end
   #     end
-  # 
+  #
   #     class Klass
   #       def hello
   #         "Hello from Klass.\n"
   #       end
   #     end
-  # 
+  #
   #     k = Klass.new
   #     k.hello         #=> "Hello from Klass.\n"
   #     k.extend(Mod)   #=> #<Klass:0x401b3bc8>
   #     k.hello         #=> "Hello from Mod.\n"
-  # 
+  #
   def `extend`: (*Module) -> self
 
   # Prevents further modifications to *obj*. A `RuntimeError` will be raised if
   # modification is attempted. There is no way to unfreeze a frozen object. See
   # also `Object#frozen?`.
-  # 
+  #
   # This method returns self.
-  # 
+  #
   #     a = [ "a", "b", "c" ]
   #     a.freeze
   #     a << "z"
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     prog.rb:3:in `<<': can't modify frozen Array (FrozenError)
   #      from prog.rb:3
-  # 
+  #
   # Objects of the following classes are always frozen: Integer, Float, Symbol.
-  # 
+  #
   def freeze: () -> self
 
   # Returns the freeze status of *obj*.
-  # 
+  #
   #     a = [ "a", "b", "c" ]
   #     a.freeze    #=> ["a", "b", "c"]
   #     a.frozen?   #=> true
-  # 
+  #
   def frozen?: () -> bool
 
   def hash: () -> Integer
@@ -341,40 +341,40 @@ class Object < BasicObject
   # each of them). User defined classes should override this method to provide a
   # better representation of *obj*.  When overriding this method, it should return
   # a string whose encoding is compatible with the default external encoding.
-  # 
+  #
   #     [ 1, 2, 3..4, 'five' ].inspect   #=> "[1, 2, 3..4, \"five\"]"
   #     Time.new.inspect                 #=> "2008-03-08 19:43:39 +0900"
-  # 
+  #
   #     class Foo
   #     end
   #     Foo.new.inspect                  #=> "#<Foo:0x0300c868>"
-  # 
+  #
   #     class Bar
   #       def initialize
   #         @bar = 1
   #       end
   #     end
   #     Bar.new.inspect                  #=> "#<Bar:0x0300c868 @bar=1>"
-  # 
+  #
   def inspect: () -> String
 
   # Returns `true` if *obj* is an instance of the given class. See also
   # `Object#kind_of?`.
-  # 
+  #
   #     class A;     end
   #     class B < A; end
   #     class C < B; end
-  # 
+  #
   #     b = B.new
   #     b.instance_of? A   #=> false
   #     b.instance_of? B   #=> true
   #     b.instance_of? C   #=> false
-  # 
+  #
   def instance_of?: (Module) -> bool
 
   # Returns `true` if the given instance variable is defined in *obj*. String
   # arguments are converted to symbols.
-  # 
+  #
   #     class Fred
   #       def initialize(p1, p2)
   #         @a, @b = p1, p2
@@ -384,7 +384,7 @@ class Object < BasicObject
   #     fred.instance_variable_defined?(:@a)    #=> true
   #     fred.instance_variable_defined?("@b")   #=> true
   #     fred.instance_variable_defined?("@c")   #=> false
-  # 
+  #
   def instance_variable_defined?: (String | Symbol var) -> bool
 
   # Returns the value of the given instance variable, or nil if the instance
@@ -392,7 +392,7 @@ class Object < BasicObject
   # regular instance variables. Throws a `NameError` exception if the supplied
   # symbol is not valid as an instance variable name. String arguments are
   # converted to symbols.
-  # 
+  #
   #     class Fred
   #       def initialize(p1, p2)
   #         @a, @b = p1, p2
@@ -401,7 +401,7 @@ class Object < BasicObject
   #     fred = Fred.new('cat', 99)
   #     fred.instance_variable_get(:@a)    #=> "cat"
   #     fred.instance_variable_get("@b")   #=> 99
-  # 
+  #
   def instance_variable_get: (String | Symbol var) -> untyped
 
   # Sets the instance variable named by *symbol* to the given object, thereby
@@ -409,7 +409,7 @@ class Object < BasicObject
   # encapsulation. The variable does not have to exist prior to this call. If the
   # instance variable name is passed as a string, that string is converted to a
   # symbol.
-  # 
+  #
   #     class Fred
   #       def initialize(p1, p2)
   #         @a, @b = p1, p2
@@ -419,12 +419,12 @@ class Object < BasicObject
   #     fred.instance_variable_set(:@a, 'dog')   #=> "dog"
   #     fred.instance_variable_set(:@c, 'cat')   #=> "cat"
   #     fred.inspect                             #=> "#<Fred:0x401b3da8 @a=\"dog\", @b=99, @c=\"cat\">"
-  # 
+  #
   def instance_variable_set: [X] (String | Symbol var, X value) -> X
 
   # Returns an array of instance variable names for the receiver. Note that simply
   # defining an accessor does not create the corresponding instance variable.
-  # 
+  #
   #     class Fred
   #       attr_accessor :a1
   #       def initialize
@@ -432,67 +432,67 @@ class Object < BasicObject
   #       end
   #     end
   #     Fred.new.instance_variables   #=> [:@iv]
-  # 
+  #
   def instance_variables: () -> Array[Symbol]
 
   # Returns `true` if *class* is the class of *obj*, or if *class* is one of the
   # superclasses of *obj* or modules included in *obj*.
-  # 
+  #
   #     module M;    end
   #     class A
   #       include M
   #     end
   #     class B < A; end
   #     class C < B; end
-  # 
+  #
   #     b = B.new
   #     b.is_a? A          #=> true
   #     b.is_a? B          #=> true
   #     b.is_a? C          #=> false
   #     b.is_a? M          #=> true
-  # 
+  #
   #     b.kind_of? A       #=> true
   #     b.kind_of? B       #=> true
   #     b.kind_of? C       #=> false
   #     b.kind_of? M       #=> true
-  # 
+  #
   def is_a?: (Module) -> bool
 
   # Returns `true` if *class* is the class of *obj*, or if *class* is one of the
   # superclasses of *obj* or modules included in *obj*.
-  # 
+  #
   #     module M;    end
   #     class A
   #       include M
   #     end
   #     class B < A; end
   #     class C < B; end
-  # 
+  #
   #     b = B.new
   #     b.is_a? A          #=> true
   #     b.is_a? B          #=> true
   #     b.is_a? C          #=> false
   #     b.is_a? M          #=> true
-  # 
+  #
   #     b.kind_of? A       #=> true
   #     b.kind_of? B       #=> true
   #     b.kind_of? C       #=> false
   #     b.kind_of? M       #=> true
-  # 
+  #
   alias kind_of? is_a?
 
   # Returns the receiver.
-  # 
+  #
   #     string = "my string"
   #     string.itself.object_id == string.object_id   #=> true
-  # 
+  #
   def `itself`: () -> self
 
   # Looks up the named method as a receiver in *obj*, returning a `Method` object
   # (or raising `NameError`). The `Method` object acts as a closure in *obj*'s
   # object instance, so instance variables and the value of `self` remain
   # available.
-  # 
+  #
   #     class Demo
   #       def initialize(n)
   #         @iv = n
@@ -501,27 +501,27 @@ class Object < BasicObject
   #         "Hello, @iv = #{@iv}"
   #       end
   #     end
-  # 
+  #
   #     k = Demo.new(99)
   #     m = k.method(:hello)
   #     m.call   #=> "Hello, @iv = 99"
-  # 
+  #
   #     l = Demo.new('Fred')
   #     m = l.method("hello")
   #     m.call   #=> "Hello, @iv = Fred"
-  # 
+  #
   # Note that `Method` implements `to_proc` method, which means it can be used
   # with iterators.
-  # 
+  #
   #     [ 1, 2, 3 ].each(&method(:puts)) # => prints 3 lines to stdout
-  # 
+  #
   #     out = File.open('test.txt', 'w')
   #     [ 1, 2, 3 ].each(&out.method(:puts)) # => prints 3 lines to file
-  # 
+  #
   #     require 'date'
   #     %w[2017-03-01 2017-03-02].collect(&Date.method(:parse))
   #     #=> [#<Date: 2017-03-01 ((2457814j,0s,0n),+0s,2299161j)>, #<Date: 2017-03-02 ((2457815j,0s,0n),+0s,2299161j)>]
-  # 
+  #
   def method: (String | Symbol name) -> Method
 
   # Returns a list of the names of public and protected methods of *obj*. This
@@ -529,7 +529,7 @@ class Object < BasicObject
   # parameter is `false`, it returns an array of *obj<i>'s public and protected
   # singleton methods, the array will not include methods in modules included in
   # <i>obj*.
-  # 
+  #
   #     class Klass
   #       def klass_method()
   #       end
@@ -539,69 +539,69 @@ class Object < BasicObject
   #                        #    :==~, :!, :eql?
   #                        #    :hash, :<=>, :class, :singleton_class]
   #     k.methods.length   #=> 56
-  # 
+  #
   #     k.methods(false)   #=> []
   #     def k.singleton_method; end
   #     k.methods(false)   #=> [:singleton_method]
-  # 
+  #
   #     module M123; def m123; end end
   #     k.extend M123
   #     k.methods(false)   #=> [:singleton_method]
-  # 
+  #
   def methods: () -> Array[Symbol]
 
   # Only the object *nil* responds `true` to `nil?`.
-  # 
+  #
   #     Object.new.nil?   #=> false
   #     nil.nil?          #=> true
-  # 
+  #
   def `nil?`: () -> bool
 
   # Returns an integer identifier for `obj`.
-  # 
+  #
   # The same number will be returned on all calls to `object_id` for a given
   # object, and no two active objects will share an id.
-  # 
+  #
   # Note: that some objects of builtin classes are reused for optimization. This
   # is the case for immediate values and frozen string literals.
-  # 
+  #
   # Immediate values are not passed by reference but are passed by value: `nil`,
   # `true`, `false`, Fixnums, Symbols, and some Floats.
-  # 
+  #
   #     Object.new.object_id  == Object.new.object_id  # => false
   #     (21 * 2).object_id    == (21 * 2).object_id    # => true
   #     "hello".object_id     == "hello".object_id     # => false
   #     "hi".freeze.object_id == "hi".freeze.object_id # => true
-  # 
+  #
   def object_id: () -> Integer
 
   # Returns the list of private methods accessible to *obj*. If the *all*
   # parameter is set to `false`, only those methods in the receiver will be
   # listed.
-  # 
+  #
   def private_methods: () -> Array[Symbol]
 
   # Returns the list of protected methods accessible to *obj*. If the *all*
   # parameter is set to `false`, only those methods in the receiver will be
   # listed.
-  # 
+  #
   def protected_methods: () -> Array[Symbol]
 
   # Similar to *method*, searches public method only.
-  # 
+  #
   def public_method: (name name) -> Method
 
   # Invokes the method identified by *symbol*, passing it any arguments specified.
   # Unlike send, public_send calls public methods only. When the method is
   # identified by a string, the string is converted to a symbol.
-  # 
+  #
   #     1.public_send(:puts, "hello")  # causes NoMethodError
-  # 
+  #
   def `public_send`: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
   # Removes the named instance variable from *obj*, returning that variable's
   # value. String arguments are converted to symbols.
-  # 
+  #
   #     class Dummy
   #       attr_reader :var
   #       def initialize
@@ -615,29 +615,29 @@ class Object < BasicObject
   #     d.var      #=> 99
   #     d.remove   #=> 99
   #     d.var      #=> nil
-  # 
+  #
   def remove_instance_variable: (name name) -> untyped
 
   # Returns `true` if *obj* responds to the given method.  Private and protected
   # methods are included in the search only if the optional second parameter
   # evaluates to `true`.
-  # 
+  #
   # If the method is not implemented, as Process.fork on Windows, File.lchmod on
   # GNU/Linux, etc., false is returned.
-  # 
+  #
   # If the method is not defined, `respond_to_missing?` method is called and the
   # result is returned.
-  # 
+  #
   # When the method name parameter is given as a string, the string is converted
   # to a symbol.
-  # 
+  #
   def respond_to?: (name name, ?bool include_all) -> bool
 
   # Invokes the method identified by *symbol*, passing it any arguments specified.
   # You can use `__send__` if the name `send` clashes with an existing method in
   # *obj*. When the method is identified by a string, the string is converted to a
   # symbol.
-  # 
+  #
   #     class Klass
   #       def hello(*args)
   #         "Hello " + args.join(' ')
@@ -645,24 +645,24 @@ class Object < BasicObject
   #     end
   #     k = Klass.new
   #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
-  # 
+  #
   def `send`: (name name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
 
   # Returns the singleton class of *obj*.  This method creates a new singleton
   # class if *obj* does not have one.
-  # 
+  #
   # If *obj* is `nil`, `true`, or `false`, it returns NilClass, TrueClass, or
   # FalseClass, respectively. If *obj* is an Integer, a Float or a Symbol, it
   # raises a TypeError.
-  # 
+  #
   #     Object.new.singleton_class  #=> #<Class:#<Object:0xb7ce1e24>>
   #     String.singleton_class      #=> #<Class:String>
   #     nil.singleton_class         #=> NilClass
-  # 
+  #
   def `singleton_class`: () -> Class
 
   # Similar to *method*, searches singleton method only.
-  # 
+  #
   #     class Demo
   #       def initialize(n)
   #         @iv = n
@@ -671,7 +671,7 @@ class Object < BasicObject
   #         "Hello, @iv = #{@iv}"
   #       end
   #     end
-  # 
+  #
   #     k = Demo.new(99)
   #     def k.hi
   #       "Hi, @iv = #{@iv}"
@@ -679,99 +679,99 @@ class Object < BasicObject
   #     m = k.singleton_method(:hi)
   #     m.call   #=> "Hi, @iv = 99"
   #     m = k.singleton_method(:hello) #=> NameError
-  # 
+  #
   def singleton_method: (name name) -> Method
 
   # Returns an array of the names of singleton methods for *obj*. If the optional
   # *all* parameter is true, the list will include methods in modules included in
   # *obj*. Only public and protected singleton methods are returned.
-  # 
+  #
   #     module Other
   #       def three() end
   #     end
-  # 
+  #
   #     class Single
   #       def Single.four() end
   #     end
-  # 
+  #
   #     a = Single.new
-  # 
+  #
   #     def a.one()
   #     end
-  # 
+  #
   #     class << a
   #       include Other
   #       def two()
   #       end
   #     end
-  # 
+  #
   #     Single.singleton_methods    #=> [:four]
   #     a.singleton_methods(false)  #=> [:two, :one]
   #     a.singleton_methods         #=> [:two, :one, :three]
-  # 
+  #
   def singleton_methods: () -> Array[Symbol]
 
   # Mark the object as tainted.
-  # 
+  #
   # Objects that are marked as tainted will be restricted from various built-in
   # methods. This is to prevent insecure data, such as command-line arguments or
   # strings read from Kernel#gets, from inadvertently compromising the user's
   # system.
-  # 
+  #
   # To check whether an object is tainted, use #tainted?.
-  # 
+  #
   # You should only untaint a tainted object if your code has inspected it and
   # determined that it is safe. To do so use #untaint.
-  # 
+  #
   def taint: () -> self
 
   # Deprecated method that is equivalent to #taint.
-  # 
+  #
   alias untrust taint
 
   # Returns true if the object is tainted.
-  # 
+  #
   # See #taint for more information.
-  # 
+  #
   def tainted?: () -> bool
 
   # Deprecated method that is equivalent to #tainted?.
-  # 
+  #
   alias untrusted? tainted?
 
   # Yields self to the block, and then returns self. The primary purpose of this
   # method is to "tap into" a method chain, in order to perform operations on
   # intermediate results within the chain.
-  # 
+  #
   #     (1..10)                  .tap {|x| puts "original: #{x}" }
   #       .to_a                  .tap {|x| puts "array:    #{x}" }
   #       .select {|x| x.even? } .tap {|x| puts "evens:    #{x}" }
   #       .map {|x| x*x }        .tap {|x| puts "squares:  #{x}" }
-  # 
+  #
   def tap: () { (self) -> void } -> self
 
   # Yields self to the block and returns the result of the block.
-  # 
+  #
   #     3.next.then {|x| x**x }.to_s             #=> "256"
   #     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
-  # 
+  #
   # Good usage for `yield_self` is value piping in method chains:
-  # 
+  #
   #     require 'open-uri'
   #     require 'json'
-  # 
+  #
   #     construct_url(arguments).
   #       yield_self {|url| open(url).read }.
   #       yield_self {|response| JSON.parse(response) }
-  # 
+  #
   # When called without block, the method returns `Enumerator`, which can be used,
   # for example, for conditional circuit-breaking:
-  # 
+  #
   #     # meets condition, no-op
   #     1.yield_self.detect(&:odd?)            # => 1
   #     # does not meet condition, drop value
   #     2.yield_self.detect(&:odd?)            # => nil
-  # 
+  #
   def `yield_self`: [X] () { (self) -> X } -> X
                   | () -> Enumerator[self, untyped]
 
@@ -779,41 +779,41 @@ class Object < BasicObject
   # class and an encoding of the object id. As a special case, the top-level
   # object that is the initial execution context of Ruby programs returns
   # ``main''.
-  # 
+  #
   def to_s: () -> String
 
   # Removes the tainted mark from the object.
-  # 
+  #
   # See #taint for more information.
-  # 
+  #
   def untaint: () -> self
 
   # Deprecated method that is equivalent to #untaint.
-  # 
+  #
   alias trust untaint
 
   # Yields self to the block and returns the result of the block.
-  # 
+  #
   #     3.next.then {|x| x**x }.to_s             #=> "256"
   #     "my string".yield_self {|s| s.upcase }   #=> "MY STRING"
-  # 
+  #
   # Good usage for `yield_self` is value piping in method chains:
-  # 
+  #
   #     require 'open-uri'
   #     require 'json'
-  # 
+  #
   #     construct_url(arguments).
   #       yield_self {|url| open(url).read }.
   #       yield_self {|response| JSON.parse(response) }
-  # 
+  #
   # When called without block, the method returns `Enumerator`, which can be used,
   # for example, for conditional circuit-breaking:
-  # 
+  #
   #     # meets condition, no-op
   #     1.yield_self.detect(&:odd?)            # => 1
   #     # does not meet condition, drop value
   #     2.yield_self.detect(&:odd?)            # => nil
-  # 
+  #
   alias then yield_self
 end
 

--- a/stdlib/builtin/proc.rbs
+++ b/stdlib/builtin/proc.rbs
@@ -3,152 +3,152 @@
 # [Proc](Proc), and can be called.
 # [Proc](Proc) is an essential concept in Ruby and a
 # core of its functional programming features.
-# 
+#
 # ```ruby
 # square = Proc.new {|x| x**2 }
-# 
+#
 # square.call(3)  #=> 9
 # # shorthands:
 # square.(3)      #=> 9
 # square[3]       #=> 9
 # ```
-# 
+#
 # [Proc](Proc) objects are *closures* , meaning they
 # remember and can use the entire context in which they were created.
-# 
+#
 # ```ruby
 # def gen_times(factor)
 #   Proc.new {|n| n*factor } # remembers the value of factor at the moment of creation
 # end
-# 
+#
 # times3 = gen_times(3)
 # times5 = gen_times(5)
-# 
+#
 # times3.call(12)               #=> 36
 # times5.call(5)                #=> 25
 # times3.call(times5.call(4))   #=> 60
 # ```
-# 
-# 
+#
+#
 # There are several methods to create a [Proc](Proc)
-# 
+#
 #   - Use the [Proc](Proc) class constructor:
-# 
+#
 #     ```ruby
 #     proc1 = Proc.new {|x| x**2 }
 #     ```
-# 
+#
 #   - Use the
 #     [Kernel\#proc](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-proc)
 #     method as a shorthand of
 #     [::new](Proc#method-c-new):
-# 
+#
 #     ```ruby
 #     proc2 = proc {|x| x**2 }
 #     ```
-# 
+#
 #   - Receiving a block of code into proc argument (note the `&` ):
-# 
+#
 #     ```ruby
 #     def make_proc(&block)
 #       block
 #     end
-# 
+#
 #     proc3 = make_proc {|x| x**2 }
 #     ```
-# 
+#
 #   - Construct a proc with lambda semantics using the
 #     [Kernel\#lambda](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-lambda)
 #     method (see below for explanations about lambdas):
-# 
+#
 #     ```ruby
 #     lambda1 = lambda {|x| x**2 }
 #     ```
-# 
+#
 #   - Use the Lambda literal syntax (also constructs a proc with lambda
 #     semantics):
-# 
+#
 #     ```ruby
 #     lambda2 = ->(x) { x**2 }
 #     ```
-# 
-# 
+#
+#
 # Procs are coming in two flavors: lambda and non-lambda (regular procs).
 # Differences are:
-# 
+#
 #   - In lambdas, `return` means exit from this lambda;
-# 
+#
 #   - In regular procs, `return` means exit from embracing method (and
 #     will throw `LocalJumpError` if invoked outside the method);
-# 
+#
 #   - In lambdas, arguments are treated in the same way as in methods:
 #     strict, with `ArgumentError` for mismatching argument number, and no
 #     additional argument processing;
-# 
+#
 #   - Regular procs accept arguments more generously: missing arguments
 #     are filled with `nil`, single
 #     [Array](https://ruby-doc.org/core-2.6.3/Array.html) arguments are
 #     deconstructed if the proc has multiple arguments, and there is no
 #     error raised on extra arguments.
-# 
+#
 # Examples:
-# 
+#
 # ```ruby
 # p = proc {|x, y| "x=#{x}, y=#{y}" }
 # p.call(1, 2)      #=> "x=1, y=2"
 # p.call([1, 2])    #=> "x=1, y=2", array deconstructed
 # p.call(1, 2, 8)   #=> "x=1, y=2", extra argument discarded
 # p.call(1)         #=> "x=1, y=", nil substituted instead of error
-# 
+#
 # l = lambda {|x, y| "x=#{x}, y=#{y}" }
 # l.call(1, 2)      #=> "x=1, y=2"
 # l.call([1, 2])    # ArgumentError: wrong number of arguments (given 1, expected 2)
 # l.call(1, 2, 8)   # ArgumentError: wrong number of arguments (given 3, expected 2)
 # l.call(1)         # ArgumentError: wrong number of arguments (given 1, expected 2)
-# 
+#
 # def test_return
 #   -> { return 3 }.call      # just returns from lambda into method body
 #   proc { return 4 }.call    # returns from method
 #   return 5
 # end
-# 
+#
 # test_return # => 4, return from proc
 # ```
-# 
+#
 # Lambdas are useful as self-sufficient functions, in particular useful as
 # arguments to higher-order functions, behaving exactly like Ruby methods.
-# 
+#
 # Procs are useful for implementing iterators:
-# 
+#
 # ```ruby
 # def test
 #   [[1, 2], [3, 4], [5, 6]].map {|a, b| return a if a + b > 10 }
 #                             #  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 # end
 # ```
-# 
+#
 # Inside `map`, the block of code is treated as a regular (non-lambda)
 # proc, which means that the internal arrays will be deconstructed to
 # pairs of arguments, and `return` will exit from the method `test` . That
 # would not be possible with a stricter lambda.
-# 
+#
 # You can tell a lambda from a regular proc by using the
 # [lambda?](Proc#method-i-lambda-3F) instance method.
-# 
+#
 # Lambda semantics is typically preserved during the proc lifetime,
 # including `&` -deconstruction to a block of code:
-# 
+#
 # ```ruby
 # p = proc {|x, y| x }
 # l = lambda {|x, y| x }
 # [[1, 2], [3, 4]].map(&p) #=> [1, 2]
 # [[1, 2], [3, 4]].map(&l) # ArgumentError: wrong number of arguments (given 1, expected 2)
 # ```
-# 
+#
 # The only exception is dynamic method definition: even if defined by
 # passing a non-lambda proc, methods still have normal semantics of
 # argument checking.
-# 
+#
 # ```ruby
 # class C
 #   define_method(:e, &proc {})
@@ -156,57 +156,57 @@
 # C.new.e(1,2)       #=> ArgumentError
 # C.new.method(:e).to_proc.lambda?   #=> true
 # ```
-# 
+#
 # This exception ensures that methods never have unusual argument passing
 # conventions, and makes it easy to have wrappers defining methods that
 # behave as usual.
-# 
+#
 # ```ruby
 # class C
 #   def self.def2(name, &body)
 #     define_method(name, &body)
 #   end
-# 
+#
 #   def2(:f) {}
 # end
 # C.new.f(1,2)       #=> ArgumentError
 # ```
-# 
+#
 # The wrapper *def2* receives `body` as a non-lambda proc, yet defines a
 # method which has normal semantics.
-# 
-# 
+#
+#
 # Any object that implements the `to_proc` method can be converted into a
 # proc by the `&` operator, and therefore con be consumed by iterators.
-# 
+#
 # ```ruby
 # class Greater
 #   def initialize(greating)
 #     @greating = greating
 #   end
-# 
+#
 #   def to_proc
 #     proc {|name| "#{@greating}, #{name}!" }
 #   end
 # end
-# 
+#
 # hi = Greater.new("Hi")
 # hey = Greater.new("Hey")
 # ["Bob", "Jane"].map(&hi)    #=> ["Hi, Bob!", "Hi, Jane!"]
 # ["Bob", "Jane"].map(&hey)   #=> ["Hey, Bob!", "Hey, Jane!"]
 # ```
-# 
+#
 # Of the Ruby core classes, this method is implemented by
 # [Symbol](https://ruby-doc.org/core-2.6.3/Symbol.html),
 # [Method](https://ruby-doc.org/core-2.6.3/Method.html), and
 # [Hash](https://ruby-doc.org/core-2.6.3/Hash.html).
-# 
+#
 #     :to_s.to_proc.call(1)           #=> "1"
 #     [1, 2].map(&:to_s)              #=> ["1", "2"]
-# 
+#
 #     method(:puts).to_proc.call(1)   # prints 1
 #     [1, 2].each(&method(:puts))     # prints 1, 2
-# 
+#
 #     {test: 1}.to_proc.call(:test)       #=> 1
 #     %i[test many keys].map(&{test: 1})  #=> [1, nil, nil]
 class Proc < Object
@@ -220,7 +220,7 @@ class Proc < Object
   # mandatory if any keyword argument is mandatory. A `proc` with no
   # argument declarations is the same as a block declaring `||` as its
   # arguments.
-  # 
+  #
   #     proc {}.arity                  #=>  0
   #     proc { || }.arity              #=>  0
   #     proc { |a| }.arity             #=>  1
@@ -231,7 +231,7 @@ class Proc < Object
   #     proc { |a, *b, c| }.arity      #=> -3
   #     proc { |x:, y:, z:0| }.arity   #=>  1
   #     proc { |*a, x:, y:0| }.arity   #=> -2
-  # 
+  #
   #     proc   { |a=0| }.arity         #=>  0
   #     lambda { |a=0| }.arity         #=> -1
   #     proc   { |a=0, b| }.arity      #=>  1
@@ -247,12 +247,12 @@ class Proc < Object
   def arity: () -> Integer
 
   # Returns the binding associated with *prc* .
-  # 
+  #
   # ```ruby
   # def fred(param)
   #   proc {}
   # end
-  # 
+  #
   # b = fred(99)
   # eval("param", b.binding)   #=> 99
   # ```
@@ -265,7 +265,7 @@ class Proc < Object
   def curry: (?Integer arity) -> Proc
 
   # Returns a hash value corresponding to proc body.
-  # 
+  #
   # See also Object\#hash.
   def hash: () -> Integer
 
@@ -274,94 +274,94 @@ class Proc < Object
   # Returns `true` for a [Proc](Proc.downloaded.ruby_doc) object for which
   # argument handling is rigid. Such procs are typically generated by
   # `lambda` .
-  # 
+  #
   # A [Proc](Proc.downloaded.ruby_doc) object generated by `proc` ignores
   # extra arguments.
-  # 
+  #
   # ```ruby
   # proc {|a,b| [a,b] }.call(1,2,3)    #=> [1,2]
   # ```
-  # 
+  #
   # It provides `nil` for missing arguments.
-  # 
+  #
   # ```ruby
   # proc {|a,b| [a,b] }.call(1)        #=> [1,nil]
   # ```
-  # 
+  #
   # It expands a single array argument.
-  # 
+  #
   # ```ruby
   # proc {|a,b| [a,b] }.call([1,2])    #=> [1,2]
   # ```
-  # 
+  #
   # A [Proc](Proc.downloaded.ruby_doc) object generated by `lambda` doesn’t
   # have such tricks.
-  # 
+  #
   # ```ruby
   # lambda {|a,b| [a,b] }.call(1,2,3)  #=> ArgumentError
   # lambda {|a,b| [a,b] }.call(1)      #=> ArgumentError
   # lambda {|a,b| [a,b] }.call([1,2])  #=> ArgumentError
   # ```
-  # 
+  #
   # [\#lambda?](Proc.downloaded.ruby_doc#method-i-lambda-3F) is a predicate
   # for the tricks. It returns `true` if no tricks apply.
-  # 
+  #
   # ```ruby
   # lambda {}.lambda?            #=> true
   # proc {}.lambda?              #=> false
   # ```
-  # 
+  #
   # [::new](Proc.downloaded.ruby_doc#method-c-new) is the same as `proc` .
-  # 
+  #
   # ```ruby
   # Proc.new {}.lambda?          #=> false
   # ```
-  # 
+  #
   # `lambda`, `proc` and [::new](Proc.downloaded.ruby_doc#method-c-new)
   # preserve the tricks of a [Proc](Proc.downloaded.ruby_doc) object given
   # by `&` argument.
-  # 
+  #
   # ```ruby
   # lambda(&lambda {}).lambda?   #=> true
   # proc(&lambda {}).lambda?     #=> true
   # Proc.new(&lambda {}).lambda? #=> true
-  # 
+  #
   # lambda(&proc {}).lambda?     #=> false
   # proc(&proc {}).lambda?       #=> false
   # Proc.new(&proc {}).lambda?   #=> false
   # ```
-  # 
+  #
   # A [Proc](Proc.downloaded.ruby_doc) object generated by `&` argument has
   # the tricks
-  # 
+  #
   # ```ruby
   # def n(&b) b.lambda? end
   # n {}                         #=> false
   # ```
-  # 
+  #
   # The `&` argument preserves the tricks if a
   # [Proc](Proc.downloaded.ruby_doc) object is given by `&` argument.
-  # 
+  #
   # ```ruby
   # n(&lambda {})                #=> true
   # n(&proc {})                  #=> false
   # n(&Proc.new {})              #=> false
   # ```
-  # 
+  #
   # A [Proc](Proc.downloaded.ruby_doc) object converted from a method has no
   # tricks.
-  # 
+  #
   # ```ruby
   # def m() end
   # method(:m).to_proc.lambda?   #=> true
-  # 
+  #
   # n(&method(:m))               #=> true
   # n(&method(:m).to_proc)       #=> true
   # ```
-  # 
+  #
   # `define_method` is treated the same as method definition. The defined
   # method has no tricks.
-  # 
+  #
   # ```ruby
   # class C
   #   define_method(:d) {}
@@ -369,11 +369,11 @@ class Proc < Object
   # C.new.d(1,2)       #=> ArgumentError
   # C.new.method(:d).to_proc.lambda?   #=> true
   # ```
-  # 
+  #
   # `define_method` always defines a method without the tricks, even if a
   # non-lambda [Proc](Proc.downloaded.ruby_doc) object is given. This is the
   # only exception for which the tricks are not preserved.
-  # 
+  #
   # ```ruby
   # class C
   #   define_method(:e, &proc {})
@@ -381,26 +381,26 @@ class Proc < Object
   # C.new.e(1,2)       #=> ArgumentError
   # C.new.method(:e).to_proc.lambda?   #=> true
   # ```
-  # 
+  #
   # This exception ensures that methods never have tricks and makes it easy
   # to have wrappers to define methods that behave as usual.
-  # 
+  #
   # ```ruby
   # class C
   #   def self.def2(name, &body)
   #     define_method(name, &body)
   #   end
-  # 
+  #
   #   def2(:f) {}
   # end
   # C.new.f(1,2)       #=> ArgumentError
   # ```
-  # 
+  #
   # The wrapper *def2* defines a method which has no tricks.
   def lambda?: () -> bool
 
   # Returns the parameter information of this proc.
-  # 
+  #
   # ```ruby
   # prc = lambda{|x, y=42, *other|}
   # prc.parameters  #=> [[:req, :x], [:opt, :y], [:rest, :other]]
@@ -417,9 +417,9 @@ class Proc < Object
 
   # Returns the unique identifier for this proc, along with an indication of
   # where the proc was defined.
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [inspect](Proc.downloaded.ruby_doc#method-i-inspect)
   def to_s: () -> String
 

--- a/stdlib/builtin/rational.rbs
+++ b/stdlib/builtin/rational.rbs
@@ -1,43 +1,43 @@
 # A rational number can be represented as a pair of integer numbers: a/b (b>0),
 # where a is the numerator and b is the denominator. Integer a equals rational
 # a/1 mathematically.
-# 
+#
 # In Ruby, you can create rational objects with the Kernel#Rational, to_r, or
 # rationalize methods or by suffixing `r` to a literal. The return values will
 # be irreducible fractions.
-# 
+#
 #     Rational(1)      #=> (1/1)
 #     Rational(2, 3)   #=> (2/3)
 #     Rational(4, -6)  #=> (-2/3)
 #     3.to_r           #=> (3/1)
 #     2/3r             #=> (2/3)
-# 
+#
 # You can also create rational objects from floating-point numbers or strings.
-# 
+#
 #     Rational(0.3)    #=> (5404319552844595/18014398509481984)
 #     Rational('0.3')  #=> (3/10)
 #     Rational('2/3')  #=> (2/3)
-# 
+#
 #     0.3.to_r         #=> (5404319552844595/18014398509481984)
 #     '0.3'.to_r       #=> (3/10)
 #     '2/3'.to_r       #=> (2/3)
 #     0.3.rationalize  #=> (3/10)
-# 
+#
 # A rational object is an exact number, which helps you to write programs
 # without any rounding errors.
-# 
+#
 #     10.times.inject(0) {|t| t + 0.1 }              #=> 0.9999999999999999
 #     10.times.inject(0) {|t| t + Rational('0.1') }  #=> (1/1)
-# 
+#
 # However, when an expression includes an inexact component (numerical value or
 # operation), it will produce an inexact result.
-# 
+#
 #     Rational(10) / 3   #=> (10/3)
 #     Rational(10) / 3.0 #=> 3.3333333333333335
-# 
+#
 #     Rational(-8) ** Rational(1, 3)
 #                        #=> (1.0000000000000002+1.7320508075688772i)
-# 
+#
 class Rational < Numeric
   public
 
@@ -47,37 +47,37 @@ class Rational < Numeric
        | (Numeric) -> Numeric
 
   # Performs multiplication.
-  # 
+  #
   #     Rational(2, 3)  * Rational(2, 3)   #=> (4/9)
   #     Rational(900)   * Rational(1)      #=> (900/1)
   #     Rational(-2, 9) * Rational(-9, 2)  #=> (1/1)
   #     Rational(9, 8)  * 4                #=> (9/2)
   #     Rational(20, 9) * 9.8              #=> 21.77777777777778
-  # 
+  #
   def *: (Float) -> Float
        | (Complex) -> Complex
        | (Numeric) -> Numeric
 
   # Performs exponentiation.
-  # 
+  #
   #     Rational(2)    ** Rational(3)     #=> (8/1)
   #     Rational(10)   ** -2              #=> (1/100)
   #     Rational(10)   ** -2.0            #=> 0.01
   #     Rational(-4)   ** Rational(1, 2)  #=> (0.0+2.0i)
   #     Rational(1, 2) ** 0               #=> (1/1)
   #     Rational(1, 2) ** 0.0             #=> 1.0
-  # 
+  #
   def **: (Complex) -> Complex
         | (Numeric) -> Numeric
 
   # Performs addition.
-  # 
+  #
   #     Rational(2, 3)  + Rational(2, 3)   #=> (4/3)
   #     Rational(900)   + Rational(1)      #=> (901/1)
   #     Rational(-2, 9) + Rational(-9, 2)  #=> (-85/18)
   #     Rational(9, 8)  + 4                #=> (41/8)
   #     Rational(20, 9) + 9.8              #=> 12.022222222222222
-  # 
+  #
   def +: (Float) -> Float
        | (Complex) -> Complex
        | (Numeric) -> Rational
@@ -85,65 +85,65 @@ class Rational < Numeric
   def +@: () -> Rational
 
   # Performs subtraction.
-  # 
+  #
   #     Rational(2, 3)  - Rational(2, 3)   #=> (0/1)
   #     Rational(900)   - Rational(1)      #=> (899/1)
   #     Rational(-2, 9) - Rational(-9, 2)  #=> (77/18)
   #     Rational(9, 8)  - 4                #=> (-23/8)
   #     Rational(20, 9) - 9.8              #=> -7.577777777777778
-  # 
+  #
   def -: (Float) -> Float
        | (Complex) -> Complex
        | (Numeric) -> Rational
 
   # Negates `rat`.
-  # 
+  #
   def -@: () -> Rational
 
   # Performs division.
-  # 
+  #
   #     Rational(2, 3)  / Rational(2, 3)   #=> (1/1)
   #     Rational(900)   / Rational(1)      #=> (900/1)
   #     Rational(-2, 9) / Rational(-9, 2)  #=> (4/81)
   #     Rational(9, 8)  / 4                #=> (9/32)
   #     Rational(20, 9) / 9.8              #=> 0.22675736961451246
-  # 
+  #
   def /: (Float) -> Float
        | (Complex) -> Complex
        | (Numeric) -> Rational
 
   # Returns -1, 0, or +1 depending on whether `rational` is less than, equal to,
   # or greater than `numeric`.
-  # 
+  #
   # `nil` is returned if the two values are incomparable.
-  # 
+  #
   #     Rational(2, 3) <=> Rational(2, 3)  #=> 0
   #     Rational(5)    <=> 5               #=> 0
   #     Rational(2, 3) <=> Rational(1, 3)  #=> 1
   #     Rational(1, 3) <=> 1               #=> -1
   #     Rational(1, 3) <=> 0.3             #=> 1
-  # 
+  #
   #     Rational(1, 3) <=> "0.3"           #=> nil
-  # 
+  #
   def <=>: (Numeric) -> Integer?
 
   # Returns `true` if `rat` equals `object` numerically.
-  # 
+  #
   #     Rational(2, 3)  == Rational(2, 3)   #=> true
   #     Rational(5)     == 5                #=> true
   #     Rational(0)     == 0.0              #=> true
   #     Rational('1/3') == 0.33             #=> false
   #     Rational('1/2') == '1/2'            #=> false
-  # 
+  #
   def ==: (untyped) -> bool
 
   # Returns the absolute value of `rat`.
-  # 
+  #
   #     (1/2r).abs    #=> (1/2)
   #     (-1/2r).abs   #=> (1/2)
-  # 
+  #
   # Rational#magnitude is an alias for Rational#abs.
-  # 
+  #
   def abs: () -> Rational
 
   def abs2: () -> Rational
@@ -154,23 +154,23 @@ class Rational < Numeric
 
   # Returns the smallest number greater than or equal to `rat` with a precision of
   # `ndigits` decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a rational when `ndigits` is positive, otherwise returns an integer.
-  # 
+  #
   #     Rational(3).ceil      #=> 3
   #     Rational(2, 3).ceil   #=> 1
   #     Rational(-3, 2).ceil  #=> -1
-  # 
+  #
   #       #    decimal      -  1  2  3 . 4  5  6
   #       #                   ^  ^  ^  ^   ^  ^
   #       #   precision      -3 -2 -1  0  +1 +2
-  # 
+  #
   #     Rational('-123.456').ceil(+1).to_f  #=> -123.4
   #     Rational('-123.456').ceil(-1)       #=> -120
-  # 
+  #
   def ceil: () -> Integer
           | (Integer digits) -> (Integer | Rational)
 
@@ -183,12 +183,12 @@ class Rational < Numeric
   def conjugate: () -> Rational
 
   # Returns the denominator (always positive).
-  # 
+  #
   #     Rational(7).denominator             #=> 1
   #     Rational(7, 1).denominator          #=> 1
   #     Rational(9, -4).denominator         #=> 4
   #     Rational(-2, -10).denominator       #=> 5
-  # 
+  #
   def denominator: () -> Integer
 
   def div: (Numeric) -> Integer
@@ -200,34 +200,34 @@ class Rational < Numeric
   def eql?: (untyped) -> bool
 
   # Performs division and returns the value as a Float.
-  # 
+  #
   #     Rational(2, 3).fdiv(1)       #=> 0.6666666666666666
   #     Rational(2, 3).fdiv(0.5)     #=> 1.3333333333333333
   #     Rational(2).fdiv(3)          #=> 0.6666666666666666
-  # 
+  #
   def fdiv: (Numeric) -> Float
 
   def finite?: () -> bool
 
   # Returns the largest number less than or equal to `rat` with a precision of
   # `ndigits` decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a rational when `ndigits` is positive, otherwise returns an integer.
-  # 
+  #
   #     Rational(3).floor      #=> 3
   #     Rational(2, 3).floor   #=> 0
   #     Rational(-3, 2).floor  #=> -2
-  # 
+  #
   #       #    decimal      -  1  2  3 . 4  5  6
   #       #                   ^  ^  ^  ^   ^  ^
   #       #   precision      -3 -2 -1  0  +1 +2
-  # 
+  #
   #     Rational('-123.456').floor(+1).to_f  #=> -123.5
   #     Rational('-123.456').floor(-1)       #=> -130
-  # 
+  #
   def floor: () -> Integer
            | (Integer digits) -> (Integer | Rational)
 
@@ -242,40 +242,40 @@ class Rational < Numeric
   def infinite?: () -> Integer?
 
   # Returns the value as a string for inspection.
-  # 
+  #
   #     Rational(2).inspect      #=> "(2/1)"
   #     Rational(-8, 6).inspect  #=> "(-4/3)"
   #     Rational('1/2').inspect  #=> "(1/2)"
-  # 
+  #
   def inspect: () -> String
 
   def integer?: () -> bool
 
   # Returns the absolute value of `rat`.
-  # 
+  #
   #     (1/2r).abs    #=> (1/2)
   #     (-1/2r).abs   #=> (1/2)
-  # 
+  #
   # Rational#magnitude is an alias for Rational#abs.
-  # 
+  #
   alias magnitude abs
 
   def modulo: (Float) -> Float
             | (Numeric) -> Rational
 
   # Returns `true` if `rat` is less than 0.
-  # 
+  #
   def negative?: () -> bool
 
   def nonzero?: () -> self?
 
   # Returns the numerator.
-  # 
+  #
   #     Rational(7).numerator        #=> 7
   #     Rational(7, 1).numerator     #=> 7
   #     Rational(9, -4).numerator    #=> -9
   #     Rational(-2, -10).numerator  #=> 1
-  # 
+  #
   def numerator: () -> Integer
 
   alias phase angle
@@ -283,29 +283,29 @@ class Rational < Numeric
   def polar: () -> [ Rational, Integer | Float ]
 
   # Returns `true` if `rat` is greater than 0.
-  # 
+  #
   def positive?: () -> bool
 
   # Performs division.
-  # 
+  #
   #     Rational(2, 3)  / Rational(2, 3)   #=> (1/1)
   #     Rational(900)   / Rational(1)      #=> (900/1)
   #     Rational(-2, 9) / Rational(-9, 2)  #=> (4/81)
   #     Rational(9, 8)  / 4                #=> (9/32)
   #     Rational(20, 9) / 9.8              #=> 0.22675736961451246
-  # 
+  #
   def quo: (Float) -> Float
          | (Complex) -> Complex
          | (Numeric) -> Rational
 
   # Returns a simpler approximation of the value if the optional argument `eps` is
   # given (rat-|eps| <= result <= rat+|eps|), self otherwise.
-  # 
+  #
   #     r = Rational(5033165, 16777216)
   #     r.rationalize                    #=> (5033165/16777216)
   #     r.rationalize(Rational('0.01'))  #=> (3/10)
   #     r.rationalize(Rational('0.1'))   #=> (1/3)
-  # 
+  #
   def rationalize: (?Numeric eps) -> Rational
 
   def real: () -> Rational
@@ -321,25 +321,25 @@ class Rational < Numeric
 
   # Returns `rat` rounded to the nearest value with a precision of `ndigits`
   # decimal digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a rational when `ndigits` is positive, otherwise returns an integer.
-  # 
+  #
   #     Rational(3).round      #=> 3
   #     Rational(2, 3).round   #=> 1
   #     Rational(-3, 2).round  #=> -2
-  # 
+  #
   #       #    decimal      -  1  2  3 . 4  5  6
   #       #                   ^  ^  ^  ^   ^  ^
   #       #   precision      -3 -2 -1  0  +1 +2
-  # 
+  #
   #     Rational('-123.456').round(+1).to_f  #=> -123.5
   #     Rational('-123.456').round(-1)       #=> -120
-  # 
+  #
   # The optional `half` keyword argument is available similar to Float#round.
-  # 
+  #
   #     Rational(25, 100).round(1, half: :up)    #=> (3/10)
   #     Rational(25, 100).round(1, half: :down)  #=> (1/5)
   #     Rational(25, 100).round(1, half: :even)  #=> (1/5)
@@ -349,7 +349,7 @@ class Rational < Numeric
   #     Rational(-25, 100).round(1, half: :up)   #=> (-3/10)
   #     Rational(-25, 100).round(1, half: :down) #=> (-1/5)
   #     Rational(-25, 100).round(1, half: :even) #=> (-1/5)
-  # 
+  #
   def round: (?half: :up | :down | :even) -> Integer
            | (Integer digits, ?half: :up | :down | :even) -> (Integer | Rational)
 
@@ -361,62 +361,62 @@ class Rational < Numeric
   def to_c: () -> Complex
 
   # Returns the value as a Float.
-  # 
+  #
   #     Rational(2).to_f      #=> 2.0
   #     Rational(9, 4).to_f   #=> 2.25
   #     Rational(-3, 4).to_f  #=> -0.75
   #     Rational(20, 3).to_f  #=> 6.666666666666667
-  # 
+  #
   def to_f: () -> Float
 
   # Returns the truncated value as an integer.
-  # 
+  #
   # Equivalent to Rational#truncate.
-  # 
+  #
   #     Rational(2, 3).to_i    #=> 0
   #     Rational(3).to_i       #=> 3
   #     Rational(300.6).to_i   #=> 300
   #     Rational(98, 71).to_i  #=> 1
   #     Rational(-31, 2).to_i  #=> -15
-  # 
+  #
   def to_i: () -> Integer
 
   alias to_int to_i
 
   # Returns self.
-  # 
+  #
   #     Rational(2).to_r      #=> (2/1)
   #     Rational(-8, 6).to_r  #=> (-4/3)
-  # 
+  #
   def to_r: () -> Rational
 
   # Returns the value as a string.
-  # 
+  #
   #     Rational(2).to_s      #=> "2/1"
   #     Rational(-8, 6).to_s  #=> "-4/3"
   #     Rational('1/2').to_s  #=> "1/2"
-  # 
+  #
   def to_s: () -> String
 
   # Returns `rat` truncated (toward zero) to a precision of `ndigits` decimal
   # digits (default: 0).
-  # 
+  #
   # When the precision is negative, the returned value is an integer with at least
   # `ndigits.abs` trailing zeros.
-  # 
+  #
   # Returns a rational when `ndigits` is positive, otherwise returns an integer.
-  # 
+  #
   #     Rational(3).truncate      #=> 3
   #     Rational(2, 3).truncate   #=> 0
   #     Rational(-3, 2).truncate  #=> -1
-  # 
+  #
   #       #    decimal      -  1  2  3 . 4  5  6
   #       #                   ^  ^  ^  ^   ^  ^
   #       #   precision      -3 -2 -1  0  +1 +2
-  # 
+  #
   #     Rational('-123.456').truncate(+1).to_f  #=> -123.4
   #     Rational('-123.456').truncate(-1)       #=> -120
-  # 
+  #
   def truncate: () -> Integer
               | (Integer ndigits) -> (Integer | Rational)
 

--- a/stdlib/builtin/signal.rbs
+++ b/stdlib/builtin/signal.rbs
@@ -3,7 +3,7 @@
 # trapped at the code level and acted upon. For example, your process may
 # trap the USR1 signal and use it to toggle debugging, and may use TERM to
 # initiate a controlled shutdown.
-# 
+#
 # ```ruby
 # pid = fork do
 #   Signal.trap("USR1") do
@@ -16,9 +16,9 @@
 #   end
 #   # . . . do some work . . .
 # end
-# 
+#
 # Process.detach(pid)
-# 
+#
 # # Controlling program:
 # Process.kill("USR1", pid)
 # # ...
@@ -26,15 +26,15 @@
 # # ...
 # Process.kill("TERM", pid)
 # ```
-# 
+#
 # produces:
-# 
+#
 # ```
 #  Debug now: true
 #  Debug now: false
 # Terminating...
 # ```
-# 
+#
 # The list of available signal names and their interpretation is system
 # dependent. [Signal](Signal) delivery semantics may
 # also vary between systems; in particular signal delivery may not always
@@ -42,7 +42,7 @@
 module Signal
   # Returns a list of signal names mapped to the corresponding underlying
   # signal numbers.
-  # 
+  #
   # ```ruby
   # Signal.list   #=> {"EXIT"=>0, "HUP"=>1, "INT"=>2, "QUIT"=>3, "ILL"=>4, "TRAP"=>5, "IOT"=>6, "ABRT"=>6, "FPE"=>8, "KILL"=>9, "BUS"=>7, "SEGV"=>11, "SYS"=>31, "PIPE"=>13, "ALRM"=>14, "TERM"=>15, "URG"=>23, "STOP"=>19, "TSTP"=>20, "CONT"=>18, "CHLD"=>17, "CLD"=>17, "TTIN"=>21, "TTOU"=>22, "IO"=>29, "XCPU"=>24, "XFSZ"=>25, "VTALRM"=>26, "PROF"=>27, "WINCH"=>28, "USR1"=>10, "USR2"=>12, "PWR"=>30, "POLL"=>29}
   # ```

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -456,7 +456,7 @@ class String
   #
   # *   On some OSes such as Mac OS, `crypt(3)` is not thread safe.
   #
-  # *   So-called "traditional" usage of `crypt(3)` is very very very weak. 
+  # *   So-called "traditional" usage of `crypt(3)` is very very very weak.
   #     According to its manpage, Linux's traditional `crypt(3)` output has only
   #     2**56 variations; too easy to brute force today.  And this is the default
   #     behaviour.
@@ -735,7 +735,7 @@ class String
   # :   Sets the replacement string to the given value. The default replacement
   #     string is "uFFFD" for Unicode encoding forms, and "?" otherwise.
   # :fallback
-  # :   Sets the replacement string by the given object for undefined character. 
+  # :   Sets the replacement string by the given object for undefined character.
   #     The object should be a Hash, a Proc, a Method, or an object which has []
   #     method. Its key is an undefined character encoded in the source encoding
   #     of current transcoder. Its value can be any encoding until it can be
@@ -1532,7 +1532,7 @@ class String
   #
   def to_i: (?int base) -> Integer
 
-  # Returns the result of interpreting leading characters in `str` as a rational. 
+  # Returns the result of interpreting leading characters in `str` as a rational.
   # Leading whitespace and extraneous characters past the end of a valid number
   # are ignored. Digit sequences can be separated by an underscore. If there is
   # not a valid number at the start of `str`, zero is returned.  This method never
@@ -1806,7 +1806,7 @@ class String
   # In that case data would be lost but often it's the case that the array only
   # holds one value, especially when unpacking binary data. For instance:
   #
-  # "xffx00x00x00".unpack("l")         #=>  [255] "xffx00x00x00".unpack1("l")     
+  # "xffx00x00x00".unpack("l")         #=>  [255] "xffx00x00x00".unpack1("l")
   #   #=>  255
   #
   # Thus unpack1 is convenient, makes clear the intention and signals the expected

--- a/stdlib/builtin/string_io.rbs
+++ b/stdlib/builtin/string_io.rbs
@@ -114,7 +114,7 @@ class StringIO
   #
   def gets: (?String sep, ?Integer limit, ?chomp: bool) -> String?
 
-  # Returns the Encoding of the internal string if conversion is specified. 
+  # Returns the Encoding of the internal string if conversion is specified.
   # Otherwise returns `nil`.
   #
   def internal_encoding: () -> Encoding

--- a/stdlib/builtin/thread.rbs
+++ b/stdlib/builtin/thread.rbs
@@ -1,43 +1,43 @@
 # Threads are the Ruby implementation for a concurrent programming model.
-# 
+#
 # Programs that require multiple threads of execution are a perfect
 # candidate for Ruby's [Thread](Thread) class.
-# 
+#
 # For example, we can create a new thread separate from the main thread's
 # execution using [::new](Thread#method-c-new).
-# 
+#
 # ```ruby
 # thr = Thread.new { puts "Whats the big deal" }
 # ```
-# 
+#
 # Then we are able to pause the execution of the main thread and allow our
 # new thread to finish, using
 # [join](Thread#method-i-join):
-# 
+#
 # ```ruby
 # thr.join #=> "Whats the big deal"
 # ```
-# 
+#
 # If we don't call `thr.join` before the main thread terminates, then all
 # other threads including `thr` will be killed.
-# 
+#
 # Alternatively, you can use an array for handling multiple threads at
 # once, like in the following example:
-# 
+#
 # ```ruby
 # threads = []
 # threads << Thread.new { puts "Whats the big deal" }
 # threads << Thread.new { 3.times { puts "Threads are fun!" } }
 # ```
-# 
+#
 # After creating a few threads we wait for them all to finish
 # consecutively.
-# 
+#
 # ```ruby
 # threads.each { |thr| thr.join }
 # ```
-# 
-# 
+#
+#
 # In order to create new threads, Ruby provides
 # [::new](Thread#method-c-new),
 # [::start](Thread#method-c-start), and
@@ -45,59 +45,59 @@
 # provided with each of these methods, otherwise a
 # [ThreadError](https://ruby-doc.org/core-2.6.3/ThreadError.html) will be
 # raised.
-# 
+#
 # When subclassing the [Thread](Thread) class, the
 # `initialize` method of your subclass will be ignored by
 # [::start](Thread#method-c-start) and
 # [::fork](Thread#method-c-fork). Otherwise, be sure
 # to call super in your `initialize` method.
-# 
-# 
+#
+#
 # For terminating threads, Ruby provides a variety of ways to do this.
-# 
+#
 # The class method [::kill](Thread#method-c-kill), is
 # meant to exit a given thread:
-# 
+#
 #     thr = Thread.new { ... }
 #     Thread.kill(thr) # sends exit() to thr
-# 
+#
 # Alternatively, you can use the instance method
 # [exit](Thread#method-i-exit), or any of its aliases
 # [kill](Thread#method-i-kill) or
 # [terminate](Thread#method-i-terminate).
-# 
+#
 # ```ruby
 # thr.exit
 # ```
-# 
-# 
+#
+#
 # Ruby provides a few instance methods for querying the state of a given
 # thread. To get a string with the current thread's state use
 # [status](Thread#method-i-status)
-# 
+#
 # ```ruby
 # thr = Thread.new { sleep }
 # thr.status # => "sleep"
 # thr.exit
 # thr.status # => false
 # ```
-# 
+#
 # You can also use [alive?](Thread#method-i-alive-3F)
 # to tell if the thread is running or sleeping, and
 # [stop?](Thread#method-i-stop-3F) if the thread is
 # dead or sleeping.
-# 
-# 
+#
+#
 # Since threads are created with blocks, the same rules apply to other
 # Ruby blocks for variable scope. Any local variables created within this
 # block are accessible to only this thread.
-# 
-# 
+#
+#
 # Each fiber has its own bucket for
 # [\#\[\]](Thread#method-i-5B-5D) storage. When you
 # set a new fiber-local it is only accessible within this
 # [Fiber](https://ruby-doc.org/core-2.6.3/Fiber.html). To illustrate:
-# 
+#
 # ```ruby
 # Thread.new {
 #   Thread.current[:foo] = "bar"
@@ -106,7 +106,7 @@
 #   }.resume
 # }.join
 # ```
-# 
+#
 # This example uses [\[\]](Thread#method-i-5B-5D) for
 # getting and [\[\]=](Thread#method-i-5B-5D-3D) for
 # setting fiber-locals, you can also use
@@ -114,10 +114,10 @@
 # fiber-locals for a given thread and
 # [key?](Thread#method-i-key-3F) to check if a
 # fiber-local exists.
-# 
+#
 # When it comes to thread-locals, they are accessible within the entire
 # scope of the thread. Given the following example:
-# 
+#
 # ```ruby
 # Thread.new{
 #   Thread.current.thread_variable_set(:foo, 1)
@@ -129,29 +129,29 @@
 #   p Thread.current.thread_variable_get(:foo)   # => 2
 # }.join
 # ```
-# 
+#
 # You can see that the thread-local `:foo` carried over into the fiber and
 # was changed to `2` by the end of the thread.
-# 
+#
 # This example makes use of
 # [thread\_variable\_set](Thread#method-i-thread_variable_set)
 # to create new thread-locals, and
 # [thread\_variable\_get](Thread#method-i-thread_variable_get)
 # to reference them.
-# 
+#
 # There is also
 # [thread\_variables](Thread#method-i-thread_variables)
 # to list all thread-locals, and
 # [thread\_variable?](Thread#method-i-thread_variable-3F)
 # to check if a given thread-local exists.
-# 
-# 
+#
+#
 # Any thread can raise an exception using the
 # [raise](Thread#method-i-raise) instance method,
 # which operates similarly to
 # [Kernel\#raise](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-raise)
 # .
-# 
+#
 # However, it's important to note that an exception that occurs in any
 # thread except the main thread depends on
 # [abort\_on\_exception](Thread#method-i-abort_on_exception)
@@ -162,22 +162,22 @@
 # default by either
 # [abort\_on\_exception=](Thread#method-i-abort_on_exception-3D)
 # `true` or setting $DEBUG to `true` .
-# 
+#
 # With the addition of the class method
 # [::handle\_interrupt](Thread#method-c-handle_interrupt)
 # , you can now handle exceptions asynchronously with threads.
-# 
-# 
+#
+#
 # Ruby provides a few ways to support scheduling threads in your program.
-# 
+#
 # The first way is by using the class method
 # [::stop](Thread#method-c-stop), to put the current
 # running thread to sleep and schedule the execution of another thread.
-# 
+#
 # Once a thread is asleep, you can use the instance method
 # [wakeup](Thread#method-i-wakeup) to mark your thread
 # as eligible for scheduling.
-# 
+#
 # You can also try [::pass](Thread#method-c-pass),
 # which attempts to pass execution to another thread but is dependent on
 # the OS whether a running thread will switch or not. The same goes for
@@ -195,9 +195,9 @@ class Thread < Object
 
   # Attribute Assignment—Sets or creates the value of a fiber-local
   # variable, using either a symbol or a string.
-  # 
+  #
   # See also [\#\[\]](Thread.downloaded.ruby_doc#method-i-5B-5D).
-  # 
+  #
   # For thread-local variables, please see
   # [thread\_variable\_set](Thread.downloaded.ruby_doc#method-i-thread_variable_set)
   # and
@@ -208,23 +208,23 @@ class Thread < Object
   def alive?: () -> bool
 
   # Terminates `thr` and schedules another thread to be run.
-  # 
+  #
   # If this thread is already marked to be killed,
   # [exit](Thread.downloaded.ruby_doc#method-i-exit) returns the
   # [Thread](Thread.downloaded.ruby_doc).
-  # 
+  #
   # If this is the main thread, or the last thread, exits the process.
   def kill: () -> Thread?
 
   # Returns the status of the thread-local “abort on exception” condition
   # for this `thr` .
-  # 
+  #
   # The default is `false` .
-  # 
+  #
   # See also
   # [abort\_on\_exception=](Thread.downloaded.ruby_doc#method-i-abort_on_exception-3D)
   # .
-  # 
+  #
   # There is also a class level method to set this for all threads, see
   # [::abort\_on\_exception](Thread.downloaded.ruby_doc#method-c-abort_on_exception)
   # .
@@ -232,18 +232,18 @@ class Thread < Object
 
   # When set to `true`, if this `thr` is aborted by an exception, the
   # raised exception will be re-raised in the main thread.
-  # 
+  #
   # See also
   # [abort\_on\_exception](Thread.downloaded.ruby_doc#method-i-abort_on_exception)
   # .
-  # 
+  #
   # There is also a class level method to set this for all threads, see
   # [::abort\_on\_exception=](Thread.downloaded.ruby_doc#method-c-abort_on_exception-3D)
   # .
   def abort_on_exception=: (bool abort_on_exception) -> untyped
 
   # Adds *proc* as a handler for tracing.
-  # 
+  #
   # See
   # [\#set\_trace\_func](Thread.downloaded.ruby_doc#method-i-set_trace_func)
   # and
@@ -256,22 +256,22 @@ class Thread < Object
 
   # Returns the execution stack for the target thread—an array containing
   # backtrace location objects.
-  # 
+  #
   # See
   # [Thread::Backtrace::Location](https://ruby-doc.org/core-2.6.3/Thread/Backtrace/Location.html)
   # for more information.
-  # 
+  #
   # This method behaves similarly to
   # [Kernel\#caller\_locations](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-caller_locations)
   # except it applies to a specific thread.
   def backtrace_locations: (*untyped args) -> ::Array[untyped]?
 
   # Terminates `thr` and schedules another thread to be run.
-  # 
+  #
   # If this thread is already marked to be killed,
   # [exit](Thread.downloaded.ruby_doc#method-i-exit) returns the
   # [Thread](Thread.downloaded.ruby_doc).
-  # 
+  #
   # If this is the main thread, or the last thread, exits the process.
   def exit: () -> Thread?
 
@@ -290,36 +290,36 @@ class Thread < Object
   def initialize: (*untyped args) -> Thread
 
   # The calling thread will suspend execution and run this `thr` .
-  # 
+  #
   # Does not return until `thr` exits or until the given `limit` seconds
   # have passed.
-  # 
+  #
   # If the time limit expires, `nil` will be returned, otherwise `thr` is
   # returned.
-  # 
+  #
   # Any threads not joined will be killed when the main program exits.
-  # 
+  #
   # If `thr` had previously raised an exception and the
   # [::abort\_on\_exception](Thread.downloaded.ruby_doc#method-c-abort_on_exception)
   # or $DEBUG flags are not set, (so the exception has not yet been
   # processed), it will be processed at this time.
-  # 
+  #
   # ```ruby
   # a = Thread.new { print "a"; sleep(10); print "b"; print "c" }
   # x = Thread.new { print "x"; Thread.pass; print "y"; print "z" }
   # x.join # Let thread x finish, thread a will be killed on exit.
   # #=> "axyz"
   # ```
-  # 
+  #
   # The following example illustrates the `limit` parameter.
-  # 
+  #
   # ```ruby
   # y = Thread.new { 4.times { sleep 0.1; puts 'tick... ' }}
   # puts "Waiting" until y.join(0.15)
   # ```
-  # 
+  #
   # This will produce:
-  # 
+  #
   #     tick...
   #     Waiting
   #     tick...
@@ -330,7 +330,7 @@ class Thread < Object
 
   # Returns `true` if the given string (or symbol) exists as a fiber-local
   # variable.
-  # 
+  #
   # ```ruby
   # me = Thread.current
   # me[:oliver] = "a"
@@ -350,9 +350,9 @@ class Thread < Object
 
   # Returns whether or not the asynchronous queue is empty for the target
   # thread.
-  # 
+  #
   # If `error` is given, then check only for `error` type deferred events.
-  # 
+  #
   # See
   # [::pending\_interrupt?](Thread.downloaded.ruby_doc#method-c-pending_interrupt-3F)
   # for more information.
@@ -362,10 +362,10 @@ class Thread < Object
   # thread which creating the new thread, or zero for the initial main
   # thread; higher-priority thread will run more frequently than
   # lower-priority threads (but lower-priority threads can also run).
-  # 
+  #
   # This is just hint for Ruby thread scheduler. It may be ignored on some
   # platform.
-  # 
+  #
   # ```ruby
   # Thread.current.priority   #=> 0
   # ```
@@ -374,17 +374,17 @@ class Thread < Object
   # Sets the priority of *thr* to *integer* . Higher-priority threads will
   # run more frequently than lower-priority threads (but lower-priority
   # threads can also run).
-  # 
+  #
   # This is just hint for Ruby thread scheduler. It may be ignored on some
   # platform.
-  # 
+  #
   # ```ruby
   # count1 = count2 = 0
   # a = Thread.new do
   #       loop { count1 += 1 }
   #     end
   # a.priority = -1
-  # 
+  #
   # b = Thread.new do
   #       loop { count2 += 1 }
   #     end
@@ -397,16 +397,16 @@ class Thread < Object
 
   # Returns the status of the thread-local “report on exception” condition
   # for this `thr` .
-  # 
+  #
   # The default value when creating a [Thread](Thread.downloaded.ruby_doc)
   # is the value of the global flag
   # [::report\_on\_exception](Thread.downloaded.ruby_doc#method-c-report_on_exception)
   # .
-  # 
+  #
   # See also
   # [report\_on\_exception=](Thread.downloaded.ruby_doc#method-i-report_on_exception-3D)
   # .
-  # 
+  #
   # There is also a class level method to set this for all new threads, see
   # [::report\_on\_exception=](Thread.downloaded.ruby_doc#method-c-report_on_exception-3D)
   # .
@@ -416,18 +416,18 @@ class Thread < Object
   # kills this `thr` . See
   # [::report\_on\_exception](Thread.downloaded.ruby_doc#method-c-report_on_exception)
   # for details.
-  # 
+  #
   # See also
   # [report\_on\_exception](Thread.downloaded.ruby_doc#method-i-report_on_exception)
   # .
-  # 
+  #
   # There is also a class level method to set this for all new threads, see
   # [::report\_on\_exception=](Thread.downloaded.ruby_doc#method-c-report_on_exception-3D)
   # .
   def report_on_exception=: (bool report_on_exception) -> untyped
 
   # Wakes up `thr`, making it eligible for scheduling.
-  # 
+  #
   # ```ruby
   # a = Thread.new { puts "a"; Thread.stop; puts "c" }
   # sleep 0.1 while a.status!='sleep'
@@ -435,21 +435,21 @@ class Thread < Object
   # a.run
   # a.join
   # ```
-  # 
+  #
   # This will produce:
-  # 
+  #
   # ```ruby
   # a
   # Got here
   # c
   # ```
-  # 
+  #
   # See also the instance method
   # [wakeup](Thread.downloaded.ruby_doc#method-i-wakeup).
   def run: () -> Thread
 
   # Returns the safe level.
-  # 
+  #
   # This method is obsolete because $SAFE is a process global state. Simply
   # check $SAFE.
   def safe_level: () -> Integer
@@ -457,37 +457,37 @@ class Thread < Object
   def status: () -> (String | bool)?
 
   # Returns `true` if `thr` is dead or sleeping.
-  # 
+  #
   # ```ruby
   # a = Thread.new { Thread.stop }
   # b = Thread.current
   # a.stop?   #=> true
   # b.stop?   #=> false
   # ```
-  # 
+  #
   # See also [alive?](Thread.downloaded.ruby_doc#method-i-alive-3F) and
   # [status](Thread.downloaded.ruby_doc#method-i-status).
   def `stop?`: () -> bool
 
   # Terminates `thr` and schedules another thread to be run.
-  # 
+  #
   # If this thread is already marked to be killed,
   # [exit](Thread.downloaded.ruby_doc#method-i-exit) returns the
   # [Thread](Thread.downloaded.ruby_doc).
-  # 
+  #
   # If this is the main thread, or the last thread, exits the process.
   def terminate: () -> Thread?
 
   # Returns `true` if the given string (or symbol) exists as a thread-local
   # variable.
-  # 
+  #
   # ```ruby
   # me = Thread.current
   # me.thread_variable_set(:oliver, "a")
   # me.thread_variable?(:oliver)    #=> true
   # me.thread_variable?(:stanley)   #=> false
   # ```
-  # 
+  #
   # Note that these are not fiber local variables. Please see
   # [\#\[\]](Thread.downloaded.ruby_doc#method-i-5B-5D) and
   # [\#thread\_variable\_get](Thread.downloaded.ruby_doc#method-i-thread_variable_get)
@@ -498,15 +498,15 @@ class Thread < Object
   # that these are different than fiber local values. For fiber local
   # values, please see [\#\[\]](Thread.downloaded.ruby_doc#method-i-5B-5D)
   # and [\#\[\]=](Thread.downloaded.ruby_doc#method-i-5B-5D-3D).
-  # 
+  #
   # [Thread](Thread.downloaded.ruby_doc) local values are carried along with
   # threads, and do not respect fibers. For example:
-  # 
+  #
   # ```ruby
   # Thread.new {
   #   Thread.current.thread_variable_set("foo", "bar") # set a thread local
   #   Thread.current["foo"] = "bar"                    # set a fiber local
-  # 
+  #
   #   Fiber.new {
   #     Fiber.yield [
   #       Thread.current.thread_variable_get("foo"), # get the thread local
@@ -515,7 +515,7 @@ class Thread < Object
   #   }.resume
   # }.join.value # => ['bar', nil]
   # ```
-  # 
+  #
   # The value “bar” is returned for the thread local, where nil is returned
   # for the fiber local. The fiber is executed in the same thread, so the
   # thread local values are available.
@@ -533,11 +533,11 @@ class Thread < Object
   # Waits for `thr` to complete, using
   # [join](Thread.downloaded.ruby_doc#method-i-join), and returns its value
   # or raises the exception which terminated the thread.
-  # 
+  #
   # ```ruby
   # a = Thread.new { 2 + 2 }
   # a.value   #=> 4
-  # 
+  #
   # b = Thread.new { raise 'something went wrong' }
   # b.value   #=> RuntimeError: something went wrong
   # ```
@@ -545,10 +545,10 @@ class Thread < Object
 
   # Marks a given thread as eligible for scheduling, however it may still
   # remain blocked on I/O.
-  # 
+  #
   # **Note:** This does not invoke the scheduler, see
   # [run](Thread.downloaded.ruby_doc#method-i-run) for more information.
-  # 
+  #
   # ```ruby
   # c = Thread.new { Thread.stop; puts "hey!" }
   # sleep 0.1 while c.status!='sleep'
@@ -559,19 +559,19 @@ class Thread < Object
   def wakeup: () -> Thread
 
   # Returns the status of the global “abort on exception” condition.
-  # 
+  #
   # The default is `false` .
-  # 
+  #
   # When set to `true`, if any thread is aborted by an exception, the
   # raised exception will be re-raised in the main thread.
-  # 
+  #
   # Can also be specified by the global $DEBUG flag or command line option
   # `-d` .
-  # 
+  #
   # See also
   # [::abort\_on\_exception=](Thread.downloaded.ruby_doc#method-c-abort_on_exception-3D)
   # .
-  # 
+  #
   # There is also an instance level method to set this for a specific
   # thread, see
   # [abort\_on\_exception](Thread.downloaded.ruby_doc#method-i-abort_on_exception)
@@ -581,7 +581,7 @@ class Thread < Object
   # When set to `true`, if any thread is aborted by an exception, the
   # raised exception will be re-raised in the main thread. Returns the new
   # state.
-  # 
+  #
   # ```ruby
   # Thread.abort_on_exception = true
   # t1 = Thread.new do
@@ -591,19 +591,19 @@ class Thread < Object
   # sleep(1)
   # puts "not reached"
   # ```
-  # 
+  #
   # This will produce:
-  # 
+  #
   #     In new thread
   #     prog.rb:4: Exception from thread (RuntimeError)
   #      from prog.rb:2:in `initialize'
   #      from prog.rb:2:in `new'
   #      from prog.rb:2
-  # 
+  #
   # See also
   # [::abort\_on\_exception](Thread.downloaded.ruby_doc#method-c-abort_on_exception)
   # .
-  # 
+  #
   # There is also an instance level method to set this for a specific
   # thread, see
   # [abort\_on\_exception=](Thread.downloaded.ruby_doc#method-i-abort_on_exception-3D)
@@ -619,11 +619,11 @@ class Thread < Object
 
   # Terminates the currently running thread and schedules another thread to
   # be run.
-  # 
+  #
   # If this thread is already marked to be killed,
   # [::exit](Thread.downloaded.ruby_doc#method-c-exit) returns the
   # [Thread](Thread.downloaded.ruby_doc).
-  # 
+  #
   # If this is the main thread, or the last thread, exit the process.
   def self.exit: () -> untyped
 
@@ -634,46 +634,46 @@ class Thread < Object
   def self.fork: (*untyped args) -> untyped
 
   # Changes asynchronous interrupt timing.
-  # 
+  #
   # *interrupt* means asynchronous event and corresponding procedure by
   # [\#raise](Thread.downloaded.ruby_doc#method-i-raise),
   # [\#kill](Thread.downloaded.ruby_doc#method-i-kill), signal trap (not
   # supported yet) and main thread termination (if main thread terminates,
   # then all other thread will be killed).
-  # 
+  #
   # The given `hash` has pairs like `ExceptionClass => :TimingSymbol` .
   # Where the ExceptionClass is the interrupt handled by the given block.
   # The TimingSymbol can be one of the following symbols:
-  # 
+  #
   #   - `:immediate`
   #     Invoke interrupts immediately.
-  # 
+  #
   #   - `:on_blocking`
   #     Invoke interrupts while *BlockingOperation* .
-  # 
+  #
   #   - `:never`
   #     Never invoke all interrupts.
-  # 
+  #
   # *BlockingOperation* means that the operation will block the calling
   # thread, such as read and write. On CRuby implementation,
   # *BlockingOperation* is any operation executed without GVL.
-  # 
+  #
   # Masked asynchronous interrupts are delayed until they are enabled. This
   # method is similar to sigprocmask(3).
-  # 
-  # 
+  #
+  #
   # Asynchronous interrupts are difficult to use.
-  # 
+  #
   # If you need to communicate between threads, please consider to use
   # another way such as [Queue](https://ruby-doc.org/core-2.6.3/Queue.html)
   # .
-  # 
+  #
   # Or use them with deep understanding about this method.
-  # 
-  # 
+  #
+  #
   # In this example, we can guard from
   # [\#raise](Thread.downloaded.ruby_doc#method-i-raise) exceptions.
-  # 
+  #
   # Using the `:never` TimingSymbol the
   # [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html)
   # exception will always be ignored in the first block of the main thread.
@@ -682,7 +682,7 @@ class Thread < Object
   # block we can purposefully handle
   # [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html)
   # exceptions.
-  # 
+  #
   # ```ruby
   # th = Thread.new do
   #   Thread.handle_interrupt(RuntimeError => :never) {
@@ -700,18 +700,18 @@ class Thread < Object
   # # ...
   # th.raise "stop"
   # ```
-  # 
+  #
   # While we are ignoring the
   # [RuntimeError](https://ruby-doc.org/core-2.6.3/RuntimeError.html)
   # exception, it’s safe to write our resource allocation code. Then, the
   # ensure block is where we can safely deallocate your resources.
-  # 
-  # 
+  #
+  #
   # In the next example, we will guard from the Timeout::Error exception.
   # This will help prevent from leaking resources when Timeout::Error
   # exceptions occur during normal ensure clause. For this example we use
   # the help of the standard library Timeout, from lib/timeout.rb
-  # 
+  #
   # ```ruby
   # require 'timeout'
   # Thread.handle_interrupt(Timeout::Error => :never) {
@@ -725,18 +725,18 @@ class Thread < Object
   #   }
   # }
   # ```
-  # 
+  #
   # In the first part of the `timeout` block, we can rely on Timeout::Error
   # being ignored. Then in the `Timeout::Error => :on_blocking` block, any
   # operation that will block the calling thread is susceptible to a
   # Timeout::Error exception being raised.
-  # 
-  # 
+  #
+  #
   # It’s possible to stack multiple levels of
   # [::handle\_interrupt](Thread.downloaded.ruby_doc#method-c-handle_interrupt)
   # blocks in order to control more than one ExceptionClass and TimingSymbol
   # at a time.
-  # 
+  #
   # ```ruby
   # Thread.handle_interrupt(FooError => :never) {
   #   Thread.handle_interrupt(BarError => :never) {
@@ -744,11 +744,11 @@ class Thread < Object
   #   }
   # }
   # ```
-  # 
-  # 
+  #
+  #
   # All exceptions inherited from the ExceptionClass parameter will be
   # considered.
-  # 
+  #
   # ```ruby
   # Thread.handle_interrupt(Exception => :never) {
   #   # all exceptions inherited from Exception are prohibited.
@@ -765,18 +765,18 @@ class Thread < Object
   def self.pass: () -> untyped
 
   # Returns whether or not the asynchronous queue is empty.
-  # 
+  #
   # Since
   # [::handle\_interrupt](Thread.downloaded.ruby_doc#method-c-handle_interrupt)
   # can be used to defer asynchronous events, this method can be used to
   # determine if there are any deferred events.
-  # 
+  #
   # If you find this method returns true, then you may finish `:never`
   # blocks.
-  # 
+  #
   # For example, the following method processes deferred asynchronous events
   # immediately.
-  # 
+  #
   # ```ruby
   # def Thread.kick_interrupt_immediately
   #   Thread.handle_interrupt(Object => :immediate) {
@@ -784,10 +784,10 @@ class Thread < Object
   #   }
   # end
   # ```
-  # 
+  #
   # If `error` is given, then check only for `error` type deferred events.
-  # 
-  # 
+  #
+  #
   #     th = Thread.new{
   #       Thread.handle_interrupt(RuntimeError => :on_blocking){
   #         while true
@@ -802,10 +802,10 @@ class Thread < Object
   #     }
   #     ...
   #     th.raise # stop thread
-  # 
+  #
   # This example can also be written as the following, which you should use
   # to avoid asynchronous interrupts.
-  # 
+  #
   #     flag = true
   #     th = Thread.new{
   #       Thread.handle_interrupt(RuntimeError => :on_blocking){
@@ -833,7 +833,7 @@ class Thread < Object
 
   # Stops execution of the current thread, putting it into a “sleep” state,
   # and schedules execution of another thread.
-  # 
+  #
   # ```ruby
   # a = Thread.new { print "a"; Thread.stop; print "c" }
   # sleep 0.1 while a.status!='sleep'
@@ -864,13 +864,13 @@ end
 # augment class [Mutex](https://ruby-doc.org/core-2.6.3/Mutex.html).
 # Using condition variables, it is possible to suspend while in the middle
 # of a critical section until a resource becomes available.
-# 
+#
 # Example:
-# 
+#
 # ```ruby
 # mutex = Mutex.new
 # resource = ConditionVariable.new
-# 
+#
 # a = Thread.new {
 #    mutex.synchronize {
 #      # Thread 'a' now needs the resource
@@ -878,7 +878,7 @@ end
 #      # 'a' can now have the resource
 #    }
 # }
-# 
+#
 # b = Thread.new {
 #    mutex.synchronize {
 #      # Thread 'b' has finished using the resource
@@ -895,7 +895,7 @@ class Thread::ConditionVariable < Object
 
   # Releases the lock held in `mutex` and waits; reacquires the lock on
   # wakeup.
-  # 
+  #
   # If `timeout` is given, this method returns after `timeout` seconds
   # passed, even if no other thread doesn't signal.
   def wait: (Thread::Mutex mutex, ?Integer timeout) -> self
@@ -904,18 +904,18 @@ end
 # [Mutex](Mutex) implements a simple semaphore that
 # can be used to coordinate access to shared data from multiple concurrent
 # threads.
-# 
+#
 # Example:
-# 
+#
 # ```ruby
 # semaphore = Mutex.new
-# 
+#
 # a = Thread.new {
 #   semaphore.synchronize {
 #     # access shared resource
 #   }
 # }
-# 
+#
 # b = Thread.new {
 #   semaphore.synchronize {
 #     # access shared resource
@@ -951,15 +951,15 @@ end
 # when information must be exchanged safely between multiple threads. The
 # [Queue](Queue) class implements all the required
 # locking semantics.
-# 
+#
 # The class implements FIFO type of queue. In a FIFO queue, the first
 # tasks added are the first retrieved.
-# 
+#
 # Example:
-# 
+#
 # ```ruby
 # queue = Queue.new
-# 
+#
 # producer = Thread.new do
 #   5.times do |i|
 #      sleep rand(i) # simulate expense
@@ -967,7 +967,7 @@ end
 #      puts "#{i} produced"
 #   end
 # end
-# 
+#
 # consumer = Thread.new do
 #   5.times do |i|
 #      value = queue.pop
@@ -975,7 +975,7 @@ end
 #      puts "consumed #{value}"
 #   end
 # end
-# 
+#
 # consumer.join
 # ```
 class Thread::Queue < Object
@@ -986,28 +986,28 @@ class Thread::Queue < Object
   def clear: () -> void
 
   # Closes the queue. A closed queue cannot be re-opened.
-  # 
+  #
   # After the call to close completes, the following are true:
-  # 
+  #
   #   - `closed?` will return true
-  # 
+  #
   #   - `close` will be ignored.
-  # 
+  #
   #   - calling enq/push/\<\< will raise a `ClosedQueueError` .
-  # 
+  #
   #   - when `empty?` is false, calling deq/pop/shift will return an object
   #     from the queue as usual.
-  # 
+  #
   #   - when `empty?` is true, deq(false) will not suspend the thread and
   #     will return nil. deq(true) will raise a `ThreadError` .
-  # 
+  #
   # [ClosedQueueError](https://ruby-doc.org/core-2.6.3/ClosedQueueError.html)
   # is inherited from
   # [StopIteration](https://ruby-doc.org/core-2.6.3/StopIteration.html), so
   # that you can break loop block.
-  # 
+  #
   #     Example:
-  # 
+  #
   #         q = Queue.new
   #         Thread.new{
   #           while e = q.deq # wait for nil to break loop
@@ -1030,9 +1030,9 @@ class Thread::Queue < Object
   alias enq push
 
   # Returns the length of the queue.
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [size](Queue.downloaded.ruby_doc#method-i-size)
   def length: () -> Integer
 
@@ -1040,21 +1040,21 @@ class Thread::Queue < Object
   def num_waiting: () -> Integer
 
   # Retrieves data from the queue.
-  # 
+  #
   # If the queue is empty, the calling thread is suspended until data is
   # pushed onto the queue. If `non_block` is true, the thread isn't
   # suspended, and `ThreadError` is raised.
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [deq](Queue.downloaded.ruby_doc#method-i-deq),
   # [shift](Queue.downloaded.ruby_doc#method-i-shift)
   def pop: (?bool non_block) -> untyped
 
   # Pushes the given `object` to the queue.
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [enq](Queue.downloaded.ruby_doc#method-i-enq),
   # [\<\<](Queue.downloaded.ruby_doc#method-i-3C-3C)
   def push: (untyped obj) -> void
@@ -1068,7 +1068,7 @@ end
 
 # This class represents queues of specified size capacity. The push
 # operation may be blocked if the capacity is full.
-# 
+#
 # See [Queue](https://ruby-doc.org/core-2.6.3/Queue.html) for an example
 # of how a [SizedQueue](SizedQueue) works.
 class Thread::SizedQueue < Thread::Queue
@@ -1087,13 +1087,13 @@ class Thread::SizedQueue < Thread::Queue
   def max=: (Integer max) -> void
 
   # Pushes `object` to the queue.
-  # 
+  #
   # If there is no space left in the queue, waits until space becomes
   # available, unless `non_block` is true. If `non_block` is true, the
   # thread isn't suspended, and `ThreadError` is raised.
-  # 
-  # 
-  # 
+  #
+  #
+  #
   # Also aliased as: [enq](SizedQueue.downloaded.ruby_doc#method-i-enq),
   # [\<\<](SizedQueue.downloaded.ruby_doc#method-i-3C-3C)
   def push: (untyped obj, ?bool non_block) -> void

--- a/stdlib/builtin/thread_group.rbs
+++ b/stdlib/builtin/thread_group.rbs
@@ -1,11 +1,11 @@
 # [ThreadGroup](ThreadGroup) provides a means of
 # keeping track of a number of threads as a group.
-# 
+#
 # A given [Thread](https://ruby-doc.org/core-2.6.3/Thread.html) object can
 # only belong to one [ThreadGroup](ThreadGroup) at a
 # time; adding a thread to a new group will remove it from any previous
 # group.
-# 
+#
 # Newly created threads belong to the same group as the thread from which
 # they were created.
 class ThreadGroup < Object

--- a/stdlib/builtin/true_class.rbs
+++ b/stdlib/builtin/true_class.rbs
@@ -1,14 +1,14 @@
 # The global value `true` is the only instance of class TrueClass and represents
 # a logically true value in boolean expressions. The class provides operators
 # allowing `true` to be used in logical expressions.
-# 
+#
 class TrueClass
   public
 
   def !: () -> bool
 
   # And---Returns `false` if *obj* is `nil` or `false`, `true` otherwise.
-  # 
+  #
   def &: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool
@@ -16,12 +16,12 @@ class TrueClass
   # Case Equality -- For class Object, effectively the same as calling `#==`, but
   # typically overridden by descendants to provide meaningful semantics in `case`
   # statements.
-  # 
+  #
   def ===: (true) -> true
          | (untyped obj) -> bool
 
   # Exclusive Or---Returns `true` if *obj* is `nil` or `false`, `false` otherwise.
-  # 
+  #
   def ^: (nil) -> true
        | (false) -> true
        | (untyped obj) -> bool
@@ -29,18 +29,18 @@ class TrueClass
   alias inspect to_s
 
   # The string representation of `true` is "true".
-  # 
+  #
   def to_s: () -> "true"
 
   # Or---Returns `true`. As *obj* is an argument to a method call, it is always
   # evaluated; there is no short-circuit evaluation in this case.
-  # 
+  #
   #     true |  puts("or")
   #     true || puts("logical or")
-  # 
+  #
   # *produces:*
-  # 
+  #
   #     or
-  # 
+  #
   def |: (bool obj) -> bool
 end

--- a/stdlib/builtin/warning.rbs
+++ b/stdlib/builtin/warning.rbs
@@ -3,7 +3,7 @@
 # module extends itself, making `Warning.warn` available.
 # [\#warn](Warning#method-i-warn) is called for all
 # warnings issued by Ruby. By default, warnings are printed to $stderr.
-# 
+#
 # By overriding [\#warn](Warning#method-i-warn), you
 # can change how warnings are handled by Ruby, either filtering some
 # warnings, and/or outputting warnings somewhere other than $stderr. When

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -318,7 +318,7 @@ class Date
   #
   def self.ordinal: (?Integer year, ?Integer yday, ?Integer start) -> Date
 
-  # Parses the given representation of date and time, and creates a date object. 
+  # Parses the given representation of date and time, and creates a date object.
   # This method does not function as a validator.
   #
   # If the optional second argument is true and the detected year is in the range
@@ -448,7 +448,7 @@ class Date
   #
   def +: (Integer | Rational other) -> Date
 
-  # Returns the difference between the two dates if the other is a date object. 
+  # Returns the difference between the two dates if the other is a date object.
   # If the other is a numeric value, returns a date object pointing `other` days
   # before self.  If the other is a fractional number, assumes its precision is at
   # most nanosecond.

--- a/stdlib/find/find.rbs
+++ b/stdlib/find/find.rbs
@@ -1,12 +1,12 @@
 # The `Find` module supports the top-down traversal of a set of file paths.
-# 
+#
 # For example, to total the size of all files under your home directory,
 # ignoring anything in a "dot" directory (e.g. $HOME/.ssh):
-# 
+#
 #     require 'find'
-# 
+#
 #     total_size = 0
-# 
+#
 #     Find.find(ENV["HOME"]) do |path|
 #       if FileTest.directory?(path)
 #         if File.basename(path).start_with?('.')
@@ -18,23 +18,23 @@
 #         total_size += FileTest.size(path)
 #       end
 #     end
-# 
+#
 module Find
   # Calls the associated block with the name of every file and directory listed as
   # arguments, then recursively on their subdirectories, and so on.
-  # 
+  #
   # Returns an enumerator if no block is given.
-  # 
+  #
   # See the `Find` module documentation for an example.
-  # 
+  #
   def self?.find: (*String | _ToPath paths, ?ignore_error: bool) -> Enumerator[String, nil]
                 | (*String | _ToPath paths, ?ignore_error: bool) { (String arg0) -> void } -> nil
 
   # Skips the current file or directory, restarting the loop with the next entry.
   # If the current file is a directory, that directory will not be recursively
   # entered. Meaningful only within the block associated with Find::find.
-  # 
+  #
   # See the `Find` module documentation for an example.
-  # 
+  #
   def self?.prune: () -> void
 end

--- a/stdlib/pathname/pathname.rbs
+++ b/stdlib/pathname/pathname.rbs
@@ -1078,7 +1078,7 @@ end
 
 module Kernel
   private
-  
+
   # Creates a new Pathname object from the given string, `path`, and returns
   # pathname object.
   #

--- a/stdlib/tmpdir/tmpdir.rbs
+++ b/stdlib/tmpdir/tmpdir.rbs
@@ -1,13 +1,13 @@
 class Dir
   # Returns the operating system's temporary file path.
-  # 
+  #
   def self.tmpdir: () -> String
 
   # Dir.mktmpdir creates a temporary directory.
-  # 
+  #
   # The directory is created with 0700 permission. Application should not change
   # the permission to make the temporary directory accessible from other users.
-  # 
+  #
   # The prefix and suffix of the name of the directory is specified by the
   # optional first argument, *prefix_suffix*.
   # *   If it is not specified or nil, "d" is used as the prefix and no suffix is
@@ -15,30 +15,30 @@ class Dir
   # *   If it is a string, it is used as the prefix and no suffix is used.
   # *   If it is an array, first element is used as the prefix and second element
   #     is used as a suffix.
-  # 
-  # 
+  #
+  #
   #     Dir.mktmpdir {|dir| dir is ".../d..." }
   #     Dir.mktmpdir("foo") {|dir| dir is ".../foo..." }
   #     Dir.mktmpdir(["foo", "bar"]) {|dir| dir is ".../foo...bar" }
-  # 
+  #
   # The directory is created under Dir.tmpdir or the optional second argument
   # *tmpdir* if non-nil value is given.
-  # 
+  #
   #     Dir.mktmpdir {|dir| dir is "#{Dir.tmpdir}/d..." }
   #     Dir.mktmpdir(nil, "/var/tmp") {|dir| dir is "/var/tmp/d..." }
-  # 
+  #
   # If a block is given, it is yielded with the path of the directory. The
   # directory and its contents are removed using FileUtils.remove_entry before
   # Dir.mktmpdir returns. The value of the block is returned.
-  # 
+  #
   #     Dir.mktmpdir {|dir|
   #       # use the directory...
   #       open("#{dir}/foo", "w") { ... }
   #     }
-  # 
+  #
   # If a block is not given, The path of the directory is returned. In this case,
   # Dir.mktmpdir doesn't remove the directory.
-  # 
+  #
   #     dir = Dir.mktmpdir
   #     begin
   #       # use the directory...
@@ -47,7 +47,7 @@ class Dir
   #       # remove the directory.
   #       FileUtils.remove_entry dir
   #     end
-  # 
+  #
   def self.mktmpdir: (?(String | [ String, String ] | nil), ?String?, ?max_try: Integer?) -> String
                    | [X] (?(String | [ String, String ] | nil), ?String?, ?max_try: Integer?) { (String) -> X } -> X
 end

--- a/test/rbs/comment_test.rb
+++ b/test/rbs/comment_test.rb
@@ -10,12 +10,12 @@ class RBS::CommentTest < Minitest::Test
       string: 'foo',
       location: RBS::Location.new(buffer: buffer, start_pos: 0, end_pos: 3)
     )
-    
+
     comment.concat(
       string: 'bar',
       location: RBS::Location.new(buffer: buffer, start_pos: 4, end_pos: 7)
     )
-    
+
     assert_equal "foobar", comment.string
     assert_equal 0, comment.location.start_pos
     assert_equal 7, comment.location.end_pos

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -65,7 +65,7 @@ end
 RBS::RuntimePrototypeTest::TestTargets::Test::NAME: String
     EOF
       end
-    end 
+    end
   end
 
   def test_merge_types

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -24,7 +24,7 @@ class SetupHelperTest < Minitest::Test
   def assert_raises_invalid_sample_size_error(invalid_value)
     assert_raises InvalidSampleSizeError do
       get_sample_size(invalid_value)
-    end    
+    end
   end
 
   def test_to_double_class

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -86,7 +86,7 @@ EOF
 
         assert typecheck.value({}, parse_type("::Hash[::Integer, ::String]"))
         assert typecheck.value(Array.new(100) {|i| [i, i.to_s] }.to_h, parse_type("::Hash[::Integer, ::String]"))
-        
+
         assert typecheck.value(Array.new(1000) {|i| [i, i.to_s] }.to_h, parse_type("::Hash[::Integer, ::String]"))
       end
     end
@@ -113,7 +113,7 @@ EOF
     SignatureManager.new do |manager|
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
-        
+
           assert_sampling_check(builder, 1, [0,1,2,3,4])
           assert_sampling_check(builder, 3, [1,2,3,4,5])
           assert_sampling_check(builder, 3, [1,2,3,4,'a'])

--- a/test/stdlib/MatchData_test.rb
+++ b/test/stdlib/MatchData_test.rb
@@ -45,7 +45,7 @@ class MatchDataTest < StdlibTest
     $~.end 'first'
     $~.end 'third'
     $~.end :first
-    $~.end :third 
+    $~.end :third
   end
 
   def test_eql?
@@ -80,7 +80,7 @@ class MatchDataTest < StdlibTest
     $~.offset 'first'
     $~.offset 'third'
     $~.offset :first
-    $~.offset :third 
+    $~.offset :third
   end
 
   def test_post_match

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -642,8 +642,8 @@ class StringInstanceTest < Minitest::Test
                      "string", :encode!, "ascii", invalid: :replace
     assert_send_type "(Encoding, Encoding, undef: nil) -> self",
                      "string", :encode!, Encoding::ASCII_8BIT, Encoding::ASCII_8BIT, undef: nil
-    assert_send_type "(invalid: nil, undef: :replace, replace: String, fallback: Hash[String, String], xml: :text, universal_newline: true) -> self",                 
-                     "string", :encode!, 
+    assert_send_type "(invalid: nil, undef: :replace, replace: String, fallback: Hash[String, String], xml: :text, universal_newline: true) -> self",
+                     "string", :encode!,
                      invalid: nil,
                      undef: :replace,
                      replace: "foo",

--- a/test/stdlib/Time_test.rb
+++ b/test/stdlib/Time_test.rb
@@ -227,7 +227,7 @@ class TimeTest < StdlibTest
 
   def test_utc?
     t = Time.utc(2000, "jan", 1, 20, 15, 1)
-    t.utc? 
+    t.utc?
   end
 
   def test_utc_offset


### PR DESCRIPTION
This PR removes trailing whitespaces in the code base.

It tweaks `bin/annotate-with-rdoc` to avoid outputing some.