### PR TITLE
_Reader, _Writer, _Rewindable, and _ToIO interfaces.

### DIFF
--- a/stdlib/builtin/builtin.rbs
+++ b/stdlib/builtin/builtin.rbs
@@ -30,6 +30,25 @@ interface _Each[out A, out B]
   def each: { (A) -> void } -> B
 end
 
+interface _Reader
+  def read: (?int length, ?string outbuf) -> String?
+end
+
+interface _Writer
+  # Writes the +data+ string. Returns the number of bytes written
+  def write: (*_ToS data) -> Integer
+end
+
+interface _Rewindable
+  # Positions the stream to the beginning of input, resetting `lineno` to zero.
+  #
+  def rewind: () -> Integer
+end
+
+interface _ToIO
+  def to_io: () -> IO
+end
+
 interface _Exception
   def exception: () -> Exception
                | (String arg0) -> Exception
@@ -40,3 +59,5 @@ type real = Integer | Float | Rational
 
 type string = String | _ToStr
 type encoding = Encoding | string
+
+type io = IO | _ToIO

--- a/stdlib/builtin/io.rbs
+++ b/stdlib/builtin/io.rbs
@@ -514,7 +514,7 @@ class IO < Object
 
   def self.binwrite: (String name, _ToS arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> Integer
 
-  def self.copy_stream: (String | IO src, String | IO dst, ?Integer copy_length, ?Integer src_offset) -> Integer
+  def self.copy_stream: (_Reader src, _Writer dst, ?Integer copy_length, ?Integer src_offset) -> Integer
 
   def self.popen: (*untyped args) -> untyped
 
@@ -522,7 +522,7 @@ class IO < Object
 
   def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> ::Array[String]
 
-  def self.select: (::Array[IO]? read_array, ?::Array[IO]? write_array, ?::Array[IO]? error_array, ?Integer? timeout) -> ::Array[::Array[IO]]?
+  def self.select: (::Array[io]? read_array, ?::Array[io]? write_array, ?::Array[io]? error_array, ?Integer? timeout) -> ::Array[::Array[io]]?
 
   def self.sysopen: (String path, ?String mode, ?String perm) -> Integer
 


### PR DESCRIPTION
These enhance certain methods which expect duck-types of IO, in certain cases methods which work as well with StringIO and Tempfile.

Fixes #425 

