### PR TITLE
Set up test method hook for #initialize and private_instance_methods

### DIFF
--- a/lib/rbs/test/tester.rb
+++ b/lib/rbs/test/tester.rb
@@ -56,7 +56,10 @@ module RBS
                 RBS.logger.info { "Skipping ##{name} because of `#{reason}`..." }
               end
             else
-              if klass.instance_methods(false).include?(name) && !set.include?(name)
+              if !set.include?(name) && (
+                  name == :initialize ||
+                  klass.instance_methods(false).include?(name) ||
+                  klass.private_instance_methods(false).include?(name))
                 RBS.logger.info { "Setting up method hook in ##{name}..." }
                 Hook.hook_instance_method klass, name, key: instance_key
                 set << name


### PR DESCRIPTION
**Issue**: klass.new(...) is not validated by rbs/test

### Steps to repro
rbs
```ruby
module ChatApp
  class User
    attr_reader login: String
    attr_reader email: String

    def initialize: (String, String) -> void
  end
end
```

rb
```ruby
module ChatApp
  class User
    attr_reader :login
    attr_reader :email

    def initialize(login, email)
      @login = login
      @email = email
    end
  end
```

test
```ruby
ChatApp::User.new('1', '2')
ChatApp::User.new(1, 2) # expect: TypeError, actual: no error
```

logs
```
I, [2020-10-18T09:04:35.228437 #46637]  INFO -- : Setting up hooks for ::ChatApp::User
I, [2020-10-18T09:04:35.228528 #46637]  INFO -- rbs: Installing runtime type checker in ChatApp::User...
I, [2020-10-18T09:04:35.236533 #46637]  INFO -- rbs: Setting up method hook in #login...
I, [2020-10-18T09:04:35.237329 #46637]  INFO -- rbs: Setting up method hook in #email...
```

### After the patch
The patch treats `#initialize` as a special instance method, since it's not part of `klass.instance_methods`.

test
```ruby
ChatApp::User.new('1', '2')
ChatApp::User.new(1, 2) # TypeError: [ChatApp::User#initialize] ArgumentError: expected method type (email: ::String, login: ::String) -> void (RBS::Test::Tester::TypeError)
```

logs
```
I, [2020-10-18T09:04:35.228437 #46637]  INFO -- : Setting up hooks for ::ChatApp::User
I, [2020-10-18T09:04:35.228528 #46637]  INFO -- rbs: Installing runtime type checker in ChatApp::User...
I, [2020-10-18T09:04:35.235397 #46637]  INFO -- rbs: Setting up method hook in #initialize...
I, [2020-10-18T09:04:35.236533 #46637]  INFO -- rbs: Setting up method hook in #login...
I, [2020-10-18T09:04:35.237329 #46637]  INFO -- rbs: Setting up method hook in #email...
```
