### PR TITLE
Fix signature for `Enumerable#find`.

### DIFF
--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -307,11 +307,17 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # ```
   def to_h: () -> ::Hash[untyped, untyped]
 
-  def each_slice: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
+  def each_slice: (Integer n) { (::Array[Elem]) -> untyped } -> NilClass
                 | (Integer n) -> ::Enumerator[::Array[Elem], Return]
 
-  def find: (?Proc ifnone) { (Elem arg0) -> bool } -> Elem?
-          | (?Proc ifnone) -> ::Enumerator[Elem, Return]
+  interface _NotFound[T]
+    def call: () -> T
+  end
+
+  def find: () { (Elem) -> bool } -> Elem?
+          | () -> ::Enumerator[Elem, Elem?]
+          | [T] (_NotFound[T] ifnone) { (Elem) -> bool } -> (Elem | T)
+          | [T] (_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
 
   def flat_map: [U] () { (Elem arg0) -> U } -> U
               | () -> ::Enumerator[Elem, Return]


### PR DESCRIPTION
I wanted to put the `interface` declaration just above `find`, but I was getting an error:

```
/Users/mal/ruby/rbs/lib/rbs/errors.rb:122:in `check!': /Users/mal/ruby/rbs/stdlib/builtin/enumerable.rbs:323:26...323:30: Could not find Elem (RBS::NoTypeFoundError)
```

Is this a bug?