### PR TITLE
Make Enumerable's predicate blocks return bool instead of untyped

### DIFF
--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -22,7 +22,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   #     [nil, true, 99].all?                              #=> false
   #     [].all?                                           #=> true
   def all?: () -> bool
-          | () { (Elem arg0) -> untyped } -> bool
+          | () { (Elem arg0) -> bool } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block ever returns a value other than `false` or
@@ -43,7 +43,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [].any?                                           #=> false
   # ```
   def `any?`: () -> bool
-            | () { (Elem arg0) -> untyped } -> bool
+            | () { (Elem arg0) -> bool } -> bool
 
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
              | () -> ::Enumerator[Elem, ::Array[untyped]]
@@ -63,17 +63,17 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # ```
   def count: () -> Integer
            | (?untyped arg0) -> Integer
-           | () { (Elem arg0) -> untyped } -> Integer
+           | () { (Elem arg0) -> bool } -> Integer
 
   def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
            | (?Integer n) -> ::Enumerator[Elem, Return]
 
-  def detect: (?Proc ifnone) { (Elem arg0) -> untyped } -> Elem?
+  def detect: (?Proc ifnone) { (Elem arg0) -> bool } -> Elem?
             | (?Proc ifnone) -> ::Enumerator[Elem, Return]
 
   def drop: (Integer n) -> ::Array[Elem]
 
-  def drop_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
+  def drop_while: () { (Elem arg0) -> bool } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
   def each_cons: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
@@ -96,14 +96,14 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # ```
   def entries: () -> ::Array[Elem]
 
-  def find_all: () { (Elem arg0) -> untyped } -> ::Array[Elem]
+  def find_all: () { (Elem arg0) -> bool } -> ::Array[Elem]
               | () -> ::Enumerator[Elem, Return]
 
   alias select find_all
   alias filter find_all
 
   def find_index: (?untyped value) -> Integer?
-                | () { (Elem arg0) -> untyped } -> Integer?
+                | () { (Elem arg0) -> bool } -> Integer?
                 | () -> ::Enumerator[Elem, Return]
 
   # Returns the first element, or the first `n` elements, of the enumerable.
@@ -228,7 +228,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [nil, false, true].none?                           #=> false
   # ```
   def none?: () -> bool
-           | () { (Elem arg0) -> untyped } -> bool
+           | () { (Elem arg0) -> bool } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block returns `true` exactly once. If the block is
@@ -249,12 +249,12 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [].one?                                            #=> false
   # ```
   def one?: () -> bool
-          | () { (Elem arg0) -> untyped } -> bool
+          | () { (Elem arg0) -> bool } -> bool
 
-  def partition: () { (Elem arg0) -> untyped } -> [ ::Array[Elem], ::Array[Elem] ]
+  def partition: () { (Elem arg0) -> bool } -> [ ::Array[Elem], ::Array[Elem] ]
                | () -> ::Enumerator[Elem, Return]
 
-  def reject: () { (Elem arg0) -> untyped } -> ::Array[Elem]
+  def reject: () { (Elem arg0) -> bool } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, Return]
 
   def reverse_each: () { (Elem arg0) -> untyped } -> ::Enumerator[Elem, Return]
@@ -288,7 +288,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
 
   def take: (Integer n) -> ::Array[Elem]?
 
-  def take_while: () { (Elem arg0) -> untyped } -> ::Array[Elem]
+  def take_while: () { (Elem arg0) -> bool } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
   # Implemented in C++
@@ -310,7 +310,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   def each_slice: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
                 | (Integer n) -> ::Enumerator[::Array[Elem], Return]
 
-  def find: (?Proc ifnone) { (Elem arg0) -> untyped } -> Elem?
+  def find: (?Proc ifnone) { (Elem arg0) -> bool } -> Elem?
           | (?Proc ifnone) -> ::Enumerator[Elem, Return]
 
   def flat_map: [U] () { (Elem arg0) -> U } -> U


### PR DESCRIPTION
For example, the return value of the block of Enumerable#all? is handled
as bool. In this case, it will bring no difference, but I think it is a
good habit to use a more explicit name instead of "untyped".

Note, if the definition of `bool` is changed according to #133, they
should be changed again.