### PR TITLE
added [] and []= operators to the list of potential methods

### DIFF
--- a/lib/rbs/test/hook.rb
+++ b/lib/rbs/test/hook.rb
@@ -5,6 +5,8 @@ module RBS
   module Test
     module Hook
       OPERATORS = {
+        :[] => "indexlookup",
+        :[]= => "indexset",
         :== => "eqeq",
         :=== => "eqeqeq",
         :!= => "noteq",


### PR DESCRIPTION
This fixes:

```
syntax error, unexpected '(', expecting ';' or '\\n' (SyntaxError)
def []__with__RBS_TEST_7414c4(*args)
                             ^
```

when having an annotation for a `def []` of r`def[]=` methods.