### PR TITLE
Fix potential NoMethodError for Module.name

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -178,6 +178,12 @@ end
     module M2
       include Module.new
     end
+
+    module M3
+      def self.name
+        raise
+      end
+    end
   end
 
   def test_decls_for_anonymous_class_or_module


### PR DESCRIPTION
Fix #446

This change aims to fix potential `NoMethodError` in the `RBS::Prototype::Runtime` class.

To call the original `Module.name` method, not redefined `.name`, the `const_name` method is added to the `RBS::Prototype::Runtime` class.
But I'm not confident if the method logic is right. Please feel free to give me feedback. 🙏 

