### PR TITLE
Fix proc type parsing

### DIFF
--- a/lib/rbs/parser.rb
+++ b/lib/rbs/parser.rb
@@ -2856,7 +2856,7 @@ module_eval(<<'.,.,', 'parser.y', 870)
           required_keywords: {},
           optional_keywords: {},
           rest_keywords: nil,
-          return_type: val[2]
+          return_type: val[1]
         )
 
         result = LocatedValue.new(value: type, location: location)

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -877,7 +877,7 @@ rule
           required_keywords: {},
           optional_keywords: {},
           rest_keywords: nil,
-          return_type: val[2]
+          return_type: val[1]
         )
 
         result = LocatedValue.new(value: type, location: location)

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -1073,4 +1073,21 @@ EOF
       end
     end
   end
+
+  def test_proc
+    Parser.parse_signature(<<EOF).tap do |decls|
+module A
+  def bar: () -> ^->Integer
+end
+EOF
+
+      decls[0].members[0].tap do |member|
+        assert_instance_of Members::MethodDefinition, member
+        member.types[0].type.return_type.tap do |return_type|
+          assert_instance_of Types::Proc, return_type
+          assert_instance_of Types::ClassInstance, return_type.type.return_type
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows parsing the following RBS correctly.

```rbs
class Foo
  def foo: -> ^-> Integer
end
```