### PR TITLE
Bool semantics

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -179,7 +179,7 @@ Proc type denotes type of procedures, `Proc` instances.
 
 `instance` denotes the type of instance of the class. `class` is the singleton of the class.
 
-`bool` is an abstract type for truth value.
+`bool` is an alias of `true | false`.
 
 `untyped` is for _a type without type checking_. It is `?` in gradual typing, _dynamic_ in some languages like C#, and _any_ in TypeScript. It is both subtype _and_ supertype of all of the types. (The type was `any` but renamed to `untyped`.)
 
@@ -193,15 +193,34 @@ Proc type denotes type of procedures, `Proc` instances.
 
 We recommend using `nil`.
 
-#### `bool` or `TrueClass | FalseClass`
+#### `bool` or `boolish`
 
-We recommend using `bool` because it is more close to Ruby's semantics. If the type of a parameter of a method is `bool`, we usually pass `true` and `false`, and also `nil` or any other values. `TrueClass | FalseClass` rejects other values than `true` and `false`.
+We have a builtin type alias called `boolish`.
+It is an alias of `top` type, and you can use `boolish` if we want to allow any object of any type.
 
-#### `void`, `bool`, or `top`?
+We can see an example at the definition of `Enumerable#find`:
+
+```
+module Enumerable[Elem, Return]
+  def find: () { (Elem) -> boolish } -> Elem?
+  ...
+end
+```
+
+We want to write something like:
+
+```
+array.find {|x| x && x.some_test? }               # The block will return (bool | nil)
+```
+
+We recommend using `boolish` for method arguments and block return values, if you only use the values for conditions.
+You can write `bool` if you strictly want `true | false`.
+
+#### `void`, `boolish`, or `top`?
 
 They are all equivalent for the type system; they are all _top type_.
 
-`void` tells developers a hint that _the value should not be used_. `bool` implies the value is used as a truth value. `top` is anything else.
+`void` tells developers a hint that _the value should not be used_. `boolish` implies the value is used as a truth value. `top` is anything else.
 
 ## Method Types
 

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -225,7 +225,7 @@ module RBS
         when Types::Bases::Any
           true
         when Types::Bases::Bool
-          true
+          val.is_a?(TrueClass) || val.is_a?(FalseClass)
         when Types::Bases::Top
           true
         when Types::Bases::Bottom

--- a/sig/constant_table.rbs
+++ b/sig/constant_table.rbs
@@ -19,7 +19,7 @@ module RBS
 
     def resolve_constant_reference_context: (Symbol, context: Array[Namespace]) -> Constant?
 
-    def resolve_constant_reference_inherit: (Symbol, scopes: Array[Namespace], ?no_object: bool) -> Constant?
+    def resolve_constant_reference_inherit: (Symbol, scopes: Array[Namespace], ?no_object: boolish) -> Constant?
 
     def constant_scopes: (TypeName) -> Array[Namespace]
 

--- a/sig/declarations.rbs
+++ b/sig/declarations.rbs
@@ -14,7 +14,7 @@ module RBS
           attr_reader variance: variance
           attr_reader skip_validation: bool
 
-          def initialize: (name: Symbol, variance: variance, skip_validation: bool) -> void
+          def initialize: (name: Symbol, variance: variance, skip_validation: boolish) -> void
 
           include _ToJson
         end

--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -42,12 +42,12 @@ module RBS
 
     def gem?: (String, String?) -> Pathname?
 
-    def each_signature: (Pathname, ?immediate: bool) { (Pathname) -> void } -> void
-                      | (Pathname, ?immediate: bool) -> Enumerator[Pathname, void]
+    def each_signature: (Pathname, ?immediate: boolish) { (Pathname) -> void } -> void
+                      | (Pathname, ?immediate: boolish) -> Enumerator[Pathname, void]
 
     def each_library_path: { (path, Pathname) -> void } -> void
 
-    def no_builtin!: (?bool) -> self
+    def no_builtin!: (?boolish) -> self
 
     def no_builtin?: () -> bool
 

--- a/sig/members.rbs
+++ b/sig/members.rbs
@@ -23,7 +23,7 @@ module RBS
         attr_reader comment: Comment?
         attr_reader overload: bool
 
-        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: Location?, comment: Comment?, overload: bool) -> void
+        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: Location?, comment: Comment?, overload: boolish) -> void
 
         include _HashEqual
         include _ToJson
@@ -34,7 +34,7 @@ module RBS
 
         def overload?: () -> bool
 
-        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: Location?, ?comment: Comment?, ?overload: bool) -> MethodDefinition
+        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: Location?, ?comment: Comment?, ?overload: boolish) -> MethodDefinition
       end
 
       module Var

--- a/sig/method_types.rbs
+++ b/sig/method_types.rbs
@@ -4,7 +4,7 @@ module RBS
       attr_reader type: Types::Function
       attr_reader required: bool
 
-      def initialize: (type: Types::Function, required: bool) -> void
+      def initialize: (type: Types::Function, required: boolish) -> void
 
       def ==: (untyped other) -> bool
 

--- a/sig/namespace.rbs
+++ b/sig/namespace.rbs
@@ -28,7 +28,7 @@ module RBS
   class Namespace
     attr_reader path: Array[Symbol]
 
-    def initialize: (path: Array[Symbol], absolute: bool) -> void
+    def initialize: (path: Array[Symbol], absolute: boolish) -> void
 
     # Returns new _empty_ namespace.
     def self.empty: () -> Namespace

--- a/stdlib/base64/base64.rbs
+++ b/stdlib/base64/base64.rbs
@@ -67,5 +67,5 @@ module Base64
   # 64 Encoding with URL and Filename Safe Alphabet'' in RFC 4648. The alphabet
   # uses '-' instead of '+' and '_' instead of '/'. Note that the result can still
   # contain '='. You can remove the padding by setting `padding` as false.
-  def self?.urlsafe_encode64: (String bin, ?padding: bool) -> String
+  def self?.urlsafe_encode64: (String bin, ?padding: boolish) -> String
 end

--- a/stdlib/builtin/array.rbs
+++ b/stdlib/builtin/array.rbs
@@ -494,7 +494,7 @@ class Array[unchecked out Elem] < Object
   #
   def all?: () -> bool
           | (_Pattern[Elem] pattern) -> bool
-          | () { (Elem obj) -> bool } -> bool
+          | () { (Elem obj) -> boolish } -> bool
 
   # See also Enumerable#any?
   #
@@ -699,7 +699,7 @@ class Array[unchecked out Elem] < Object
   #
   def count: () -> ::Integer
            | (untyped obj) -> ::Integer
-           | () { (Elem) -> bool } -> ::Integer
+           | () { (Elem) -> boolish } -> ::Integer
 
   # Calls the given block for each element `n` times or forever if `nil` is given.
   #
@@ -759,7 +759,7 @@ class Array[unchecked out Elem] < Object
   #     scores = [ 97, 42, 75 ]
   #     scores.delete_if {|score| score < 80 }   #=> [97]
   #
-  def delete_if: () { (Elem item) -> bool } -> self
+  def delete_if: () { (Elem item) -> boolish } -> self
                | () -> ::Enumerator[Elem, self]
 
   # Array Difference
@@ -824,7 +824,7 @@ class Array[unchecked out Elem] < Object
   #     a = [1, 2, 3, 4, 5, 0]
   #     a.drop_while {|i| i < 3 }   #=> [3, 4, 5, 0]
   #
-  def drop_while: () { (Elem obj) -> bool } -> ::Array[Elem]
+  def drop_while: () { (Elem obj) -> boolish } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   # Calls the given block once for each element in `self`, passing that element as
@@ -929,7 +929,7 @@ class Array[unchecked out Elem] < Object
   #
   # Array#filter is an alias for Array#select.
   #
-  def filter: () { (Elem item) -> bool } -> ::Array[Elem]
+  def filter: () { (Elem item) -> boolish } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   # Invokes the given block passing in successive elements from `self`, deleting
@@ -945,7 +945,7 @@ class Array[unchecked out Elem] < Object
   #
   # Array#filter! is an alias for Array#select!.
   #
-  def filter!: () { (Elem item) -> bool } -> self?
+  def filter!: () { (Elem item) -> boolish } -> self?
              | () -> ::Enumerator[Elem, self?]
 
   # Returns the *index* of the first object in `ary` such that the object is `==`
@@ -965,7 +965,7 @@ class Array[unchecked out Elem] < Object
   #     a.index {|x| x == "b"}    #=> 1
   #
   def find_index: (untyped obj) -> ::Integer?
-                | () { (Elem item) -> bool } -> ::Integer?
+                | () { (Elem item) -> boolish } -> ::Integer?
                 | () -> ::Enumerator[Elem, ::Integer?]
 
   # Returns the first element, or the first `n` elements, of the array. If the
@@ -1106,7 +1106,7 @@ class Array[unchecked out Elem] < Object
   #
   # See also Array#select!.
   #
-  def keep_if: () { (Elem item) -> bool } -> self
+  def keep_if: () { (Elem item) -> boolish } -> self
              | () -> ::Enumerator[Elem, self]
 
   # Returns the last element(s) of `self`. If the array is empty, the first form
@@ -1436,7 +1436,7 @@ class Array[unchecked out Elem] < Object
   #
   # If no block is given, an Enumerator is returned instead.
   #
-  def reject!: () { (Elem item) -> bool } -> self?
+  def reject!: () { (Elem item) -> boolish } -> self?
              | () -> ::Enumerator[Elem, self?]
 
   # When invoked with a block, yields all repeated combinations of length `n` of
@@ -1535,7 +1535,7 @@ class Array[unchecked out Elem] < Object
   #     a.rindex {|x| x == "b"}   #=> 3
   #
   def rindex: (untyped obj) -> ::Integer?
-            | () { (Elem item) -> bool } -> ::Integer?
+            | () { (Elem item) -> boolish } -> ::Integer?
             | () -> ::Enumerator[Elem, ::Integer?]
 
   # Returns a new array by rotating `self` so that the element at `count` is the
@@ -1601,7 +1601,7 @@ class Array[unchecked out Elem] < Object
   #
   # Array#filter is an alias for Array#select.
   #
-  def select: () { (Elem item) -> bool } -> ::Array[Elem]
+  def select: () { (Elem item) -> boolish } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   # Invokes the given block passing in successive elements from `self`, deleting
@@ -1617,7 +1617,7 @@ class Array[unchecked out Elem] < Object
   #
   # Array#filter! is an alias for Array#select!.
   #
-  def select!: () { (Elem item) -> bool } -> self?
+  def select!: () { (Elem item) -> boolish } -> self?
              | () -> ::Enumerator[Elem, self?]
 
   # Removes the first element of `self` and returns it (shifting all other
@@ -1828,7 +1828,7 @@ class Array[unchecked out Elem] < Object
   #     a = [1, 2, 3, 4, 5, 0]
   #     a.take_while {|i| i < 3}    #=> [1, 2]
   #
-  def take_while: () { (Elem obj) -> bool } -> ::Array[Elem]
+  def take_while: () { (Elem obj) -> boolish } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   # Returns `self`.

--- a/stdlib/builtin/builtin.rbs
+++ b/stdlib/builtin/builtin.rbs
@@ -61,3 +61,10 @@ type string = String | _ToStr
 type encoding = Encoding | string
 
 type io = IO | _ToIO
+
+# `boolish` is a type for documentation.
+# It means the value of this type is only for testing a condition.
+# Unlike `bool` type, it doesn't require the value is one of `true` or `false`.
+# Any Ruby object can have `boolish` type.
+#
+type boolish = top

--- a/stdlib/builtin/enumerable.rbs
+++ b/stdlib/builtin/enumerable.rbs
@@ -22,7 +22,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   #     [nil, true, 99].all?                              #=> false
   #     [].all?                                           #=> true
   def all?: () -> bool
-          | () { (Elem arg0) -> bool } -> bool
+          | () { (Elem) -> boolish } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block ever returns a value other than `false` or
@@ -43,7 +43,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [].any?                                           #=> false
   # ```
   def `any?`: () -> bool
-            | () { (Elem arg0) -> bool } -> bool
+            | () { (Elem) -> boolish } -> bool
 
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
              | () -> ::Enumerator[Elem, ::Array[untyped]]
@@ -62,18 +62,18 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # ary.count{ |x| x%2==0 } #=> 3
   # ```
   def count: () -> Integer
-           | (?untyped arg0) -> Integer
-           | () { (Elem arg0) -> bool } -> Integer
+           | (?untyped) -> Integer
+           | () { (Elem) -> boolish } -> Integer
 
   def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
            | (?Integer n) -> ::Enumerator[Elem, Return]
 
-  def detect: (?Proc ifnone) { (Elem arg0) -> bool } -> Elem?
+  def detect: (?Proc ifnone) { (Elem) -> boolish } -> Elem?
             | (?Proc ifnone) -> ::Enumerator[Elem, Return]
 
   def drop: (Integer n) -> ::Array[Elem]
 
-  def drop_while: () { (Elem arg0) -> bool } -> ::Array[Elem]
+  def drop_while: () { (Elem) -> boolish } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
   def each_cons: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
@@ -96,14 +96,14 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # ```
   def entries: () -> ::Array[Elem]
 
-  def find_all: () { (Elem arg0) -> bool } -> ::Array[Elem]
+  def find_all: () { (Elem) -> boolish } -> ::Array[Elem]
               | () -> ::Enumerator[Elem, Return]
 
   alias select find_all
   alias filter find_all
 
   def find_index: (?untyped value) -> Integer?
-                | () { (Elem arg0) -> bool } -> Integer?
+                | () { (Elem) -> boolish } -> Integer?
                 | () -> ::Enumerator[Elem, Return]
 
   # Returns the first element, or the first `n` elements, of the enumerable.
@@ -228,7 +228,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [nil, false, true].none?                           #=> false
   # ```
   def none?: () -> bool
-           | () { (Elem arg0) -> bool } -> bool
+           | () { (Elem) -> boolish } -> bool
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block returns `true` exactly once. If the block is
@@ -249,12 +249,12 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   # [].one?                                            #=> false
   # ```
   def one?: () -> bool
-          | () { (Elem arg0) -> bool } -> bool
+          | () { (Elem) -> boolish } -> bool
 
-  def partition: () { (Elem arg0) -> bool } -> [ ::Array[Elem], ::Array[Elem] ]
+  def partition: () { (Elem) -> boolish } -> [ ::Array[Elem], ::Array[Elem] ]
                | () -> ::Enumerator[Elem, Return]
 
-  def reject: () { (Elem arg0) -> bool } -> ::Array[Elem]
+  def reject: () { (Elem) -> boolish } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, Return]
 
   def reverse_each: () { (Elem arg0) -> untyped } -> ::Enumerator[Elem, Return]
@@ -288,7 +288,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
 
   def take: (Integer n) -> ::Array[Elem]?
 
-  def take_while: () { (Elem arg0) -> bool } -> ::Array[Elem]
+  def take_while: () { (Elem) -> boolish } -> ::Array[Elem]
                 | () -> ::Enumerator[Elem, Return]
 
   # Implemented in C++
@@ -314,9 +314,9 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
     def call: () -> T
   end
 
-  def find: () { (Elem) -> bool } -> Elem?
+  def find: () { (Elem) -> boolish } -> Elem?
           | () -> ::Enumerator[Elem, Elem?]
-          | [T] (_NotFound[T] ifnone) { (Elem) -> bool } -> (Elem | T)
+          | [T] (_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
           | [T] (_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
 
   def flat_map: [U] () { (Elem arg0) -> U } -> U
@@ -398,13 +398,13 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   def chunk: () -> ::Enumerator[Elem, Return]
            | [U] () { (Elem elt) -> U } -> ::Enumerator[[U, Array[Elem]], void]
 
-  def chunk_while: () { (Elem elt_before, Elem elt_after) -> bool } -> ::Enumerator[::Array[Elem], void]
+  def chunk_while: () { (Elem elt_before, Elem elt_after) -> boolish } -> ::Enumerator[::Array[Elem], void]
 
-  def slice_when: () { (Elem elt_before, Elem elt_after) -> bool } -> ::Enumerator[::Array[Elem], void]
+  def slice_when: () { (Elem elt_before, Elem elt_after) -> boolish } -> ::Enumerator[::Array[Elem], void]
 
   def slice_after: (untyped pattern) -> ::Enumerator[::Array[Elem], void]
-                 | () { (Elem elt) -> bool } -> ::Enumerator[::Array[Elem], void]
+                 | () { (Elem elt) -> boolish } -> ::Enumerator[::Array[Elem], void]
 
   def slice_before: (untyped pattern) -> ::Enumerator[::Array[Elem], void]
-                  | () { (Elem elt) -> bool } -> ::Enumerator[::Array[Elem], void]
+                  | () { (Elem elt) -> boolish } -> ::Enumerator[::Array[Elem], void]
 end

--- a/stdlib/builtin/errors.rbs
+++ b/stdlib/builtin/errors.rbs
@@ -266,7 +266,7 @@ class NoMethodError[T] < NameError[T]
   #
   # *receiver* argument stores an object whose method was called.
   #
-  def initialize: (?string? msg, ?String? name, ?Array[untyped] args, ?bool `private`, ?receiver: T?) -> void
+  def initialize: (?string? msg, ?String? name, ?Array[untyped] args, ?boolish `private`, ?receiver: T?) -> void
 
   public
 

--- a/stdlib/builtin/gc.rbs
+++ b/stdlib/builtin/gc.rbs
@@ -42,7 +42,7 @@ module GC
   # are not guaranteed to be future-compatible, and may be ignored if the
   # underlying implementation does not support them.
   #
-  def self.start: (?immediate_sweep: bool immediate_sweep, ?immediate_mark: bool immediate_mark, ?full_mark: bool full_mark) -> nil
+  def self.start: (?immediate_sweep: boolish immediate_sweep, ?immediate_mark: boolish immediate_mark, ?full_mark: boolish full_mark) -> nil
 
   # Returns a Hash containing information about the GC.
   #
@@ -132,7 +132,7 @@ module GC
                          | [K] (?Hash[K, untyped] hash) -> ::Hash[::Symbol | K, untyped]
                          | (Symbol key) -> untyped
 
-  def garbage_collect: (?immediate_sweep: bool immediate_sweep, ?immediate_mark: bool immediate_mark, ?full_mark: bool full_mark) -> nil
+  def garbage_collect: (?immediate_sweep: boolish immediate_sweep, ?immediate_mark: boolish immediate_mark, ?full_mark: boolish full_mark) -> nil
 end
 
 # internal constants

--- a/stdlib/builtin/hash.rbs
+++ b/stdlib/builtin/hash.rbs
@@ -230,7 +230,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   def any?: () -> bool
           | (untyped pattern) -> bool
-          | () { (K, V) -> bool } -> bool
+          | () { (K, V) -> boolish } -> bool
 
   # Searches through the hash comparing *obj* with the key using `==`. Returns the
   # key-value pair (two elements array) or `nil` if no match is found.  See
@@ -360,7 +360,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h = { "a" => 100, "b" => 200, "c" => 300 }
   #     h.delete_if {|key, value| key >= "b" }   #=> {"a"=>100}
   #
-  def delete_if: () { (K arg0, V arg1) -> bool } -> self
+  def delete_if: () { (K, V) -> boolish } -> self
                | () -> ::Enumerator[[ K, V ], self]
 
   # Extracts the nested value specified by the sequence of *key* objects by
@@ -498,14 +498,14 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   # Hash#filter is an alias for Hash#select.
   #
-  def filter: () { (K arg0, V arg1) -> bool } -> self
+  def filter: () { (K, V) -> boolish } -> self
             | () -> ::Enumerator[[ K, V ], self]
 
   # Equivalent to Hash#keep_if, but returns `nil` if no changes were made.
   #
   # Hash#filter! is an alias for Hash#select!.
   #
-  def filter!: () { (K arg0, V arg1) -> bool } -> self?
+  def filter!: () { (K, V) -> boolish } -> self?
              | () -> ::Enumerator[[ K, V ], self?]
 
   # Returns a new array that is a one-dimensional flattening of this hash. That
@@ -604,7 +604,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   # See also Hash#select!.
   #
-  def keep_if: () { (K, V) -> bool } -> self
+  def keep_if: () { (K, V) -> boolish } -> self
              | () -> ::Enumerator[[ K, V ], self]
 
   # Returns the key of an occurrence of a given value. If the value is not found,
@@ -758,12 +758,12 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h.reject {|k,v| v > 100}  #=> {"a" => 100}
   #
   def reject: () -> ::Enumerator[[ K, V ], self]
-            | () { (K arg0, V arg1) -> bool } -> self
+            | () { (K, V) -> boolish } -> self
 
   # Equivalent to Hash#delete_if, but returns `nil` if no changes were made.
   #
   def reject!: () -> ::Enumerator[[ K, V ], self?]
-            | () { (K arg0, V arg1) -> bool } -> self?
+            | () { (K, V) -> boolish } -> self?
 
   # Replaces the contents of *hsh* with the contents of *other_hash*.
   #

--- a/stdlib/builtin/io.rbs
+++ b/stdlib/builtin/io.rbs
@@ -111,7 +111,7 @@ class IO < Object
 
   def advise: (Symbol arg0, ?Integer offset, ?Integer len) -> NilClass
 
-  def autoclose=: (bool arg0) -> bool
+  def autoclose=: (boolish) -> bool
 
   # Returns `true` if the underlying file descriptor of *ios* will be closed
   # automatically at its finalization, otherwise `false` .
@@ -141,7 +141,7 @@ class IO < Object
   # just ignored since Ruby 2.3.
   def close: () -> NilClass
 
-  def close_on_exec=: (bool arg0) -> bool
+  def close_on_exec=: (boolish) -> bool
 
   # Returns `true` if *ios* will be closed on exec.
   #
@@ -474,7 +474,7 @@ class IO < Object
   # ```
   def sync: () -> bool
 
-  def sync=: (bool arg0) -> bool
+  def sync=: (boolish) -> bool
 
   def sysread: (Integer maxlen, String outbuf) -> String
 

--- a/stdlib/builtin/kernel.rbs
+++ b/stdlib/builtin/kernel.rbs
@@ -247,7 +247,7 @@ module Kernel
   # ```
   def global_variables: () -> ::Array[Symbol]
 
-  def load: (String filename, ?bool arg0) -> bool
+  def load: (String filename, ?boolish) -> bool
 
   # Repeatedly executes the block.
   #

--- a/stdlib/builtin/module.rbs
+++ b/stdlib/builtin/module.rbs
@@ -237,7 +237,7 @@ class Module < Object
   #     B.autoload?(:CONST)          #=> "const.rb", found in A (ancestor)
   #     B.autoload?(:CONST, false)   #=> nil, not found in B itself
   #
-  def autoload?: (Symbol name, ?bool inherit) -> String?
+  def autoload?: (Symbol name, ?boolish inherit) -> String?
 
   # Evaluates the string or block in the context of *mod*, except that when a
   # block is given, constant/class variable lookup is not affected. This can be
@@ -329,7 +329,7 @@ class Module < Object
   #     Two.class_variables          #=> [:@@var2, :@@var1]
   #     Two.class_variables(false)   #=> [:@@var2]
   #
-  def class_variables: (?bool inherit) -> ::Array[Symbol]
+  def class_variables: (?boolish inherit) -> ::Array[Symbol]
 
   # Says whether *mod* or its ancestors have a constant with the given name:
   #
@@ -364,7 +364,7 @@ class Module < Object
   #
   #     Hash.const_defined? 'foobar'   #=> NameError: wrong constant name foobar
   #
-  def const_defined?: (Symbol | String arg0, ?bool inherit) -> bool
+  def const_defined?: (Symbol | String name, ?boolish inherit) -> bool
 
   # Checks for a constant with the given name in *mod*. If `inherit` is set, the
   # lookup will also search the ancestors (and `Object` if *mod* is a `Module`).
@@ -398,7 +398,7 @@ class Module < Object
   #
   #     Object.const_get 'foobar' #=> NameError: wrong constant name foobar
   #
-  def const_get: (Symbol | String arg0, ?bool inherit) -> untyped
+  def const_get: (Symbol | String name, ?boolish inherit) -> untyped
 
   # Invoked when a reference is made to an undefined constant in *mod*. It is
   # passed a symbol for the undefined constant, and returns a value to be used for
@@ -455,7 +455,7 @@ class Module < Object
   #
   # Also see Module#const_defined?.
   #
-  def constants: (?bool inherit) -> ::Array[Symbol]
+  def constants: (?boolish inherit) -> ::Array[Symbol]
 
   # Defines an instance method in the receiver. The *method* parameter can be a
   # `Proc`, a `Method` or an `UnboundMethod` object. If a block is specified, it
@@ -662,7 +662,7 @@ class Module < Object
   #     C.instance_methods(false)                   #=> [:method3]
   #     C.instance_methods.include?(:method2)       #=> true
   #
-  def instance_methods: (?bool include_super) -> ::Array[Symbol]
+  def instance_methods: (?boolish include_super) -> ::Array[Symbol]
 
   # Invoked as a callback whenever an instance method is added to the receiver.
   #
@@ -709,7 +709,7 @@ class Module < Object
   #     C.method_defined? "method4"             #=> false
   #     C.method_defined? "private_method2"     #=> false
   #
-  def method_defined?: (Symbol | String arg0, ?bool inherit) -> bool
+  def method_defined?: (Symbol | String name, ?boolish inherit) -> bool
 
   # Invoked as a callback whenever an instance method is removed from the
   # receiver.
@@ -881,7 +881,7 @@ class Module < Object
   #     Mod.instance_methods           #=> [:method2]
   #     Mod.private_instance_methods   #=> [:method1]
   #
-  def private_instance_methods: (?bool include_super) -> ::Array[Symbol]
+  def private_instance_methods: (?boolish include_super) -> ::Array[Symbol]
 
   # Returns `true` if the named private method is defined by *mod*.  If *inherit*
   # is set, the lookup will also search *mod*'s ancestors. String arguments are
@@ -906,7 +906,7 @@ class Module < Object
   #     C.private_method_defined? "method2", false   #=> false
   #     C.method_defined? "method2"                  #=> false
   #
-  def private_method_defined?: (Symbol | String arg0, ?bool inherit) -> bool
+  def private_method_defined?: (Symbol | String name, ?boolish inherit) -> bool
 
   # With no arguments, sets the default visibility for subsequently defined
   # methods to protected. With arguments, sets the named methods to have protected
@@ -926,7 +926,7 @@ class Module < Object
   # Returns a list of the protected instance methods defined in *mod*. If the
   # optional parameter is `false`, the methods of any ancestors are not included.
   #
-  def protected_instance_methods: (?bool include_super) -> ::Array[Symbol]
+  def protected_instance_methods: (?boolish include_super) -> ::Array[Symbol]
 
   # Returns `true` if the named protected method is defined *mod*.  If *inherit*
   # is set, the lookup will also search *mod*'s ancestors. String arguments are
@@ -951,7 +951,7 @@ class Module < Object
   #     C.protected_method_defined? "method2", false  #=> false
   #     C.method_defined? "method2"                   #=> true
   #
-  def protected_method_defined?: (Symbol | String arg0, ?bool inherit) -> bool
+  def protected_method_defined?: (Symbol | String name, ?boolish inherit) -> bool
 
   # With no arguments, sets the default visibility for subsequently defined
   # methods to public. With arguments, sets the named methods to have public
@@ -976,7 +976,7 @@ class Module < Object
   # Returns a list of the public instance methods defined in *mod*. If the
   # optional parameter is `false`, the methods of any ancestors are not included.
   #
-  def public_instance_methods: (?bool include_super) -> ::Array[Symbol]
+  def public_instance_methods: (?boolish include_super) -> ::Array[Symbol]
 
   # Returns `true` if the named public method is defined by *mod*.  If *inherit*
   # is set, the lookup will also search *mod*'s ancestors. String arguments are
@@ -1001,7 +1001,7 @@ class Module < Object
   #     C.public_method_defined? "method2"         #=> false
   #     C.method_defined? "method2"                #=> true
   #
-  def public_method_defined?: (Symbol | String arg0, ?bool inherit) -> bool
+  def public_method_defined?: (Symbol | String name, ?boolish inherit) -> bool
 
   # Refine *mod* in the receiver.
   #

--- a/stdlib/builtin/object.rbs
+++ b/stdlib/builtin/object.rbs
@@ -631,7 +631,7 @@ class Object < BasicObject
   # When the method name parameter is given as a string, the string is converted
   # to a symbol.
   #
-  def respond_to?: (name name, ?bool include_all) -> bool
+  def respond_to?: (name name, ?boolish include_all) -> bool
 
   # Invokes the method identified by *symbol*, passing it any arguments specified.
   # You can use `__send__` if the name `send` clashes with an existing method in

--- a/stdlib/builtin/random.rbs
+++ b/stdlib/builtin/random.rbs
@@ -246,7 +246,7 @@ module Random::Formatter
   #
   # See RFC 3548 for the definition of URL-safe base64.
   #
-  def urlsafe_base64: (?Integer? n, ?bool padding) -> String
+  def urlsafe_base64: (?Integer? n, ?boolish padding) -> String
 
   # SecureRandom.uuid generates a random v4 UUID (Universally Unique IDentifier).
   #

--- a/stdlib/builtin/range.rbs
+++ b/stdlib/builtin/range.rbs
@@ -101,7 +101,7 @@ class Range[out Elem] < Object
   # ```
   def begin: () -> Elem
 
-  def bsearch: [U] () { (Elem arg0) -> bool } -> U?
+  def bsearch: [U] () { (Elem) -> boolish } -> U?
 
   def cover?: (untyped obj) -> bool
 
@@ -144,7 +144,7 @@ class Range[out Elem] < Object
 
   def `include?`: (untyped obj) -> bool
 
-  def initialize: (Elem from, Elem to, ?bool exclude_end) -> void
+  def initialize: (Elem from, Elem to, ?boolish exclude_end) -> void
 
   # Convert this range object to a printable form (using `inspect` to
   # convert the begin and end objects).

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -317,7 +317,7 @@ class String
   #     "foo".casecmp?(2)   #=> nil
   #     "\u{e4 f6 fc}".encode("ISO-8859-1").casecmp?("\u{c4 d6 dc}")   #=> nil
   #
-  def casecmp?: (untyped other) -> bool
+  def casecmp?: (untyped other) -> bool?
 
   # Centers `str` in `width`.  If `width` is greater than the length of `str`,
   # returns a new String of length `width` with `str` centered and padded with

--- a/stdlib/builtin/string.rbs
+++ b/stdlib/builtin/string.rbs
@@ -698,8 +698,8 @@ class String
   #     #   "o\nwor"
   #     #   "d"
   #
-  def each_line: (?string separator, ?chomp: bool) { (String line) -> void } -> self
-               | (?string separator, ?chomp: bool) -> Enumerator[String, self]
+  def each_line: (?string separator, ?chomp: boolish) { (String line) -> void } -> self
+               | (?string separator, ?chomp: boolish) -> Enumerator[String, self]
 
   # Returns `true` if *str* has a length of zero.
   #
@@ -948,7 +948,7 @@ class String
   # If a block is given, which is a deprecated form, works the same as
   # `each_line`.
   #
-  def lines: (?string separator, ?chomp: bool) -> Array[String]
+  def lines: (?string separator, ?chomp: boolish) -> Array[String]
 
   # If *integer* is greater than the length of *str*, returns a new String of
   # length *integer* with *str* left justified and padded with *padstr*;
@@ -1861,8 +1861,8 @@ class String
   #     "25".upto("5").to_a   #=> []
   #     "07".upto("11").to_a  #=> ["07", "08", "09", "10", "11"]
   #
-  def upto: (string other_str, ?bool exclusive) -> Enumerator[String, self]
-          | (string other_str, ?bool exclusive) { (String s) -> void } -> self
+  def upto: (string other_str, ?boolish exclusive) -> Enumerator[String, self]
+          | (string other_str, ?boolish exclusive) { (String s) -> void } -> self
 
   # Returns true for a string which is encoded correctly.
   #

--- a/stdlib/builtin/string_io.rbs
+++ b/stdlib/builtin/string_io.rbs
@@ -63,8 +63,8 @@ class StringIO
 
   # See IO#each.
   #
-  def each: (?String sep, ?Integer limit, ?chomp: bool) { (String arg0) -> untyped } -> self
-          | (?String sep, ?Integer limit, ?chomp: bool) -> ::Enumerator[String, self]
+  def each: (?String sep, ?Integer limit, ?chomp: boolish) { (String) -> untyped } -> self
+          | (?String sep, ?Integer limit, ?chomp: boolish) -> ::Enumerator[String, self]
 
   # See IO#each_byte.
   #
@@ -112,7 +112,7 @@ class StringIO
 
   # See IO#gets.
   #
-  def gets: (?String sep, ?Integer limit, ?chomp: bool) -> String?
+  def gets: (?String sep, ?Integer limit, ?chomp: boolish) -> String?
 
   # Returns the Encoding of the internal string if conversion is specified.
   # Otherwise returns `nil`.
@@ -177,7 +177,7 @@ class StringIO
 
   # See IO#readlines.
   #
-  def readlines: (?String sep, ?Integer limit, ?chomp: bool) -> ::Array[String]
+  def readlines: (?String sep, ?Integer limit, ?chomp: boolish) -> ::Array[String]
 
   def readpartial: (Integer maxlen) -> String
                  | (Integer maxlen, ?String outbuf) -> String
@@ -222,7 +222,7 @@ class StringIO
 
   # Returns the argument unchanged.  Just for compatibility to IO.
   #
-  def sync=: (bool arg0) -> bool
+  def sync=: (boolish) -> bool
 
   def sysread: (Integer maxlen, String outbuf) -> String
 
@@ -269,8 +269,8 @@ class StringIO
 
   # See IO#each.
   #
-  def each_line: (?String sep, ?Integer limit, ?chomp: bool) { (String arg0) -> untyped } -> self
-               | (?String sep, ?Integer limit, ?chomp: bool) -> ::Enumerator[String, self]
+  def each_line: (?String sep, ?Integer limit, ?chomp: boolish) { (String) -> untyped } -> self
+               | (?String sep, ?Integer limit, ?chomp: boolish) -> ::Enumerator[String, self]
 
   # Returns true if the stream is at the end of the data (underlying string). The
   # stream must be opened for reading or an `IOError` will be raised.

--- a/stdlib/builtin/struct.rbs
+++ b/stdlib/builtin/struct.rbs
@@ -31,7 +31,7 @@ class Struct[Elem] < Object
 
   type attribute_name = Symbol | String
 
-  def initialize: (attribute_name, *attribute_name, ?keyword_init: bool) ?{ () -> void } -> void
+  def initialize: (attribute_name, *attribute_name, ?keyword_init: boolish) ?{ () -> void } -> void
 
   def each: () { (Elem) -> untyped } -> untyped
 

--- a/stdlib/builtin/symbol.rbs
+++ b/stdlib/builtin/symbol.rbs
@@ -109,7 +109,7 @@ class Symbol
   #     :foo.casecmp?(2)   #=> nil
   #     "\u{e4 f6 fc}".encode("ISO-8859-1").to_sym.casecmp?(:"\u{c4 d6 dc}")   #=> nil
   #
-  def casecmp?: (untyped other) -> bool
+  def casecmp?: (untyped other) -> bool?
 
   # Same as `sym.to_s.downcase.intern`.
   #

--- a/stdlib/builtin/thread.rbs
+++ b/stdlib/builtin/thread.rbs
@@ -240,7 +240,7 @@ class Thread < Object
   # There is also a class level method to set this for all threads, see
   # [::abort\_on\_exception=](Thread.downloaded.ruby_doc#method-c-abort_on_exception-3D)
   # .
-  def abort_on_exception=: (bool abort_on_exception) -> untyped
+  def abort_on_exception=: (boolish abort_on_exception) -> untyped
 
   # Adds *proc* as a handler for tracing.
   #
@@ -424,7 +424,7 @@ class Thread < Object
   # There is also a class level method to set this for all new threads, see
   # [::report\_on\_exception=](Thread.downloaded.ruby_doc#method-c-report_on_exception-3D)
   # .
-  def report_on_exception=: (bool report_on_exception) -> untyped
+  def report_on_exception=: (boolish report_on_exception) -> untyped
 
   # Wakes up `thr`, making it eligible for scheduling.
   #
@@ -1049,7 +1049,7 @@ class Thread::Queue < Object
   #
   # Also aliased as: [deq](Queue.downloaded.ruby_doc#method-i-deq),
   # [shift](Queue.downloaded.ruby_doc#method-i-shift)
-  def pop: (?bool non_block) -> untyped
+  def pop: (?boolish non_block) -> untyped
 
   # Pushes the given `object` to the queue.
   #
@@ -1096,7 +1096,7 @@ class Thread::SizedQueue < Thread::Queue
   #
   # Also aliased as: [enq](SizedQueue.downloaded.ruby_doc#method-i-enq),
   # [\<\<](SizedQueue.downloaded.ruby_doc#method-i-3C-3C)
-  def push: (untyped obj, ?bool non_block) -> void
+  def push: (untyped obj, ?boolish non_block) -> void
 end
 
 ConditionVariable: singleton(Thread::ConditionVariable)

--- a/stdlib/builtin/true_class.rbs
+++ b/stdlib/builtin/true_class.rbs
@@ -42,5 +42,5 @@ class TrueClass
   #
   #     or
   #
-  def |: (bool obj) -> bool
+  def |: (boolish obj) -> bool
 end

--- a/stdlib/coverage/coverage.rbs
+++ b/stdlib/coverage/coverage.rbs
@@ -49,7 +49,7 @@ module Coverage
   # `clear` is true, it clears the counters to zero. If `stop` is true, it
   # disables coverage measurement.
   #
-  def self.result: (?stop: bool, ?clear: bool) -> Hash[String, untyped]
+  def self.result: (?stop: boolish, ?clear: boolish) -> Hash[String, untyped]
 
   # Returns true if coverage stats are currently being collected (after
   # Coverage.start call, but before Coverage.result call)
@@ -58,5 +58,5 @@ module Coverage
 
   # Enables coverage measurement.
   #
-  def self.start: (?lines: bool, ?branches: bool, ?methods: bool, ?oneshot_lines: bool) -> nil
+  def self.start: (?lines: boolish, ?branches: boolish, ?methods: boolish, ?oneshot_lines: boolish) -> nil
 end

--- a/stdlib/csv/csv.rbs
+++ b/stdlib/csv/csv.rbs
@@ -755,7 +755,7 @@ class CSV::Table[out Elem] < Object
   # This method assumes you want the Table.headers(), unless you explicitly pass
   # `:write_headers => false`.
   #
-  def to_csv: (?write_headers: bool, **untyped) -> untyped
+  def to_csv: (?write_headers: boolish, **untyped) -> untyped
 
   alias to_s to_csv
 

--- a/stdlib/date/date.rbs
+++ b/stdlib/date/date.rbs
@@ -178,7 +178,7 @@ class Date
   #
   #     Date._parse('2001-02-03') #=> {:year=>2001, :mon=>2, :mday=>3}
   #
-  def self._parse: (String str, ?bool complete) -> Hash[Symbol, Integer]
+  def self._parse: (String str, ?boolish complete) -> Hash[Symbol, Integer]
 
   # Returns a hash of parsed elements.
   #
@@ -328,7 +328,7 @@ class Date
   #     Date.parse('20010203')            #=> #<Date: 2001-02-03 ...>
   #     Date.parse('3rd Feb 2001')        #=> #<Date: 2001-02-03 ...>
   #
-  def self.parse: (String str, ?bool complete, ?Integer start) -> Date
+  def self.parse: (String str, ?boolish complete, ?Integer start) -> Date
 
   # Creates a new Date object by parsing from a string according to some typical
   # RFC 2822 formats.

--- a/stdlib/date/date_time.rbs
+++ b/stdlib/date/date_time.rbs
@@ -236,7 +236,7 @@ class DateTime < Date
   #     DateTime.parse('3rd Feb 2001 04:05:06 PM')
   #                               #=> #<DateTime: 2001-02-03T16:05:06+00:00 ...>
   #
-  def self.parse: (String str, ?bool complete, ?Integer start) -> DateTime
+  def self.parse: (String str, ?boolish complete, ?Integer start) -> DateTime
 
   # Creates a new DateTime object by parsing from a string according to some
   # typical RFC 2822 formats.

--- a/stdlib/find/find.rbs
+++ b/stdlib/find/find.rbs
@@ -27,8 +27,8 @@ module Find
   #
   # See the `Find` module documentation for an example.
   #
-  def self?.find: (*String | _ToPath paths, ?ignore_error: bool) -> Enumerator[String, nil]
-                | (*String | _ToPath paths, ?ignore_error: bool) { (String arg0) -> void } -> nil
+  def self?.find: (*String | _ToPath paths, ?ignore_error: boolish) -> Enumerator[String, nil]
+                | (*String | _ToPath paths, ?ignore_error: boolish) { (String) -> void } -> nil
 
   # Skips the current file or directory, restarting the loop with the next entry.
   # If the current file is a directory, that directory will not be recursively

--- a/stdlib/logger/log_device.rbs
+++ b/stdlib/logger/log_device.rbs
@@ -24,7 +24,7 @@ class Logger
 
     def create_logfile: (String filename) -> File
 
-    def initialize: (?untyped logdev, ?binmode: bool, ?shift_period_suffix: String, ?shift_size: Integer, ?shift_age: Numeric | String) -> void
+    def initialize: (?untyped logdev, ?binmode: boolish, ?shift_period_suffix: String, ?shift_size: Integer, ?shift_age: Numeric | String) -> void
 
     def lock_shift_log: () { () -> untyped } -> untyped
 

--- a/stdlib/logger/logger.rbs
+++ b/stdlib/logger/logger.rbs
@@ -495,7 +495,7 @@ class Logger
   #
   # Create an instance.
   #
-  def initialize: (logdev logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: bool, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer) -> void
+  def initialize: (logdev logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: boolish, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer) -> void
 end
 
 Logger::ProgName: String

--- a/stdlib/pathname/pathname.rbs
+++ b/stdlib/pathname/pathname.rbs
@@ -324,9 +324,9 @@ class Pathname
                  ?external_encoding: encoding,
                  ?internal_encoding: encoding,
                  ?encoding: encoding,
-                 ?textmode: bool,
-                 ?binmode: bool,
-                 ?autoclose: bool,
+                 ?textmode: boolish,
+                 ?binmode: boolish,
+                 ?autoclose: boolish,
 
                  # From String#encode
                  ?invalid: :replace ?,
@@ -373,7 +373,7 @@ class Pathname
   # Note that the results never contain the entries `.` and `..` in the directory
   # because they are not children.
   #
-  def children: (?bool with_directory) -> untyped
+  def children: (?boolish with_directory) -> untyped
 
   # Changes file permissions.
   #
@@ -397,7 +397,7 @@ class Pathname
   #
   # See Pathname#realpath.
   #
-  def cleanpath: (?bool consider_symlink) -> Pathname
+  def cleanpath: (?boolish consider_symlink) -> Pathname
 
   # Returns the last change time, using directory information, not the file
   # itself.
@@ -485,8 +485,8 @@ class Pathname
   #
   # See Pathname#children
   #
-  def each_child: (?bool with_directory) { (Pathname) -> void } -> Array[Pathname]
-                | (?bool with_directory) -> Enumerator[Pathname, Array[Pathname]]
+  def each_child: (?boolish with_directory) { (Pathname) -> void } -> Array[Pathname]
+                | (?boolish with_directory) -> Enumerator[Pathname, Array[Pathname]]
 
   # Iterates over the entries (files and subdirectories) in the directory,
   # yielding a Pathname object for each entry.
@@ -517,11 +517,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) { (String) -> untyped } -> nil
                | (Integer limit,
                   # open_args
@@ -530,11 +530,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) { (String) -> untyped } -> nil
                | (?String sep, ?Integer limit,
                   # open_args
@@ -543,11 +543,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) -> Enumerator[String, nil]
                | (Integer limit,
                   # open_args
@@ -556,11 +556,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) -> Enumerator[String, nil]
 
   # Tests the file is empty.
@@ -643,8 +643,8 @@ class Pathname
   #
   # See Find.find
   #
-  def find: (?ignore_error: bool) { (Pathname) -> untyped } -> nil
-          | (?ignore_error: bool) -> Enumerator[Pathname, nil]
+  def find: (?ignore_error: boolish) { (Pathname) -> untyped } -> nil
+          | (?ignore_error: boolish) -> Enumerator[Pathname, nil]
 
   # Return `true` if the receiver matches the given pattern.
   #
@@ -789,9 +789,9 @@ class Pathname
              ?external_encoding: encoding,
              ?internal_encoding: encoding,
              ?encoding: encoding,
-             ?textmode: bool,
-             ?binmode: bool,
-             ?autoclose: bool,
+             ?textmode: boolish,
+             ?binmode: boolish,
+             ?autoclose: boolish,
             ) -> String
 
   # See FileTest.readable?.
@@ -813,11 +813,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) -> Array[String]
                | (Integer limit,
                   # open_args
@@ -826,11 +826,11 @@ class Pathname
                   ?external_encoding: encoding,
                   ?internal_encoding: encoding,
                   ?encoding: encoding,
-                  ?textmode: bool,
-                  ?binmode: bool,
-                  ?autoclose: bool,
+                  ?textmode: boolish,
+                  ?binmode: boolish,
+                  ?autoclose: boolish,
                   # getline_args
-                  ?chomp: bool,
+                  ?chomp: boolish,
                  ) -> Array[String]
 
   # Read symbolic link.
@@ -1033,9 +1033,9 @@ class Pathname
               ?external_encoding: encoding,
               ?internal_encoding: encoding,
               ?encoding: encoding,
-              ?textmode: bool,
-              ?binmode: bool,
-              ?autoclose: bool,
+              ?textmode: boolish,
+              ?binmode: boolish,
+              ?autoclose: boolish,
              ) -> Integer
 
   # See FileTest.zero?.

--- a/stdlib/pstore/pstore.rbs
+++ b/stdlib/pstore/pstore.rbs
@@ -243,7 +243,7 @@ class PStore
   # PStore objects are always reentrant. But if *thread_safe* is set to true, then
   # it will become thread-safe at the cost of a minor performance hit.
   #
-  def initialize: (untyped file, ?bool thread_safe) -> untyped
+  def initialize: (untyped file, ?boolish thread_safe) -> untyped
 
   def load: (untyped content) -> untyped
 

--- a/stdlib/pty/pty.rbs
+++ b/stdlib/pty/pty.rbs
@@ -66,7 +66,7 @@ module PTY
   # :   If `true` and the process identified by `pid` is no longer alive a
   #     PTY::ChildExited is raised.
   #
-  def self.check: (Integer pid, ?bool raise) -> Process::Status?
+  def self.check: (Integer pid, ?boolish raise) -> Process::Status?
 
   alias self.getpty self.spawn
 

--- a/stdlib/uri/generic.rbs
+++ b/stdlib/uri/generic.rbs
@@ -193,7 +193,7 @@ module URI
     #
     # Creates a new URI::Generic instance from ``generic'' components without check.
     #
-    def initialize: (String scheme, String userinfo, String host, Integer port, String? registry, String path, String? opaque, String query, String fragment, ?untyped parser, ?bool arg_check) -> URI::Generic
+    def initialize: (String scheme, String userinfo, String host, Integer port, String? registry, String path, String? opaque, String query, String fragment, ?untyped parser, ?boolish arg_check) -> URI::Generic
 
     #
     # Returns the scheme component of the URI.

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -56,6 +56,11 @@ EOF
 
         assert typecheck.value([1,2,3].each, parse_type("Enumerator[Integer, Array[Integer]]"))
         assert typecheck.value(loop, parse_type("Enumerator[nil, bot]"))
+
+        assert typecheck.value(true, parse_type("bool"))
+        assert typecheck.value(false, parse_type("bool"))
+        refute typecheck.value(nil, parse_type("bool"))
+        refute typecheck.value("", parse_type("bool"))
       end
     end
   end

--- a/test/stdlib/Base64_test.rb
+++ b/test/stdlib/Base64_test.rb
@@ -19,6 +19,8 @@ class Base64Test < StdlibTest
 
   def test_urlsafe_encode64_urlsafe_decode64
     Base64.urlsafe_decode64(Base64.urlsafe_encode64(""))
+    Base64.urlsafe_decode64(Base64.urlsafe_encode64("", padding: "true"))
     urlsafe_decode64(urlsafe_encode64(""))
+    urlsafe_decode64(urlsafe_encode64("", padding: 30))
   end
 end

--- a/test/stdlib/DateTime_test.rb
+++ b/test/stdlib/DateTime_test.rb
@@ -139,6 +139,8 @@ class DateTimeSingletonTest < Minitest::Test
                       DateTime, :parse, "2020-08-15T00:00:00+0900"
     assert_send_type  "(::String str, bool complete) -> ::DateTime",
                       DateTime, :parse, "2020-08-15T00:00:00+0900", true
+    assert_send_type  "(::String str, Symbol complete) -> ::DateTime",
+                      DateTime, :parse, "2020-08-15T00:00:00+0900", :true
     assert_send_type  "(::String str, bool complete, ::Integer start) -> ::DateTime",
                       DateTime, :parse, "2020-08-15T00:00:00+0900", true, Date::ITALY
   end

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -154,6 +154,8 @@ class DateSingletonTest < Minitest::Test
                       Date, :parse, "2020-08-15"
     assert_send_type  "(::String str, bool complete) -> ::Date",
                       Date, :parse, "2020-08-15", true
+    assert_send_type  "(::String str, Symbol) -> ::Date",
+                      Date, :parse, "2020-08-15", :true
     assert_send_type  "(::String str, bool complete, ::Integer start) -> ::Date",
                       Date, :parse, "2020-08-15", true, Date::ITALY
   end

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -96,7 +96,7 @@ class DirSingletonTest < Minitest::Test
 
   def test_exist?
     assert_send_type "(::ToStr) -> bool",
-                     Dir, :entries, ToStr.new(__dir__)
+                     Dir, :exist?, ToStr.new(__dir__)
   end
 
   def test_foreach

--- a/test/stdlib/File_test.rb
+++ b/test/stdlib/File_test.rb
@@ -180,11 +180,11 @@ class FileSingletonTest < Minitest::Test
   end
 
   def test_dirname
-    assert_send_type "(String) -> bool",
+    assert_send_type "(String) -> String",
                      File, :dirname, __FILE__
-    assert_send_type "(ToStr) -> bool",
+    assert_send_type "(ToStr) -> String",
                      File, :dirname, ToStr.new(__FILE__)
-    assert_send_type "(ToPath) -> bool",
+    assert_send_type "(ToPath) -> String",
                      File, :dirname, ToPath.new(__FILE__)
   end
 

--- a/test/stdlib/Find_test.rb
+++ b/test/stdlib/Find_test.rb
@@ -14,10 +14,12 @@ class FindTest < StdlibTest
       Find.find("#{dir}/a", "#{dir}/b")
       Find.find(to_path_class.new(dir))
       Find.find(dir, ignore_error: true)
+      Find.find(dir, ignore_error: :true)
       Find.find(dir){}
       Find.find("#{dir}/a", "#{dir}/b"){}
       Find.find(to_path_class.new(dir)){}
       Find.find(dir, ignore_error: true){}
+      Find.find(dir, ignore_error: :true){}
     end
   end
 

--- a/test/stdlib/Logger_test.rb
+++ b/test/stdlib/Logger_test.rb
@@ -22,6 +22,8 @@ class LoggerSingletonTest < Minitest::Test
                       Logger, :new, '/dev/null', 1, 1
     assert_send_type  "(String logdev, Integer shift_age, Integer shift_size, shift_period_suffix: String, binmode: bool, datetime_format: String, formatter: Proc, progname: String, level: Integer) -> void",
                       Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: Logger::INFO
+    assert_send_type  "(String logdev, Integer shift_age, Integer shift_size, shift_period_suffix: String, binmode: Symbol, datetime_format: String, formatter: Proc, progname: String, level: Integer) -> void",
+                      Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: :true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: Logger::INFO
   end
 end
 

--- a/test/stdlib/PStore_test.rb
+++ b/test/stdlib/PStore_test.rb
@@ -9,5 +9,7 @@ class PStoreSingletonTest < Minitest::Test
   def test_initialize
     assert_send_type  "(untyped file, ?bool thread_safe) -> PStore",
                       PStore, :new, "file_name", false
+    assert_send_type  "(untyped file, ?Symbol) -> PStore",
+                      PStore, :new, "file_name", :false
   end
 end

--- a/test/stdlib/PTY_test.rb
+++ b/test/stdlib/PTY_test.rb
@@ -19,6 +19,8 @@ class PTYSingletonTest < Minitest::Test
 
     assert_send_type  "(::Integer pid) -> (::Process::Status | nil)",
                       PTY, :check, pid
+    assert_send_type  "(::Integer pid, Symbol) -> (::Process::Status | nil)",
+                      PTY, :check, pid, :true
     assert_send_type  "(::Integer pid, ::FalseClass raise) -> nil",
                       PTY, :check, pid, false
     assert_send_type  "(::Integer pid, ::TrueClass raise) -> nil",

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -127,6 +127,8 @@ class PathnameInstanceTest < Minitest::Test
                        path, :binwrite, 'foo'
       assert_send_type '(String, Integer) -> Integer',
                        path, :binwrite, 'foo', 42
+      assert_send_type '(String, Integer, textmode: String) -> Integer',
+                       path, :binwrite, 'foo', 42, textmode: "true"
     end
   end
 
@@ -317,6 +319,8 @@ class PathnameInstanceTest < Minitest::Test
                      Pathname(__dir__), :find do end
     assert_send_type '(ignore_error: bool) -> Enumerator[Pathname, nil]',
                      Pathname(__dir__), :find, ignore_error: true
+    assert_send_type '(ignore_error: Symbol) -> Enumerator[Pathname, nil]',
+                     Pathname(__dir__), :find, ignore_error: :true
     assert_send_type '() -> Enumerator[Pathname, nil]',
                      Pathname(__dir__), :find
   end

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -26,4 +26,15 @@ class StringIOTest < StdlibTest
     io.close_write
     io.closed_write?
   end
+
+  def test_each
+    io = StringIO.new("")
+    io.each(chomp: 3) do end
+    io.each(chomp: 3)
+  end
+
+  def test_gets
+    io = StringIO.new("")
+    io.gets(chomp: :true)
+  end
 end

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -583,6 +583,8 @@ class StringInstanceTest < Minitest::Test
                      "hello", :each_line, "l", chomp: true do |line| line end
     assert_send_type "(ToStr, chomp: true) { (String) -> void } -> self",
                      "hello", :each_line, ToStr.new("l"), chomp: true do |line| line end
+    assert_send_type "(ToStr, chomp: Symbol) { (String) -> void } -> self",
+                     "hello", :each_line, ToStr.new("l"), chomp: :true do |line| line end
     assert_send_type "(String, chomp: false) { (String) -> void } -> self",
                      "hello", :each_line, "l", chomp: false do |line| line end
     assert_send_type "(ToStr, chomp: false) { (String) -> void } -> self",
@@ -837,6 +839,8 @@ class StringInstanceTest < Minitest::Test
                      "", :lines, "\n"
     assert_send_type "(String, chomp: true) -> Array[String]",
                      "", :lines, "\n", chomp: true
+    assert_send_type "(String, chomp: Symbol) -> Array[String]",
+                     "", :lines, "\n", chomp: :true
     assert_send_type "(String, chomp: false) -> Array[String]",
                      "", :lines, "\n", chomp: false
     assert_send_type "(ToStr) -> Array[String]",


### PR DESCRIPTION
1. Make `bool` strict (an alias of `true | false`)
2. Introduce `boolish` type, an alias of `top`
3. Replace `bool` in RBS to `boolish` if applicable

See https://github.com/ruby/rbs/issues/133.