### PR TITLE
Support alias in `rbs prototype rb`

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -178,9 +178,9 @@ module RBS
             end
           when :attr_reader
             args.each do |arg|
-              if arg&.type == :LIT && arg.children[0].is_a?(Symbol)
+              if arg && (name = literal_to_symbol(arg))
                 decls << AST::Members::AttrReader.new(
-                  name: arg.children[0],
+                  name: name,
                   ivar_name: nil,
                   type: Types::Bases::Any.new(location: nil),
                   location: nil,
@@ -191,9 +191,9 @@ module RBS
             end
           when :attr_accessor
             args.each do |arg|
-              if arg&.type == :LIT && arg.children[0].is_a?(Symbol)
+              if arg && (name = literal_to_symbol(arg))
                 decls << AST::Members::AttrAccessor.new(
-                  name: arg.children[0],
+                  name: name,
                   ivar_name: nil,
                   type: Types::Bases::Any.new(location: nil),
                   location: nil,
@@ -204,9 +204,9 @@ module RBS
             end
           when :attr_writer
             args.each do |arg|
-              if arg&.type == :LIT && arg.children[0].is_a?(Symbol)
+              if arg && (name = literal_to_symbol(arg))
                 decls << AST::Members::AttrWriter.new(
-                  name: arg.children[0],
+                  name: name,
                   ivar_name: nil,
                   type: Types::Bases::Any.new(location: nil),
                   location: nil,

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -246,7 +246,7 @@ class Hello
 
   attr_reader :x
   attr_accessor :y, :z
-  attr_writer foo, :a
+  attr_writer foo, :a, 'b'
 end
     EOR
 
@@ -265,6 +265,8 @@ class Hello
   attr_accessor z: untyped
 
   attr_writer a: untyped
+
+  attr_writer b: untyped
 end
     EOF
   end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -269,6 +269,39 @@ end
     EOF
   end
 
+  def test_aliases
+    parser = RB.new
+
+    rb = <<-EOR
+class Hello
+  alias a b
+  alias_method :c, 'd'
+
+  # Ignore global variable alias
+  alias $a $b
+
+  class << self
+    alias e f
+    alias_method 'g', :h
+  end
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  alias a b
+
+  alias c d
+
+  alias self.e self.f
+
+  alias self.g self.h
+end
+    EOF
+  end
+
   def test_comments
     parser = RB.new
 


### PR DESCRIPTION
This pull request makes `rbs prototype rb` to support `alias`.

Currently `rbs prototype rb` just ignores `alias` syntax and `alias_method`. It will output `alias` by this change.


For example:

```ruby
# test.rb

class C
  def m() end
  alias m2 m
end
```

```bash
# Before
$ rbs prototype rb test.rb
class C
  def m: () -> nil
end

# after
$ rbs prototype rb test.rb
class C
  def m: () -> nil

  alias m2 m
end
```