### PR TITLE
Update Enumerable#to_h type

### DIFF
--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -306,6 +306,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
   #   #=> {1=>1, 2=>4, 3=>9, 4=>16, 5=>25}
   # ```
   def to_h: () -> ::Hash[untyped, untyped]
+          | [T, U] () { (Elem) -> [T, U] } -> ::Hash[T, U]
 
   def each_slice: (Integer n) { (::Array[Elem]) -> untyped } -> NilClass
                 | (Integer n) -> ::Enumerator[::Array[Elem], Return]

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -58,6 +58,20 @@ class EnumerableTest < StdlibTest
     end
   end
 
+  def test_to_h
+    enumerable = Class.new {
+      def each
+        yield [1, 2]
+        yield [2, 3]
+        yield [3, 4]
+      end
+
+      include Enumerable
+    }.new
+    enumerable.to_h
+    enumerable.to_h { |obj| obj }
+  end
+
   def test_each_entry
     enumerable.each_entry
     enumerable.each_entry { |x| x }


### PR DESCRIPTION
`Enumerable#to_h` actually receives a block, but the type wasn't aware of the block.
So this pull request adds a method type to be aware of the block argument.


By the way, other `to_h`s support the block argument.

https://github.com/ruby/rbs/blob/967a421db6ff6907536235f2ae744791455a354e/core/hash.rbs#L857-L858
https://github.com/ruby/rbs/blob/967a421db6ff6907536235f2ae744791455a354e/core/array.rbs#L1855-L1856