### PR TITLE
Fix error of prototype rb on hash spread syntax

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -411,7 +411,8 @@ module RBS
         when :HASH
           list = node.children[0]
           if list
-            children = list.children.compact
+            children = list.children
+            children.pop
           else
             children = []
           end
@@ -419,8 +420,13 @@ module RBS
           key_types = []
           value_types = []
           children.each_slice(2) do |k, v|
-            key_types << literal_to_type(k)
-            value_types << literal_to_type(v)
+            if k
+              key_types << literal_to_type(k)
+              value_types << literal_to_type(v)
+            else
+              key_types << untyped
+              value_types << untyped
+            end
           end
 
           if !key_types.empty? && key_types.all? { |t| t.is_a?(Types::Literal) }

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -102,6 +102,7 @@ class Hello
   def hash1() {} end
   def hash2() { foo: 1 } end
   def hash3() { foo: { bar: 42 }, x: { y: z } } end
+  def hash4() { foo: 1, **({ bar: x}).compact } end
 end
     EOR
 
@@ -158,6 +159,8 @@ class Hello
   def hash2: () -> { foo: 1 }
 
   def hash3: () -> { foo: { bar: 42 }, x: { y: untyped } }
+
+  def hash4: () -> ::Hash[:foo | untyped, 1 | untyped]
 end
     EOF
   end


### PR DESCRIPTION
Fix #464

# Cause

Hash key will be a `nil` on hash spread syntax.
For example


```ruby
pp RubyVM::AbstractSyntaxTree.parse('{ called: true, **({ foo: foo }.compact) }')
```

```
(SCOPE@1:0-1:42
 tbl: []
 args: nil
 body:
   (HASH@1:0-1:42
      (LIST@1:2-1:39 (LIT@1:2-1:9 :called) (TRUE@1:10-1:14) nil # ← here
         (CALL@1:19-1:39
            (HASH@1:19-1:31
               (LIST@1:21-1:29 (LIT@1:21-1:25 :foo) (VCALL@1:26-1:29 :foo)
                  nil)) :compact nil) nil)))
```

# Solution


Determine key and value types as `untyped` if it a hash has `**`.

So, the type for the reported code will be the following.

```ruby
# ruby
def a(foo:)
  { called: true, **({ foo: foo }.compact) }
end
```

```bash
$ exe/rbs prototype rb test.rb
class Object
  def a: (foo: untyped foo) -> ::Hash[:called | untyped, ::TrueClass | untyped]
end
```


---


By the way, @ybiquitous says "unless .compact, the command passes:".
Because Ruby optimizes a hash spread for a hash literal.

```ruby
pp RubyVM::AbstractSyntaxTree.parse('{ called: true, **({ foo: foo }) }')
```

```
(SCOPE@1:0-1:34
 tbl: []
 args: nil
 body:
   (HASH@1:0-1:34
      (LIST@1:2-1:29 (LIT@1:2-1:9 :called) (TRUE@1:10-1:14)
         (LIT@1:21-1:25 :foo) (VCALL@1:26-1:29 :foo) nil)))
```

The AST does not have nil as a key.