### PR TITLE
Make Hash#merge! strict so that it can accept only the same type

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -720,8 +720,8 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   # Hash#update is an alias for Hash#merge!.
   #
-  def merge!: [A, B] (*::Hash[A, B] other_hashes) -> ::Hash[A | K, B | V]
-            | [A, B, C] (*::Hash[A, B] other_hashes) { (K key, V oldval, B newval) -> (C) } -> ::Hash[A | K, B | V | C]
+  def merge!: (*::Hash[K, V] other_hashes) -> ::Hash[K, V]
+            | (*::Hash[K, V] other_hashes) { (K key, V oldval, V newval) -> (V) } -> ::Hash[K, V]
 
   # Searches through the hash comparing *obj* with the value using `==`. Returns
   # the first key-value pair (two-element array) that matches. See also
@@ -770,7 +770,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h = { "a" => 100, "b" => 200 }
   #     h.replace({ "c" => 300, "d" => 400 })   #=> {"c"=>300, "d"=>400}
   #
-  def replace: [A, B] (Hash[A, B] | _ToHash[A, B]) -> Hash[A, B]
+  def replace: (Hash[K, V]) -> Hash[K, V]
 
   # Returns a new hash consisting of entries for which the block returns true.
   #

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -720,8 +720,8 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   # Hash#update is an alias for Hash#merge!.
   #
-  def merge!: (*::Hash[K, V] other_hashes) -> ::Hash[K, V]
-            | (*::Hash[K, V] other_hashes) { (K key, V oldval, V newval) -> (V) } -> ::Hash[K, V]
+  def merge!: (*::Hash[K, V] other_hashes) -> self
+            | (*::Hash[K, V] other_hashes) { (K key, V oldval, V newval) -> (V) } -> self
 
   # Searches through the hash comparing *obj* with the value using `==`. Returns
   # the first key-value pair (two-element array) that matches. See also
@@ -770,7 +770,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h = { "a" => 100, "b" => 200 }
   #     h.replace({ "c" => 300, "d" => 400 })   #=> {"c"=>300, "d"=>400}
   #
-  def replace: (Hash[K, V]) -> Hash[K, V]
+  def replace: (Hash[K, V]) -> self
 
   # Returns a new hash consisting of entries for which the block returns true.
   #


### PR DESCRIPTION
... and Hash#replace, too.

Actually, these methods can accept a hash that has arbitrary key and
value types. However, they destructively changes its receiver. Thus,
their RBS declarations should be strict so that they can accept only
`Hash[K, V]`. Otherwise, a type checker will overlook the change of
element types of the receiver hashes. This is not new; `Array#concat`
only accepts `Array[Elem]` though the method actually accepts any array
that has arbitrary elements.

In addition, TypeProf assumes that contravariant occurences of type variables `K` and `V` updates the receiver's elements. The former declarations are inconvenient for TypeProf.