### PR TITLE
Allow `Hash#<` and its friends to accept arbitrary hashes

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -143,7 +143,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h2 < h1    #=> false
   #     h1 < h1    #=> false
   #
-  def <: (::Hash[K, V]) -> bool
+  def <: [A, B] (::Hash[A, B]) -> bool
 
   # Returns `true` if *hash* is subset of *other* or equals to *other*.
   #
@@ -153,7 +153,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h2 <= h1   #=> false
   #     h1 <= h1   #=> true
   #
-  def <=: (::Hash[K, V]) -> bool
+  def <=: [A, B] (::Hash[A, B]) -> bool
 
   # Equality---Two hashes are equal if they each contain the same number of keys
   # and if each key-value pair is equal to (according to Object#==) the
@@ -183,7 +183,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h2 > h1    #=> true
   #     h1 > h1    #=> false
   #
-  def >: (::Hash[K, V]) -> bool
+  def >: [A, B] (::Hash[A, B]) -> bool
 
   # Returns `true` if *other* is subset of *hash* or equals to *hash*.
   #
@@ -193,7 +193,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h2 >= h1   #=> true
   #     h1 >= h1   #=> true
   #
-  def >=: (::Hash[K, V]) -> bool
+  def >=: [A, B] (::Hash[A, B]) -> bool
 
   # Element Reference---Retrieves the *value* object corresponding to the *key*
   # object. If not found, returns the default value (see Hash::new for details).


### PR DESCRIPTION
For example, `{1=>1} < {"a"=>"a"}` is allowed in Ruby. As the methods
have no side-effect, I don't see any good reason to make them so strict.