### PR TITLE
Drop second type parameter of `Enumerable` and `_Each`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ module ChatApp
     def initialize: (name: String) -> void
 
     def each_member: () { (User | Bot) -> void } -> void  # `{` and `}` means block.
-                   | () -> Enumerable[User | Bot, void]   # Method can be overloaded.
+                   | () -> Enumerator[User | Bot, void]   # Method can be overloaded.
   end
 end
 ```

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -234,7 +234,7 @@
 # for pack.c
 #
 class Array[unchecked out Elem] < Object
-  include Enumerable[Elem, self]
+  include Enumerable[Elem]
 
   # Returns a new array.
   #

--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -26,8 +26,8 @@ interface _ToPath
   def to_path: () -> String
 end
 
-interface _Each[out A, out B]
-  def each: { (A) -> void } -> B
+interface _Each[out A]
+  def each: { (A) -> void } -> void
 end
 
 interface _Reader

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -7,7 +7,7 @@
 # itself (`.`).
 #
 class Dir
-  include Enumerable[String, Dir]
+  include Enumerable[String]
 
   # Returns a new directory object for the named directory.
   #

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -384,7 +384,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   def filter_map: [U] () { (Elem elem) -> (nil | false | U) } -> ::Array[U]
                 | () -> ::Enumerator[Elem, ::Array[untyped]]
 
-  def chain: (*self enumerables) -> ::Enumerator::Chain[Elem, ::Array[self]]
+  def chain: (*self enumerables) -> ::Enumerator::Chain[Elem]
 
   def tally: () -> ::Hash[Elem, Integer]
 

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -66,24 +66,24 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
            | () { (Elem) -> boolish } -> Integer
 
   def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
-           | (?Integer n) -> ::Enumerator[Elem, Return]
+           | (?Integer n) -> ::Enumerator[Elem, NilClass]
 
   def detect: (?Proc ifnone) { (Elem) -> boolish } -> Elem?
-            | (?Proc ifnone) -> ::Enumerator[Elem, Return]
+            | (?Proc ifnone) -> ::Enumerator[Elem, Elem?]
 
   def drop: (Integer n) -> ::Array[Elem]
 
   def drop_while: () { (Elem) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, Return]
+                | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   def each_cons: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
-               | (Integer n) -> ::Enumerator[::Array[Elem], Return]
+               | (Integer n) -> ::Enumerator[::Array[Elem], NilClass]
 
-  def each_with_index: () { (Elem arg0, Integer arg1) -> untyped } -> ::Enumerable[Elem, Return]
+  def each_with_index: () { (Elem arg0, Integer arg1) -> untyped } -> Return
                      | () -> ::Enumerator[[ Elem, Integer ], Return]
 
   def each_with_object: [U] (U arg0) { (Elem arg0, untyped arg1) -> untyped } -> U
-                      | [U] (U arg0) -> ::Enumerator[[ Elem, U ], Return]
+                      | [U] (U arg0) -> ::Enumerator[[ Elem, U ], U]
 
   # Returns an array containing the items in *enum* .
   #
@@ -97,14 +97,14 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   def entries: () -> ::Array[Elem]
 
   def find_all: () { (Elem) -> boolish } -> ::Array[Elem]
-              | () -> ::Enumerator[Elem, Return]
+              | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   alias select find_all
   alias filter find_all
 
   def find_index: (?untyped value) -> Integer?
                 | () { (Elem) -> boolish } -> Integer?
-                | () -> ::Enumerator[Elem, Return]
+                | () -> ::Enumerator[Elem, Integer?]
 
   # Returns the first element, or the first `n` elements, of the enumerable.
   # If the enumerable is empty, the first form returns `nil`, and the
@@ -127,7 +127,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
             | [U] (untyped arg0) { (Elem arg0) -> U } -> ::Array[U]
 
   def group_by: [U] () { (Elem arg0) -> U } -> ::Hash[U, ::Array[Elem]]
-              | () -> ::Enumerator[Elem, Return]
+              | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   def `include?`: (untyped arg0) -> bool
 
@@ -160,9 +160,9 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
          | (Integer arg0) -> ::Array[Elem]
          | (Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
-  def max_by: () -> ::Enumerator[Elem, Return]
+  def max_by: () -> ::Enumerator[Elem, Elem?]
             | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
-            | (Integer arg0) -> ::Enumerator[Elem, Return]
+            | (Integer arg0) -> ::Enumerator[Elem, ::Array[Elem]]
             | (Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
 
   # Returns the object in *enum* with the minimum value. The first form
@@ -189,9 +189,9 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
          | (Integer arg0) -> ::Array[Elem]
          | (Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
-  def min_by: () -> ::Enumerator[Elem, Return]
+  def min_by: () -> ::Enumerator[Elem, Elem?]
             | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
-            | (Integer arg0) -> ::Enumerator[Elem, Return]
+            | (Integer arg0) -> ::Enumerator[Elem, ::Array[Elem]]
             | (Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
 
   # Returns a two element array which contains the minimum and the maximum
@@ -207,7 +207,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
             | () { (Elem arg0, Elem arg1) -> Integer } -> [ Elem?, Elem? ]
 
   def minmax_by: () -> [ Elem?, Elem? ]
-               | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Enumerator[Elem, Return]
+               | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> [ Elem?, Elem? ]
 
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block never returns `true` for all elements. If
@@ -252,12 +252,12 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
           | () { (Elem) -> boolish } -> bool
 
   def partition: () { (Elem) -> boolish } -> [ ::Array[Elem], ::Array[Elem] ]
-               | () -> ::Enumerator[Elem, Return]
+               | () -> ::Enumerator[Elem, [ ::Array[Elem], ::Array[Elem] ]]
 
   def reject: () { (Elem) -> boolish } -> ::Array[Elem]
-            | () -> ::Enumerator[Elem, Return]
+            | () -> ::Enumerator[Elem, ::Array[Elem]]
 
-  def reverse_each: () { (Elem arg0) -> untyped } -> ::Enumerator[Elem, Return]
+  def reverse_each: () { (Elem arg0) -> untyped } -> Return
                   | () -> ::Enumerator[Elem, Return]
 
   # Returns an array containing the items in *enum* sorted.
@@ -284,12 +284,12 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
           | () { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
 
   def sort_by: () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
-             | () -> ::Enumerator[Elem, Return]
+             | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   def take: (Integer n) -> ::Array[Elem]?
 
   def take_while: () { (Elem) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, Return]
+                | () -> ::Enumerator[Elem, ::Array[Elem]]
 
   # Implemented in C++
   # Returns the result of interpreting *enum* as a list of `[key, value]`
@@ -309,7 +309,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
           | [T, U] () { (Elem) -> [T, U] } -> ::Hash[T, U]
 
   def each_slice: (Integer n) { (::Array[Elem]) -> untyped } -> NilClass
-                | (Integer n) -> ::Enumerator[::Array[Elem], Return]
+                | (Integer n) -> ::Enumerator[::Array[Elem], NilClass]
 
   interface _NotFound[T]
     def call: () -> T
@@ -320,8 +320,8 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
           | [T] (_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
           | [T] (_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
 
-  def flat_map: [U] () { (Elem arg0) -> U } -> U
-              | () -> ::Enumerator[Elem, Return]
+  def flat_map: [U] () { (Elem) -> (Array[U] | U) } -> Array[U]
+              | () -> ::Enumerator[Elem, Array[untyped]]
 
   def map: [U] () { (Elem arg0) -> U } -> ::Array[U]
          | () -> ::Enumerator[Elem, ::Array[untyped]]
@@ -382,13 +382,13 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
          | [U] (?U arg0) { (Elem arg0) -> U } -> U
 
   def filter_map: [U] () { (Elem elem) -> (nil | false | U) } -> ::Array[U]
-                | () -> ::Enumerator[Elem, Return]
+                | () -> ::Enumerator[Elem, ::Array[untyped]]
 
   def chain: (*self enumerables) -> ::Enumerator::Chain[Elem, ::Array[self]]
 
   def tally: () -> ::Hash[Elem, Integer]
 
-  def each_entry: () -> ::Enumerator[Elem, Return]
+  def each_entry: () -> ::Enumerator[Elem, self]
                 | () { (Elem arg0) -> untyped } -> self
 
   # variadic type parameter is not supported yet
@@ -396,8 +396,8 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   def zip: [Elem2, Return2] (::Enumerable[Elem2, Return2] enum) -> ::Array[[Elem, Elem2 | nil]]
          | [U, Elem2, Return2] (::Enumerable[Elem2, Return2]) { ([Elem, Elem2 | nil]) -> U } -> nil
 
-  def chunk: () -> ::Enumerator[Elem, Return]
-           | [U] () { (Elem elt) -> U } -> ::Enumerator[[U, Array[Elem]], void]
+  def chunk: [U] () { (Elem elt) -> U } -> ::Enumerator[[U, Array[Elem]], void]
+           | () -> ::Enumerator[Elem, Enumerator[untyped, untyped]]
 
   def chunk_while: () { (Elem elt_before, Elem elt_after) -> boolish } -> ::Enumerator[::Array[Elem], void]
 

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -5,7 +5,7 @@
 # objects in the collection must also implement a meaningful `<=>`
 # operator, as these methods rely on an ordering between members of the
 # collection.
-module Enumerable[unchecked out Elem, out Return]: _Each[Elem, Return]
+module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block never returns `false` or `nil` . If the
   # block is not given, Ruby adds an implicit block of `{ |obj| obj }` which

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -5,7 +5,7 @@
 # objects in the collection must also implement a meaningful `<=>`
 # operator, as these methods rely on an ordering between members of the
 # collection.
-module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
+module Enumerable[unchecked out Elem]: _Each[Elem]
   # Passes each element of the collection to the given block. The method
   # returns `true` if the block never returns `false` or `nil` . If the
   # block is not given, Ruby adds an implicit block of `{ |obj| obj }` which
@@ -79,8 +79,8 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   def each_cons: (Integer n) { (::Array[Elem] arg0) -> untyped } -> NilClass
                | (Integer n) -> ::Enumerator[::Array[Elem], NilClass]
 
-  def each_with_index: () { (Elem arg0, Integer arg1) -> untyped } -> Return
-                     | () -> ::Enumerator[[ Elem, Integer ], Return]
+  def each_with_index: () { (Elem arg0, Integer arg1) -> untyped } -> void
+                     | () -> ::Enumerator[[ Elem, Integer ], void]
 
   def each_with_object: [U] (U arg0) { (Elem arg0, untyped arg1) -> untyped } -> U
                       | [U] (U arg0) -> ::Enumerator[[ Elem, U ], U]
@@ -257,8 +257,8 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   def reject: () { (Elem) -> boolish } -> ::Array[Elem]
             | () -> ::Enumerator[Elem, ::Array[Elem]]
 
-  def reverse_each: () { (Elem arg0) -> untyped } -> Return
-                  | () -> ::Enumerator[Elem, Return]
+  def reverse_each: () { (Elem arg0) -> untyped } -> void
+                  | () -> ::Enumerator[Elem, void]
 
   # Returns an array containing the items in *enum* sorted.
   #
@@ -371,7 +371,7 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
   # # show pythagorean triples less than 100
   # p pythagorean_triples.take_while { |*, z| z < 100 }.force
   # ```
-  def lazy: () -> Enumerator::Lazy[Elem, Return]
+  def lazy: () -> Enumerator::Lazy[Elem, void]
 
   def uniq: () -> ::Array[Elem]
           | () { (Elem item) -> untyped } -> ::Array[Elem]
@@ -393,8 +393,8 @@ module Enumerable[unchecked out Elem, out Return]: _Each[Elem]
 
   # variadic type parameter is not supported yet
   # https://github.com/ruby/rbs/issues/21
-  def zip: [Elem2, Return2] (::Enumerable[Elem2, Return2] enum) -> ::Array[[Elem, Elem2 | nil]]
-         | [U, Elem2, Return2] (::Enumerable[Elem2, Return2]) { ([Elem, Elem2 | nil]) -> U } -> nil
+  def zip: [Elem2] (::Enumerable[Elem2] enum) -> ::Array[[Elem, Elem2 | nil]]
+         | [U, Elem2] (::Enumerable[Elem2]) { ([Elem, Elem2 | nil]) -> U } -> nil
 
   def chunk: [U] () { (Elem elt) -> U } -> ::Enumerator[[U, Array[Elem]], void]
            | () -> ::Enumerator[Elem, Enumerator[untyped, untyped]]

--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -96,7 +96,7 @@
 # # => [], [:b], [1], [:b, 1], [1, 2], [:b, 1, 2], 3
 # ```
 class Enumerator[unchecked out Elem, out Return] < Object
-  include Enumerable[Elem, Return]
+  include Enumerable[Elem]
 
   def each: () { (Elem arg0) -> untyped } -> Return
           | () -> self
@@ -243,7 +243,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
 end
 
 class Enumerator::Generator[out Elem, out Return] < Object
-  include Enumerable[Elem, Return]
+  include Enumerable[Elem]
 end
 
 class Enumerator::Lazy[out Elem, out Return] < Enumerator[Elem, Return]
@@ -258,5 +258,5 @@ class Enumerator::Yielder < Object
 end
 
 class Enumerator::Chain[out Elem, out Return] < Object
-  include Enumerable[Elem, Return]
+  include Enumerable[Elem]
 end

--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -242,7 +242,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
                  | [U] (U arg0) -> ::Enumerator[[ Elem, U ], Return]
 end
 
-class Enumerator::Generator[out Elem, out Return] < Object
+class Enumerator::Generator[out Elem] < Object
   include Enumerable[Elem]
 end
 
@@ -257,6 +257,6 @@ class Enumerator::Yielder < Object
   def to_proc: () -> Proc
 end
 
-class Enumerator::Chain[out Elem, out Return] < Object
+class Enumerator::Chain[out Elem] < Object
   include Enumerable[Elem]
 end

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -106,7 +106,7 @@
 # See also Object#hash and Object#eql?
 #
 class Hash[unchecked out K, unchecked out V] < Object
-  include Enumerable[[K, V], Hash[K, V]]
+  include Enumerable[[K, V]]
 
   # Creates a new hash populated with the given objects.
   #

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -105,7 +105,7 @@
 class IO < Object
   include File::Constants
 
-  include Enumerable[String, IO]
+  include Enumerable[String]
 
   def <<: (untyped arg0) -> self
 

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -88,7 +88,7 @@
 # r.member?(Xs.new(5))       #=> true
 # ```
 class Range[out Elem] < Object
-  include Enumerable[Elem, Range[Elem]]
+  include Enumerable[Elem]
 
   def ==: (untyped obj) -> bool
 

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -27,7 +27,7 @@
 # struct member which is either a quoted string ( `"name"` ) or a
 # [Symbol](https://ruby-doc.org/core-2.6.3/Symbol.html) ( `:name` ).
 class Struct[Elem] < Object
-  include Enumerable[Elem, Struct[Elem]]
+  include Enumerable[Elem]
 
   type attribute_name = Symbol | String
 

--- a/stdlib/csv/0/csv.rbs
+++ b/stdlib/csv/0/csv.rbs
@@ -159,7 +159,7 @@
 # with it.
 #
 class CSV < Object
-  include Enumerable[untyped, untyped]
+  include Enumerable[untyped]
 
   # This method is intended as the primary interface for reading CSV files. You
   # pass a `path` and any `options` you wish to set for the read. Each row of file
@@ -407,7 +407,7 @@ CSV::VERSION: String
 # processing is activated.
 #
 class CSV::Row < Object
-  include Enumerable[untyped, untyped]
+  include Enumerable[untyped]
 
   # If a two-element Array is provided, it is assumed to be a header and field and
   # the pair is appended. A Hash works the same way with the key being the header
@@ -578,7 +578,7 @@ end
 # processing is activated.
 #
 class CSV::Table[out Elem] < Object
-  include Enumerable[untyped, untyped]
+  include Enumerable[untyped]
 
   # Constructs a new CSV::Table from `array_of_rows`, which are expected to be
   # CSV::Row objects. All rows are assumed to have the same headers.

--- a/stdlib/dbm/0/dbm.rbs
+++ b/stdlib/dbm/0/dbm.rbs
@@ -61,7 +61,7 @@
 #     puts db['822']
 #
 class DBM
-  include Enumerable[untyped, untyped]
+  include Enumerable[untyped]
 
   # Open a dbm database and yields it if a block is given. See also `DBM.new`.
   #

--- a/stdlib/prime/0/prime.rbs
+++ b/stdlib/prime/0/prime.rbs
@@ -137,7 +137,7 @@ class Prime
   class PseudoPrimeGenerator
     def initialize: (?Integer?) -> void
 
-    include Enumerable[Integer, void]
+    include Enumerable[Integer]
 
     attr_accessor upper_bound (): Integer?
 

--- a/stdlib/set/0/set.rbs
+++ b/stdlib/set/0/set.rbs
@@ -297,5 +297,5 @@ class Set[A]
   #
   def to_a: () -> Array[A]
 
-  include Enumerable[A, self]
+  include Enumerable[A]
 end

--- a/stdlib/set/0/set.rbs
+++ b/stdlib/set/0/set.rbs
@@ -51,8 +51,8 @@ class Set[A]
   #     Set.new(1..5)                         #=> #<Set: {1, 2, 3, 4, 5}>
   #     Set.new([1, 2, 3]) { |x| x * x }      #=> #<Set: {1, 4, 9}>
   #
-  def initialize: (_Each[A, untyped]) -> untyped
-                | [X] (_Each[X, untyped]) { (X) -> A } -> untyped
+  def initialize: (_Each[A]) -> untyped
+                | [X] (_Each[X]) { (X) -> A } -> untyped
                 | (?nil) -> untyped
 
   # Creates a new set containing the given objects.
@@ -69,7 +69,7 @@ class Set[A]
   #     Set[1, 3, 5] & Set[3, 2, 1]             #=> #<Set: {3, 1}>
   #     Set['a', 'b', 'z'] & ['a', 'b', 'c']    #=> #<Set: {"a", "b"}>
   #
-  def &: (_Each[A, untyped]) -> self
+  def &: (_Each[A]) -> self
 
   alias intersection &
 
@@ -79,7 +79,7 @@ class Set[A]
   #     Set[1, 2, 3] | Set[2, 4, 5]         #=> #<Set: {1, 2, 3, 4, 5}>
   #     Set[1, 5, 'z'] | (1..6)             #=> #<Set: {1, 5, "z", 2, 3, 4, 6}>
   #
-  def |: (_Each[A, untyped]) -> self
+  def |: (_Each[A]) -> self
 
   alias union |
 
@@ -91,7 +91,7 @@ class Set[A]
   #     Set[1, 3, 5] - Set[1, 5]                #=> #<Set: {3}>
   #     Set['a', 'b', 'z'] - ['a', 'c']         #=> #<Set: {"b", "z"}>
   #
-  def -: (_Each[A, untyped]) -> self
+  def -: (_Each[A]) -> self
 
   alias difference -
 
@@ -133,7 +133,7 @@ class Set[A]
   #     Set[1, 2] ^ Set[2, 3]                   #=> #<Set: {3, 1}>
   #     Set[1, 'b', 'c'] ^ ['b', 'd']           #=> #<Set: {"d", 1, "c"}>
   #
-  def ^: (_Each[A, untyped]) -> self
+  def ^: (_Each[A]) -> self
 
   # Classifies the set by the return value of the given block and returns a hash
   # of {value => set of elements} pairs.  The block is called once for each
@@ -248,7 +248,7 @@ class Set[A]
   # Merges the elements of the given enumerable object to the set and returns
   # self.
   #
-  def merge: (_Each[A, untyped]) -> self
+  def merge: (_Each[A]) -> self
 
   # Returns true if the set is a subset of the given set.
   #
@@ -271,7 +271,7 @@ class Set[A]
   #     set.replace([1, 2])               #=> #<Set: {1, 2}>
   #     set                               #=> #<Set: {1, 2}>
   #
-  def replace: (_Each[A, untyped]) -> self
+  def replace: (_Each[A]) -> self
 
   # Resets the internal state after modification to existing elements and returns
   # self.
@@ -288,7 +288,7 @@ class Set[A]
   # Deletes every element that appears in the given enumerable object and returns
   # self.
   #
-  def subtract: (_Each[A, untyped]) -> self
+  def subtract: (_Each[A]) -> self
 
   # Converts the set to an array.  The order of elements is uncertain.
   #

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -74,7 +74,7 @@ class RBS::CliTest < Minitest::Test
       cli.run(%w(-r set ancestors ::Set))
       assert_equal <<-EOF, stdout.string
 ::Set[A]
-::Enumerable[A, self]
+::Enumerable[A]
 ::Object
 ::Kernel
 ::BasicObject
@@ -85,7 +85,7 @@ class RBS::CliTest < Minitest::Test
       cli.run(%w(-r set ancestors --instance ::Set))
       assert_equal <<-EOF, stdout.string
 ::Set[A]
-::Enumerable[A, self]
+::Enumerable[A]
 ::Object
 ::Kernel
 ::BasicObject

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -134,7 +134,7 @@ class EnumerableTest2 < Minitest::Test
     end
   end
 
-  testing "::Enumerable[String, TestEnumerable]"
+  testing "::Enumerable[String]"
 
   def test_inject
     assert_send_type "(String init, Symbol method) -> untyped", TestEnumerable.new, :inject, '', :<<


### PR DESCRIPTION
* The second type parameter is not used so much.
* To make the type definition more compatible with Sorbet.
