### PR TITLE
Support more meta programmings for prototype rb

### DIFF
--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -274,6 +274,40 @@ end
     EOF
   end
 
+  def test_module_function
+    parser = RB.new
+
+    rb = <<-EOR
+module Hello
+  def foo() end
+
+  def bar() end
+  module_function :bar
+
+  module_function def baz() end
+
+  module_function
+
+  def foobar() end
+
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+module Hello
+  def foo: () -> nil
+
+  def self?.bar: () -> nil
+
+  def self?.baz: () -> nil
+
+  def self?.foobar: () -> nil
+end
+    EOF
+  end
+
   def test_aliases
     parser = RB.new
 

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -289,7 +289,6 @@ module Hello
   module_function
 
   def foobar() end
-
 end
     EOR
 
@@ -304,6 +303,54 @@ module Hello
   def self?.baz: () -> nil
 
   def self?.foobar: () -> nil
+end
+    EOF
+  end
+
+  def test_accessibility
+    parser = RB.new
+
+    rb = <<-EOR
+class Hello
+  attr_reader :private_attr
+
+  private :private_attr
+
+  private def foo() end
+
+  private
+
+  def bar() end
+
+  public
+
+  def baz() end
+
+  def foobar() end
+
+  private :foobar
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  private
+
+  attr_reader private_attr: untyped
+
+  def foo: () -> nil
+
+  def bar: () -> nil
+
+  public
+
+  def baz: () -> nil
+
+  private
+
+  def foobar: () -> nil
 end
     EOF
   end
@@ -505,7 +552,7 @@ end
 
     rb = <<-'EOR'
 class C
-  private def foo
+  some_method_takes_method_name def foo
   end
 end
     EOR


### PR DESCRIPTION
`rbs protoype rb` will be aware of `private`, `public`, and `module_function` by this pull request.


For example:

```ruby
# ruby code

module M
  def foo
  end

  module_function def bar
  end

  module_function

  def baz
  end
end

class C
  private def foo
  end

  def bar
  end

  private

  def baz
  end
end
```

```ruby
# generated rbs

module M
  def foo: () -> nil

  def self?.bar: () -> nil

  def self?.baz: () -> nil
end

class C
  private

  def foo: () -> nil

  public

  def bar: () -> nil

  private

  def baz: () -> nil
end
```