### PR TITLE
Add type of Singleton module

### DIFF
--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -89,30 +89,23 @@
 #     p a.keep  #  => "keep this"
 #     p a.strip #  => nil
 module Singleton
-  def self.__init__: (untyped klass) -> untyped
+  def self.__init__: (Class klass) -> Class
+
+  def self.instance: () -> instance
 
   public
 
   # By default, do not retain any state when marshalling.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     _dump(depth = -1)
-  #
-  def _dump: (?untyped depth) -> untyped
+  def _dump: (?Integer depth) -> String
 
   # Raises a TypeError to prevent cloning.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     clone()
-  #
-  def clone: () -> untyped
+  def clone: () -> bot
 
   # Raises a TypeError to prevent duping.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     dup()
-  #
-  def dup: () -> untyped
+  def dup: () -> bot
 end
 
 Singleton::VERSION: String

--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -1,12 +1,117 @@
+# The Singleton module implements the Singleton pattern.
+#
+# ## Usage
+#
+# To use Singleton, include the module in your class.
+#
+#     class Klass
+#        include Singleton
+#        # ...
+#     end
+#
+# This ensures that only one instance of Klass can be created.
+#
+#     a,b = Klass.instance, Klass.instance
+#
+#     a == b
+#     # => true
+#
+#     Klass.new
+#     # => NoMethodError - new is private ...
+#
+# The instance is created at upon the first call of Klass.instance().
+#
+#     class OtherKlass
+#       include Singleton
+#       # ...
+#     end
+#
+#     ObjectSpace.each_object(OtherKlass){}
+#     # => 0
+#
+#     OtherKlass.instance
+#     ObjectSpace.each_object(OtherKlass){}
+#     # => 1
+#
+# This behavior is preserved under inheritance and cloning.
+#
+# ## Implementation
+#
+# This above is achieved by:
+#
+# *   Making Klass.new and Klass.allocate private.
+#
+# *   Overriding Klass.inherited(sub_klass) and Klass.clone() to ensure that the
+#     Singleton properties are kept when inherited and cloned.
+#
+# *   Providing the Klass.instance() method that returns the same object each
+#     time it is called.
+#
+# *   Overriding Klass._load(str) to call Klass.instance().
+#
+# *   Overriding Klass#clone and Klass#dup to raise TypeErrors to prevent
+#     cloning or duping.
+#
+#
+# ## Singleton and Marshal
+#
+# By default Singleton's #_dump(depth) returns the empty string. Marshalling by
+# default will strip state information, e.g. instance variables from the
+# instance. Classes using Singleton can provide custom _load(str) and
+# _dump(depth) methods to retain some of the previous state of the instance.
+#
+#     require 'singleton'
+#
+#     class Example
+#       include Singleton
+#       attr_accessor :keep, :strip
+#       def _dump(depth)
+#         # this strips the @strip information from the instance
+#         Marshal.dump(@keep, depth)
+#       end
+#
+#       def self._load(str)
+#         instance.keep = Marshal.load(str)
+#         instance
+#       end
+#     end
+#
+#     a = Example.instance
+#     a.keep = "keep this"
+#     a.strip = "get rid of this"
+#
+#     stored_state = Marshal.dump(a)
+#
+#     a.keep = nil
+#     a.strip = nil
+#     b = Marshal.load(stored_state)
+#     p a == b  #  => true
+#     p a.keep  #  => "keep this"
+#     p a.strip #  => nil
 module Singleton
   def self.__init__: (untyped klass) -> untyped
 
   public
 
+  # By default, do not retain any state when marshalling.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     _dump(depth = -1)
+  #
   def _dump: (?untyped depth) -> untyped
 
+  # Raises a TypeError to prevent cloning.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     clone()
+  #
   def clone: () -> untyped
 
+  # Raises a TypeError to prevent duping.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     dup()
+  #
   def dup: () -> untyped
 end
 

--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -1,0 +1,13 @@
+module Singleton
+  def self.__init__: (untyped klass) -> untyped
+
+  public
+
+  def _dump: (?untyped depth) -> untyped
+
+  def clone: () -> untyped
+
+  def dup: () -> untyped
+end
+
+Singleton::VERSION: String

--- a/test/stdlib/singleton_test.rb
+++ b/test/stdlib/singleton_test.rb
@@ -1,0 +1,17 @@
+require_relative './test_helper'
+require 'singleton'
+
+class SingletonSingletonTest < Minitest::Test
+  include TypeAssertions
+  library 'singleton'
+  testing 'singleton(::Singleton)'
+
+  class TestClass
+    include Singleton
+  end
+
+  def test_instance
+    assert_send_type  '() -> SingletonSingletonTest::TestClass',
+                      TestClass, :instance
+  end
+end


### PR DESCRIPTION
This pull request adds types of Singleton module.


Note that Singleton module makes `new` and `allocate` methods private, but this pull request doesn't treat it.
https://github.com/ruby/ruby/blob/53e352fd718cd2cae6d77298e6e92736dddcfeeb/lib/singleton.rb#L164


I added a test only for `Singleton.instance` method. Because tests for other methods are not useful. I guess they are almost private APIs.