### PR TITLE
Avoid to generate RBS with Syntax Error by prototype runtime

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -94,6 +94,7 @@ module RBS
             optional_positionals << Types::Function::Param.new(name: name, type: untyped)
           when :rest
             requireds = trailing_positionals
+            name = nil if name == :* # For `def f(...) end` syntax
             rest = Types::Function::Param.new(name: name, type: untyped)
           when :keyreq
             required_keywords[name] = Types::Function::Param.new(name: nil, type: untyped)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -194,4 +194,29 @@ end
     end
     assert(true) # nothing raised above
   end
+
+  if RUBY_VERSION >= '2.7'
+    class TestForArgumentForwarding
+      eval <<~RUBY
+        def foo(...)
+        end
+      RUBY
+    end
+
+    def test_argument_forwarding
+      SignatureManager.new do |manager|
+        manager.build do |env|
+          p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForArgumentForwarding"], env: env, merge: true)
+
+          assert_write p.decls, <<-EOF
+class RBS::RuntimePrototypeTest::TestForArgumentForwarding
+  public
+
+  def foo: (*untyped) { (*untyped) -> untyped } -> untyped
+end
+          EOF
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request fixes a syntax error that is generated by `rbs prototype runtime` command on `def f(...) end` syntax.



# Problem


`rbs prototype runtime` command generates RBS with a syntax error if a method is defined with argument forwarding syntax that is introduced since Ruby 2.7.


For example:

```ruby
# test.rb

class C
  def f(...) end
end
```

```
$ rbs prototype runtime -R ./test.rb C
class C
  public

  def f: (*untyped *) { (*untyped) -> untyped } -> untyped
end
```

It displays `*untyped *` as the method arguments, but the trailing `*` is meaningless.


# Cause

RubyVM::AST::Node includes `:*` as an argument name if the method is defined with argument forwarding syntax.
For example:

```ruby
irb> pp RubyVM::AbstractSyntaxTree.parse('def f(...) end')
(SCOPE@1:0-1:14
 tbl: []
 args: nil
 body:
   (DEFN@1:0-1:14
    mid: :f
    body:
      (SCOPE@1:0-1:14
       tbl: [:*, :&]
       args:
         (ARGS@1:5-1:10
          pre_num: 0
          pre_init: nil
          opt: nil
          first_post: nil
          post_num: 0
          post_init: nil
          rest: :*        # <- HERE!
          kw: nil
          kwrest: nil
          block: :&)
       body: nil)))
```

# Solution

Treat `:*` as an unnamed argument.
