### PR TITLE
Fix dependency definition to let tsort success

### DIFF
--- a/lib/rbs/environment_walker.rb
+++ b/lib/rbs/environment_walker.rb
@@ -1,5 +1,9 @@
 module RBS
   class EnvironmentWalker
+    InstanceNode = Struct.new(:type_name, keyword_init: true)
+    SingletonNode = Struct.new(:type_name, keyword_init: true)
+    TypeNameNode = Struct.new(:type_name, keyword_init: true)
+
     attr_reader :env
 
     def initialize(env:)
@@ -23,50 +27,70 @@ module RBS
     include TSort
 
     def tsort_each_node(&block)
-      env.class_decls.each_key(&block)
-      env.interface_decls.each_key(&block)
-      env.alias_decls.each_key(&block)
+      env.class_decls.each_key do |type_name|
+        yield InstanceNode.new(type_name: type_name)
+        yield SingletonNode.new(type_name: type_name)
+      end
+      env.interface_decls.each_key do |type_name|
+        yield TypeNameNode.new(type_name: type_name)
+      end
+      env.alias_decls.each_key do |type_name|
+        yield TypeNameNode.new(type_name: type_name)
+      end
     end
 
-    def tsort_each_child(name, &block)
+    def tsort_each_child(node, &block)
+      name = node.type_name
+
       unless name.namespace.empty?
-        yield name.namespace.to_type_name
+        yield SingletonNode.new(type_name: name.namespace.to_type_name)
       end
 
-      case
-      when name.class?, name.interface?
-        definitions = []
-
+      case node
+      when TypeNameNode
         case
-        when name.class?
-          definitions << builder.build_instance(name)
-          definitions << builder.build_singleton(name)
         when name.interface?
-          definitions << builder.build_interface(name)
-        end
-
-        definitions.each do |definition|
-          if ancestors = definition.ancestors
-            ancestors.ancestors.each do |ancestor|
-              yield ancestor.name
-
-              case ancestor
-              when Definition::Ancestor::Instance
-                ancestor.args.each do |type|
-                  each_type_name type, &block
-                end
-              end
-            end
-          end
-
+          definition = builder.build_interface(name)
           unless only_ancestors?
             definition.each_type do |type|
               each_type_name type, &block
             end
           end
+        when name.alias?
+          each_type_name builder.expand_alias(name), &block
+        else
+          raise "Unexpected TypeNameNode with type_name=#{name}"
         end
-      when name.alias?
-        each_type_name builder.expand_alias(name), &block
+
+      when InstanceNode, SingletonNode
+        definition = if node.is_a?(InstanceNode)
+                       builder.build_instance(name)
+                     else
+                       builder.build_singleton(name)
+                     end
+
+        if ancestors = definition.ancestors
+          ancestors.ancestors.each do |ancestor|
+            case ancestor
+            when Definition::Ancestor::Instance
+              yield InstanceNode.new(type_name: ancestor.name)
+
+              unless only_ancestors?
+                ancestor.args.each do |type|
+                  each_type_name type, &block
+                end
+              end
+            when Definition::Ancestor::Singleton
+              yield SingletonNode.new(type_name: ancestor.name)
+            end
+          end
+        end
+
+        unless only_ancestors?
+          definition.each_type do |type|
+            each_type_name type, &block
+          end
+        end
       end
     end
 
@@ -83,14 +107,19 @@ module RBS
       when RBS::Types::Bases::Nil
       when RBS::Types::Variable
       when RBS::Types::ClassSingleton
-        yield type.name
-      when RBS::Types::ClassInstance, RBS::Types::Interface
-        yield type.name
+        yield SingletonNode.new(type_name: type.name)
+      when RBS::Types::ClassInstance
+        yield InstanceNode.new(type_name: type.name)
+        type.args.each do |ty|
+          each_type_name(ty, &block)
+        end
+      when RBS::Types::Interface
+        yield TypeNameNode.new(type_name: type.name)
         type.args.each do |ty|
           each_type_name(ty, &block)
         end
       when RBS::Types::Alias
-        yield type.name
+        yield TypeNameNode.new(type_name: type.name)
       when RBS::Types::Union, RBS::Types::Intersection, RBS::Types::Tuple
         type.types.each do |ty|
           each_type_name ty, &block

--- a/test/rbs/environment_walker_test.rb
+++ b/test/rbs/environment_walker_test.rb
@@ -44,23 +44,53 @@ EOF
         walker = EnvironmentWalker.new(env: env)
 
         components = walker.each_strongly_connected_component.to_a
-        foo = components.find {|c| c.any? {|name| name.to_s == "::A::Foo" } }
-        a = components.find {|c| c.any? {|name| name.to_s == "::A" } }
+        foo_instance = components.find_index do |component|
+          component.any? {|node|
+            node.is_a?(EnvironmentWalker::InstanceNode) && node.type_name.to_s == "::A::Foo"
+          }
+        end
+        foo_singleton = components.find_index do |component|
+          component.any? {|node|
+            node.is_a?(EnvironmentWalker::SingletonNode) && node.type_name.to_s == "::A::Foo"
+          }
+        end
+        a_instance = components.find_index do |component|
+          component.any? {|node|
+            node.is_a?(EnvironmentWalker::InstanceNode) && node.type_name.to_s == "::A"
+          }
+        end
+        a_singleton = components.find_index do |component|
+          component.any? {|node|
+            node.is_a?(EnvironmentWalker::SingletonNode) && node.type_name.to_s == "::A"
+          }
+        end
 
-        # module A::Foo makes a dependency to A
-        # A#hello makes a dependency to A::Foo
-        assert_operator a.map(&:to_s), :==, foo.map(&:to_s)
+        # singleton(A) <| A::Foo, singleton(A) <| singleton(A::Foo)
+        # A::Foo <| A
+        assert_operator a_singleton, :<, foo_instance
+        assert_operator a_singleton, :<, foo_singleton
+        assert_operator foo_instance, :<, a_instance
       end
     end
   end
 
-  def test_stdlib
+  def test_stdlib_strongly_connected_components
     env = Environment.from_loader(EnvironmentLoader.new).resolve_type_names
 
     walker = EnvironmentWalker.new(env: env.resolve_type_names).only_ancestors!
 
     walker.each_strongly_connected_component do |component|
       # pp component.map(&:to_s)
+    end
+  end
+
+  def test_stdlib_tsort
+    env = Environment.from_loader(EnvironmentLoader.new).resolve_type_names
+
+    walker = EnvironmentWalker.new(env: env.resolve_type_names).only_ancestors!
+
+    walker.tsort_each do |type_name|
+      # pp type_name.to_s
     end
   end
 end


### PR DESCRIPTION
This is to make topological sort of core classes succeed.

* Stop adding dependencies to ancestor arguments
* Introduce `*Node` classes to distinguish instance and singleton

Thus, `EnvironmentWalker` runes over `InstanceNode`, `SingletonNode`, and `TypeNameNode` instances, not `TypeName` instances.