### PR TITLE
Add type of monitor library

### DIFF
--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -1,33 +1,33 @@
 class Monitor
   public
 
-  def enter: () -> untyped
+  def enter: () -> nil
 
-  def exit: () -> untyped
+  def exit: () -> nil
 
-  def mon_check_owner: () -> untyped
+  def mon_check_owner: () -> nil
 
   alias mon_enter enter
 
   alias mon_exit exit
 
-  def mon_locked?: () -> untyped
+  def mon_locked?: () -> bool
 
-  def mon_owned?: () -> untyped
+  def mon_owned?: () -> bool
 
   alias mon_synchronize synchronize
 
   alias mon_try_enter try_enter
 
-  def new_cond: () -> untyped
+  def new_cond: () -> ::MonitorMixin::ConditionVariable
 
-  def synchronize: () -> untyped
+  def synchronize: [T] () { () -> T } -> T
 
-  def try_enter: () -> untyped
+  def try_enter: () -> bool
 
   alias try_mon_enter try_enter
 
-  def wait_for_cond: (untyped, untyped) -> untyped
+  def wait_for_cond: (::MonitorMixin::ConditionVariable, Numeric? timeout) -> untyped
 end
 
 module MonitorMixin
@@ -35,19 +35,19 @@ module MonitorMixin
 
   public
 
-  def mon_enter: () -> untyped
+  def mon_enter: () -> nil
 
-  def mon_exit: () -> untyped
+  def mon_exit: () -> nil
 
-  def mon_locked?: () -> untyped
+  def mon_locked?: () -> bool
 
-  def mon_owned?: () -> untyped
+  def mon_owned?: () -> bool
 
-  def mon_synchronize: () { (*untyped) -> untyped } -> untyped
+  def mon_synchronize: [T] () { () -> T } -> T
 
-  def mon_try_enter: () -> untyped
+  def mon_try_enter: () -> bool
 
-  def new_cond: () -> untyped
+  def new_cond: () -> ::MonitorMixin::ConditionVariable
 
   alias synchronize mon_synchronize
 
@@ -55,9 +55,9 @@ module MonitorMixin
 
   private
 
-  def initialize: (*untyped) { (*untyped) -> untyped } -> untyped
+  def initialize: (*untyped) { (*untyped) -> untyped } -> void
 
-  def mon_check_owner: () -> untyped
+  def mon_check_owner: () -> nil
 
   def mon_initialize: () -> untyped
 end
@@ -65,17 +65,17 @@ end
 class MonitorMixin::ConditionVariable
   public
 
-  def broadcast: () -> untyped
+  def broadcast: () -> Thread::ConditionVariable
 
-  def signal: () -> untyped
+  def signal: () -> Thread::ConditionVariable
 
-  def wait: (?untyped timeout) -> untyped
+  def wait: (?Numeric? timeout) -> untyped
 
-  def wait_until: () -> untyped
+  def wait_until: () { () -> boolish } -> untyped
 
-  def wait_while: () -> untyped
+  def wait_while: () { () -> boolish } -> untyped
 
   private
 
-  def initialize: (untyped monitor) -> untyped
+  def initialize: (Monitor monitor) -> void
 end

--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -55,7 +55,7 @@ module MonitorMixin
 
   private
 
-  def initialize: (*untyped *) { (*untyped) -> untyped } -> untyped
+  def initialize: (*untyped) { (*untyped) -> untyped } -> untyped
 
   def mon_check_owner: () -> untyped
 

--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -1,3 +1,12 @@
+# Use the Monitor class when you want to have a lock object for blocks with
+# mutual exclusion.
+#
+#     require 'monitor'
+#
+#     lock = Monitor.new
+#     lock.synchronize do
+#       # exclusive access
+#     end
 class Monitor
   public
 
@@ -25,6 +34,7 @@ class Monitor
 
   def try_enter: () -> bool
 
+  # for compatibility
   alias try_mon_enter try_enter
 
   def wait_for_cond: (::MonitorMixin::ConditionVariable, Numeric? timeout) -> untyped
@@ -35,44 +45,72 @@ module MonitorMixin
 
   public
 
+  # Enters exclusive section.
   def mon_enter: () -> nil
 
+  # Leaves exclusive section.
   def mon_exit: () -> nil
 
+  # Returns true if this monitor is locked by any thread
   def mon_locked?: () -> bool
 
+  # Returns true if this monitor is locked by current thread.
   def mon_owned?: () -> bool
 
+  # Enters exclusive section and executes the block.  Leaves the exclusive section
+  # automatically when the block exits.  See example under `MonitorMixin`.
   def mon_synchronize: [T] () { () -> T } -> T
 
+  # Attempts to enter exclusive section.  Returns `false` if lock fails.
   def mon_try_enter: () -> bool
 
+  # Creates a new MonitorMixin::ConditionVariable associated with the Monitor
+  # object.
   def new_cond: () -> ::MonitorMixin::ConditionVariable
 
   alias synchronize mon_synchronize
 
+  # For backward compatibility
   alias try_mon_enter mon_try_enter
 
   private
 
+  # Use `extend MonitorMixin` or `include MonitorMixin` instead of this
+  # constructor.  Have look at the examples above to understand how to use this
+  # module.
   def initialize: (*untyped) { (*untyped) -> untyped } -> void
 
   def mon_check_owner: () -> nil
 
+  # Initializes the MonitorMixin after being included in a class or when an object
+  # has been extended with the MonitorMixin
   def mon_initialize: () -> untyped
 end
 
+# FIXME: This isn't documented in Nutshell.
+#
+# Since MonitorMixin.new_cond returns a ConditionVariable, and the example above
+# calls while_wait and signal, this class should be documented.
 class MonitorMixin::ConditionVariable
   public
 
+  # Wakes up all threads waiting for this lock.
   def broadcast: () -> Thread::ConditionVariable
 
+  # Wakes up the first thread in line waiting for this lock.
   def signal: () -> Thread::ConditionVariable
 
+  # Releases the lock held in the associated monitor and waits; reacquires the
+  # lock on wakeup.
+  #
+  # If `timeout` is given, this method returns after `timeout` seconds passed,
+  # even if no other thread doesn't signal.
   def wait: (?Numeric? timeout) -> untyped
 
+  # Calls wait repeatedly until the given block yields a truthy value.
   def wait_until: () { () -> boolish } -> untyped
 
+  # Calls wait repeatedly while the given block yields a truthy value.
   def wait_while: () { () -> boolish } -> untyped
 
   private

--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -1,0 +1,81 @@
+class Monitor
+  public
+
+  def enter: () -> untyped
+
+  def exit: () -> untyped
+
+  def mon_check_owner: () -> untyped
+
+  alias mon_enter enter
+
+  alias mon_exit exit
+
+  def mon_locked?: () -> untyped
+
+  def mon_owned?: () -> untyped
+
+  alias mon_synchronize synchronize
+
+  alias mon_try_enter try_enter
+
+  def new_cond: () -> untyped
+
+  def synchronize: () -> untyped
+
+  def try_enter: () -> untyped
+
+  alias try_mon_enter try_enter
+
+  def wait_for_cond: (untyped, untyped) -> untyped
+end
+
+module MonitorMixin
+  def self.extend_object: (untyped obj) -> untyped
+
+  public
+
+  def mon_enter: () -> untyped
+
+  def mon_exit: () -> untyped
+
+  def mon_locked?: () -> untyped
+
+  def mon_owned?: () -> untyped
+
+  def mon_synchronize: () { (*untyped) -> untyped } -> untyped
+
+  def mon_try_enter: () -> untyped
+
+  def new_cond: () -> untyped
+
+  alias synchronize mon_synchronize
+
+  alias try_mon_enter mon_try_enter
+
+  private
+
+  def initialize: (*untyped *) { (*untyped) -> untyped } -> untyped
+
+  def mon_check_owner: () -> untyped
+
+  def mon_initialize: () -> untyped
+end
+
+class MonitorMixin::ConditionVariable
+  public
+
+  def broadcast: () -> untyped
+
+  def signal: () -> untyped
+
+  def wait: (?untyped timeout) -> untyped
+
+  def wait_until: () -> untyped
+
+  def wait_while: () -> untyped
+
+  private
+
+  def initialize: (untyped monitor) -> untyped
+end

--- a/test/stdlib/Monitor_test.rb
+++ b/test/stdlib/Monitor_test.rb
@@ -1,0 +1,150 @@
+require_relative "test_helper"
+require 'monitor'
+
+class MonitorInstanceTest < Minitest::Test
+  include TypeAssertions
+
+  library 'monitor'
+  testing "::Monitor"
+
+  def test_enter
+    assert_send_type "() -> nil",
+                     Monitor.new, :enter
+  end
+
+  def test_exit
+    m = Monitor.new
+    m.enter
+    assert_send_type "() -> nil",
+                     m, :exit
+  end
+
+  def test_new_cond
+    m = Monitor.new
+    assert_send_type '() -> ::MonitorMixin::ConditionVariable',
+                     m, :new_cond
+  end
+
+  def test_synchronize
+    m = Monitor.new
+    assert_send_type '() { () -> String } -> String',
+                     m, :synchronize do 'foo' end
+  end
+
+  def test_try_enter
+    m = Monitor.new
+    assert_send_type '() -> bool',
+                     m, :try_enter
+  end
+end
+
+class MonitorMixinInstanceTest < Minitest::Test
+  include TypeAssertions
+
+  library 'monitor'
+  testing "::MonitorMixin"
+
+  class C
+    include MonitorMixin
+  end
+
+  def test_mon_enter
+    obj = C.new
+    assert_send_type '() -> nil',
+                     obj, :mon_enter
+  end
+
+  def test_mon_exit
+    obj = C.new
+    obj.mon_enter
+    assert_send_type '() -> nil',
+                     obj, :mon_exit
+  end
+
+  def test_mon_locked?
+    obj = C.new
+    assert_send_type '() -> bool',
+                     obj, :mon_locked?
+  end
+
+  def test_mon_owned?
+    obj = C.new
+    assert_send_type '() -> bool',
+                     obj, :mon_owned?
+  end
+
+  def test_mon_synchronize
+    obj = C.new
+    assert_send_type '() { () -> String } -> String',
+                     obj, :mon_synchronize do 'foo' end
+  end
+
+  def test_mon_try_enter
+    obj = C.new
+    assert_send_type '() -> bool',
+                     obj, :mon_try_enter
+  end
+
+  def test_new_cond
+    obj = C.new
+    assert_send_type '() -> ::MonitorMixin::ConditionVariable',
+                     obj, :new_cond
+  end
+end
+
+class MonitorMixinConditionVariableInstanceTest < Minitest::Test
+  include TypeAssertions
+
+  library 'monitor'
+  testing "::MonitorMixin::ConditionVariable"
+
+  def test_broadcast
+    m, v = cond_var
+    m.enter
+    assert_send_type '() -> Thread::ConditionVariable',
+                     v, :broadcast
+  end
+
+  def test_signal
+    m, v = cond_var
+    m.enter
+    assert_send_type '() -> Thread::ConditionVariable',
+                     v, :signal
+  end
+
+  def test_wait_1
+    m, v = cond_var
+    m.enter
+    Thread.new { sleep 0.01; m.enter; v.signal } # to wake up main thread
+    assert_send_type '() -> untyped',
+                     v, :wait
+  end
+
+  def test_wait_2
+    m, v = cond_var
+    m.enter
+    assert_send_type '(Float) -> untyped',
+                     v, :wait, 0.01
+  end
+
+  def test_wait_until
+    m, v = cond_var
+    m.enter
+
+    assert_send_type '() { () -> true } -> untyped',
+                     v, :wait_until do true end
+  end
+
+  def test_wait_while
+    m, v = cond_var
+    m.enter
+
+    assert_send_type '() { () -> false } -> untyped',
+                     v, :wait_while do false end
+  end
+
+  def cond_var
+    m = Monitor.new
+    return m, MonitorMixin::ConditionVariable.new(m)
+  end
+end


### PR DESCRIPTION
This pull request adds RBS files for monitor library.


Note:


* `bin/annotate-with-rdoc stdlib/monitor/0/monitor.rbs` does nothing.
  * I'm not sure why it doesn't work, but I don't apply RDoc comment to monitor.rbs.
* I wrote test cases only for public APIs.
  * I didn't write tests for private APIs, such as `Monitor#mon_locked?`. https://github.com/ruby/ruby/blob/53e352fd718cd2cae6d77298e6e92736dddcfeeb/ext/monitor/monitor.c#L214-L220
  * And I also ignored aliases, such as `Monitor#mon_enter`, so I wrote tests only for the original methods.
* Since Ruby 2.7, Monitor doesn't include `MonitorMixin`, but it includes `MonitorMixin` until 2.6.
  * ```
    $ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-1.8.0 ./all-ruby -rmonitor -e 'p Monitor.ancestors'
    ruby-1.8.0            [Monitor, MonitorMixin, MonitorMixin::Initializable, MonitorMixin::Accessible, Object, Kernel]
    ruby-1.8.1            [Monitor, MonitorMixin, Object, Kernel]
    ...
    ruby-1.8.7-p374       [Monitor, MonitorMixin, Object, Kernel]
    ruby-1.9.0-0          [Monitor, MonitorMixin, Object, Kernel, BasicObject]
    ...
    ruby-2.7.0-preview1   [Monitor, MonitorMixin, Object, Kernel, BasicObject]
    ruby-2.7.0-preview2   [Monitor, Object, Kernel, BasicObject]
    ...
    ruby-2.7.1            [Monitor, Object, Kernel, BasicObject]
    ```
  * The RBS file follows Ruby 2.7, so it doesn't include MonitorMixin.
