### PR TITLE
Fix error of `module_function` for method that isn't defined at the same place

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -252,8 +252,9 @@ module RBS
               module_func_context = context.dup.tap { |ctx| ctx.module_function = true }
               args.each do |arg|
                 if arg && (name = literal_to_symbol(arg))
-                  i = find_def_index_by_name(decls, name)
-                  decls[i] = decls[i].update(kind: :singleton_instance)
+                  if i = find_def_index_by_name(decls, name)
+                    decls[i] = decls[i].update(kind: :singleton_instance)
+                  end
                 elsif arg
                   process arg, decls: decls, comments: comments, context: module_func_context
                 end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -289,6 +289,8 @@ module Hello
   module_function
 
   def foobar() end
+
+  module_function :unknown_method
 end
     EOR
 


### PR DESCRIPTION
I added `module_function` support to prototype rb in #481, but it is broken on `module_function` for method that isn't defined at the same place.
This pull request fixes this problem.



For example, `rbs prototype rb` raises an error with the following Ruby code.


```ruby
module M
  module_function :unknwon_method # prototybe rb can't find `unknown_method` definition, so it raises an error.
end
```



This pull request suppresses the error by ignoring `module_function` if the method definition doesn't exist.



By the way, in Ruby, the `unknwon_method` is actually defined in another place, such as an ancestor. But I think supporting this case is a bit difficult, so ignoring is acceptable behaviour. 