### PR TITLE
Ignore refinements in `rbs prototype rb`

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -120,9 +120,7 @@ module RBS
           end
 
           ctx = Context.initial.tap { |ctx| ctx.singleton = true}
-          each_child(body) do |child|
-            process child, decls: decls, comments: comments, context: ctx
-          end
+          process_children(body, decls: decls, comments: comments, context: ctx)
 
         when :DEFN, :DEFS
             if node.type == :DEFN
@@ -279,15 +277,20 @@ module RBS
               # For `private def foo` syntax
               current = current_accessibility(decls)
               decls << accessibility
-              each_child node do |child|
-                process child, decls: decls, comments: comments, context: context
-              end
+              process_children(node, decls: decls, comments: comments, context: context)
               decls << current
             end
           else
-            each_child node do |child|
-              process child, decls: decls, comments: comments, context: context
-            end
+            process_children(node, decls: decls, comments: comments, context: context)
+          end
+
+        when :ITER
+          method_name = node.children.first.children.first
+          case method_name
+          when :refine
+            # ignore
+          else
+            process_children(node, decls: decls, comments: comments, context: context)
           end
 
         when :CDECL
@@ -306,9 +309,13 @@ module RBS
           )
 
         else
-          each_child node do |child|
-            process child, decls: decls, comments: comments, context: context
-          end
+          process_children(node, decls: decls, comments: comments, context: context)
+        end
+      end
+
+      def process_children(node, decls:, comments:, context:)
+        each_child node do |child|
+          process child, decls: decls, comments: comments, context: context
         end
       end
 

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -621,4 +621,28 @@ class C
 end
     EOF
   end
+
+  def test_refinements
+    parser = RB.new
+
+    rb = <<~'RUBY'
+module M
+  def not_refinements
+  end
+
+  refine Array do
+    def by_refinements
+    end
+  end
+end
+    RUBY
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<~RBS
+module M
+  def not_refinements: () -> nil
+end
+    RBS
+  end
 end


### PR DESCRIPTION
`rbs prototype rb` will ignore refinements by this pull request.

# Problem

Currently `rbs prototype rb` command generates incorrect RBS code for Ruby code that uses refinements.
For example


```ruby
# test.rb

module M
  refine Array do
    def cool_method() end
  end
end
```

```console
$ exe/rbs prototype rb test.rb
module M
  def cool_method: () -> nil
end
```

The `cool_method` is not `M` module's method, but prototype rb isn't aware of it.


# Solution


Just ignore the body of `refine` method.
By this change, it just omits methods for refinements.

```console
# For the same test.rb

$ exe/rbs prototype rb test.rb
module M
end
```


RBS doesn't have support for refinements, so I think we can ignore it.