### PR TITLE
Fix generating incorrect accessibility by prototype rb

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -661,7 +661,7 @@ module RBS
         @public ||= AST::Members::Public.new(location: nil)
       end
 
-      def current_accessibility(decls, index = [0, decls.size - 1].max)
+      def current_accessibility(decls, index = decls.size)
         idx = decls.slice(0, index).rindex { |decl| decl == private || decl == public }
         (idx && decls[idx]) || public
       end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -318,19 +318,23 @@ class Hello
 
   private :private_attr
 
-  private def foo() end
+  private def prv1() end
+
+  private def prv2() end
+
+  def pub1() end
 
   private
 
-  def bar() end
+  def prv3() end
 
   public
 
-  def baz() end
+  def pub2() end
 
-  def foobar() end
+  def prv4() end
 
-  private :foobar
+  private :prv4
 end
     EOR
 
@@ -342,17 +346,25 @@ class Hello
 
   attr_reader private_attr: untyped
 
-  def foo: () -> nil
+  def prv1: () -> nil
 
-  def bar: () -> nil
+  def prv2: () -> nil
 
   public
 
-  def baz: () -> nil
+  def pub1: () -> nil
 
   private
 
-  def foobar: () -> nil
+  def prv3: () -> nil
+
+  public
+
+  def pub2: () -> nil
+
+  private
+
+  def prv4: () -> nil
 end
     EOF
   end


### PR DESCRIPTION
# Problem

I implemented generating accessibility methods in #481 , but it has a bug :bowing_man: 
It generates incorrect accessibility when methods are continually defined with multiple `private def foo() end` syntax.

For example:


```ruby
class C
  private def prv1() end
  private def prv2() end
  def pub() end
end
```

```bash
$ exe/rbs prototype rb test.rb
class C
  private

  def prv1: () -> nil

  def prv2: () -> nil

  def pub: () -> nil
end
```

it needs `public` before `def pub: () -> nil`, but there isn't.


# Cause

I misunderstood the usage of Array#slice. It needs to receive the size of the array if I need the entire of the array, but I passed the size - 1.

So this pull request replaces `size - 1` with just `Array#size`
