### PR TITLE
Support `extend self` by prototype rb

### DIFF
--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -251,6 +251,14 @@ class Hello
   attr_accessor :y, :z
   attr_writer foo, :a, 'b'
 end
+
+module Mod
+  extend self
+
+  module Mod2
+    extend self
+  end
+end
     EOR
 
     parser.parse(rb)
@@ -270,6 +278,14 @@ class Hello
   attr_writer a: untyped
 
   attr_writer b: untyped
+end
+
+module Mod
+  extend ::Mod
+
+  module Mod2
+    extend ::Mod::Mod2
+  end
 end
     EOF
   end


### PR DESCRIPTION
This pull request adds support for `extend self` by prototype rb.


For example, `module M; extend self; end` will be converted to `module M; extend ::M; end`. `self` that is in arguments of `extend` is converted to the module name in the current scope. 

It converts `self` to an absolute type name. It means it always generates a full path as an argument of `extend`.
Because a relative path can be incorrect.
For example:

```ruby
module M
  module M
  end

  # In this context, `extend M` means `extend ::M::M`,
  # so it should be converted to `extend ::M`.
  extend self
end
```


---


it can resolve `include self` with the same technique, but I didn't implement it because of meaningless.
`include self` raises an error, so actually no one uses this.

```bash
$ ruby -e module M; include self; end
-e:1:in `append_features': cyclic include detected (ArgumentError)
	from -e:1:in `include'
	from -e:1:in `<module:M>'
	from -e:1:in `<main>'
```