### PR TITLE
Assume that rbs files are encoded in UTF-8

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -118,7 +118,7 @@ module RBS
           next if files.include?(path)
 
           files << path
-          buffer = Buffer.new(name: path.to_s, content: path.read)
+          buffer = Buffer.new(name: path.to_s, content: path.read(encoding: "UTF-8"))
 
           Parser.parse_signature(buffer).each do |decl|
             yield decl, buffer, source, path


### PR DESCRIPTION
Formerly, rake fails when `LANG=C` because ruby assumes the input files
are encoded in US-ASCII.

By this change, all rbs files are read as UTF-8.
Nowadays, I think a major part of ruby (and RBS) code are in UTF-8. So
this gives good first aid for the issue.

A magic comment like `# encoding: something` may be needed in RBS as
well as ruby code, but I think it requires further discussion.