### PR TITLE
Remove File.exists?

### DIFF
--- a/core/file.rbs
+++ b/core/file.rbs
@@ -192,10 +192,6 @@ class File < IO
   #
   def self.exist?: (string | _ToPath | IO file_name) -> bool
 
-  # Deprecated method. Don't use.
-  #
-  alias self.exists? self.exist?
-
   # Converts a pathname to an absolute pathname. Relative paths are referenced
   # from the current working directory of the process unless `dir_string` is
   # given, in which case it will be used as the starting point. The given pathname

--- a/test/stdlib/File_test.rb
+++ b/test/stdlib/File_test.rb
@@ -228,11 +228,6 @@ class FileSingletonTest < Minitest::Test
                      File, :exist?, IO.new(IO.sysopen(__FILE__))
   end
 
-  def test_exists?
-    assert_send_type "(String) -> bool",
-                     File, :exists?, __FILE__
-  end
-
   def test_expand_path
     assert_send_type "(String) -> String",
                      File, :expand_path, __FILE__


### PR DESCRIPTION
`File.exists?` is deprecated and will be removed in Ruby 3.