### PR TITLE
Fix runtime type checker for blocks with keyword args

### DIFF
--- a/lib/rbs/test/hook.rb
+++ b/lib/rbs/test/hook.rb
@@ -81,7 +81,8 @@ def #{with_name}(*args, &block)
 
     if block_given?
       receiver = self
-      result = __send__(:"#{without_name}", *args) do |*block_args|
+
+      wrapped_block = proc do |*block_args|
         return_from_block = false
 
         begin
@@ -117,7 +118,9 @@ def #{with_name}(*args, &block)
         end
 
         block_result
-      end
+      end.ruby2_keywords
+
+      result = __send__(:"#{without_name}", *args, &wrapped_block)
     else
       result = __send__(:"#{without_name}", *args)
     end

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -249,4 +249,21 @@ end
 Bar.new.foo(30)
 RUBY
   end
+
+  def test_block_keywords
+    assert_test_success(other_env: { 'RBS_TEST_TARGET' => 'A' }, rbs_content: <<RBS, ruby_content: <<'RUBY')
+class A
+  def call: (untyped) { (untyped) -> void } -> void
+end
+RBS
+
+class A
+  def call(val, &block)
+    yield(value: val)
+  end
+end
+
+A.new.call("foo") {|value:| puts value }
+RUBY
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/ruby/rbs/issues/480