### PR TITLE
Add support for escape sequences in double quoted rbs strings

### DIFF
--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -1294,6 +1294,10 @@ ANNOTATION_RE = Regexp.union(/%a\{.*?\}/,
                              /%a\(.*?\)/,
                              /%a\<.*?\>/,
                              /%a\|.*?\|/)
+
+escape_sequences = %w[a b e f n r s t v "].map { |l| "\\\\#{l}" }
+DBL_QUOTE_STR_ESCAPE_SEQUENCES_RE = /(#{escape_sequences.join("|")})/
+
 def next_token
   if @type
     type = @type
@@ -1373,7 +1377,21 @@ def next_token
   when input.scan(/[a-z_]\w*\b/)
     new_token(:tLIDENT)
   when input.scan(/"(\\"|[^"])*"/)
-    s = input.matched.yield_self {|s| s[1, s.length - 2] }.gsub(/\\"/, '"')
+    s = input.matched.yield_self {|s| s[1, s.length - 2] }
+                     .gsub(DBL_QUOTE_STR_ESCAPE_SEQUENCES_RE) do |match|
+                       case match
+                       when '\\a' then "\a"
+                       when '\\b' then "\b"
+                       when '\\e' then "\e"
+                       when '\\f' then "\f"
+                       when '\\n' then "\n"
+                       when '\\r' then "\r"
+                       when '\\s' then "\s"
+                       when '\\t' then "\t"
+                       when '\\v' then "\v"
+                       when '\\"' then '"'
+                       end
+                     end
     new_token(:tSTRING, s)
   when input.scan(/'(\\'|[^'])*'/)
     s = input.matched.yield_self {|s| s[1, s.length - 2] }.gsub(/\\'/, "'")

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -536,6 +536,16 @@ class RBS::TypeParsingTest < Minitest::Test
       assert_instance_of Types::Literal, type
       assert_equal "super \" duper", type.literal
     end
+
+    Parser.parse_type('"escape sequences \a\b\e\f\n\r\s\t\v\""').yield_self do |type|
+      assert_instance_of Types::Literal, type
+      assert_equal "escape sequences \a\b\e\f\n\r\s\t\v\"", type.literal
+    end
+
+    Parser.parse_type(%q{'not escape sequences \a\b\e\f\n\r\s\t\v\"'}).yield_self do |type|
+      assert_instance_of Types::Literal, type
+      assert_equal 'not escape sequences \a\b\e\f\n\r\s\t\v\"', type.literal
+    end
   end
 
   def test_record

--- a/test/rbs/types_test.rb
+++ b/test/rbs/types_test.rb
@@ -9,6 +9,8 @@ class RBS::TypesTest < Minitest::Test
     assert_equal "Array[Integer]", parse_type("Array[Integer]").to_s
     assert_equal "Array[Integer]?", parse_type("Array[Integer]?").to_s
     assert_equal '"foo"?', parse_type('"foo" ?').to_s
+    assert_equal '"foo\\\\n"', parse_type(%q{'foo\n'}).to_s
+    assert_equal '"foo\\n"', parse_type('"foo\n"').to_s
     assert_equal ":foo ?", parse_type(":foo ?").to_s
     assert_equal "[ Integer, bool? ]", parse_type("[Integer, bool?]").to_s
     assert_equal "[ ]", parse_type("[   ]").to_s


### PR DESCRIPTION
I came across these earlier:
```ruby
class A
  B = "a\nb"
end
```
```ruby
class A
  B: "a\nb"
end
```
They were incompatible because rbs appeared to be handling double-quoted strings differently to ruby. This PR aims to bring support for newlines and other relatively common escape sequences
```ruby
# rbs - existing workaround (for new lines at least)
class A
  B: "a
b"
end
```