### PR TITLE
Make the order of RBS load reproducible

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -102,7 +102,7 @@ module RBS
           end
         end
 
-        path.each_child do |child|
+        path.children.sort.each do |child|
           each_file(child, immediate: false, skip_hidden: skip_hidden, &block)
         end
       end


### PR DESCRIPTION
Formerly, the order in which RBS files in a directory are loaded
depended upon the file system, because of Pathname#each_child.

It is a bit unuseful because TypeProf uses the order to print the
classes, and thus, the CI sometimes fails depending upon the filesystem.

https://github.com/ruby/typeprof/runs/1506276392?check_suite_focus=true#step:5:195
```
diff:
  # Classes
- class Hash
-   @baz : Integer
- end
-
  class Symbol
    @foo : Integer
  end

  class Array
    @bar : Integer
  end
+
+ class Hash
+   @baz : Integer
+ end
```

This changeset makes it reproducible by manual sorting.
I believe that the additional cost is neglectable because we will not
put tons of RBS files in one directory, and because the RBS parser is
much slower :-)