### PR TITLE
Fix ruby2_keywords for Proc in Ruby <2.7

### DIFF
--- a/lib/rbs/test.rb
+++ b/lib/rbs/test.rb
@@ -100,6 +100,8 @@ end
 
 unless ::Proc.instance_methods.include?(:ruby2_keywords)
   class Proc
-    def ruby2_keywords; end
+    def ruby2_keywords
+      self
+    end
   end
 end


### PR DESCRIPTION
We should return `self` for Procs.

Otherwise hook makes `wrapped_block` to be nil here: https://github.com/ruby/rbs/blob/71b8e534e0adcc78aa76ffbd0326ffe01594d520/lib/rbs/test/hook.rb#L121 