### PR TITLE
Add `include MonitorMixin` to Logger::LogDevice

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,10 @@ task :validate => :parser do
       lib << "pstore"
     end
 
+    if lib == ["logger"]
+      lib << "monitor"
+    end
+
     sh "#{ruby} #{rbs} #{lib.map {|l| "-r #{l}"}.join(" ")} validate --silent"
   end
 end

--- a/stdlib/logger/0/log_device.rbs
+++ b/stdlib/logger/0/log_device.rbs
@@ -1,7 +1,6 @@
 class Logger
   class LogDevice
-    # TODO: Write type signature for MonitorMixin
-    # include MonitorMixin
+    include MonitorMixin
 
     include Period
 


### PR DESCRIPTION
Logger type has been added in #316, but MonitorMixin type didn't exist at that time.
Recently I added MonitorMixin type by #485, so we can add the `include`
clause to Logger::LogDevice.