### PR TITLE
Run the smoke test for RBS::Writer with all RBS in this repository

### DIFF
--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -212,10 +212,8 @@ end
   end
 
   def test_smoke
-    Pathname.glob('stdlib/**/*.rbs').each do |path|
-      orig_decls = RBS::Parser.parse_signature(path.read).reject do |decl|
-        decl.is_a?(RBS::AST::Declarations::Extension)
-      end
+    Pathname.glob('{stdlib,core,sig}/**/*.rbs').each do |path|
+      orig_decls = RBS::Parser.parse_signature(path.read)
 
       io = StringIO.new
       w = RBS::Writer.new(out: io)


### PR DESCRIPTION
I added this smoke test for RBS::Writer in https://github.com/ruby/rbs/pull/146.
RBS files are only under `stdlib/` directory at that time, but now it also has `core` and `sig` directory.
So we can execute the test with the directories to test with more RBSs.


---



By the way, I considered using a more flexible glob, like `**/*.rbs`. But personally I think it is not a good idea because it is too loose. For example, sometimes I put `test.rb` at the top level of this repository to test something. But the loose glob catches the `test.rb` unexpectedly. So I prefer specifying these directories to the loose glob.

---


The `RBS::AST::Declarations::Extension` guard looks unnecessary, because the test passes without the guard. I guess some RBS used `extension` syntax previously, but now `extention` syntax isn't used by the RBSs that are included in this repository.
