### PR TITLE
Improve `IO.binread` and `IO.binwrite` signatures

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -510,9 +510,20 @@ class IO < Object
 
   def write: (*_ToS arg0) -> Integer
 
+  # Opens the file, optionally seeks to the given *offset*, then returns *length*
+  # bytes (defaulting to the rest of the file). #binread ensures the file is
+  # closed before returning.  The open mode would be `"rb:ASCII-8BIT"`.
+  #
+  #     IO.binread("testfile")           #=> "This is line one\nThis is line two\nThis is line three\nAnd so on...\n"
+  #     IO.binread("testfile", 20)       #=> "This is line one\nThi"
+  #     IO.binread("testfile", 20, 10)   #=> "ne one\nThis is line "
+  #
   def self.binread: (String name, ?Integer length, ?Integer offset) -> String
 
-  def self.binwrite: (String name, _ToS arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> Integer
+  # Same as IO.write except opening the file in binary mode and ASCII-8BIT
+  # encoding (`"wb:ASCII-8BIT"`).
+  #
+  def self.binwrite: (String name, _ToS string, ?Integer offset, ?mode: String mode) -> Integer
 
   def self.copy_stream: (_Reader src, _Writer dst, ?Integer copy_length, ?Integer src_offset) -> Integer
 

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -1,0 +1,32 @@
+require_relative "test_helper"
+
+class IOSingletonTest < Minitest::Test
+  include TypeAssertions
+
+  testing "singleton(::IO)"
+
+  def test_binread
+    assert_send_type "(String) -> String",
+                     IO, :binread, __FILE__
+    assert_send_type "(String, Integer) -> String",
+                     IO, :binread, __FILE__, 3
+    assert_send_type "(String, Integer, Integer) -> String",
+                     IO, :binread, __FILE__, 3, 0
+  end
+
+  def test_binwrite
+    Dir.mktmpdir do |dir|
+      filename = File.join(dir, "some_file")
+      content = "foo"
+
+      assert_send_type "(String, String) -> Integer",
+                       IO, :binwrite, filename, content
+      assert_send_type "(String, String, Integer) -> Integer",
+                       IO, :binwrite, filename, content, 0
+      assert_send_type "(String, String, mode: String) -> Integer",
+                       IO, :binwrite, filename, content, mode: "a"
+      assert_send_type "(String, String, Integer, mode: String) -> Integer",
+                       IO, :binwrite, filename, content, 0, mode: "a"
+    end
+  end
+end


### PR DESCRIPTION
This change aims to improve the signatures of `IO.binread` and `IO.binwrite`.

- Add missing documents.
- Add missing tests.
- Improve the argument types of the `.binwrite` method.

In creating this change, I refer to the following resources:

- https://github.com/ruby/ruby/blob/ruby_2_7/spec/ruby/core/io/binread_spec.rb
- https://github.com/ruby/ruby/blob/ruby_2_7/spec/ruby/core/io/binwrite_spec.rb
- https://github.com/ruby/ruby/blob/ruby_2_7/spec/ruby/core/io/shared/binwrite.rb
- https://ruby-doc.org/core-2.7.2/IO.html#method-c-binread
- https://ruby-doc.org/core-2.7.2/IO.html#method-c-binwrite