### PR TITLE
Fix aliasing from implemented interface

### DIFF
--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -34,6 +34,20 @@ module RBS
           @implemented_in = implemented_in
         end
 
+        def ==(other)
+          other.is_a?(TypeDef) &&
+            other.type == type &&
+            other.member == member &&
+            other.defined_in == defined_in &&
+            other.implemented_in == implemented_in
+        end
+
+        alias eql? ==
+
+        def hash
+          self.class.hash ^ type.hash ^ member.hash ^ defined_in.hash ^ implemented_in.hash
+        end
+
         def comment
           member.comment
         end
@@ -68,6 +82,21 @@ module RBS
         @accessibility = accessibility
         @extra_annotations = annotations
         @alias_of = alias_of
+      end
+
+      def ==(other)
+        other.is_a?(Method) &&
+          other.super_method == super_method &&
+          other.defs == defs &&
+          other.accessibility == accessibility &&
+          other.annotations == annotations &&
+          other.alias_of == alias_of
+      end
+
+      alias eql? ==
+
+      def hash
+        self.class.hash ^ super_method.hash ^ defs.hash ^ accessibility.hash ^ annotations.hash ^ alias_of.hash
       end
 
       def defined_in

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -257,12 +257,6 @@ module RBS
 
       super "#{Location.to_string location}: Unknown method alias name: #{original_name} => #{aliased_name}"
     end
-
-    def self.check!(methods:, original_name:, aliased_name:, location:)
-      unless methods.key?(original_name)
-        raise new(original_name: original_name, aliased_name: aliased_name, location: location)
-      end
-    end
   end
 
   class SuperclassMismatchError < StandardError

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1660,4 +1660,32 @@ end
       end
     end
   end
+
+  def test_interface_alias
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+interface _I1
+  def foo: () -> void
+end
+
+class C0
+  include _I1
+
+  alias bar foo
+end
+      EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::C0")).tap do |defn|
+          defn.methods[:bar].tap do |bar|
+            assert_equal defn.methods[:foo], bar.alias_of
+            assert_equal type_name("::C0"), bar.defined_in
+            assert_equal type_name("::C0"), bar.implemented_in
+            assert_nil bar.super_method
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
```rbs
interface _I0
  def foo: () -> void
end

class C0
  include _I0

  alias bar foo
end
```