### PR TITLE
Fix self types in module

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -10,7 +10,7 @@
 # ```ruby
 # sprintf "%.1f", 1.234 #=> "1.2"
 # ```
-module Kernel
+module Kernel : BasicObject
   private
 
   def caller: (?Integer start_or_range, ?Integer length) -> ::Array[String]?

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -150,7 +150,11 @@ module RBS
 
             if one_ancestors.self_types
               one_ancestors.self_types.each do |ans|
-                defn = build_interface(ans.name)
+                defn = if ans.name.interface?
+                         build_interface(ans.name)
+                       else
+                         build_instance(ans.name)
+                       end
 
                 # Successor interface method overwrites.
                 merge_definition(src: defn,

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -68,18 +68,20 @@ module RBS
     attr_reader :location
 
     def initialize(ancestors:, location:)
-      last = case last = ancestors.last
-             when Definition::Ancestor::Singleton
-               "singleton(#{last.name})"
-             when Definition::Ancestor::Instance
-               if last.args.empty?
-                 last.name.to_s
-               else
-                 "#{last.name}[#{last.args.join(", ")}]"
-               end
-             end
+      names = ancestors.map do |ancestor|
+        case ancestor
+        when Definition::Ancestor::Singleton
+          "singleton(#{ancestor.name})"
+        when Definition::Ancestor::Instance
+          if ancestor.args.empty?
+            ancestor.name.to_s
+          else
+            "#{ancestor.name}[#{ancestor.args.join(", ")}]"
+          end
+        end
+      end
 
-      super "#{Location.to_string location}: Detected recursive ancestors: #{last}"
+      super "#{Location.to_string location}: Detected recursive ancestors: #{names.join(" < ")}"
     end
 
     def self.check!(self_ancestor, ancestors:, location:)

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -140,6 +140,26 @@ EOF
     end
   end
 
+  def test_one_ancestors_module_no_self_type
+    SignatureManager.new(system_builtin: true) do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+module M
+end
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+        builder.one_instance_ancestors(type_name("::M")).tap do |a|
+          assert_equal type_name("::M"), a.type_name
+          assert_equal [], a.params
+          assert_nil a.super_class
+          assert_equal [Ancestor::Instance.new(name: type_name("::Object"), args: [], source: nil)],
+                       a.self_types
+        end
+      end
+    end
+  end
+
   def test_one_ancestors_interface
     SignatureManager.new(system_builtin: true) do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -264,7 +264,7 @@ EOF
           assert_equal parse_type("::Foo[X]", variables: [:X]), definition.self_type
           assert_equal [:X], definition.type_params
 
-          assert_equal Set[:get], Set.new(definition.methods.keys)
+          assert_operator Set[:get], :subset?, Set.new(definition.methods.keys)
           assert_method_definition definition.methods[:get], ["() -> X"], accessibility: :public
 
           assert_equal Set[:@value], Set.new(definition.instance_variables.keys)
@@ -298,7 +298,7 @@ EOF
           assert_equal parse_type("::M2"), definition.self_type
           assert_equal [], definition.type_params
 
-          assert_equal Set[:get], Set.new(definition.methods.keys)
+          assert_operator Set[:get], :subset?, Set.new(definition.methods.keys)
           assert_method_definition definition.methods[:get], ["(::Integer) -> ::String", "() -> ::String"], accessibility: :public
 
           assert_equal Set[:@value], Set.new(definition.instance_variables.keys)
@@ -331,7 +331,7 @@ EOF
           assert_equal parse_type("::M2"), definition.self_type
           assert_equal [], definition.type_params
 
-          assert_equal Set[:get], Set.new(definition.methods.keys)
+          assert_operator Set[:get], :subset?, Set.new(definition.methods.keys)
           assert_method_definition definition.methods[:get], ["(::Integer) -> ::String", "() -> ::String"], accessibility: :public
 
           assert definition.methods[:get].defs.all? {|td| td.implemented_in == TypeName("::M2") }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -94,7 +94,7 @@ class Object < BasicObject
   def respond_to_missing?: (Symbol, bool) -> bool
 end
 
-module Kernel
+module Kernel : BasicObject
   private
   def puts: (*untyped) -> nil
 end
@@ -139,7 +139,7 @@ SIG
           absolute_path.write(content)
         end
 
-        root = 
+        root =
           if system_builtin
             RBS::EnvironmentLoader::DEFAULT_CORE_ROOT
           else


### PR DESCRIPTION
1. Fix `super_method` calculation
2. Let `self_types` be classes
3. Assume `Object` is included in the `self_types` of modules if not specified

The 3 results in that we need to explicitly specify `self_types` if we want to `include` a module in `Object`

```
module M
end

class Object
  include M     # M implicitly assumes Object is the `self_type`, which causes a loop in ancestor chain.
end
```

The workaround is to specify `BasicObject` or an interface.

```
interface _WithSend
  def send: (Symbol) -> untyped
end

module M : _WithSend
end
```