### PR TITLE
[prototype runtime] Use the original Module#name to avoid generating incorrect module name

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -302,7 +302,7 @@ module RBS
                  end
 
           @decls << AST::Declarations::Constant.new(
-            name: "#{mod.to_s}::#{name}",
+            name: "#{const_name(mod)}::#{name}",
             type: type,
             location: nil,
             comment: nil
@@ -311,14 +311,14 @@ module RBS
       end
 
       def generate_class(mod)
-        type_name = to_type_name(mod.name)
+        type_name = to_type_name(const_name(mod))
         super_class = if mod.superclass == ::Object
                         nil
-                      elsif mod.superclass.name.nil?
+                      elsif const_name(mod.superclass).nil?
                         RBS.logger.warn("Skipping anonymous superclass #{mod.superclass} of #{mod}")
                         nil
                       else
-                        AST::Declarations::Class::Super.new(name: to_type_name(mod.superclass.name), args: [], location: nil)
+                        AST::Declarations::Class::Super.new(name: to_type_name(const_name(mod.superclass)), args: [], location: nil)
                       end
 
         decl = AST::Declarations::Class.new(
@@ -332,12 +332,12 @@ module RBS
         )
 
         each_mixin(mod.included_modules, *mod.superclass.included_modules, *mod.included_modules.flat_map(&:included_modules)) do |included_module|
-          unless included_module.name
+          unless const_name(included_module)
             RBS.logger.warn("Skipping anonymous module #{included_module} included in #{mod}")
             next
           end
 
-          module_name = to_type_name(included_module.name)
+          module_name = to_type_name(const_name(included_module))
           if module_name.namespace == type_name.namespace
             module_name = TypeName.new(name: module_name.name, namespace: Namespace.empty)
           end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -219,4 +219,47 @@ end
       end
     end
   end
+
+  module TestForOverrideModuleName
+    module M
+      def self.name() 'FakeNameM' end
+      def self.to_s() 'FakeToS' end
+      X = 1
+    end
+
+    class C
+      def self.name() 'FakeNameC' end
+      include M
+    end
+
+    class C2 < C
+    end
+  end
+
+  def test_for_overwritten_module_name
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForOverrideModuleName::*"], env: env, merge: true)
+
+        assert_write p.decls, <<~RBS
+          class RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
+            include M
+
+            def self.name: () -> untyped
+          end
+
+          class RBS::RuntimePrototypeTest::TestForOverrideModuleName::C2 < RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
+          end
+
+          module RBS::RuntimePrototypeTest::TestForOverrideModuleName::M
+            def self.name: () -> untyped
+
+            def self.to_s: () -> untyped
+          end
+
+          RBS::RuntimePrototypeTest::TestForOverrideModuleName::M::X: Integer
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Problem

`rbs prototype runtime` command generates RBS with incorrect module names if `Module#name` is re-defined.
For example:

```ruby
# test.rb

module X
  module M
    def self.name() 'FakeNameM' end
    def self.to_s() 'FakeToS' end
    X = 1
  end

  class C
    def self.name() 'FakeNameC' end
    include M
  end

  class C2 < C
  end
end
```

```bash
$ exe/rbs prototype runtime -R test.rb X::*
class FakeNameC                 # ← It should be C, but not
  include FakeNameM             # ← It should be M, but not

  def self.name: () -> untyped
end

class FakeNameC < FakeNameC     # ← It should be X::C2 < C, but not
end

module X::M
  def self.name: () -> untyped

  def self.to_s: () -> untyped
end

FakeToS::X: Integer             # ← It should be X::M::X, but not
```

# Solution

This pull request fixes this problem by using the original `Module#name` to get a constant name.
It will display the following result. 


```bash
$ exe/rbs prototype runtime -R test.rb X::*
class X::C
  include M

  def self.name: () -> untyped
end

class X::C2 < X::C
end

module X::M
  def self.name: () -> untyped

  def self.to_s: () -> untyped
end

X::M::X: Integer
```


---

By the way, `prototype runtime` still uses other Module's methods that can be re-defined. For example, it uses `Module#instance_method` to get a method object of a module.
At first, I thought I should replace them with the original methods, but I didn't.
Because I guess it is not problematic in most cases. On the contrary, redefined methods can be more appropriate than the original methods.
For example, delegator's `instance_method` is re-defined to work with delegated methods.  https://github.com/ruby/ruby/blob/53e352fd718cd2cae6d77298e6e92736dddcfeeb/lib/delegate.rb#L436 
So I think we don't need to use the original method for them. 