### PR TITLE
Remove `[options...]` from help message of prototype rb(i) commands

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -626,7 +626,7 @@ EOU
 
       opts = OptionParser.new
       opts.banner = <<EOU
-Usage: rbs prototype #{format} [options...] [files...]
+Usage: rbs prototype #{format} [files...]
 #{availability}
 Generate RBS prototype from source code.
 It parses specified Ruby code and and generates RBS prototypes.


### PR DESCRIPTION
Because they receive no options.


I've confirmed other help messages correspond with the implementations. :heavy_check_mark: 