### PR TITLE
Add Goodcheck rule for boolish

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -28,6 +28,26 @@ rules:
     pass:
       - "def `send`: (String | Symbol, *untyped) -> untyped"
 
+  - id: rbs.prefer_boolish
+    pattern:
+      - regexp: '\([^(]*\bbool\b[^\n]*\)'
+      - token: "-> bool }"
+    message: |
+      Prefer `boolish` over `bool` for method arguments and block return values
+
+      See the doc below:
+      https://github.com/ruby/rbs/blob/78d04a2db0f1c4925d2b13c2939868edf9465d6c/docs/syntax.md#bool-or-boolish
+    glob:
+      - "**/*.rbs"
+    justification:
+      - When you strictly want `true | false`.
+    pass:
+      - "(arg: boolish)"
+      - "{ () -> boolish }"
+    fail:
+      - "(arg: bool)"
+      - "{ () -> bool }"
+
   - id: deprecate_stdlib_test
     pattern:
       token: < StdlibTest


### PR DESCRIPTION
The syntax document (`docs/syntax.md`) says:

> We recommend using `boolish` for method arguments and block return values, if you only use the values for conditions.
> You can write `bool` if you strictly want `true | false`.

so this change adds a Goodcheck rule to check the recommendation above about the use of `boolish`.

See also:
- https://github.com/ruby/rbs/blob/78d04a2db0f1c4925d2b13c2939868edf9465d6c/docs/syntax.md#bool-or-boolish
- https://github.com/ruby/rbs/pull/529#issuecomment-748168144

For example:

<details>
<summary><code>bundle exec goodcheck check -R rbs.prefer_boolish core</code></summary>

```
core/complex.rbs:168:14: Prefer `boolish` over `bool` for method arguments and block return values
  def clone: (?freeze: bool) -> self
             ^~~~~~~~~~~~~~~
core/exception.rbs:193:21: Prefer `boolish` over `bool` for method arguments and block return values
  def full_message: (?highlight: bool, ?order: :top | :bottom) -> String
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/float.rbs:174:14: Prefer `boolish` over `bool` for method arguments and block return values
  def clone: (?freeze: bool) -> self
             ^~~~~~~~~~~~~~~
core/integer.rbs:274:14: Prefer `boolish` over `bool` for method arguments and block return values
  def clone: (?freeze: bool) -> self
             ^~~~~~~~~~~~~~~
core/kernel.rbs:121:16: Prefer `boolish` over `bool` for method arguments and block return values
  def Complex: (Numeric | String x, ?Numeric | String y, ?exception: bool exception) -> Complex
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/kernel.rbs:123:14: Prefer `boolish` over `bool` for method arguments and block return values
  def Float: (Numeric | String x, ?exception: bool exception) -> Float
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/kernel.rbs:127:16: Prefer `boolish` over `bool` for method arguments and block return values
  def Integer: (Numeric | String arg, ?exception: bool exception) -> Integer
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/kernel.rbs:128:16: Prefer `boolish` over `bool` for method arguments and block return values
             | (String arg, ?Integer base, ?exception: bool exception) -> Integer
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/kernel.rbs:130:17: Prefer `boolish` over `bool` for method arguments and block return values
  def Rational: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/object.rbs:79:14: Prefer `boolish` over `bool` for method arguments and block return values
  def clone: (?freeze: bool) -> self
             ^~~~~~~~~~~~~~~
core/object_space.rbs:89:29: Prefer `boolish` over `bool` for method arguments and block return values
  def self.garbage_collect: (?full_mark: bool, ?immediate_mark: bool, ?immediate_sweep: bool) -> void
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/object_space.rbs:97:24: Prefer `boolish` over `bool` for method arguments and block return values
  def garbage_collect: (?full_mark: bool, ?immediate_mark: bool, ?immediate_sweep: bool) -> void
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core/rational.rbs:177:14: Prefer `boolish` over `bool` for method arguments and block return values
  def clone: (?freeze: bool) -> self
             ^~~~~~~~~~~~~~~
core/thread.rbs:457:21: Prefer `boolish` over `bool` for method arguments and block return values
  def status: () -> (String | bool)?
                    ^~~~~~~~~~~~~~~

57 files inspected, 14 issues detected
```

</details>

**NOTE: This new rule can report some false positives, so please reject if you don't really want.**