### PR TITLE
[prototype runtime] Remove overwritable `Class#to_s` call

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -298,7 +298,7 @@ module RBS
                      location: nil
                    )
                  else
-                   Types::ClassInstance.new(name: to_type_name(value.class.to_s), args: [], location: nil)
+                   Types::ClassInstance.new(name: to_type_name(const_name(value.class)), args: [], location: nil)
                  end
 
           @decls << AST::Declarations::Constant.new(

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -229,8 +229,12 @@ end
 
     class C
       def self.name() 'FakeNameC' end
+      def self.to_s() 'FakeToS2' end
       include M
+
+      INSTANCE = C.new
     end
+
 
     class C2 < C
     end
@@ -246,7 +250,11 @@ end
             include M
 
             def self.name: () -> untyped
+
+            def self.to_s: () -> untyped
           end
+
+          RBS::RuntimePrototypeTest::TestForOverrideModuleName::C::INSTANCE: RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
 
           class RBS::RuntimePrototypeTest::TestForOverrideModuleName::C2 < RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
           end


### PR DESCRIPTION
It is the same problem with #526, but I overlooked this method call in #526 :see_no_evil: 