### PR TITLE
[prototype runtime] Fill type arguments with untyped

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -50,7 +50,7 @@ module RBS::RuntimePrototypeTest::TestTargets::Bar
 end
 
 module RBS::RuntimePrototypeTest::TestTargets::Foo
-  include Enumerable
+  include Enumerable[untyped]
 
   extend Comparable
 end
@@ -109,7 +109,7 @@ module RBS::RuntimePrototypeTest::TestTargets::Bar
 end
 
 module RBS::RuntimePrototypeTest::TestTargets::Foo
-  include Enumerable
+  include Enumerable[untyped]
 
   extend Comparable
 end
@@ -286,6 +286,41 @@ end
           end
 
           RBS::RuntimePrototypeTest::TestForOverrideModuleName::M::X: Integer
+        RBS
+      end
+    end
+  end
+
+  module TestForTypeParameters
+    module M
+      HASH = { foo: 42 }
+    end
+
+    class C < Hash
+    end
+
+    class C2
+      include Enumerable
+    end
+  end
+
+  def test_for_type_parameters
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForTypeParameters::*"], env: env, merge: true)
+
+        assert_write p.decls, <<~RBS
+          class RBS::RuntimePrototypeTest::TestForTypeParameters::C < Hash[untyped, untyped]
+          end
+
+          class RBS::RuntimePrototypeTest::TestForTypeParameters::C2
+            include Enumerable[untyped]
+          end
+
+          module RBS::RuntimePrototypeTest::TestForTypeParameters::M
+          end
+
+          RBS::RuntimePrototypeTest::TestForTypeParameters::M::HASH: Hash[untyped, untyped]
         RBS
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -121,7 +121,11 @@ end
 module Comparable
 end
 
-module Enumerable[A, B]
+module Enumerable[A]
+end
+
+class Hash[unchecked out K, unchecked out V]
+  include Enumerable[[K, V]]
 end
 SIG
 


### PR DESCRIPTION
This pull request makes `rbs prototype runtime` to fill type arguments to super classes, included modules, and constant types.

Problem
===

Currently `rbs prototype runtime` isn't ware of type parameters.
So it generates unusable RBS for Array, Hash, and so on.
For example:

```ruby
class C < Array
  ARRAY = [1,2,3]
  HASH = { foo: 42 }
end

class C2
  include Enumerable
end
```

```console
$ rbs prototype runtime -R test.rb C C2
class C < Array      # it should be Array[something]
end

C::ARRAY: Array      # it should be Array[something]

C::HASH: Hash        # it should be Hash[something, something]

class C2
  include Enumerable # it should be Enumerable[something]
end
```

It doesn't pass `rbs validate` check.

```
$ rbs -I . validate --silent
/path/to/lib/rbs/errors.rb:33:in `check!': test.rbs:2:0...3:3: ::Array expects parameters [Elem], but given args [] (RBS::InvalidTypeApplicationError)
	from /path/to/lib/rbs/definition.rb:156:in `apply'
	from /path/to/lib/rbs/definition_builder.rb:294:in `instance_ancestors'
	from /path/to/lib/rbs/definition_builder.rb:409:in `block in build_instance'
	from /path/to/lib/rbs/definition_builder.rb:1098:in `try_cache'
	from /path/to/lib/rbs/definition_builder.rb:403:in `build_instance'
	from /path/to/lib/rbs/cli.rb:423:in `block in run_validate'
	from /path/to/lib/rbs/cli.rb:421:in `each_key'
	from /path/to/lib/rbs/cli.rb:421:in `run_validate'
	from /path/to/lib/rbs/cli.rb:113:in `run'
	from /path/to/exe/rbs:7:in `<top (required)>'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `load'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `<main>'
```

Solution
====

Fill type arguments with `untyped`.

So the command generates the following RBS with this patch.

```console
$ rbs prototype runtime -R test.rb C C2
class C < Array[untyped]
end

C::ARRAY: Array[untyped]

C::HASH: Hash[untyped, untyped]

class C2
  include Enumerable[untyped]
end
```

Note
===

* It uses `env` to search type parameters information. It means it only
  knows core classes by default. But we can use `-I`, `-r` options to
  change the loaded libraries.
* Currently it always fill type arguments with `untyped`. But I think we
  can guess the type arguments for Array and Hash constants. For
  example, `[1,2,3]` is `Array[Integer]`. So I'd like to support Array
  and Hash to output specific types in the future.
* I guess we can apply the same feature to `rbs prototype rb`, but this
  patch doesn't to keep this patch simple. It is future work.