### PR TITLE
[Writer] Escape method names that are invalid with `def` syntax

### DIFF
--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -232,10 +232,11 @@ module RBS
     def method_name(name)
       s = name.to_s
 
-      if /\A#{Parser::KEYWORDS_RE}\z/.match?(s)
-        "`#{s}`"
-      else
+      if [:tOPERATOR, :kAMP, :kHAT, :kSTAR, :kLT, :kEXCLAMATION, :kSTAR2, :kBAR].include?(Parser::PUNCTS[s]) ||
+          (/\A[a-zA-Z_]\w*[?!=]?\z/.match?(s) && !/\A#{Parser::KEYWORDS_RE}\z/.match?(s))
         s
+      else
+        "`#{s}`"
       end
     end
 

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -233,7 +233,7 @@ module RBS
       s = name.to_s
 
       if [:tOPERATOR, :kAMP, :kHAT, :kSTAR, :kLT, :kEXCLAMATION, :kSTAR2, :kBAR].include?(Parser::PUNCTS[s]) ||
-          (/\A[a-zA-Z_]\w*[?!=]?\z/.match?(s) && !/\A#{Parser::KEYWORDS_RE}\z/.match?(s))
+          (/\A[a-zA-Z_]\w*[?!=]?\z/.match?(s) && !/\Aself\??\z/.match?(s))
         s
       else
         "`#{s}`"

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -111,7 +111,11 @@ interface _Each[X, Y]
 
   def __id__: () -> Integer
 
-  def `def`: () -> Symbol
+  def def: () -> Symbol
+
+  def `self`: () -> void
+
+  def `self?`: () -> void
 
   def timeout: () -> Integer
 

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -115,6 +115,8 @@ interface _Each[X, Y]
 
   def timeout: () -> Integer
 
+  def `foo!=`: () -> Integer
+
   def `: (String) -> untyped
 end
     SIG


### PR DESCRIPTION
This pull request fixes the escaping strategy of RBS::Writer to escape invalid method names for `def` syntax correctly.



# Problem

Currently `RBS::Writer` doesn't escape invalid method names for `def` syntax. For example

```ruby
require 'rbs'
require 'stringio'

rbs = RBS::Parser.parse_signature(<<~RBS)
  class C
    def `foo!=`: () -> untyped
  end
RBS

io = StringIO.new

RBS::Writer.new(out: io).write(rbs)

puts io.string
# => class C
#      def foo!=: () -> untyped
#    end

RBS::Parser.parse_signature(io.string)
# => RBS::Parser::SyntaxError
```


I expect ``def `foo!=`: () -> untyped`` as the output, but it displays without backtick escaping. So it generates invalid RBS.


By the way, we can't define `foo!=` method with `def` syntax even in Ruby. But we can use `define_method` for this method name.

```ruby
class C
  define_method(:'foo!=') {}
end

p C.instance_methods(false) # => [:"foo!="]
```

# Solution


Escape method names correctly.

