### PR TITLE
Add signature for Module#const_source_location

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -443,6 +443,47 @@ class Module < Object
   #
   def const_set: (Symbol | String arg0, untyped arg1) -> untyped
 
+  # Returns the Ruby source filename and line number containing first definition
+  # of constant specified. If the named constant is not found, `nil` is returned.
+  # If the constant is found, but its source location can not be extracted
+  # (constant is defined in C code), empty array is returned.
+  #
+  # *inherit* specifies whether to lookup in `mod.ancestors` (`true` by default).
+  #
+  #     # test.rb:
+  #     class A
+  #       C1 = 1
+  #     end
+  #
+  #     module M
+  #       C2 = 2
+  #     end
+  #
+  #     class B < A
+  #       include M
+  #       C3 = 3
+  #     end
+  #
+  #     class A # continuation of A definition
+  #     end
+  #
+  #     p B.const_source_location('C3')           # => ["test.rb", 11]
+  #     p B.const_source_location('C2')           # => ["test.rb", 6]
+  #     p B.const_source_location('C1')           # => ["test.rb", 2]
+  #
+  #     p B.const_source_location('C2', false)    # => nil  -- don't lookup in ancestors
+  #
+  #     p Object.const_source_location('B')       # => ["test.rb", 9]
+  #     p Object.const_source_location('A')       # => ["test.rb", 1]  -- note it is first entry, not "continuation"
+  #
+  #     p B.const_source_location('A')            # => ["test.rb", 1]  -- because Object is in ancestors
+  #     p M.const_source_location('A')            # => ["test.rb", 1]  -- Object is not ancestor, but additionally checked for modules
+  #
+  #     p Object.const_source_location('A::C1')   # => ["test.rb", 2]  -- nesting is supported
+  #     p Object.const_source_location('String')  # => []  -- constant is defined in C code
+  #
+  def const_source_location: (Symbol | String name, ?boolish inherit) -> ([String, Integer] | [ ] | nil)
+
   # Returns an array of the names of the constants accessible in *mod*. This
   # includes the names of constants in any included modules (example at start of
   # section), unless the *inherit* parameter is set to `false`.

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -1,9 +1,45 @@
 require_relative "test_helper"
 
-class ModuleTest < StdlibTest
-  target Module
+class ModuleSingletonTest < Minitest::Test
+  include TypeAssertions
+
+  testing "singleton(::Module)"
 
   def test_used_modules
-    Module.used_modules
+    assert_send_type "() -> Array[Module]",
+                     Module, :used_modules
+  end
+end
+
+class ModuleInstanceTest < Minitest::Test
+  include TypeAssertions
+
+  testing "::Module"
+
+  module Foo
+    BAR = 1
+  end
+
+  def test_const_source_location
+    assert_send_type "(Symbol) -> [String, Integer]",
+                     Foo, :const_source_location, :BAR
+    assert_send_type "(Symbol) -> nil",
+                     Foo, :const_source_location, :UNKNOWN
+    assert_send_type "(String) -> [String, Integer]",
+                     Foo, :const_source_location, "BAR"
+    assert_send_type "(String) -> nil",
+                     Foo, :const_source_location, "UNKNOWN"
+    assert_send_type "(Symbol, true) -> [String, Integer]",
+                     Foo, :const_source_location, :BAR, true
+    assert_send_type "(String, nil) -> [String, Integer]",
+                     Foo, :const_source_location, "BAR", nil
+    assert_send_type "(Symbol) -> [ ]",
+                     Foo, :const_source_location, :String
+    assert_send_type "(String) -> [ ]",
+                     Foo, :const_source_location, "String"
+    assert_send_type "(Symbol, true) -> [ ]",
+                     Foo, :const_source_location, :String, true
+    assert_send_type "(String, nil) -> nil",
+                     Foo, :const_source_location, "String", nil
   end
 end


### PR DESCRIPTION
This change aims to add a missing signature for the `Module#const_source_location` method.
See the API doc: <https://ruby-doc.org/core-2.7.2/Module.html#const_source_location-method>
