### PR TITLE
Display other locations when DuplicatedMethodDefinitionError occurred

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -205,7 +205,11 @@ module RBS
       @method_name = method_name
       @members = members
 
-      super "#{Location.to_string location}: #{qualified_method_name} has duplicated definitions"
+      message = "#{Location.to_string location}: #{qualified_method_name} has duplicated definitions"
+      if members.size > 1
+        message << " in #{other_locations.map { |loc| Location.to_string loc }.join(', ')}"
+      end
+      super message
     end
 
     def qualified_method_name
@@ -219,6 +223,10 @@ module RBS
 
     def location
       members[0].location
+    end
+
+    def other_locations
+      members[1..-1].map(&:location)
     end
   end
 


### PR DESCRIPTION
This pull request improves the message of `DuplicatedMethodDefinitionError`.

# Problem


Currently `DuplicatedMethodDefinitionError` displays only one location, but duplicated methods are defined in two locations at least. So currently we can't find easily both method definitions from the error message.


For example

```ruby
# test.rbs

class C
  def foo: () -> untyped
end

class C
  def foo: () -> untyped
end
```

```bash
$ rbs -I . validate --silent
/path/to/lib/rbs/definition_builder/method_builder.rb:30:in `block in validate!': test.rbs:4:2...4:24: ::C#foo has duplicated definitions (RBS::DuplicatedMethodDefinitionError)
	from /path/to/lib/rbs/definition_builder/method_builder.rb:28:in `each_value'
	from /path/to/lib/rbs/definition_builder/method_builder.rb:28:in `validate!'
	from /path/to/lib/rbs/definition_builder/method_builder.rb:116:in `build_instance'
	from /path/to/lib/rbs/definition_builder.rb:139:in `block (2 levels) in build_instance'
	from <internal:kernel>:90:in `tap'
	from /path/to/lib/rbs/definition_builder.rb:137:in `block in build_instance'
	from /path/to/lib/rbs/definition_builder.rb:731:in `try_cache'
	from /path/to/lib/rbs/definition_builder.rb:126:in `build_instance'
	from /path/to/lib/rbs/cli.rb:423:in `block in run_validate'
	from /path/to/lib/rbs/cli.rb:421:in `each_key'
	from /path/to/lib/rbs/cli.rb:421:in `run_validate'
	from /path/to/lib/rbs/cli.rb:113:in `run'
	from /path/to/exe/rbs:7:in `<top (required)>'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `load'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `<main>'
```


# Solutoon

Display both locations in the error message.


The error message will be the following.

```bash

$ rbs -I . validate --silent
/path/to/lib/rbs/definition_builder/method_builder.rb:30:in `block in validate!': test.rbs:4:2...4:24: ::C#foo has duplicated definitions in test.rbs:8:2...8:24 (RBS::DuplicatedMethodDefinitionError)
	from /path/to/lib/rbs/definition_builder/method_builder.rb:28:in `each_value'
	from /path/to/lib/rbs/definition_builder/method_builder.rb:28:in `validate!'
	from /path/to/lib/rbs/definition_builder/method_builder.rb:116:in `build_instance'
	from /path/to/lib/rbs/definition_builder.rb:139:in `block (2 levels) in build_instance'
	from <internal:kernel>:90:in `tap'
	from /path/to/lib/rbs/definition_builder.rb:137:in `block in build_instance'
	from /path/to/lib/rbs/definition_builder.rb:731:in `try_cache'
	from /path/to/lib/rbs/definition_builder.rb:126:in `build_instance'
	from /path/to/lib/rbs/cli.rb:423:in `block in run_validate'
	from /path/to/lib/rbs/cli.rb:421:in `each_key'
	from /path/to/lib/rbs/cli.rb:421:in `run_validate'
	from /path/to/lib/rbs/cli.rb:113:in `run'
	from /path/to/exe/rbs:7:in `<top (required)>'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `load'
	from /home/pocke/.rbenv/versions/trunk/bin/rbs:23:in `<main>'
```