### PR TITLE
Add missing extended/included modules to stdlib

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,14 @@ task :validate => :parser do
       lib << "monitor"
     end
 
+    if lib == ["csv"]
+      lib << "forwardable"
+    end
+
+    if lib == ["prime"]
+      lib << "singleton"
+    end
+
     sh "#{ruby} #{rbs} #{lib.map {|l| "-r #{l}"}.join(" ")} validate --silent"
   end
 end

--- a/stdlib/csv/0/csv.rbs
+++ b/stdlib/csv/0/csv.rbs
@@ -160,6 +160,7 @@
 #
 class CSV < Object
   include Enumerable[untyped]
+  extend Forwardable
 
   # This method is intended as the primary interface for reading CSV files. You
   # pass a `path` and any `options` you wish to set for the read. Each row of file
@@ -408,6 +409,7 @@ CSV::VERSION: String
 #
 class CSV::Row < Object
   include Enumerable[untyped]
+  extend Forwardable
 
   # If a two-element Array is provided, it is assumed to be a header and field and
   # the pair is appended. A Hash works the same way with the key being the header
@@ -579,6 +581,7 @@ end
 #
 class CSV::Table[out Elem] < Object
   include Enumerable[untyped]
+  extend Forwardable
 
   # Constructs a new CSV::Table from `array_of_rows`, which are expected to be
   # CSV::Row objects. All rows are assumed to have the same headers.

--- a/stdlib/prime/0/prime.rbs
+++ b/stdlib/prime/0/prime.rbs
@@ -42,6 +42,12 @@
 #
 #
 class Prime
+  include Singleton
+
+  include Enumerable[Integer]
+
+  extend Enumerable[Integer]
+
   # Iterates the given block over all prime numbers.
   #
   # ## Parameters

--- a/stdlib/securerandom/0/securerandom.rbs
+++ b/stdlib/securerandom/0/securerandom.rbs
@@ -1,4 +1,6 @@
 module SecureRandom
+  extend Random::Formatter
+
   def self.alphanumeric: (?Integer?) -> String
   def self.base64: (?Integer?) -> String
   def self.hex: (?Integer?) -> String


### PR DESCRIPTION
This pull request adds missing `include`s and `extend`s to stdlib type definitions.


We use `rbs prototype runtime` to generate a prototype of standard library types, but it didn't output `extend` until #535.
So I guessed we have some missing `extend`s in stdlib. Actually, they have some missing `extend`s, so I added them.


# How 


I checked all RBS under `stdlib/` with `Klass.singleton_class.included_modules - Object.included_modules`.

By the way, I didn't check `core/` directory, because I was tired, and I guess we have a few (or nothing) `extend`s in core libraries.
