### PR TITLE
[prototype rb] Fix incorrect accessibility on `class << self` syntax

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -129,8 +129,12 @@ module RBS
             RBS.logger.warn "`class <<` syntax with not-self may be compiled to incorrect code: #{this}"
           end
 
+          accessibility = current_accessibility(decls)
+
           ctx = Context.initial.tap { |ctx| ctx.singleton = true }
           process_children(body, decls: decls, comments: comments, context: ctx)
+
+          decls << accessibility
 
         when :DEFN, :DEFS
             if node.type == :DEFN

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -401,6 +401,36 @@ end
     EOF
   end
 
+  def test_accessibility_and_sclass
+    parser = RB.new
+
+    rb = <<~RUBY
+      class C
+        class << self
+          private
+
+          def foo() end
+        end
+
+        def bar() end
+      end
+    RUBY
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<~RBS
+      class C
+        private
+
+        def self.foo: () -> nil
+
+        public
+
+        def bar: () -> nil
+      end
+    RBS
+  end
+
   def test_aliases
     parser = RB.new
 


### PR DESCRIPTION


`rbs prototype rb` generates incorrect accessibility if `private` is available in `class << self`.

for example

```ruby
class C
  class << self
    private

    def foo
    end
  end

  def bar
  end
end
```

```console
$ rbs prototype rb test.rb
class C
  private

  def self.foo: () -> nil

  def bar: () -> nil       # ← It should be public, but not
end
```


This pull request fixing this problem by inserting the correct accessibility member after `class << self`.