### PR TITLE
Declare supported ruby versions of rbs

### DIFF
--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = ">= 2.6"
 end


### PR DESCRIPTION
This PR provides a patch to declare ruby versions supported by rbs.