### PR TITLE
Add support for all operator symbols

### DIFF
--- a/lib/rbs/parser.rb
+++ b/lib/rbs/parser.rb
@@ -315,7 +315,7 @@ def next_token
     new_token(:tWRITE_ATTR)
   when input.scan(KEYWORDS_RE)
     new_token(KEYWORDS[input.matched], input.matched.to_sym)
-  when input.scan(/:((@{,2}|\$)?\w+(\?|\!)?|\+|\-)\b?/)
+  when input.scan(/:((@{,2}|\$)?\w+(\?|\!)?|[|&\/%~`^]|<=>|={2,3}|=~|[<>]{2}|[<>]=?|[-+]@?|\*{1,2}|\[\]=?|![=~]?)\b?/)
     s = input.matched.yield_self {|s| s[1, s.length] }.to_sym
     new_token(:tSYMBOL, s)
   when input.scan(/[+-]?\d[\d_]*/)

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -1361,7 +1361,7 @@ def next_token
     new_token(:tWRITE_ATTR)
   when input.scan(KEYWORDS_RE)
     new_token(KEYWORDS[input.matched], input.matched.to_sym)
-  when input.scan(/:((@{,2}|\$)?\w+(\?|\!)?|\+|\-)\b?/)
+  when input.scan(/:((@{,2}|\$)?\w+(\?|\!)?|[|&\/%~`^]|<=>|={2,3}|=~|[<>]{2}|[<>]=?|[-+]@?|\*{1,2}|\[\]=?|![=~]?)\b?/)
     s = input.matched.yield_self {|s| s[1, s.length] }.to_sym
     new_token(:tSYMBOL, s)
   when input.scan(/[+-]?\d[\d_]*/)

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -530,14 +530,13 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal :@@foo, type.literal
     end
 
-    Parser.parse_type(":+").yield_self do |type|
-      assert_instance_of Types::Literal, type
-      assert_equal :+, type.literal
-    end
+    operator_symbols = %i(| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ +@ -@ [] []= ` ! != !~)
 
-    Parser.parse_type(":-").yield_self do |type|
-      assert_instance_of Types::Literal, type
-      assert_equal :-, type.literal
+    operator_symbols.each do |symbol|
+      Parser.parse_type(symbol.inspect).yield_self do |type|
+        assert_instance_of Types::Literal, type
+        assert_equal symbol, type.literal
+      end
     end
 
     assert_raises Parser::SyntaxError do


### PR DESCRIPTION
This pull request adds support for all operator symbols.

RBS v1.0.0 recognizes only `:+` or `:-` as an operator symbol literal, while Ruby syntax allows the use of all redeclarable operators.

> シンボル
>
> (snip)
>
>  文法:
>
> ```
>`:' 識別子
> `:' 変数名
> `:' 演算子
> ```
>
> (snip)
>
> Symbol リテラルに指定できる演算子はメソッドとして再定義できる演算子だけです。演算子式 を参照して下さい。 
>
> (<cite>Cited from "[リテラル (Ruby 2.7.0 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/2.7.0/doc/spec=2fliteral.html#symbol)"</cite>)

> 再定義できる演算子(メソッド)
>
> +@, -@ は単項演算子 +, - を表しメソッド定義などではこの記法を利用します。 
>
> ```
> |  ^  &  <=>  ==  ===  =~  >   >=  <   <=   <<  >>
> +  -  *  /    %   **   ~   +@  -@  []  []=  ` ! != !~
> ```
>
> (<cite>Cited from "[演算子式 (Ruby 2.7.0 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/2.7.0/doc/spec=2foperator.html)"</cite>)

This pull request adds regex patterns to support all operator symbol literals. They are tested to be recognized as an `RBS::Types::Literal`.