### PR TITLE
Migrate to test-unit to make test run on Ruby 3.1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -33,8 +33,9 @@ jobs:
         gem install bundler
     - name: bundle config set with
       run: |
-        bundle config set --local with 'minitest'
-      if: "!contains(matrix.container_tag, 'master-nightly')"
+        echo "NO_MINITEST=true" >> $GITHUB_ENV
+        bundle config set --local without 'minitest'
+      if: "contains(matrix.container_tag, 'master-nightly')"
     - name: bin/setup
       run: |
         bin/setup

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         container_tag:
+        - master-nightly-focal
         - 3.0-focal
         - 2.7-bionic
         job:
@@ -26,10 +27,16 @@ jobs:
       run: |
         apt-get update
         apt-get install -y libdb-dev
-    - name: Install
+    - name: Install bundler
       run: |
         ruby -v
         gem install bundler
+    - name: bundle config set with
+      run: |
+        bundle config set --local with 'minitest'
+      if: "!contains(matrix.container_tag, 'master-nightly')"
+    - name: bin/setup
+      run: |
         bin/setup
     - name: Run test
       run: |

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,4 +42,3 @@ jobs:
     - name: Run test
       run: |
         bundle exec rake ${{ matrix.job }}
-      if: "!(matrix.job == 'stdlib_test' && contains(matrix.container_tag, '2.6'))"

--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,11 @@ gemspec
 
 # Development dependencies
 gem "rake"
-gem "minitest"
+gem "test-unit"
 gem "rspec"
 gem "racc"
 gem "rubocop"
 gem "rubocop-rubycw"
-gem "minitest-reporters"
 gem "json"
 gem "json-schema"
 gem 'stackprof'

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,7 @@ gem "rbs-amber", path: "test/assets/test-gem"
 group :ide, optional: true do
   gem "ruby-debug-ide"
 end
+
+group :minitest, optional: true do
+  gem "minitest"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 # Development dependencies
 gem "rake"
 gem "test-unit"
+gem "test-unit-rr"
 gem "rspec"
 gem "racc"
 gem "rubocop"

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,6 @@ group :ide, optional: true do
   gem "ruby-debug-ide"
 end
 
-group :minitest, optional: true do
+group :minitest do
   gem "minitest"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -115,7 +115,7 @@ namespace :generate do
           require_relative "test_helper"
 
           <%- unless class_methods.empty? -%>
-          class <%= klass %>SingletonTest < Minitest::Test
+          class <%= klass %>SingletonTest < Test::Unit::TestCase
             include TypeAssertions
 
             # library "pathname", "set", "securerandom"     # Declare library signatures to load
@@ -133,7 +133,7 @@ namespace :generate do
           <%- end -%>
 
           <%- unless instance_methods.empty? -%>
-          class <%= klass %>Test < Minitest::Test
+          class <%= klass %>Test < Test::Unit::TestCase
             include TypeAssertions
 
             # library "pathname", "set", "securerandom"     # Declare library signatures to load

--- a/bin/test_runner.rb
+++ b/bin/test_runner.rb
@@ -4,13 +4,12 @@ $LOAD_PATH << File.join(__dir__, "../lib")
 
 require "set"
 
-IS_RUBY_27 = Gem::Version.new(RUBY_VERSION).yield_self do |ruby_version|
-  Gem::Version.new('2.7.0') <= ruby_version &&
-    ruby_version <= Gem::Version.new('2.8.0')
+IS_LATEST_RUBY = Gem::Version.new(RUBY_VERSION).yield_self do |ruby_version|
+  Gem::Version.new('3.0.0') <= ruby_version && ruby_version < Gem::Version.new('3.1.0')
 end
 
-unless IS_RUBY_27
-  STDERR.puts "⚠️⚠️⚠️⚠️ stdlib test assumes Ruby 2.7 but RUBY_VERSION==#{RUBY_VERSION} ⚠️⚠️⚠️⚠️"
+unless IS_LATEST_RUBY
+  STDERR.puts "⚠️⚠️⚠️⚠️ stdlib test assumes Ruby 3.0 but RUBY_VERSION==#{RUBY_VERSION} ⚠️⚠️⚠️⚠️"
 end
 
 KNOWN_FAILS = %w(dbm).map do |lib|

--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -71,7 +71,7 @@ rules:
         end
     pass:
       - |
-        class IntegerTest < Minitest::Test
+        class IntegerTest < Test::Unit::TestCase
           include TypeAssertions
 
           testing "Integer"

--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -38,7 +38,6 @@ module RBS
           nil
         end
       end
-
     end
   end
 end

--- a/test/assets/test1/hello.rb
+++ b/test/assets/test1/hello.rb
@@ -39,7 +39,7 @@ module Kaigi
   end
 end
 
-class Kaigi::ConferenceTest < Minitest::Test
+class Kaigi::ConferenceTest < Test::Unit::TestCase
   def test_1
     conference = Kaigi::Conference.new
 

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::AncestorBuilderTest < Minitest::Test
+class RBS::AncestorBuilderTest < Test::Unit::TestCase
   include TestHelper
 
   AST = RBS::AST

--- a/test/rbs/buffer_test.rb
+++ b/test/rbs/buffer_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::BufferTest < Minitest::Test
+class RBS::BufferTest < Test::Unit::TestCase
   Buffer = RBS::Buffer
 
   def test_buffer

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -223,7 +223,7 @@ singleton(::BasicObject)
         with_cli do |cli|
           cli.run(%w(vendor --vendor-dir=dir1))
 
-          assert_operator Pathname(d) + "dir1/core", :directory?
+          assert_predicate Pathname(d) + "dir1/core", :directory?
         end
       end
     end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require "stringio"
 require "rbs/cli"
 
-class RBS::CliTest < Minitest::Test
+class RBS::CliTest < Test::Unit::TestCase
   include TestHelper
 
   CLI = RBS::CLI

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -208,7 +208,7 @@ singleton(::BasicObject)
   end
 
   def test_paths_with_gem
-    skip unless has_gem?("rbs-amber")
+    omit unless has_gem?("rbs-amber")
 
     with_cli do |cli|
       cli.run(%w(-r rbs-amber paths))
@@ -230,7 +230,7 @@ singleton(::BasicObject)
   end
 
   def test_vendor_gem
-    skip unless has_gem?("rbs-amber")
+    omit unless has_gem?("rbs-amber")
 
     Dir.mktmpdir do |d|
       Dir.chdir(d) do

--- a/test/rbs/comment_test.rb
+++ b/test/rbs/comment_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::CommentTest < Minitest::Test
+class RBS::CommentTest < Test::Unit::TestCase
   include TestHelper
 
   def test_concat

--- a/test/rbs/constant_table_test.rb
+++ b/test/rbs/constant_table_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::ConstantTableTest < Minitest::Test
+class RBS::ConstantTableTest < Test::Unit::TestCase
   include TestHelper
 
   ConstantTable = RBS::ConstantTable

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::DefinitionBuilderTest < Minitest::Test
+class RBS::DefinitionBuilderTest < Test::Unit::TestCase
   include TestHelper
 
   AST = RBS::AST

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::EnvironmentLoaderTest < Minitest::Test
+class RBS::EnvironmentLoaderTest < Test::Unit::TestCase
   include TestHelper
 
   Environment = RBS::Environment

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -133,7 +133,7 @@ end
   end
 
   def test_loading_from_gem
-    skip unless has_gem?("rbs-amber")
+    omit unless has_gem?("rbs-amber")
 
     mktmpdir do |path|
       repo = RBS::Repository.new()
@@ -149,7 +149,7 @@ end
   end
 
   def test_loading_from_gem_without_rbs
-    skip unless has_gem?("minitest")
+    omit if skip_minitest?
 
     mktmpdir do |path|
       repo = RBS::Repository.new()

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::EnvironmentTest < Minitest::Test
+class RBS::EnvironmentTest < Test::Unit::TestCase
   include TestHelper
 
   Environment = RBS::Environment

--- a/test/rbs/environment_walker_test.rb
+++ b/test/rbs/environment_walker_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::EnvironmentWalkerTest < Minitest::Test
+class RBS::EnvironmentWalkerTest < Test::Unit::TestCase
   include TestHelper
 
   Environment = RBS::Environment

--- a/test/rbs/factory_test.rb
+++ b/test/rbs/factory_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::FactoryTest < Minitest::Test
+class RBS::FactoryTest < Test::Unit::TestCase
   include TestHelper
 
   def test_type_name

--- a/test/rbs/location_test.rb
+++ b/test/rbs/location_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::LocationTest < Minitest::Test
+class RBS::LocationTest < Test::Unit::TestCase
   Buffer = RBS::Buffer
   Location = RBS::Location
 

--- a/test/rbs/method_builder_test.rb
+++ b/test/rbs/method_builder_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::MethodBuilderTest < Minitest::Test
+class RBS::MethodBuilderTest < Test::Unit::TestCase
   include TestHelper
 
   AST = RBS::AST

--- a/test/rbs/method_type_parsing_test.rb
+++ b/test/rbs/method_type_parsing_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::MethodTypeParsingTest < Minitest::Test
+class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   Parser = RBS::Parser
   Buffer = RBS::Buffer
   Types = RBS::Types

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::RbPrototypeTest < Minitest::Test
+class RBS::RbPrototypeTest < Test::Unit::TestCase
   RB = RBS::Prototype::RB
 
   include TestHelper

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::RbiPrototypeTest < Minitest::Test
+class RBS::RbiPrototypeTest < Test::Unit::TestCase
   RBI = RBS::Prototype::RBI
 
   include TestHelper

--- a/test/rbs/repository_test.rb
+++ b/test/rbs/repository_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::RepositoryTest < Minitest::Test
+class RBS::RepositoryTest < Test::Unit::TestCase
   Repository = RBS::Repository
 
   def dir

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::RuntimePrototypeTest < Minitest::Test
+class RBS::RuntimePrototypeTest < Test::Unit::TestCase
   Runtime = RBS::Prototype::Runtime
   DefinitionBuilder = RBS::DefinitionBuilder
 

--- a/test/rbs/schema_test.rb
+++ b/test/rbs/schema_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "json_validator"
 
-class RBS::SchemaTest < Minitest::Test
+class RBS::SchemaTest < Test::Unit::TestCase
   include TestHelper
 
   def test_location_schema

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -1079,12 +1079,12 @@ end
 EOF
       decls[0].members[0].tap do |member|
         assert_instance_of Members::MethodDefinition, member
-        assert_operator member, :overload?
+        assert_predicate member, :overload?
       end
 
       decls[0].members[1].tap do |member|
         assert_instance_of Members::MethodDefinition, member
-        refute_operator member, :overload?
+        refute_predicate member, :overload?
       end
     end
   end
@@ -1098,7 +1098,7 @@ end
 EOF
         decls[0].members[0].tap do |member|
           assert_instance_of Members::MethodDefinition, member
-          assert_operator member, :overload?
+          assert_predicate member, :overload?
         end
       end
     end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::SignatureParsingTest < Minitest::Test
+class RBS::SignatureParsingTest < Test::Unit::TestCase
   Parser = RBS::Parser
   Buffer = RBS::Buffer
   Types = RBS::Types

--- a/test/rbs/test/hook_test.rb
+++ b/test/rbs/test/hook_test.rb
@@ -54,7 +54,7 @@ class RBS::Test::HookTest < Test::Unit::TestCase
     traces[0].tap do |t|
       assert_instance_of RBS::Test::CallTrace, t
       assert_equal :+, t.method_name
-      assert_operator t.method_call, :return?
+      assert_predicate t.method_call, :return?
       assert_equal [30], t.method_call.arguments
       assert_equal :plus, t.method_call.return_value
     end
@@ -79,7 +79,7 @@ class RBS::Test::HookTest < Test::Unit::TestCase
     traces[0].tap do |t|
       assert_instance_of RBS::Test::CallTrace, t
       assert_equal :hello, t.method_name
-      assert_operator t.method_call, :return?
+      assert_predicate t.method_call, :return?
       assert_equal [1,2], t.method_call.arguments
       assert_equal 3, t.method_call.return_value
     end
@@ -107,7 +107,7 @@ class RBS::Test::HookTest < Test::Unit::TestCase
       assert_instance_of RBS::Test::CallTrace, t
       assert_equal :hello, t.method_name
       assert_equal [1, 0], t.method_call.arguments
-      assert_operator t.method_call, :exception?
+      assert_predicate t.method_call, :exception?
       assert_instance_of RuntimeError, t.method_call.exception
       assert_equal "Aborting", t.method_call.exception.message
     end
@@ -136,7 +136,7 @@ class RBS::Test::HookTest < Test::Unit::TestCase
 
       assert_equal :world, t.method_name
 
-      assert_operator t.method_call, :return?
+      assert_predicate t.method_call, :return?
       assert_equal [1,2], t.method_call.arguments
       assert_equal :world, t.method_call.return_value
 
@@ -205,10 +205,10 @@ class RBS::Test::HookTest < Test::Unit::TestCase
 
       assert_equal :foo, t.method_name
 
-      assert_operator t.method_call, :return?
+      assert_predicate t.method_call, :return?
       assert_equal [{ x: "x", hello: :world }], t.method_call.arguments
       assert_equal "x", t.method_call.return_value
-      assert_operator t, :block_given
+      assert_predicate t, :block_given
       assert_empty t.block_calls
     end
   end

--- a/test/rbs/test/hook_test.rb
+++ b/test/rbs/test/hook_test.rb
@@ -5,7 +5,7 @@ require "logger"
 
 return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
 
-class RBS::Test::HookTest < Minitest::Test
+class RBS::Test::HookTest < Test::Unit::TestCase
   class Example
     def hello(x, y)
       raise "Aborting" if y == 0

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -136,7 +136,7 @@ RBS
   end
 
   def test_minitest
-    skip unless has_gem?("minitest")
+    omit if skip_minitest?
 
     assert_test_success(other_env: { 'RBS_TEST_TARGET' => 'Foo', 'RBS_TEST_DOUBLE_SUITE' => 'minitest' }, rbs_content: <<RBS, ruby_content: <<RUBY)
 class Foo
@@ -168,7 +168,7 @@ RUBY
   end
 
   def test_rspec
-    skip unless has_gem?("rspec")
+    omit unless has_gem?("rspec")
 
     assert_test_success(other_env: { "RBS_TEST_TARGET" => 'Foo', "RBS_TEST_DOUBLE_SUITE" => 'rspec' }, rbs_content: <<RBS, ruby_content: <<RUBY)
 class Foo

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -151,7 +151,7 @@ end
 
 require "minitest/autorun"
 
-class FooTest < Test::Unit::TestCase
+class FooTest < Minitest::Test
   def test_foo_mock
     # Confirm if mock is correctly ignored.
     Foo.new.foo(::Minitest::Mock.new)

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -4,7 +4,7 @@ require "logger"
 
 return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
 
-class RBS::Test::RuntimeTestTest < Minitest::Test
+class RBS::Test::RuntimeTestTest < Test::Unit::TestCase
   include TestHelper
 
   def test_runtime_success
@@ -151,7 +151,7 @@ end
 
 require "minitest/autorun"
 
-class FooTest < Minitest::Test
+class FooTest < Test::Unit::TestCase
   def test_foo_mock
     # Confirm if mock is correctly ignored.
     Foo.new.foo(::Minitest::Mock.new)

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -10,7 +10,7 @@ class RBS::Test::RuntimeTestTest < Test::Unit::TestCase
   def test_runtime_success
     output = assert_test_success()
     assert_match "Setting up hooks for ::Hello", output
-    refute_match "No type checker was installed!", output
+    refute_match /#{Regexp.escape("No type checker was installed!")}/, output
   end
 
   def test_runtime_test_with_sample_size
@@ -100,8 +100,8 @@ RUBY
 
   def test_no_test_install
     output = assert_test_success(other_env: { "RBS_TEST_TARGET" => "NO_SUCH_CLASS" })
-    refute_match "Setting up hooks for ::Hello", output
-    assert_match "No type checker was installed!", output
+    refute_match /#{Regexp.escape("Setting up hooks for ::Hello")}/, output
+    assert_match /#{Regexp.escape("No type checker was installed!")}/, output
   end
 
   def test_name_override

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "rbs/test"
 
-class SetupHelperTest < Minitest::Test
+class SetupHelperTest < Test::Unit::TestCase
   include RBS::Test::SetupHelper
   include TestHelper
 

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -28,8 +28,8 @@ class SetupHelperTest < Test::Unit::TestCase
   end
 
   def test_to_double_class
-    assert '::RSpec::Mocks::Double', to_double_class('rspec')
-    assert '::Minitest::Mock', to_double_class('rspec')
+    assert_equal ['::RSpec::Mocks::Double'], to_double_class('rspec')
+    assert_equal ['::Minitest::Mock'], to_double_class('minitest')
 
     silence_warnings do
       assert_nil to_double_class('rr')

--- a/test/rbs/test/tester_test.rb
+++ b/test/rbs/test/tester_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 require "rbs/test"
 
-class RBS::Test::TesterTest < Minitest::Test
+class RBS::Test::TesterTest < Test::Unit::TestCase
   include TestHelper
 
   ArgumentsReturn = RBS::Test::ArgumentsReturn

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -393,8 +393,10 @@ EOF
 
   def test_is_double
     skip unless has_gem?("rspec")
+    skip unless has_gem?("minitest")
 
     require "rspec/mocks/standalone"
+    require "minitest/mock"
 
     SignatureManager.new do |manager|
       manager.build do |env|

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -7,7 +7,7 @@ return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
 
 RSPEC_MOCK = -> { double('foo') }
 
-class RBS::Test::TypeCheckTest < Minitest::Test
+class RBS::Test::TypeCheckTest < Test::Unit::TestCase
   include TestHelper
   include RBS
 

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -392,8 +392,8 @@ EOF
   end
 
   def test_is_double
-    skip unless has_gem?("rspec")
-    skip unless has_gem?("minitest")
+    omit unless has_gem?("rspec")
+    omit if skip_minitest?
 
     require "rspec/mocks/standalone"
     require "minitest/mock"

--- a/test/rbs/type_name_resolver_test.rb
+++ b/test/rbs/type_name_resolver_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::DefinitionBuilderTest < Minitest::Test
+class RBS::DefinitionBuilderTest < Test::Unit::TestCase
   include TestHelper
   include RBS
 

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::TypeParsingTest < Minitest::Test
+class RBS::TypeParsingTest < Test::Unit::TestCase
   include TestHelper
 
   Parser = RBS::Parser

--- a/test/rbs/types_test.rb
+++ b/test/rbs/types_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::TypesTest < Minitest::Test
+class RBS::TypesTest < Test::Unit::TestCase
   Types = RBS::Types
 
   include TestHelper

--- a/test/rbs/variance_calculator_test.rb
+++ b/test/rbs/variance_calculator_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::VarianceCalculatorTest < Minitest::Test
+class RBS::VarianceCalculatorTest < Test::Unit::TestCase
   include TestHelper
 
   DefinitionBuilder = RBS::DefinitionBuilder

--- a/test/rbs/vendorer_test.rb
+++ b/test/rbs/vendorer_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "open3"
 
-class RBS::VendorerTest < Minitest::Test
+class RBS::VendorerTest < Test::Unit::TestCase
   include TestHelper
 
   Environment = RBS::Environment

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class RBS::WriterTest < Minitest::Test
+class RBS::WriterTest < Test::Unit::TestCase
   include TestHelper
 
   Parser = RBS::Parser

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class ArraySingletonTest < Minitest::Test
+class ArraySingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::Array)"
@@ -35,7 +35,7 @@ class ArraySingletonTest < Minitest::Test
   end
 end
 
-class ArrayInstanceTest < Minitest::Test
+class ArrayInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Array[::Integer]"

--- a/test/stdlib/BigDecimal_test.rb
+++ b/test/stdlib/BigDecimal_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "bigdecimal"
 
-class BigDecimalSingletonTest < Minitest::Test
+class BigDecimalSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library "bigdecimal"
   testing "singleton(::BigDecimal)"
@@ -53,7 +53,7 @@ class BigDecimalSingletonTest < Minitest::Test
   end
 end
 
-class BigDecimalTest < Minitest::Test
+class BigDecimalTest < Test::Unit::TestCase
   include TypeAssertions
   library "bigdecimal"
   testing "::BigDecimal"

--- a/test/stdlib/BigMath_test.rb
+++ b/test/stdlib/BigMath_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 require "bigdecimal"
 require "bigdecimal/math"
 
-class BigMathSingletonTest < Minitest::Test
+class BigMathSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library "bigdecimal", "bigdecimal-math"
   testing "singleton(::BigMath)"
@@ -48,7 +48,7 @@ class BigMathSingletonTest < Minitest::Test
   end
 end
 
-class BigMathTest < Minitest::Test
+class BigMathTest < Test::Unit::TestCase
   include TypeAssertions
   library "bigdecimal", "bigdecimal-math"
   testing "::BigMath"

--- a/test/stdlib/Comparable_test.rb
+++ b/test/stdlib/Comparable_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class ComparableTest < Minitest::Test
+class ComparableTest < Test::Unit::TestCase
   include TypeAssertions
 
   class Test

--- a/test/stdlib/DBM_test.rb
+++ b/test/stdlib/DBM_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "dbm"
 
-class DBMSingletonTest < Minitest::Test
+class DBMSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library "dbm"
   testing "singleton(::DBM)"
@@ -18,7 +18,7 @@ class DBMSingletonTest < Minitest::Test
   end
 end
 
-class DBMTest < Minitest::Test
+class DBMTest < Test::Unit::TestCase
   include TypeAssertions
   library "dbm"
   testing "::DBM"

--- a/test/stdlib/DateTime_test.rb
+++ b/test/stdlib/DateTime_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "date"
 
-class DateTimeSingletonTest < Minitest::Test
+class DateTimeSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "date"
@@ -190,7 +190,7 @@ class DateTimeSingletonTest < Minitest::Test
   end
 end
 
-class DateTimeTest < Minitest::Test
+class DateTimeTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "date"

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "date"
 
-class DateSingletonTest < Minitest::Test
+class DateSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "date"
@@ -238,7 +238,7 @@ class DateSingletonTest < Minitest::Test
   end
 end
 
-class DateTest < Minitest::Test
+class DateTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "date"

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class DirSingletonTest < Minitest::Test
+class DirSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::Dir)"
@@ -158,7 +158,7 @@ class DirSingletonTest < Minitest::Test
   end
 end
 
-class DirInstanceTest < Minitest::Test
+class DirInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Dir"

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -120,7 +120,7 @@ class EnumerableTest < StdlibTest
   end
 end
 
-class EnumerableTest2 < Minitest::Test
+class EnumerableTest2 < Test::Unit::TestCase
   include TypeAssertions
 
   class TestEnumerable

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class EnumeratorTest < Minitest::Test
+class EnumeratorTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Enumerator[::Integer, Array[::Integer]]"
@@ -14,7 +14,7 @@ class EnumeratorTest < Minitest::Test
   end
 end
 
-class EnumeratorYielderTest < Minitest::Test
+class EnumeratorYielderTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Enumerator::Yielder"

--- a/test/stdlib/Fiber_test.rb
+++ b/test/stdlib/Fiber_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class FiberSingletonTest < Minitest::Test
+class FiberSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::Fiber)"
@@ -28,7 +28,7 @@ class FiberSingletonTest < Minitest::Test
   end
 end
 
-class FiberTest < Minitest::Test
+class FiberTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Fiber"
@@ -73,7 +73,7 @@ end
 
 require 'fiber'
 
-class FiberSingletonExtTest < Minitest::Test
+class FiberSingletonExtTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'fiber'
@@ -85,7 +85,7 @@ class FiberSingletonExtTest < Minitest::Test
   end
 end
 
-class FiberExtTest < Minitest::Test
+class FiberExtTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'fiber'

--- a/test/stdlib/File_test.rb
+++ b/test/stdlib/File_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "socket"
 
-class FileSingletonTest < Minitest::Test
+class FileSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::File)"
@@ -831,7 +831,7 @@ class FileSingletonTest < Minitest::Test
   end
 end
 
-class FileInstanceTest < Minitest::Test
+class FileInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::File"

--- a/test/stdlib/Forwardable_test.rb
+++ b/test/stdlib/Forwardable_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "forwardable"
 
-class ForwardableTest < Minitest::Test
+class ForwardableTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "forwardable"
@@ -64,7 +64,7 @@ class ForwardableTest < Minitest::Test
   end
 end
 
-class SingleForwardableTest < Minitest::Test
+class SingleForwardableTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "forwardable"

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class IOSingletonTest < Minitest::Test
+class IOSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::IO)"
@@ -87,7 +87,7 @@ class IOSingletonTest < Minitest::Test
   end
 end
 
-class IOInstanceTest < Minitest::Test
+class IOInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::IO"

--- a/test/stdlib/Logger_test.rb
+++ b/test/stdlib/Logger_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 require 'logger'
 require 'stringio'
 
-class LoggerSingletonTest < Minitest::Test
+class LoggerSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'logger'
@@ -27,7 +27,7 @@ class LoggerSingletonTest < Minitest::Test
   end
 end
 
-class LoggerTest < Minitest::Test
+class LoggerTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'logger'

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class ModuleSingletonTest < Minitest::Test
+class ModuleSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::Module)"
@@ -11,7 +11,7 @@ class ModuleSingletonTest < Minitest::Test
   end
 end
 
-class ModuleInstanceTest < Minitest::Test
+class ModuleInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Module"

--- a/test/stdlib/Monitor_test.rb
+++ b/test/stdlib/Monitor_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require 'monitor'
 
-class MonitorInstanceTest < Minitest::Test
+class MonitorInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'monitor'
@@ -38,7 +38,7 @@ class MonitorInstanceTest < Minitest::Test
   end
 end
 
-class MonitorMixinInstanceTest < Minitest::Test
+class MonitorMixinInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'monitor'
@@ -92,7 +92,7 @@ class MonitorMixinInstanceTest < Minitest::Test
   end
 end
 
-class MonitorMixinConditionVariableInstanceTest < Minitest::Test
+class MonitorMixinConditionVariableInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'monitor'

--- a/test/stdlib/Mutex_m_test.rb
+++ b/test/stdlib/Mutex_m_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require 'mutex_m'
 
-class Mutex_mInstanceTest < Minitest::Test
+class Mutex_mInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'mutex_m'

--- a/test/stdlib/ObjectSpace_test.rb
+++ b/test/stdlib/ObjectSpace_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class ObjectSpaceTest < Minitest::Test
+class ObjectSpaceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::ObjectSpace)"

--- a/test/stdlib/PStore_test.rb
+++ b/test/stdlib/PStore_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "pstore"
 
-class PStoreSingletonTest < Minitest::Test
+class PStoreSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library "pstore"
   testing "singleton(::PStore)"

--- a/test/stdlib/PTY_test.rb
+++ b/test/stdlib/PTY_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "pty"
 
-class PTYSingletonTest < Minitest::Test
+class PTYSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "pty"

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require 'pathname'
 
-class PathnameSingletonTest < Minitest::Test
+class PathnameSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'pathname'
   testing 'singleton(::Pathname)'
@@ -37,7 +37,7 @@ class PathnameSingletonTest < Minitest::Test
   end
 end
 
-class PathnameInstanceTest < Minitest::Test
+class PathnameInstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'pathname'
   testing '::Pathname'

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class StringSingletonTest < Minitest::Test
+class StringSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::String)"
@@ -34,7 +34,7 @@ class StringSingletonTest < Minitest::Test
   end
 end
 
-class StringInstanceTest < Minitest::Test
+class StringInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::String"

--- a/test/stdlib/Symbol_test.rb
+++ b/test/stdlib/Symbol_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-class SymbolSingletonTest < Minitest::Test
+class SymbolSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "singleton(::Symbol)"
@@ -11,7 +11,7 @@ class SymbolSingletonTest < Minitest::Test
   end
 end
 
-class SymbolInstanceTest < Minitest::Test
+class SymbolInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   testing "::Symbol"

--- a/test/stdlib/TSort_test.rb
+++ b/test/stdlib/TSort_test.rb
@@ -2,7 +2,7 @@ require_relative "test_helper"
 
 require "tsort"
 
-class TSortSingletonTest < Minitest::Test
+class TSortSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'tsort'
@@ -79,7 +79,7 @@ class TSortSingletonTest < Minitest::Test
   end
 end
 
-class TSortInstanceTest < Minitest::Test
+class TSortInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library 'tsort'

--- a/test/stdlib/TimeExtension_test.rb
+++ b/test/stdlib/TimeExtension_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "time"
 
-class TimeExtensionSingletonTest < Minitest::Test
+class TimeExtensionSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "time"
@@ -82,7 +82,7 @@ class TimeExtensionSingletonTest < Minitest::Test
   end
 end
 
-class TimeExtensionInstanceTest < Minitest::Test
+class TimeExtensionInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "time"

--- a/test/stdlib/URI_test.rb
+++ b/test/stdlib/URI_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "uri"
 
-class URISingletonTest < Minitest::Test
+class URISingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "uri"

--- a/test/stdlib/Zlib_test.rb
+++ b/test/stdlib/Zlib_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "zlib"
 
-class ZlibSingletonTest < Minitest::Test
+class ZlibSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "zlib"

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -1,7 +1,7 @@
 require_relative "../test_helper"
 require "json"
 
-class JSONSingletonTest < Minitest::Test
+class JSONSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
   library "json"
@@ -153,7 +153,7 @@ class JSONSingletonTest < Minitest::Test
   end
 end
 
-class JSONInstanceTest < Minitest::Test
+class JSONInstanceTest < Test::Unit::TestCase
   include TypeAssertions
 
   class MyJSON

--- a/test/stdlib/singleton_test.rb
+++ b/test/stdlib/singleton_test.rb
@@ -1,7 +1,7 @@
 require_relative './test_helper'
 require 'singleton'
 
-class SingletonSingletonTest < Minitest::Test
+class SingletonSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'singleton'
   testing 'singleton(::Singleton)'

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -1,6 +1,9 @@
 require "rbs"
 require "rbs/test"
 require "test/unit"
+require "tmpdir"
+require "stringio"
+require "tempfile"
 
 module Spy
   def self.wrap(object, method_name)

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -1,12 +1,6 @@
 require "rbs"
 require "rbs/test"
-require "minitest/autorun"
-
-begin
-  require 'minitest/reporters'
-  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new]
-rescue LoadError
-end
+require "test/unit"
 
 module Spy
   def self.wrap(object, method_name)
@@ -394,7 +388,7 @@ class ArefFromStringToString
   end
 end
 
-class StdlibTest < Minitest::Test
+class StdlibTest < Test::Unit::TestCase
   RBS.logger_level = ENV["RBS_TEST_LOGLEVEL"] || "info"
 
   loader = RBS::EnvironmentLoader.new

--- a/test/stdlib/uri/file_test.rb
+++ b/test/stdlib/uri/file_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 require 'uri'
 
-class URIFileSingletonTest < Minitest::Test
+class URIFileSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing 'singleton(::URI::File)'
@@ -19,7 +19,7 @@ class URIFileSingletonTest < Minitest::Test
   end
 end
 
-class URIFileInstanceTest < Minitest::Test
+class URIFileInstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing '::URI::File'

--- a/test/stdlib/uri/generic_test.rb
+++ b/test/stdlib/uri/generic_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 require 'uri'
 
-class URIGenericSingletonTest < Minitest::Test
+class URIGenericSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing 'singleton(::URI::Generic)'
@@ -82,7 +82,7 @@ class URIGenericSingletonTest < Minitest::Test
   end
 end
 
-class URIGenericInstanceTest < Minitest::Test
+class URIGenericInstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing '::URI::Generic'

--- a/test/stdlib/uri/http_test.rb
+++ b/test/stdlib/uri/http_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 require 'uri'
 
-class URIHTTPSingletonTest < Minitest::Test
+class URIHTTPSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing 'singleton(::URI::HTTP)'
@@ -31,7 +31,7 @@ class URIHTTPSingletonTest < Minitest::Test
   end
 end
 
-class URIHTTPInstanceTest < Minitest::Test
+class URIHTTPInstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing '::URI::HTTP'

--- a/test/stdlib/uri/ldap_test.rb
+++ b/test/stdlib/uri/ldap_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 require 'uri'
 
-class URILDAPSingletonTest < Minitest::Test
+class URILDAPSingletonTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing 'singleton(::URI::LDAP)'
@@ -45,7 +45,7 @@ class URILDAPSingletonTest < Minitest::Test
   end
 end
 
-class URILDAPInstanceTest < Minitest::Test
+class URILDAPInstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'uri'
   testing '::URI::LDAP'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,12 +3,7 @@ require "rbs"
 require "tmpdir"
 require "stringio"
 require "open3"
-
-begin
-  require 'minitest/reporters'
-  Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new]
-rescue LoadError
-end
+require "test/unit"
 
 begin
   require "amber"
@@ -173,7 +168,7 @@ SIG
       items.each do |item|
         begin
           yield item
-        rescue Minitest::Assertion
+        rescue Test::Unit::AssertionFailedError
           next
         else
           # Pass test
@@ -205,5 +200,3 @@ SIG
     assert_empty(sample - array)
   end
 end
-
-require "minitest/autorun"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,10 @@ module TestHelper
     false
   end
 
+  def skip_minitest?
+    ENV.key?("NO_MINITEST")
+  end
+
   def parse_type(string, variables: Set.new)
     RBS::Parser.parse_type(string, variables: variables)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "tmpdir"
 require "stringio"
 require "open3"
 require "test/unit"
+require "test/unit/rr"
 
 begin
   require "amber"
@@ -37,13 +38,13 @@ module TestHelper
   end
 
   def silence_errors
-    RBS.logger.stub :error, nil do
+    stub(RBS.logger).error do
       yield
     end
   end
 
   def silence_warnings
-    RBS.logger.stub :warn, nil do
+    stub(RBS.logger).warn do
       yield
     end
   end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ValidatorTest < Minitest::Test
+class ValidatorTest < Test::Unit::TestCase
   include TestHelper
 
   Environment = RBS::Environment


### PR DESCRIPTION
Minitest doesn't install on Ruby 3.1 (RBS is testing with nightly-master too). So, we are moving to test-unit today. 💪 