### PR TITLE
[prototype rb] Avoid an error on argument forwarding syntax

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -400,7 +400,8 @@ module RBS
         end
 
         if rest
-          fun = fun.update(rest_positionals: Types::Function::Param.new(name: rest, type: untyped))
+          rest_name = rest == :* ? nil : rest # # For `def f(...) end` syntax
+          fun = fun.update(rest_positionals: Types::Function::Param.new(name: rest_name, type: untyped))
         end
 
         table_node.drop(fun.required_positionals.size + fun.optional_positionals.size + (fun.rest_positionals ? 1 : 0)).take(post_num).each do |name|
@@ -565,7 +566,10 @@ module RBS
 
         if block
           method_block = Types::Block.new(
-            required: true,
+            # HACK: The `block` is :& on `def m(...)` syntax.
+            #       In this case the block looks optional in most cases, so it marks optional.
+            #       In other cases, we can't determine which is required or optional, so it marks required.
+            required: block != :&,
             type: Types::Function.empty(untyped)
           )
         end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -721,4 +721,24 @@ module M
 end
     RBS
   end
+
+  if RUBY_VERSION >= '2.7'
+    def test_argument_forwarding
+      parser = RB.new
+
+      rb = <<~'RUBY'
+module M
+  def foo(...) end
+end
+      RUBY
+
+      parser.parse(rb)
+
+      assert_write parser.decls, <<~RBS
+module M
+  def foo: (*untyped) ?{ () -> untyped } -> nil
+end
+      RBS
+    end
+  end
 end


### PR DESCRIPTION
Fix #554


# Problem


`rbs prototype rb` comamnd raises an error on argument forwarding syntax.
See #554 for more information.


# Solution


Handle `:*` variable name as rest arguments. `:*` means the argument forwarding syntax.



# Note

It also handles `:&` as block argument name. `:&` also means the argument forwarding syntax.

`rbs prototype rb` generates all block arguments as required. But in argument forwarding syntax, I think the block argument is optional in most cases.
So it marks block argument optional if the block argument is available by the argument forwarding syntax.


I think it is ad-hoc, but I don't have a better idea. It is hard to determine a block argument is required or optional by AST.