### PR TITLE
Fix incorrect Module#class_eval type

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -259,7 +259,7 @@ class Module < Object
   #         or method `code' for Thing:Class
   #
   def class_eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
-                | [U] (untyped arg0) { (untyped m) -> U } -> U
+                | [U] { (self m) -> U } -> U
 
   # Evaluates the given block in the context of the class/module. The method
   # defined in the block will belong to the receiver. Any arguments passed to the
@@ -793,7 +793,7 @@ class Module < Object
   #         or method `code' for Thing:Class
   #
   def module_eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
-                 | [U] (untyped arg0) { (untyped m) -> U } -> U
+                 | [U] { (self m) -> U } -> U
 
   # Evaluates the given block in the context of the class/module. The method
   # defined in the block will belong to the receiver. Any arguments passed to the

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -42,4 +42,28 @@ class ModuleInstanceTest < Test::Unit::TestCase
     assert_send_type "(String, nil) -> nil",
                      Foo, :const_source_location, "String", nil
   end
+
+  def test_module_eval
+    assert_send_type "(String) -> nil",
+                     Foo, :module_eval, 'nil'
+    assert_send_type "(String, String) -> nil",
+                     Foo, :module_eval, 'nil', __FILE__
+    assert_send_type "(String, String, Integer) -> nil",
+                     Foo, :module_eval, 'nil', __FILE__, 42
+
+    assert_send_type "() { (Module) -> nil } -> nil",
+                     Foo, :module_eval do nil end
+  end
+
+  def test_class_eval
+    assert_send_type "(String) -> nil",
+                     Foo, :class_eval, 'nil'
+    assert_send_type "(String, String) -> nil",
+                     Foo, :class_eval, 'nil', __FILE__
+    assert_send_type "(String, String, Integer) -> nil",
+                     Foo, :class_eval, 'nil', __FILE__, 42
+
+    assert_send_type "() { (Module) -> nil } -> nil",
+                     Foo, :class_eval do nil end
+  end
 end


### PR DESCRIPTION
`Module#class_eval` doesn't take any arguments in Ruby,
but the RBS says "it takes one argument" mistakenly.
So this patch fixes the incorrect `Module#class_eval` type.