### PR TITLE
Fix non-existent `stdlib/builtin`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,8 +28,6 @@ task :validate => :parser do
   sh "#{ruby} #{rbs} validate --silent"
 
   FileList["stdlib/*"].each do |path|
-    next if path =~ %r{stdlib/builtin}
-
     lib = [File.basename(path).to_s]
 
     if lib == ["bigdecimal-math"]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,12 +49,12 @@ You may find the *Good for first contributor* column where you can find some cla
   * `--merge` tells to use the method types in RBS if exists.
 * `rbs prototype runtime --merge --method-owner=Numeric Integer`
   * You can use --method-owner if you want to print method of other classes too, for documentation purpose.
-* `bin/annotate-with-rdoc stdlib/builtin/string.rbs`
+* `bin/annotate-with-rdoc core/string.rbs`
   * Write comments using RDoc.
   * It contains arglists section, but I don't think we should have it in RBS files.
 * `bin/query-rdoc String#initialize`
   * Print RDoc documents in the format you can copy-and-paste to RBS.
-* `bin/sort stdlib/builtin/string.rbs`
+* `bin/sort core/string.rbs`
   * Sort declarations members in RBS files.
 * `rbs validate -r LIB`
   Validate the syntax and some of the semantics.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -11,7 +11,7 @@ The typical steps of writing signatures will be like the following:
 
 ## Signatures
 
-Signatures for standard libraries are located in `stdlib` directory. `stdlib/builtin` is for builtin libraries. Other libraries have directories like `stdlib/set` or `stdlib/pathname`.
+Signatures for builtin libraries are located in `core` directory. Also, signatures for standard libraries are located in `stdlib` directory.
 
 To write signatures see [syntax guide](syntax.md).
 


### PR DESCRIPTION
The `stdlib/builtin` directory moved to the `core` directory on PR #405.
This change fixes `stdlib/builtin` in a Rake task code and documents.