### PR TITLE
Fix module-self-type overrides

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "rbs-amber", path: "test/assets/test-gem"
 
 group :ide, optional: true do
   gem "ruby-debug-ide"
+  gem "debase", ">= 0.2.5.beta2"
 end
 
 group :minitest do

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -5,7 +5,7 @@ module RBS
     attr_reader ancestor_builder: AncestorBuilder
     attr_reader method_builder: MethodBuilder
 
-    attr_reader instance_cache: Hash[TypeName, Definition | false | nil]
+    attr_reader instance_cache: Hash[[TypeName, bool], Definition | false | nil]
     attr_reader singleton_cache: Hash[TypeName, Definition | false | nil]
     attr_reader singleton0_cache: Hash[TypeName, Definition | false | nil]
     attr_reader interface_cache: Hash[TypeName, Definition | false | nil]
@@ -18,7 +18,7 @@ module RBS
 
     def build_interface: (TypeName) -> Definition
 
-    def build_instance: (TypeName) -> Definition
+    def build_instance: (TypeName, ?no_self_types: bool) -> Definition
 
     def build_singleton0: (TypeName) -> Definition
 
@@ -31,6 +31,7 @@ module RBS
     def merge_variable: (Hash[Symbol, Definition::Variable], Symbol, Definition::Variable, Substitution, ?keep_super: bool) -> void
 
     def try_cache: (TypeName, cache: Hash[TypeName, Definition | false | nil]) { () -> Definition } -> Definition
+                 | [A] (TypeName, cache: Hash[A, Definition | false | nil], key: A) { () -> Definition } -> Definition
 
     def validate_params_with: (AST::Declarations::ModuleTypeParams, result: VarianceCalculator::Result) { (AST::Declarations::ModuleTypeParams::TypeParam) -> void } -> void
 


### PR DESCRIPTION
Mixing a module overrides super-class methods with self-types methods unexpectedly.

```rbs
class Base
  def initialize: (String) -> void
end

module M : Object
  def foo: () -> void
end

class Child < Base
  include M
end
```

Expected type of `Child#initialize` is `(String) -> void` from `Base`, but it was `() -> void` from `Object` through `M`.

This PR fixes the issue.