### PR TITLE
Add description to `rake generate:stdlib_test[class]`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,6 +82,7 @@ task :confirm_parser do
 end
 
 namespace :generate do
+  desc "Generate a test file for a stdlib class signatures"
   task :stdlib_test, [:class] do |_task, args|
     klass = args.fetch(:class) do
       raise "Class name is necessary. e.g. rake 'generate:stdlib_test[String]'"


### PR DESCRIPTION
The document `stdlib.md` describes the command `rake generate:stdlib_test[class]`.
(see <https://github.com/ruby/rbs/blob/018f671ed048975acf68fd40412f91e90600aa16/docs/stdlib.md#writing-tests>)

So, I think it useful that the rake task is output via `rake --tasks`:

```console
$ bundle exec rake --tasks
rake build                        # Build rbs-1.0.0.gem into the pkg directory
rake clean                        # Remove any temporary products
rake clobber                      # Remove any generated files
rake generate:stdlib_test[class]  # Generate a test file for a stdlib class signatures
rake install                      # Build and install rbs-1.0.0.gem into system gems
rake install:local                # Build and install rbs-1.0.0.gem into system gems without network access
rake release[remote]              # Create tag v1.0.0 and build and push rbs-1.0.0.gem to rubygems.org
rake test                         # Run tests
```