### PR TITLE
Renew test sample code

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -118,23 +118,61 @@ It generates `test/stdlib/[class_name]_test.rb`.
 The test scripts would look like the following:
 
 ```rb
-class StringTest < StdlibTest
-  target String
+class StringSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::String)"
+
+  def test_initialize
+    assert_send_type "() -> String",
+                     String, :new
+    assert_send_type "(String) -> String",
+                     String, :new, ""
+    assert_send_type "(String, encoding: Encoding) -> String",
+                     String, :new, "", encoding: Encoding::ASCII_8BIT
+    assert_send_type "(String, encoding: Encoding, capacity: Integer) -> String",
+                     String, :new, "", encoding: Encoding::ASCII_8BIT, capacity: 123
+    assert_send_type "(encoding: Encoding, capacity: Integer) -> String",
+                     String, :new, encoding: Encoding::ASCII_8BIT, capacity: 123
+    assert_send_type "(ToStr) -> String",
+                     String, :new, ToStr.new("")
+    assert_send_type "(encoding: ToStr) -> String",
+                     String, :new, encoding: ToStr.new('Shift_JIS')
+    assert_send_type "(capacity: ToInt) -> String",
+                     String, :new, capacity: ToInt.new(123)
+  end
+end
+
+class StringTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "::String"
 
   def test_gsub
-    s = "string"
-    s.gsub(/./, "")
-    s.gsub("a", "b")
-    s.gsub(/./) {|x| "" }
-    s.gsub(/./, {"foo" => "bar"})
-    s.gsub(/./)
-    s.gsub("")
+    assert_send_type "(Regexp, String) -> String",
+                     "string", :gsub, /./, ""
+    assert_send_type "(String, String) -> String",
+                     "string", :gsub, "a", "b"
+    assert_send_type "(Regexp) { (String) -> String } -> String",
+                     "string", :gsub, /./ do |x| "" end
+    assert_send_type "(Regexp) { (String) -> ToS } -> String",
+                     "string", :gsub, /./ do |x| ToS.new("") end
+    assert_send_type "(Regexp, Hash[String, String]) -> String",
+                     "string", :gsub, /./, {"foo" => "bar"}
+    assert_send_type "(Regexp) -> Enumerator[String, self]",
+                     "string", :gsub, /./
+    assert_send_type "(String) -> Enumerator[String, self]",
+                     "string", :gsub, ""
+    assert_send_type "(ToStr, ToStr) -> String",
+                     "string", :gsub, ToStr.new("a"), ToStr.new("b")
   end
 end
 ```
 
-You need two method calls, `target` and `using`.
-`target` method call tells which class is the subject of the class.
+You need include `TypeAssertions` which provide useful methods for you.
+`testing` method call tells which class is the subject of the class.
+`assert_send_type` method call asserts to be valid types and confirms to be able to execute without exceptions.
 And you write the sample programs which calls all of the patterns of overloads.
 
 Note that the instrumentation is based on refinements and you need to write all method calls in the unit class definitions.


### PR DESCRIPTION
We can get test sample code by executing of `generate:stdlib_test[class]` rake task and it is indicated in stdlib.md.

But, the code indicated in stdlib.md was different from the one generated by rake task.
So, I modified it.