### PR TITLE
Resurrect Kernel#block_given?

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -54,7 +54,7 @@ module Kernel : BasicObject
   # try { "hello" }      #=> "hello"
   # try do "hello" end   #=> "hello"
   # ```
-  def self.block_given?: () -> bool
+  def self?.block_given?: () -> bool
 
   # Returns the names of the current local variables.
   #


### PR DESCRIPTION
The combination of two pull requests, #569 and #549 (I merged them myself), deleted `Kernel#block_given?` unexpectedly.