### PR TITLE
Add signature of Timeout

### DIFF
--- a/stdlib/timeout/0/timeout.rbs
+++ b/stdlib/timeout/0/timeout.rbs
@@ -1,0 +1,94 @@
+# Timeout long-running blocks
+#
+# ## Synopsis
+#
+#     require 'timeout'
+#     status = Timeout::timeout(5) {
+#       # Something that should be interrupted if it takes more than 5 seconds...
+#     }
+#
+# ## Description
+#
+# Timeout provides a way to auto-terminate a potentially long-running operation
+# if it hasn't finished in a fixed amount of time.
+#
+# Previous versions didn't use a module for namespacing, however #timeout is
+# provided for backwards compatibility.  You should prefer Timeout.timeout
+# instead.
+#
+# ## Copyright
+#
+# Copyright
+# :   (C) 2000  Network Applied Communication Laboratory, Inc.
+# Copyright
+# :   (C) 2000  Information-technology Promotion Agency, Japan
+#
+module Timeout
+  # Perform an operation in a block, raising an error if it takes longer than
+  # `sec` seconds to complete.
+  #
+  # `sec`
+  # :   Number of seconds to wait for the block to terminate. Any number may be
+  #     used, including Floats to specify fractional seconds. A value of 0 or
+  #     `nil` will execute the block without any timeout.
+  # `klass`
+  # :   Exception Class to raise if the block fails to terminate in `sec` seconds.
+  #      Omitting will use the default, Timeout::Error
+  # `message`
+  # :   Error message to raise with Exception Class. Omitting will use the
+  #     default, "execution expired"
+  #
+  #
+  # Returns the result of the block **if** the block completed before `sec`
+  # seconds, otherwise throws an exception, based on the value of `klass`.
+  #
+  # The exception thrown to terminate the given block cannot be rescued inside the
+  # block unless `klass` is given explicitly. However, the block can use ensure to
+  # prevent the handling of the exception.  For that reason, this method cannot be
+  # relied on to enforce timeouts for untrusted blocks.
+  #
+  # Note that this is both a method of module Timeout, so you can `include
+  # Timeout` into your classes so they have a #timeout method, as well as a module
+  # method, so you can call it directly as Timeout.timeout().
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     timeout(sec, klass = nil, message = nil) { |sec| ... }
+  #
+  def self.timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
+
+  private
+
+  # Perform an operation in a block, raising an error if it takes longer than
+  # `sec` seconds to complete.
+  #
+  # `sec`
+  # :   Number of seconds to wait for the block to terminate. Any number may be
+  #     used, including Floats to specify fractional seconds. A value of 0 or
+  #     `nil` will execute the block without any timeout.
+  # `klass`
+  # :   Exception Class to raise if the block fails to terminate in `sec` seconds.
+  #      Omitting will use the default, Timeout::Error
+  # `message`
+  # :   Error message to raise with Exception Class. Omitting will use the
+  #     default, "execution expired"
+  #
+  #
+  # Returns the result of the block **if** the block completed before `sec`
+  # seconds, otherwise throws an exception, based on the value of `klass`.
+  #
+  # The exception thrown to terminate the given block cannot be rescued inside the
+  # block unless `klass` is given explicitly. However, the block can use ensure to
+  # prevent the handling of the exception.  For that reason, this method cannot be
+  # relied on to enforce timeouts for untrusted blocks.
+  #
+  # Note that this is both a method of module Timeout, so you can `include
+  # Timeout` into your classes so they have a #timeout method, as well as a module
+  # method, so you can call it directly as Timeout.timeout().
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     timeout(sec, klass = nil, message = nil) { |sec| ... }
+  #
+  def timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
+end
+
+Timeout::VERSION: String

--- a/stdlib/timeout/0/timeout.rbs
+++ b/stdlib/timeout/0/timeout.rbs
@@ -51,9 +51,6 @@ module Timeout
   # Timeout` into your classes so they have a #timeout method, as well as a module
   # method, so you can call it directly as Timeout.timeout().
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     timeout(sec, klass = nil, message = nil) { |sec| ... }
-  #
   def self.timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
 
   private
@@ -84,9 +81,6 @@ module Timeout
   # Note that this is both a method of module Timeout, so you can `include
   # Timeout` into your classes so they have a #timeout method, as well as a module
   # method, so you can call it directly as Timeout.timeout().
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     timeout(sec, klass = nil, message = nil) { |sec| ... }
   #
   def timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
 end

--- a/stdlib/timeout/0/timeout.rbs
+++ b/stdlib/timeout/0/timeout.rbs
@@ -51,38 +51,7 @@ module Timeout
   # Timeout` into your classes so they have a #timeout method, as well as a module
   # method, so you can call it directly as Timeout.timeout().
   #
-  def self.timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
-
-  private
-
-  # Perform an operation in a block, raising an error if it takes longer than
-  # `sec` seconds to complete.
-  #
-  # `sec`
-  # :   Number of seconds to wait for the block to terminate. Any number may be
-  #     used, including Floats to specify fractional seconds. A value of 0 or
-  #     `nil` will execute the block without any timeout.
-  # `klass`
-  # :   Exception Class to raise if the block fails to terminate in `sec` seconds.
-  #      Omitting will use the default, Timeout::Error
-  # `message`
-  # :   Error message to raise with Exception Class. Omitting will use the
-  #     default, "execution expired"
-  #
-  #
-  # Returns the result of the block **if** the block completed before `sec`
-  # seconds, otherwise throws an exception, based on the value of `klass`.
-  #
-  # The exception thrown to terminate the given block cannot be rescued inside the
-  # block unless `klass` is given explicitly. However, the block can use ensure to
-  # prevent the handling of the exception.  For that reason, this method cannot be
-  # relied on to enforce timeouts for untrusted blocks.
-  #
-  # Note that this is both a method of module Timeout, so you can `include
-  # Timeout` into your classes so they have a #timeout method, as well as a module
-  # method, so you can call it directly as Timeout.timeout().
-  #
-  def timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
+  def self?.timeout: (Numeric? sec, ?singleton(Exception) klass, ?String message) { (Numeric sec) -> untyped } -> untyped
 end
 
 Timeout::VERSION: String

--- a/test/stdlib/Timeout_test.rb
+++ b/test/stdlib/Timeout_test.rb
@@ -1,0 +1,41 @@
+require_relative "test_helper"
+require "timeout"
+require "bigdecimal"
+
+class TimeoutSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "timeout"
+  testing "singleton(::Timeout)"
+
+  class TimeoutTestException < Exception; end # exception class for test
+
+  def test_timeout
+    proc = Proc.new { |sec| sec * sec }
+    assert_send_type  "(::Integer sec) { (::Integer sec) -> untyped } -> untyped",
+                      Timeout, :timeout, 5, &proc
+    assert_send_type  "(::Float sec) { (::Float sec) -> untyped } -> untyped",
+                      Timeout, :timeout, 1.2, &proc
+    assert_send_type  "(::Rational sec) { (::Rational sec) -> untyped } -> untyped",
+                      Timeout, :timeout, Rational(5, 3), &proc
+    assert_send_type  "(::BigDecimal sec) { (::BigDecimal sec) -> untyped } -> untyped",
+                      Timeout, :timeout, BigDecimal("1.123456789123456789"), &proc
+
+    hard_process = Proc.new { _calc_pi }
+    refute_send_type  "(::Numeric sec) { (::Numeric sec) -> untyped } -> untyped",
+                      Timeout, :timeout, 0.001, &hard_process
+    refute_send_type  "(::Numeric sec, singleton(Exception) klass) { (::Numeric sec) -> untyped } -> untyped",
+                      Timeout, :timeout, 0.001, TimeoutTestException, &hard_process
+    refute_send_type  "(::Numeric sec, singleton(Exception) klass, String message) { (::Numeric sec) -> untyped } -> untyped",
+                      Timeout, :timeout, 0.001, TimeoutTestException, "timeout test error", &hard_process
+  end
+
+  def _calc_pi
+    min = [0, 0]
+    loop do
+      x = rand
+      y = rand
+      x**2 + y**2 < 1.0 ?  min[0] += 1 : min[1] += 1
+    end
+  end
+end

--- a/test/stdlib/Timeout_test.rb
+++ b/test/stdlib/Timeout_test.rb
@@ -12,21 +12,21 @@ class TimeoutSingletonTest < Test::Unit::TestCase
 
   def test_timeout
     proc = Proc.new { |sec| sec * sec }
-    assert_send_type  "(::Integer sec) { (::Integer sec) -> untyped } -> untyped",
+    assert_send_type  "(::Integer sec): [T] { (::Integer sec) -> T } -> T",
                       Timeout, :timeout, 5, &proc
-    assert_send_type  "(::Float sec) { (::Float sec) -> untyped } -> untyped",
+    assert_send_type  "(::Float sec): [T] { (::Float sec) -> T } -> T",
                       Timeout, :timeout, 1.2, &proc
-    assert_send_type  "(::Rational sec) { (::Rational sec) -> untyped } -> untyped",
+    assert_send_type  "(::Rational sec): [T] { (::Rational sec) -> T } -> T",
                       Timeout, :timeout, Rational(5, 3), &proc
-    assert_send_type  "(::BigDecimal sec) { (::BigDecimal sec) -> untyped } -> untyped",
+    assert_send_type  "(::BigDecimal sec): [T] { (::BigDecimal sec) -> T } -> T",
                       Timeout, :timeout, BigDecimal("1.123456789123456789"), &proc
 
     hard_process = Proc.new { _calc_pi }
-    refute_send_type  "(::Numeric sec) { (::Numeric sec) -> untyped } -> untyped",
+    refute_send_type  "(::Numeric sec): [T] { (::Numeric sec) -> T } -> T",
                       Timeout, :timeout, 0.001, &hard_process
-    refute_send_type  "(::Numeric sec, singleton(Exception) klass) { (::Numeric sec) -> untyped } -> untyped",
+    refute_send_type  "(::Numeric sec, singleton(Exception) klass): [T] { (::Numeric sec) -> T } -> T",
                       Timeout, :timeout, 0.001, TimeoutTestException, &hard_process
-    refute_send_type  "(::Numeric sec, singleton(Exception) klass, String message) { (::Numeric sec) -> untyped } -> untyped",
+    refute_send_type  "(::Numeric sec, singleton(Exception) klass, String message): [T] { (::Numeric sec) -> T } -> T",
                       Timeout, :timeout, 0.001, TimeoutTestException, "timeout test error", &hard_process
   end
 

--- a/test/stdlib/Timeout_test.rb
+++ b/test/stdlib/Timeout_test.rb
@@ -8,8 +8,6 @@ class TimeoutSingletonTest < Test::Unit::TestCase
   library "timeout"
   testing "singleton(::Timeout)"
 
-  class TimeoutTestException < Exception; end # exception class for test
-
   def test_timeout
     proc = Proc.new { |sec| sec * sec }
     assert_send_type  "(::Integer sec) { (::Integer sec) -> ::Integer } -> ::Integer",

--- a/test/stdlib/Timeout_test.rb
+++ b/test/stdlib/Timeout_test.rb
@@ -20,24 +20,5 @@ class TimeoutSingletonTest < Test::Unit::TestCase
                       Timeout, :timeout, Rational(5, 3), &proc
     assert_send_type  "(::BigDecimal sec) { (::BigDecimal sec) -> ::BigDecimal } -> ::BigDecimal",
                       Timeout, :timeout, BigDecimal("1.123456789123456789"), &proc
-
-    hard_process = Proc.new { _calc_pi }
-    exception = assert_raises(Timeout::Error) { Timeout.timeout 0.001, &hard_process }
-    assert_equal "execution expired", exception.message
-
-    exception = assert_raises(TimeoutTestException) { Timeout.timeout 0.001, TimeoutTestException, &hard_process }
-    assert_equal "execution expired", exception.message
-
-    exception = assert_raises(TimeoutTestException) { Timeout.timeout 0.001, TimeoutTestException, "timeout test error", &hard_process }
-    assert_equal "timeout test error", exception.message
-  end
-
-  def _calc_pi
-    min = [0, 0]
-    loop do
-      x = rand
-      y = rand
-      x**2 + y**2 < 1.0 ?  min[0] += 1 : min[1] += 1
-    end
   end
 end

--- a/test/stdlib/Timeout_test.rb
+++ b/test/stdlib/Timeout_test.rb
@@ -12,13 +12,13 @@ class TimeoutSingletonTest < Test::Unit::TestCase
 
   def test_timeout
     proc = Proc.new { |sec| sec * sec }
-    assert_send_type  "(::Integer sec): [T] { (::Integer sec) -> T } -> T",
+    assert_send_type  "(::Integer sec) { (::Integer sec) -> ::Integer } -> ::Integer",
                       Timeout, :timeout, 5, &proc
-    assert_send_type  "(::Float sec): [T] { (::Float sec) -> T } -> T",
+    assert_send_type  "(::Float sec) { (::Float sec) -> ::Float } -> ::Float",
                       Timeout, :timeout, 1.2, &proc
-    assert_send_type  "(::Rational sec): [T] { (::Rational sec) -> T } -> T",
+    assert_send_type  "(::Rational sec)  { (::Rational sec) -> ::Rational } -> ::Rational",
                       Timeout, :timeout, Rational(5, 3), &proc
-    assert_send_type  "(::BigDecimal sec): [T] { (::BigDecimal sec) -> T } -> T",
+    assert_send_type  "(::BigDecimal sec) { (::BigDecimal sec) -> ::BigDecimal } -> ::BigDecimal",
                       Timeout, :timeout, BigDecimal("1.123456789123456789"), &proc
 
     hard_process = Proc.new { _calc_pi }


### PR DESCRIPTION
This PR add signature of Timeout module.

NOTE: Timeout module has sub module(ex: `Timeout::Error` ). 
But, I first wrote in rbs. So, this is first step and doesn't include the sub module. 