### PR TITLE
Add signatures for URI::RFC2396_Parser

### DIFF
--- a/stdlib/uri/0/rfc2396_parser.rbs
+++ b/stdlib/uri/0/rfc2396_parser.rbs
@@ -1,9 +1,146 @@
-# Class that parses String's into URI's.
-#
-# It contains a Hash set of patterns and Regexp's that match and validate.
-class URI::RFC2396_Parser
-end
+module URI
+  # Includes URI::REGEXP::PATTERN
+  #
+  module RFC2396_REGEXP
+  end
 
-# Includes URI::REGEXP::PATTERN
-module URI::RFC2396_REGEXP
+  # Class that parses String's into URI's.
+  #
+  # It contains a Hash set of patterns and Regexp's that match and validate.
+  #
+  class RFC2396_Parser
+    include RFC2396_REGEXP
+
+    # The Hash of patterns.
+    #
+    # See also URI::Parser.initialize_pattern.
+    #
+    attr_reader pattern: Hash[Symbol, String]
+
+    # The Hash of Regexp.
+    #
+    # See also URI::Parser.initialize_regexp.
+    #
+    attr_reader regexp: Hash[Symbol, Regexp]
+
+    # == Synopsis
+    #
+    #   URI::Parser.new([opts])
+    #
+    # == Args
+    #
+    # The constructor accepts a hash as options for parser.
+    # Keys of options are pattern names of URI components
+    # and values of options are pattern strings.
+    # The constructor generates set of regexps for parsing URIs.
+    #
+    # You can use the following keys:
+    #
+    #   * :ESCAPED (URI::PATTERN::ESCAPED in default)
+    #   * :UNRESERVED (URI::PATTERN::UNRESERVED in default)
+    #   * :DOMLABEL (URI::PATTERN::DOMLABEL in default)
+    #   * :TOPLABEL (URI::PATTERN::TOPLABEL in default)
+    #   * :HOSTNAME (URI::PATTERN::HOSTNAME in default)
+    #
+    # == Examples
+    #
+    #   p = URI::Parser.new(:ESCAPED => "(?:%[a-fA-F0-9]{2}|%u[a-fA-F0-9]{4})")
+    #   u = p.parse("http://example.jp/%uABCD") #=> #<URI::HTTP http://example.jp/%uABCD>
+    #   URI.parse(u.to_s) #=> raises URI::InvalidURIError
+    #
+    #   s = "http://example.com/ABCD"
+    #   u1 = p.parse(s) #=> #<URI::HTTP http://example.com/ABCD>
+    #   u2 = URI.parse(s) #=> #<URI::HTTP http://example.com/ABCD>
+    #   u1 == u2 #=> true
+    #   u1.eql?(u2) #=> false
+    #
+    def initialize: (?Hash[Symbol, String] opts) -> void
+
+    # ## Args
+    #
+    # `str`
+    # :   String to make safe
+    # `unsafe`
+    # :   Regexp to apply. Defaults to [self.regexp](:UNSAFE)
+    #
+    #
+    # ## Description
+    #
+    # Constructs a safe String from `str`, removing unsafe characters, replacing
+    # them with codes.
+    #
+    def escape: (String str, ?Regexp unsafe) -> String
+
+    # ## Args
+    #
+    # `str`
+    # :   String to search
+    # `schemes`
+    # :   Patterns to apply to `str`
+    #
+    #
+    # ## Description
+    #
+    # Attempts to parse and merge a set of URIs. If no `block` given, then returns
+    # the result, else it calls `block` for each element in result.
+    #
+    # See also URI::Parser.make_regexp.
+    #
+    def extract: (String str, ?Array[String] schemes) -> Array[String]
+               | (String str, ?Array[String] schemes) { (String) -> untyped } -> nil
+
+    # ## Args
+    #
+    # `uris`
+    # :   an Array of Strings
+    #
+    #
+    # ## Description
+    #
+    # Attempts to parse and merge a set of URIs.
+    #
+    def join: (*String uris) -> URI::Generic
+
+    # Returns Regexp that is default [self.regexp](:ABS_URI_REF), unless `schemes`
+    # is provided. Then it is a Regexp.union with [self.pattern](:X_ABS_URI).
+    #
+    def make_regexp: (?Array[String] schemes) -> Regexp
+
+    # ## Args
+    #
+    # `uri`
+    # :   String
+    #
+    #
+    # ## Description
+    #
+    # Parses `uri` and constructs either matching URI scheme object (File, FTP,
+    # HTTP, HTTPS, LDAP, LDAPS, or MailTo) or URI::Generic.
+    #
+    # ## Usage
+    #
+    #     p = URI::Parser.new
+    #     p.parse("ldap://ldap.example.com/dc=example?user=john")
+    #     #=> #<URI::LDAP ldap://ldap.example.com/dc=example?user=john>
+    #
+    def parse: (String uri) -> URI::Generic
+
+    # Returns a split URI against [regexp](:ABS_URI).
+    #
+    def split: (String uri) -> [ String?, String?, String?, String?, String?, String?, String?, String?, String? ]
+
+    # ## Args
+    #
+    # `str`
+    # :   String to remove escapes from
+    # `escaped`
+    # :   Regexp to apply. Defaults to [self.regexp](:ESCAPED)
+    #
+    #
+    # ## Description
+    #
+    # Removes escapes from `str`.
+    #
+    def unescape: (String str, ?Regexp escaped) -> String
+  end
 end

--- a/test/stdlib/uri/rfc2396_parser_test.rb
+++ b/test/stdlib/uri/rfc2396_parser_test.rb
@@ -1,0 +1,80 @@
+require_relative "../test_helper"
+require "uri"
+
+class URIRFC2396_ParserSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "uri"
+  testing "singleton(::URI::RFC2396_Parser)"
+
+  def test_new
+    assert_send_type  "() -> URI::RFC2396_Parser",
+                      URI::RFC2396_Parser, :new
+  end
+end
+
+class URIRFC2396_ParserInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "uri"
+  testing "::URI::RFC2396_Parser"
+
+  def setup
+    @instance = URI::RFC2396_Parser.new
+  end
+
+  def test_pattern
+    assert_send_type  "() -> Hash[Symbol, String]",
+                      @instance, :pattern
+  end
+
+  def test_regexp
+    assert_send_type  "() -> Hash[Symbol, Regexp]",
+                      @instance, :regexp
+  end
+
+  def test_escape
+    assert_send_type  "(String) -> String",
+                      @instance, :escape, "foo"
+    assert_send_type  "(String, Regexp) -> String",
+                      @instance, :escape, "foo", /bar/
+  end
+
+  def test_extract
+    assert_send_type  "(String) -> Array[String]",
+                      @instance, :extract, "foo"
+    assert_send_type  "(String, Array[String]) -> Array[String]",
+                      @instance, :extract, "foo", ["http", "https"]
+    assert_send_type  "(String) { (String) -> untyped } -> nil",
+                      @instance, :extract, "foo" do |s| s.bytes end
+    assert_send_type  "(String, Array[String]) { (String) -> untyped } -> nil",
+                      @instance, :extract, "foo", ["http", "https"] do |s| s.bytes end
+  end
+
+  def test_join
+    assert_send_type  "(String, String) -> URI::HTTPS",
+                      @instance, :join, "https://github.com", "ruby/rbs"
+  end
+
+  def test_make_regexp
+    assert_send_type  "(Array[String]) -> Regexp",
+                      @instance, :make_regexp, ["http", "https"]
+  end
+
+  def test_parse
+    assert_send_type  "(String) -> URI::HTTPS",
+                      @instance, :parse, "https://github.com/ruby/rbs"
+  end
+
+  def test_split
+    assert_send_type  "(String) -> [String, String, String, String, nil, String, nil, nil, String]",
+                      @instance, :split, "https://user@github.com:443/ruby/rbs#readme"
+  end
+
+  def test_unescape
+    assert_send_type  "(String) -> String",
+                      @instance, :unescape, "foo"
+    assert_send_type  "(String, Regexp) -> String",
+                      @instance, :unescape, "foo", /bar/
+  end
+end


### PR DESCRIPTION
This change adds signatures for the `URI::RFC2396_Parser` class.

See also:
- https://docs.ruby-lang.org/en/3.0.0/URI/RFC2396_Parser.html
- https://github.com/ruby/uri/blob/v0.10.1/lib/uri/rfc2396_parser.rb