### PR TITLE
Add `#to_json` signatures to core classes

### DIFF
--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -339,3 +339,67 @@ JSON::VERSION_BUILD: Integer
 JSON::VERSION_MAJOR: Integer
 
 JSON::VERSION_MINOR: Integer
+
+class Object
+  # Converts this object to a string (calling #to_s), converts
+  # it to a JSON string, and returns the result. This is a fallback, if no
+  # special method #to_json was defined for some object.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class NilClass
+  # Returns a JSON string for nil: 'null'.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class TrueClass
+  # Returns a JSON string for true: 'true'.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class FalseClass
+  # Returns a JSON string for false: 'false'.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class String
+  # This string should be encoded with UTF-8 A call to this method
+  # returns a JSON string encoded with UTF16 big endian characters as
+  # \u????.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Integer
+  # Returns a JSON string representation for this Integer number.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Float
+  # Returns a JSON string representation for this Float number.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Hash[unchecked out K, unchecked out V]
+  # Returns a JSON string containing a JSON object, that is generated from
+  # this Hash instance.
+  # _state_ is a JSON::State object, that can also be used to configure the
+  # produced JSON string output further.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Array[unchecked out Elem]
+  # Returns a JSON string containing a JSON array, that is generated from
+  # this Array instance.
+  # _state_ is a JSON::State object, that can also be used to configure the
+  # produced JSON string output further.
+  #
+  def to_json: (?JSON::State state) -> String
+end

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -238,4 +238,49 @@ class JSONInstanceTest < Test::Unit::TestCase
     assert_send_type "(ToJson) -> String", MyJSON.new, :unparse, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :unparse, ToJson.new, { indent: "\t" }
   end
+
+  def test_to_json_with_object
+    assert_send_type "() -> String", Object.new, :to_json
+    assert_send_type "(JSON::State) -> String",  Object.new, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_nil
+    assert_send_type "() -> String", nil, :to_json
+    assert_send_type "(JSON::State) -> String", nil, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_true
+    assert_send_type "() -> String", true, :to_json
+    assert_send_type "(JSON::State) -> String", true, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_false
+    assert_send_type "() -> String", false, :to_json
+    assert_send_type "(JSON::State) -> String", false, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_string
+    assert_send_type "() -> String", "foo", :to_json
+    assert_send_type "(JSON::State) -> String", "foo", :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_integer
+    assert_send_type "() -> String", 123, :to_json
+    assert_send_type "(JSON::State) -> String", 123, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_float
+    assert_send_type "() -> String", 0.123, :to_json
+    assert_send_type "(JSON::State) -> String", 0.123, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_hash
+    assert_send_type "() -> String", { a: 1 }, :to_json
+    assert_send_type "(JSON::State) -> String", { a: 1 }, :to_json, JSON::State.new
+  end
+
+  def test_to_json_with_array
+    assert_send_type "() -> String", [], :to_json
+    assert_send_type "(JSON::State) -> String", [], :to_json, JSON::State.new
+  end
 end


### PR DESCRIPTION
This change adds `#to_json` method signatures of the `json` gem to core classes such as `String`, `Hash`, etc.

Note: `bin/query-rdoc` and `bin/bin/annotate-with-rdoc` does not work for these new methods,
so I manually copy the methods' RDoc from the `json` gem source code.
For example, see <https://github.com/flori/json/blob/v2.5.1/ext/json/ext/generator/generator.c#L411-L418>

```console
$ bin/query-rdoc 'Hash#to_json'
...
Finding instance method Hash # to_json ...
Nothing to print; failed to query the document...

$ bin/annotate-with-rdoc stdlib/json/0/json.rbs
...
  Importing documentation for Array...
    Processing to_json...
  👺 No document found for Array#to_json
Writing stdlib/json/0/json.rbs...
```