### PR TITLE
Improve <=> types

### DIFF
--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -121,7 +121,7 @@ class Complex < Numeric
   #     Complex(2)     <=> 2               #=> 0
   #     Complex(2)     <=> 3               #=> -1
   #
-  def <=>: (Numeric) -> Integer?
+  def <=>: (untyped) -> Integer?
 
   # Returns true if cmp equals object numerically.
   #

--- a/core/file.rbs
+++ b/core/file.rbs
@@ -985,7 +985,8 @@ class File::Stat < Object
   include Comparable
 
   def initialize: (String file) -> Object
-  def <=>: (File::Stat other) -> Integer?
+  def <=>: (File::Stat other) -> Integer
+         | (untyped) -> nil
 
   def atime: () -> Time
 

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -112,7 +112,8 @@ class Integer < Numeric
   #
   # `nil` is returned if the two values are incomparable.
   #
-  def <=>: (Numeric) -> Integer?
+  def <=>: (Integer | Rational) -> Integer
+         | (untyped) -> Integer?
 
   # Returns `true` if `int` equals `other` numerically. Contrast this with
   # Integer#eql?, which requires `other` to be an Integer.

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -90,7 +90,7 @@ class Module < Object
   # Returns `nil` if `module` has no relationship with `other_module`, if
   # `other_module` is not a module, or if the two values are incomparable.
   #
-  def <=>: (Module other) -> Integer?
+  def <=>: (untyped other) -> Integer?
 
   # Equality --- At the Object level, #== returns `true` only if `obj` and `other`
   # are the same object.  Typically, this method is overridden in descendant

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -125,7 +125,8 @@ class Rational < Numeric
   #
   #     Rational(1, 3) <=> "0.3"           #=> nil
   #
-  def <=>: (Numeric) -> Integer?
+  def <=>: (Integer | Rational) -> Integer
+         | (untyped) -> Integer?
 
   # Returns `true` if `rat` equals `object` numerically.
   #

--- a/core/string.rbs
+++ b/core/string.rbs
@@ -91,7 +91,8 @@ class String
   #     "abcdef" <=> "ABCDEF"    #=> 1
   #     "abcdef" <=> 1           #=> nil
   #
-  def <=>: (untyped other) -> Integer?
+  def <=>: (string other) -> Integer
+         | (untyped other) -> Integer?
 
   # Equality---Returns whether `str` == `obj`, similar to Object#==.
   #

--- a/core/symbol.rbs
+++ b/core/symbol.rbs
@@ -47,7 +47,8 @@ class Symbol
   #
   # See String#<=> for more information.
   #
-  def <=>: (untyped other) -> Integer?
+  def <=>: (Symbol other) -> Integer
+         | (untyped other) -> Integer?
 
   # Equality---If *sym* and *obj* are exactly the same symbol, returns `true`.
   #

--- a/core/time.rbs
+++ b/core/time.rbs
@@ -230,7 +230,8 @@ class Time < Object
   #     t2 <=> t           #=> 1
   #     t <=> t            #=> 0
   #
-  def <=>: (Time other) -> Integer?
+  def <=>: (Time other) -> Integer
+         | (untyped other) -> Integer?
 
   def >: (Time arg0) -> bool
 

--- a/stdlib/bigdecimal/0/big_decimal.rbs
+++ b/stdlib/bigdecimal/0/big_decimal.rbs
@@ -321,7 +321,7 @@ class BigDecimal < Numeric
 
   # The comparison operator. a <=> b is 0 if a == b, 1 if a > b, -1 if a < b.
   #
-  def <=>: (Numeric) -> Integer?
+  def <=>: (untyped) -> Integer?
 
   # Tests for value equality; returns true if the values are equal.
   #

--- a/stdlib/date/0/date.rbs
+++ b/stdlib/date/0/date.rbs
@@ -496,7 +496,7 @@ class Date
   #
   # See also Comparable.
   #
-  def <=>: (Date | Rational | Object other) -> Integer?
+  def <=>: (untyped other) -> Integer?
 
   # Returns true if they are the same day.
   #

--- a/stdlib/pathname/0/pathname.rbs
+++ b/stdlib/pathname/0/pathname.rbs
@@ -240,7 +240,8 @@ class Pathname
   # relative to the right argument. Or it will return `nil` if the arguments are
   # not comparable.
   #
-  def <=>: (untyped other) -> Integer?
+  def <=>: (Pathname other) -> Integer
+         | (untyped other) -> nil
 
   # Compare this pathname with `other`.  The comparison is string-based. Be aware
   # that two different paths (`foo.txt` and `./foo.txt`) can refer to the same

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -87,6 +87,8 @@ class StringInstanceTest < Test::Unit::TestCase
   def test_cmp
     assert_send_type "(String) -> Integer",
                      "abcdef", :<=>, "abcde"
+    assert_send_type "(ToStr) -> Integer",
+                     "abcdef", :<=>, ToStr.new('foo')
     assert_send_type "(Integer) -> nil",
                      "abcdef", :<=>, 1
   end


### PR DESCRIPTION
* All `<=>` accepts `untyped`
* Do not optional for specific types

ref: https://github.com/ruby/rbs/pull/588#discussion_r571589397