### PR TITLE
Add JSON additional signatures

### DIFF
--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -403,3 +403,227 @@ class Array[unchecked out Elem]
   #
   def to_json: (?JSON::State state) -> String
 end
+
+class BigDecimal
+  # Import a JSON Marshalled object.
+  #
+  # method used for JSON marshalling support.
+  #
+  def self.json_create: (Hash[String, String] object) -> instance
+
+  # Marshal the object to JSON.
+  #
+  # method used for JSON marshalling support.
+  #
+  def as_json: (*untyped) -> Hash[String, String]
+
+  # return the JSON value
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Complex
+  # Deserializes JSON string by converting Real value `r`, imaginary value `i`, to
+  # a Complex object.
+  #
+  def self.json_create: (Hash[String, String | Numeric] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Numeric]
+
+  # Stores class name (Complex) along with real value `r` and imaginary value `i`
+  # as JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Date
+  # Deserializes JSON string by converting Julian year `y`, month `m`, day `d` and
+  # Day of Calendar Reform `sg` to Date.
+  #
+  def self.json_create: (Hash[String, String | Integer | Float] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Integer | Float]
+
+  # Stores class name (Date) with Julian year `y`, month `m`, day `d` and Day of
+  # Calendar Reform `sg` as JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class DateTime
+  # Deserializes JSON string by converting year `y`, month `m`, day `d`, hour `H`,
+  # minute `M`, second `S`, offset `of` and Day of Calendar Reform `sg` to
+  # DateTime.
+  #
+  def self.json_create: (Hash[String, String | Integer | Float] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Integer | Float]
+
+  # Stores class name (DateTime) with Julian year `y`, month `m`, day `d`, hour
+  # `H`, minute `M`, second `S`, offset `of` and Day of Calendar Reform `sg` as
+  # JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Exception
+  # Deserializes JSON string by constructing new Exception object with message `m`
+  # and backtrace `b` serialized with `to_json`
+  #
+  def self.json_create: (Hash[String, String | Array[String] | nil] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Array[String] | nil]
+
+  # Stores class name (Exception) with message `m` and backtrace array `b` as JSON
+  # string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class OpenStruct
+  # Deserializes JSON string by constructing new Struct object with values `t`
+  # serialized by `to_json`.
+  #
+  def self.json_create: (Hash[String, String | Hash[Symbol, untyped]] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Hash[Symbol, untyped]]
+
+  # Stores class name (OpenStruct) with this struct's values `t` as a JSON string.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Range[out Elem]
+  # Deserializes JSON string by constructing new Range object with arguments `a`
+  # serialized by `to_json`.
+  #
+  def self.json_create: (Hash[String, String | [Elem, Elem, bool]] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | [Elem, Elem, bool]]
+
+  # Stores class name (Range) with JSON array of arguments `a` which include
+  # `first` (integer), `last` (integer), and `exclude_end?` (boolean) as JSON
+  # string.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Rational
+  # Deserializes JSON string by converting numerator value `n`, denominator value
+  # `d`, to a Rational object.
+  #
+  def self.json_create: (Hash[String, String | Integer] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Integer]
+
+  # Stores class name (Rational) along with numerator value `n` and denominator
+  # value `d` as JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Regexp
+  # Deserializes JSON string by constructing new Regexp object with source `s`
+  # (Regexp or String) and options `o` serialized by `to_json`
+  #
+  def self.json_create: (Hash[String, String | Integer] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Integer]
+
+  # Stores class name (Regexp) with options `o` and source `s` (Regexp or String)
+  # as JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Set[A]
+  # Import a JSON Marshalled object.
+  #
+  # method used for JSON marshalling support.
+  #
+  def self.json_create: (Hash[String, String | Array[A]] object) -> instance
+
+  # Marshal the object to JSON.
+  #
+  # method used for JSON marshalling support.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Array[A]]
+
+  # return the JSON value
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Struct[Elem]
+  # Deserializes JSON string by constructing new Struct object with values `v`
+  # serialized by `to_json`.
+  #
+  def self.json_create: (Hash[String, String | Array[Elem]] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Array[Elem]]
+
+  # Stores class name (Struct) with Struct values `v` as a JSON string. Only named
+  # structs are supported.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Symbol
+  # Deserializes JSON string by converting the `string` value stored in the object
+  # to a Symbol
+  #
+  def self.json_create: (Hash[String, String] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String]
+
+  # Stores class name (Symbol) with String representation of Symbol as a JSON
+  # string.
+  #
+  def to_json: (?JSON::State state) -> String
+end
+
+class Time
+  # Deserializes JSON string by converting time since epoch to Time
+  #
+  def self.json_create: (Hash[String, String | Integer] object) -> instance
+
+  # Returns a hash, that will be turned into a JSON object and represent this
+  # object.
+  #
+  def as_json: (*untyped) -> Hash[String, String | Integer]
+
+  # Stores class name (Time) with number of seconds since epoch and number of
+  # microseconds for Time as JSON string
+  #
+  def to_json: (?JSON::State state) -> String
+end

--- a/test/stdlib/json/JSONBigDecimal_test.rb
+++ b/test/stdlib/json/JSONBigDecimal_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/bigdecimal"
+
+class JSONBigDecimalSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::BigDecimal)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String]) -> BigDecimal",
+                     BigDecimal, :json_create, BigDecimal("0").as_json
+  end
+end
+
+class JSONBigDecimalInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::BigDecimal"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String]",
+                     BigDecimal("0"), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     BigDecimal("0"), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     BigDecimal("0"), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONComplex_test.rb
+++ b/test/stdlib/json/JSONComplex_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/complex"
+
+class JSONComplexSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Complex)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Numeric]) -> Complex",
+                     Complex, :json_create, Complex(0).as_json
+  end
+end
+
+class JSONComplexInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Complex"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Numeric]",
+                     Complex(0), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Complex(0), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Complex(0), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONDateTime_test.rb
+++ b/test/stdlib/json/JSONDateTime_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/date_time"
+
+class JSONDateTimeSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::DateTime)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Integer | Float]) -> DateTime",
+                     DateTime, :json_create, DateTime.now.as_json
+  end
+end
+
+class JSONDateTimeInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::DateTime"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Integer | Float]",
+                     DateTime.now, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     DateTime.now, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     DateTime.now, :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONDate_test.rb
+++ b/test/stdlib/json/JSONDate_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/date"
+
+class JSONDateSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Date)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Integer | Float]) -> Date",
+                     Date, :json_create, Date.today.as_json
+  end
+end
+
+class JSONDateInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Date"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Integer | Float]",
+                     Date.today, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Date.today, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Date.today, :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONException_test.rb
+++ b/test/stdlib/json/JSONException_test.rb
@@ -1,0 +1,48 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/exception"
+
+class JSONExceptionSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Exception)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | nil]) -> Exception",
+                     Exception, :json_create, Exception.new("foo").as_json
+  end
+
+  def test_json_create_with_backtrace
+    "foo".unknown
+  rescue => exception
+    assert_send_type "(Hash[String, String | Array[String]]) -> Exception",
+                     Exception, :json_create, exception.as_json
+  end
+end
+
+class JSONExceptionInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Exception"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | nil]",
+                     Exception.new("foo"), :as_json
+  end
+
+  def test_as_json_with_backtrace
+    "foo".unknown
+  rescue => exception
+    assert_send_type "() -> Hash[String, String | Array[String]]",
+                     exception, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Exception.new("foo"), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Exception.new("foo"), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONOpenStruct_test.rb
+++ b/test/stdlib/json/JSONOpenStruct_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/ostruct"
+
+class JSONOpenStructSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::OpenStruct)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Hash[Symbol, untyped]]) -> OpenStruct",
+                     OpenStruct, :json_create, OpenStruct.new("foo" => 1).as_json
+  end
+end
+
+class JSONOpenStructInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::OpenStruct"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Hash[Symbol, untyped]]",
+                     OpenStruct.new("foo" => 1), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     OpenStruct.new, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     OpenStruct.new, :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONRange_test.rb
+++ b/test/stdlib/json/JSONRange_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/range"
+
+class JSONRangeSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Range)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | [Integer, Integer, bool]]) -> Range[Integer]",
+                     Range, :json_create, (0..9).as_json
+  end
+end
+
+class JSONRangeInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Range[Integer]"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | [Integer, Integer, bool]]",
+                     (0..9), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     (0..9), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     (0..9), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONRational_test.rb
+++ b/test/stdlib/json/JSONRational_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/rational"
+
+class JSONRationalSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Rational)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Integer]) -> Rational",
+                     Rational, :json_create, Rational(1, 3).as_json
+  end
+end
+
+class JSONRationalInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Rational"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Integer]",
+                     Rational(1, 3), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Rational(1, 3), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Rational(1, 3), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONRegexp_test.rb
+++ b/test/stdlib/json/JSONRegexp_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/regexp"
+
+class JSONRegexpSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Regexp)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Integer]) -> Regexp",
+                     Regexp, :json_create, /foo/.as_json
+  end
+end
+
+class JSONRegexpInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Regexp"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Integer]",
+                     /foo/, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     /foo/, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     /foo/, :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONSet_test.rb
+++ b/test/stdlib/json/JSONSet_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/set"
+
+class JSONSetSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Set)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Array[Integer]]) -> Set[Integer]",
+                     Set, :json_create, Set[1, 2].as_json
+  end
+end
+
+class JSONSetInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Set[Integer]"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Array[Integer]]",
+                     Set[1, 2], :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Set[1, 2], :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Set[1, 2], :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONStruct_test.rb
+++ b/test/stdlib/json/JSONStruct_test.rb
@@ -1,0 +1,38 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/struct"
+
+class JSONStructSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  Foo = Struct.new(:a)
+
+  library "json"
+  testing "singleton(::Struct)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Array[Integer]]) -> Struct[Integer]",
+                     Foo, :json_create, Foo.new(1).as_json
+  end
+end
+
+class JSONStructInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  Foo = Struct.new(:a)
+
+  library "json"
+  testing "::Struct[Integer]"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Array[Integer]]",
+                     Foo.new(1), :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Foo.new(1), :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Foo.new(1), :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONSymbol_test.rb
+++ b/test/stdlib/json/JSONSymbol_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/symbol"
+
+class JSONSymbolSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Symbol)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String]) -> Symbol",
+                     Symbol, :json_create, :foo.as_json
+  end
+end
+
+class JSONSymbolInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Symbol"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String]",
+                     :foo, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     :foo, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     :foo, :to_json, JSON::State.new
+  end
+end

--- a/test/stdlib/json/JSONTime_test.rb
+++ b/test/stdlib/json/JSONTime_test.rb
@@ -1,0 +1,34 @@
+require_relative "../test_helper"
+require "json"
+require "json/add/time"
+
+class JSONTimeSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "singleton(::Time)"
+
+  def test_json_create
+    assert_send_type "(Hash[String, String | Integer]) -> Time",
+                     Time, :json_create, Time.now.as_json
+  end
+end
+
+class JSONTimeInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "json"
+  testing "::Time"
+
+  def test_as_json
+    assert_send_type "() -> Hash[String, String | Integer]",
+                     Time.now, :as_json
+  end
+
+  def test_to_json
+    assert_send_type "() -> String",
+                     Time.now, :to_json
+    assert_send_type "(JSON::State) -> String",
+                     Time.now, :to_json, JSON::State.new
+  end
+end


### PR DESCRIPTION
This change adds extended signatures (e.g. `#as_json` or `.json_create`) for JSON additional classes:

- BigDecimal
- Complex
- DateTime
- Date
- Exception
- OpenStruct
- Range
- Rational
- Regexp
- Set
- Struct
- Symbol
- Time

See <https://github.com/flori/json/blob/v2.5.1/lib/json/add/>

Related to #592