### PR TITLE
Add features for partial invalidation

### DIFF
--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -40,6 +40,7 @@ require "rbs/vendorer"
 require "rbs/validator"
 require "rbs/factory"
 require "rbs/repository"
+require "rbs/ancestor_graph"
 
 begin
   require "rbs/parser"

--- a/lib/rbs/ancestor_graph.rb
+++ b/lib/rbs/ancestor_graph.rb
@@ -1,0 +1,90 @@
+module RBS
+  class AncestorGraph
+    InstanceNode = _ = Struct.new(:type_name, keyword_init: true)
+    SingletonNode = _ = Struct.new(:type_name, keyword_init: true)
+
+    attr_reader :env
+    attr_reader :ancestor_builder
+    attr_reader :parents
+    attr_reader :children
+
+    def initialize(env:, ancestor_builder: DefinitionBuilder::AncestorBuilder.new(env: env))
+      @env = env
+      @ancestor_builder = ancestor_builder
+      build()
+    end
+
+    def build()
+      @parents = {}
+      @children = {}
+
+      env.class_decls.each_key do |type_name|
+        build_ancestors(InstanceNode.new(type_name: type_name), ancestor_builder.one_instance_ancestors(type_name))
+        build_ancestors(SingletonNode.new(type_name: type_name), ancestor_builder.one_singleton_ancestors(type_name))
+      end
+      env.interface_decls.each_key do |type_name|
+        build_ancestors(InstanceNode.new(type_name: type_name), ancestor_builder.one_interface_ancestors(type_name))
+      end
+    end
+
+    def build_ancestors(node, ancestors)
+      ancestors.each_ancestor do |ancestor|
+        case ancestor
+        when Definition::Ancestor::Instance
+          register(child: node, parent: InstanceNode.new(type_name: ancestor.name))
+        when Definition::Ancestor::Singleton
+          register(child: node, parent: SingletonNode.new(type_name: ancestor.name))
+        end
+      end
+    end
+
+    def register(parent:, child:)
+      (parents[child] ||= Set[]) << parent
+      (children[parent] ||= Set[]) << child
+    end
+
+    def each_parent(node, &block)
+      if block
+        parents[node]&.each(&block)
+      else
+        enum_for :each_parent, node
+      end
+    end
+
+    def each_child(node, &block)
+      if block
+        children[node]&.each(&block)
+      else
+        enum_for :each_child, node
+      end
+    end
+
+    def each_ancestor(node, yielded: Set[], &block)
+      if block
+        each_parent(node) do |parent|
+          unless yielded.member?(parent)
+            yielded << parent
+            yield parent
+            each_ancestor(parent, yielded: yielded, &block)
+          end
+        end
+      else
+        enum_for :each_ancestor, node
+      end
+    end
+
+    def each_descendant(node, yielded: Set[], &block)
+      if block
+        each_child(node) do |child|
+          unless yielded.member?(child)
+            yielded << child
+            yield child
+            each_descendant(child, yielded: yielded, &block)
+          end
+        end
+      else
+        enum_for :each_descendant, node
+      end
+    end
+  end
+end

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -10,11 +10,11 @@ module RBS
     attr_reader :singleton0_cache
     attr_reader :interface_cache
 
-    def initialize(env:)
+    def initialize(env:, ancestor_builder: nil, method_builder: nil)
       @env = env
       @type_name_resolver = TypeNameResolver.from_env(env)
-      @ancestor_builder = AncestorBuilder.new(env: env)
-      @method_builder = MethodBuilder.new(env: env)
+      @ancestor_builder = ancestor_builder || AncestorBuilder.new(env: env)
+      @method_builder = method_builder || MethodBuilder.new(env: env)
 
       @instance_cache = {}
       @singleton_cache = {}

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -788,5 +788,24 @@ module RBS
       ensure_namespace!(type_name.namespace, location: entry.decl.location)
       entry.decl.type
     end
+
+    def update(env:, except:, ancestor_builder:)
+      method_builder = self.method_builder.update(env: env, except: except)
+
+      DefinitionBuilder.new(env: env, ancestor_builder: ancestor_builder, method_builder: method_builder).tap do |builder|
+        builder.instance_cache.merge!(instance_cache)
+        builder.singleton_cache.merge!(singleton_cache)
+        builder.singleton0_cache.merge!(singleton0_cache)
+        builder.interface_cache.merge!(interface_cache)
+
+        except.each do |name|
+          builder.instance_cache.delete([name, true])
+          builder.instance_cache.delete([name, false])
+          builder.singleton_cache.delete(name)
+          builder.singleton0_cache.delete(name)
+          builder.interface_cache.delete(name)
+        end
+      end
+    end
   end
 end

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -219,6 +219,20 @@ module RBS
           end
         end
       end
+
+      def update(env:, except:)
+        MethodBuilder.new(env: env).tap do |copy|
+          copy.instance_methods.merge!(instance_methods)
+          copy.singleton_methods.merge!(singleton_methods)
+          copy.interface_methods.merge!(interface_methods)
+
+          except.each do |type_name|
+            copy.instance_methods.delete(type_name)
+            copy.singleton_methods.delete(type_name)
+            copy.interface_methods.delete(type_name)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -1,6 +1,5 @@
 module RBS
   class Environment
-    attr_reader :buffers
     attr_reader :declarations
 
     attr_reader :class_decls
@@ -431,8 +430,24 @@ module RBS
     end
 
     def inspect
-      ivars = %i[@buffers @declarations @class_decls @interface_decls @alias_decls @constant_decls @global_decls]
+      ivars = %i[@declarations @class_decls @interface_decls @alias_decls @constant_decls @global_decls]
       "\#<RBS::Environment #{ivars.map { |iv| "#{iv}=(#{instance_variable_get(iv).size} items)"}.join(' ')}>"
+    end
+
+    def buffers
+      buffers_decls.keys.compact
+    end
+
+    def buffers_decls
+      # @type var hash: Hash[Buffer, Array[AST::Declarations::t]]
+      hash = {}
+
+      declarations.each do |decl|
+        location = decl.location or next
+        (hash[location.buffer] ||= []) << decl
+      end
+
+      hash
     end
   end
 end

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -168,7 +168,7 @@ module RBS
           # @type var decl: AST::Declarations::Class
           existing_entry.insert(decl: decl, outer: outer)
         else
-          raise DuplicatedDeclarationError.new(name, decl, existing_entry.primary.decl)
+          raise DuplicatedDeclarationError.new(name, decl, existing_entry.decls[0].decl)
         end
 
         prefix = outer + [decl]
@@ -201,6 +201,12 @@ module RBS
       declarations << decl
       insert_decl(decl, outer: [], namespace: Namespace.root)
       self
+    end
+
+    def validate_type_params
+      class_decls.each_value do |decl|
+        decl.primary
+      end
     end
 
     def resolve_type_names

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -449,5 +449,17 @@ module RBS
 
       hash
     end
+
+    def reject
+      env = Environment.new
+
+      declarations.each do |decl|
+        unless yield(decl)
+          env << decl
+        end
+      end
+
+      env
+    end
   end
 end

--- a/lib/rbs/environment_walker.rb
+++ b/lib/rbs/environment_walker.rb
@@ -1,14 +1,14 @@
 module RBS
   class EnvironmentWalker
-    InstanceNode = Struct.new(:type_name, keyword_init: true)
-    SingletonNode = Struct.new(:type_name, keyword_init: true)
-    TypeNameNode = Struct.new(:type_name, keyword_init: true)
+    InstanceNode = _ = Struct.new(:type_name, keyword_init: true)
+    SingletonNode = _ = Struct.new(:type_name, keyword_init: true)
+    TypeNameNode = _ = Struct.new(:type_name, keyword_init: true)
 
     attr_reader :env
 
     def initialize(env:)
       @env = env
-      @only_ancestors = nil
+      @only_ancestors = false
     end
 
     def builder

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -14,7 +14,12 @@ module RBS
     end
   end
 
-  class InvalidTypeApplicationError < StandardError
+  class ErrorBase < StandardError; end
+  class ParsingError < ErrorBase; end
+  class LoadingError < ErrorBase; end
+  class DefinitionError < ErrorBase; end
+
+  class InvalidTypeApplicationError < DefinitionError
     attr_reader :type_name
     attr_reader :args
     attr_reader :params
@@ -35,7 +40,7 @@ module RBS
     end
   end
 
-  class RecursiveAncestorError < StandardError
+  class RecursiveAncestorError < DefinitionError
     attr_reader :ancestors
     attr_reader :location
 
@@ -73,7 +78,7 @@ module RBS
     end
   end
 
-  class NoTypeFoundError < StandardError
+  class NoTypeFoundError < ErrorBase
     attr_reader :type_name
     attr_reader :location
 
@@ -102,7 +107,7 @@ module RBS
     end
   end
 
-  class NoSuperclassFoundError < StandardError
+  class NoSuperclassFoundError < DefinitionError
     attr_reader :type_name
     attr_reader :location
 
@@ -118,7 +123,7 @@ module RBS
     end
   end
 
-  class NoSelfTypeFoundError < StandardError
+  class NoSelfTypeFoundError < DefinitionError
     attr_reader :type_name
     attr_reader :location
 
@@ -145,7 +150,7 @@ module RBS
     end
   end
 
-  class NoMixinFoundError < StandardError
+  class NoMixinFoundError < DefinitionError
     attr_reader :type_name
     attr_reader :member
 
@@ -174,7 +179,7 @@ module RBS
     end
   end
 
-  class DuplicatedMethodDefinitionError < StandardError
+  class DuplicatedMethodDefinitionError < DefinitionError
     attr_reader :type
     attr_reader :method_name
     attr_reader :members
@@ -209,7 +214,7 @@ module RBS
     end
   end
 
-  class DuplicatedInterfaceMethodDefinitionError < StandardError
+  class DuplicatedInterfaceMethodDefinitionError < DefinitionError
     attr_reader :type
     attr_reader :method_name
     attr_reader :member
@@ -232,7 +237,7 @@ module RBS
     end
   end
 
-  class UnknownMethodAliasError < StandardError
+  class UnknownMethodAliasError < DefinitionError
     attr_reader :original_name
     attr_reader :aliased_name
     attr_reader :location
@@ -246,7 +251,7 @@ module RBS
     end
   end
 
-  class SuperclassMismatchError < StandardError
+  class SuperclassMismatchError < DefinitionError
     attr_reader :name
     attr_reader :entry
 
@@ -257,7 +262,7 @@ module RBS
     end
   end
 
-  class InvalidOverloadMethodError < StandardError
+  class InvalidOverloadMethodError < DefinitionError
     attr_reader :type_name
     attr_reader :method_name
     attr_reader :kind
@@ -280,7 +285,7 @@ module RBS
     end
   end
 
-  class GenericParameterMismatchError < StandardError
+  class GenericParameterMismatchError < LoadingError
     attr_reader :name
     attr_reader :decl
 
@@ -291,7 +296,7 @@ module RBS
     end
   end
 
-  class DuplicatedDeclarationError < StandardError
+  class DuplicatedDeclarationError < LoadingError
     attr_reader :name
     attr_reader :decls
 
@@ -304,7 +309,7 @@ module RBS
     end
   end
 
-  class InvalidVarianceAnnotationError < StandardError
+  class InvalidVarianceAnnotationError < DefinitionError
     attr_reader :type_name
     attr_reader :param
     attr_reader :location
@@ -318,7 +323,7 @@ module RBS
     end
   end
 
-  class RecursiveAliasDefinitionError < StandardError
+  class RecursiveAliasDefinitionError < DefinitionError
     attr_reader :type
     attr_reader :defs
 

--- a/lib/rbs/parser.rb
+++ b/lib/rbs/parser.rb
@@ -373,7 +373,7 @@ def on_error(token_id, error_value, value_stack)
   raise SyntaxError.new(token_str: token_to_str(token_id), error_value: error_value, value_stack: value_stack)
 end
 
-class SyntaxError < StandardError
+class SyntaxError < ParsingError
   attr_reader :token_str, :error_value, :value_stack
 
   def initialize(token_str:, error_value:, value_stack: nil)
@@ -385,7 +385,7 @@ class SyntaxError < StandardError
   end
 end
 
-class SemanticsError < StandardError
+class SemanticsError < ParsingError
   attr_reader :subject, :location, :original_message
 
   def initialize(message, subject:, location:)

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -1433,7 +1433,7 @@ def on_error(token_id, error_value, value_stack)
   raise SyntaxError.new(token_str: token_to_str(token_id), error_value: error_value, value_stack: value_stack)
 end
 
-class SyntaxError < StandardError
+class SyntaxError < ParsingError
   attr_reader :token_str, :error_value, :value_stack
 
   def initialize(token_str:, error_value:, value_stack: nil)
@@ -1445,7 +1445,7 @@ class SyntaxError < StandardError
   end
 end
 
-class SemanticsError < StandardError
+class SemanticsError < ParsingError
   attr_reader :subject, :location, :original_message
 
   def initialize(message, subject:, location:)

--- a/sig/ancestor_graph.rbs
+++ b/sig/ancestor_graph.rbs
@@ -1,0 +1,40 @@
+module RBS
+  class AncestorGraph
+    class InstanceNode
+      attr_reader type_name: TypeName
+      def initialize: (type_name: TypeName) -> void
+    end
+
+    class SingletonNode
+      attr_reader type_name: TypeName
+      def initialize: (type_name: TypeName) -> void
+    end
+
+    type node = InstanceNode | SingletonNode
+
+    attr_reader env: Environment
+    attr_reader ancestor_builder: DefinitionBuilder::AncestorBuilder
+    attr_reader parents: Hash[node, Set[node]]
+    attr_reader children: Hash[node, Set[node]]
+
+    def initialize: (env: Environment, ?ancestor_builder: DefinitionBuilder::AncestorBuilder) -> void
+
+    def build: () -> void
+
+    def each_parent: (node) { (node) -> void } -> void
+                   | (node) -> Enumerator[node, void]
+
+    def each_ancestor: (node, ?yielded: Set[node]) { (node) -> void } -> void
+                     | (node) -> Enumerator[node, void]
+
+    def each_child: (node) { (node) -> void } -> void
+                  | (node) -> Enumerator[node, void]
+
+    def each_descendant: (node, ?yielded: Set[node]) { (node) -> void } -> void
+                       | (node) -> Enumerator[node, void]
+
+    def build_ancestors: (node, DefinitionBuilder::AncestorBuilder::OneAncestors) -> void
+
+    def register: (parent: node, child: node) -> void
+  end
+end

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -42,5 +42,7 @@ module RBS
     def insert_variable: (TypeName, Hash[Symbol, Definition::Variable], name: Symbol, type: Types::t) -> void
 
     def define_methods: (Definition, interface_methods: Hash[Symbol, Definition::Method], methods: MethodBuilder::Methods, super_interface_method: bool) -> void
+
+    def expand_alias: (TypeName) -> Types::t
   end
 end

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -44,5 +44,7 @@ module RBS
     def define_methods: (Definition, interface_methods: Hash[Symbol, Definition::Method], methods: MethodBuilder::Methods, super_interface_method: bool) -> void
 
     def expand_alias: (TypeName) -> Types::t
+
+    def update: (env: Environment, ancestor_builder: AncestorBuilder, except: _Each[TypeName]) -> DefinitionBuilder
   end
 end

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -10,7 +10,7 @@ module RBS
     attr_reader singleton0_cache: Hash[TypeName, Definition | false | nil]
     attr_reader interface_cache: Hash[TypeName, Definition | false | nil]
 
-    def initialize: (env: Environment) -> void
+    def initialize: (env: Environment, ?ancestor_builder: AncestorBuilder?, ?method_builder: MethodBuilder?) -> void
 
     def validate_super_class!: (TypeName, Environment::ClassEntry) -> void
 

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -58,7 +58,6 @@ module RBS
       def initialize: (name: N, decl: D, outer: Array[module_decl]) -> void
     end
 
-    attr_reader buffers: Array[Buffer]
     attr_reader declarations: Array[AST::Declarations::t]
 
     attr_reader class_decls: Hash[TypeName, ModuleEntry | ClassEntry]
@@ -90,5 +89,9 @@ module RBS
     def absolute_type_name: (TypeNameResolver, TypeName, context: Array[Namespace]) -> TypeName
 
     def inspect: () -> String
+
+    def buffers: () -> Array[Buffer]
+
+    def buffers_decls: () -> Hash[Buffer, Array[AST::Declarations::t]]
   end
 end

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -58,6 +58,7 @@ module RBS
       def initialize: (name: N, decl: D, outer: Array[module_decl]) -> void
     end
 
+    # Top level declarations.
     attr_reader declarations: Array[AST::Declarations::t]
 
     attr_reader class_decls: Hash[TypeName, ModuleEntry | ClassEntry]
@@ -76,7 +77,12 @@ module RBS
 
     def insert_decl: (AST::Declarations::t, outer: Array[module_decl], namespace: Namespace) -> void
 
+    # Insert a toplevel declaration into the env.
+    #
     def <<: (AST::Declarations::t decl) -> self
+
+    # Runs generics type params validation over each class definitions.
+    def validate_type_params: () -> void
 
     def resolve_type_names: () -> Environment
 
@@ -96,7 +102,7 @@ module RBS
 
     # Construct new environment without declarations tested `true` by block.
     # Construction of new environment is done with `<<` so that nested declarations will work well.
-    # 
+    #
     def reject: () { (AST::Declarations::t) -> boolish } -> Environment
   end
 end

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -93,5 +93,10 @@ module RBS
     def buffers: () -> Array[Buffer]
 
     def buffers_decls: () -> Hash[Buffer, Array[AST::Declarations::t]]
+
+    # Construct new environment without declarations tested `true` by block.
+    # Construction of new environment is done with `<<` so that nested declarations will work well.
+    # 
+    def reject: () { (AST::Declarations::t) -> boolish } -> Environment
   end
 end

--- a/sig/environment_walker.rbs
+++ b/sig/environment_walker.rbs
@@ -1,0 +1,39 @@
+module RBS
+  class EnvironmentWalker
+    class InstanceNode
+      attr_reader type_name: TypeName
+      def initialize: (type_name: TypeName) -> void
+    end
+
+    class SingletonNode
+      attr_reader type_name: TypeName
+      def initialize: (type_name: TypeName) -> void
+    end
+
+    class TypeNameNode
+      attr_reader type_name: TypeName
+      def initialize: (type_name: TypeName) -> void
+    end
+
+    attr_reader env: Environment
+    attr_reader only_ancestors: bool
+    attr_reader builder: DefinitionBuilder
+
+    def initialize: (env: Environment) -> void
+
+    def only_ancestors!: (?bool only) -> self
+
+    def only_ancestors?: () -> bool
+
+    type node = InstanceNode | SingletonNode | TypeNameNode
+    include TSort[node]
+
+    def tsort_each_node: () { (node) -> void } -> void
+
+    def tsort_each_child: (node) { (node) -> void } -> void
+
+    def each_type_name: (Types::t) { (TypeName) -> void } -> void
+
+    def each_type_node: (Types::t) { (node) -> void } -> void
+  end
+end

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -11,7 +11,27 @@ module RBS
     def method_name_string: () -> String
   end
 
-  class InvalidTypeApplicationError < StandardError
+  # Error class for errors defined in RBS.
+  #
+  class BaseError < StandardError
+  end
+
+  # Error class for errors raised during parsing.
+  #
+  class ParsingError < BaseError
+  end
+
+  # Error class for errors raised during loading environments.
+  #
+  class LoadingError < BaseError
+  end
+
+  # Error class for errors raised during building definitions.
+  #
+  class DefinitionError < BaseError
+  end
+
+  class InvalidTypeApplicationError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader args: Array[Types::t]
     attr_reader params: Array[Symbol]
@@ -22,16 +42,16 @@ module RBS
     def self.check!: (type_name: TypeName, args: Array[Types::t], params: Array[Symbol], location: Location?) -> void
   end
 
-  class RecursiveAncestorError < StandardError
+  class RecursiveAncestorError < DefinitionError
     attr_reader ancestors: Array[Definition::Ancestor::t]
-    attr_reader location: Location
+    attr_reader location: Location?
 
     def initialize: (ancestors: Array[Definition::Ancestor::t], location: Location?) -> void
 
     def self.check!: (Definition::Ancestor::t, ancestors: Array[Definition::Ancestor::t], location: Location?) -> void
   end
 
-  class NoTypeFoundError < StandardError
+  class NoTypeFoundError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader location: Location?
 
@@ -40,7 +60,7 @@ module RBS
     def self.check!: (TypeName, env: Environment, location: Location?) -> TypeName
   end
 
-  class NoSuperclassFoundError < StandardError
+  class NoSuperclassFoundError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader location: Location?
 
@@ -49,7 +69,7 @@ module RBS
     def self.check!: (TypeName, env: Environment, location: Location?) -> void
   end
 
-  class NoSelfTypeFoundError < StandardError
+  class NoSelfTypeFoundError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader location: Location?
 
@@ -58,7 +78,7 @@ module RBS
     def self.check!: (AST::Declarations::Module::Self, env: Environment) -> void
   end
 
-  class NoMixinFoundError < StandardError
+  class NoMixinFoundError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader member: AST::Members::t
 
@@ -69,7 +89,7 @@ module RBS
     def self.check!: (TypeName, env: Environment, member: AST::Members::t) -> void
   end
 
-  class DuplicatedMethodDefinitionError < StandardError
+  class DuplicatedMethodDefinitionError < DefinitionError
     type ty = Types::ClassSingleton | Types::ClassInstance | Types::Interface
     type original = DefinitionBuilder::MethodBuilder::Methods::Definition::original
 
@@ -86,7 +106,7 @@ module RBS
     def other_locations: () -> Array[Location?]
   end
 
-  class DuplicatedInterfaceMethodDefinitionError < StandardError
+  class DuplicatedInterfaceMethodDefinitionError < DefinitionError
     type ty = Types::ClassSingleton | Types::ClassInstance | Types::Interface
     type mixin_member = AST::Members::Include | AST::Members::Extend
 
@@ -99,7 +119,7 @@ module RBS
     def qualified_method_name: () -> String
   end
 
-  class UnknownMethodAliasError < StandardError
+  class UnknownMethodAliasError < DefinitionError
     attr_reader original_name: Symbol
     attr_reader aliased_name: Symbol
     attr_reader location: Location?
@@ -107,14 +127,14 @@ module RBS
     def initialize: (original_name: Symbol, aliased_name: Symbol, location: Location?) -> void
   end
 
-  class SuperclassMismatchError < StandardError
+  class SuperclassMismatchError < DefinitionError
     attr_reader name: TypeName
     attr_reader entry: Environment::ClassEntry
 
     def initialize: (name: TypeName, entry: Environment::ClassEntry) -> void
   end
 
-  class InvalidOverloadMethodError < StandardError
+  class InvalidOverloadMethodError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader method_name: Symbol
     attr_reader kind: :instance | :singleton
@@ -123,21 +143,21 @@ module RBS
     def initialize: (type_name: TypeName, method_name: Symbol, kind: :instance | :singleton, members: Array[AST::Members::MethodDefinition]) -> void
   end
 
-  class GenericParameterMismatchError < StandardError
+  class GenericParameterMismatchError < LoadingError
     attr_reader name: TypeName
     attr_reader decl: AST::Declarations::Class | AST::Declarations::Module
 
     def initialize: (name: TypeName, decl: AST::Declarations::Class | AST::Declarations::Module) -> void
   end
 
-  class DuplicatedDeclarationError < StandardError
+  class DuplicatedDeclarationError < LoadingError
     attr_reader name: TypeName | Symbol
     attr_reader decls: Array[AST::Declarations::t]
 
     def initialize: (TypeName | Symbol, *AST::Declarations::t) -> void
   end
 
-  class InvalidVarianceAnnotationError < StandardError
+  class InvalidVarianceAnnotationError < DefinitionError
     attr_reader type_name: TypeName
     attr_reader param: AST::Declarations::ModuleTypeParams::TypeParam
     attr_reader location: Location?
@@ -145,7 +165,7 @@ module RBS
     def initialize: (type_name: TypeName, param: AST::Declarations::ModuleTypeParams::TypeParam, location: Location?) -> void
   end
 
-  class RecursiveAliasDefinitionError < StandardError
+  class RecursiveAliasDefinitionError < DefinitionError
     type ty = Types::ClassInstance | Types::ClassSingleton | Types::Interface
     type defn = DefinitionBuilder::MethodBuilder::Methods::Definition
 

--- a/sig/method_builder.rbs
+++ b/sig/method_builder.rbs
@@ -66,6 +66,8 @@ module RBS
       def build_method: (Methods, Methods::instance_type, member: AST::Members::MethodDefinition, accessibility: Methods::Definition::accessibility) -> void
 
       def each_member_with_accessibility: (Array[AST::Members::t | AST::Declarations::t], ?accessibility: Definition::accessibility) { (AST::Members::t | AST::Declarations::t, Definition::accessibility) -> void } -> void
+
+      def update: (env: Environment, except: _Each[TypeName]) -> MethodBuilder
     end
   end
 end

--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -1,6 +1,6 @@
 module RBS
   class Parser
-    class SyntaxError < StandardError
+    class SyntaxError < ParsingError
       attr_reader token_str: String
       attr_reader error_value: untyped
       attr_reader value_stack: untyped?
@@ -8,7 +8,7 @@ module RBS
       def initialize: (token_str: String, error_value: untyped, ?value_stack: untyped?) -> void
     end
 
-    class SemanticsError < StandardError
+    class SemanticsError < ParsingError
       attr_reader subject: untyped
       attr_reader location: Location
       attr_reader original_message: String
@@ -17,9 +17,9 @@ module RBS
     end
 
     def self.parse_method_type: (String | Buffer, ?variables: Array[Symbol], ?eof_re: Regexp?) -> MethodType
-                              
+
     def self.parse_type: (String | Buffer, ?variables: Array[Symbol], ?eof_re: Regexp?) -> Types::t
-                       
+
     def self.parse_signature: (String | Buffer, ?eof_re: Regexp?) -> Array[AST::Declarations::t]
   end
 end

--- a/test/rbs/ancestor_graph_test.rb
+++ b/test/rbs/ancestor_graph_test.rb
@@ -1,0 +1,110 @@
+require "test_helper"
+
+class RBS::AncestorGraphTest < Test::Unit::TestCase
+  include TestHelper
+
+  Environment = RBS::Environment
+  EnvironmentLoader = RBS::EnvironmentLoader
+  AncestorGraph = RBS::AncestorGraph
+
+  def InstanceNode(name)
+    if name.is_a?(String)
+      name = TypeName(name)
+    end
+
+    AncestorGraph::InstanceNode.new(type_name: name)
+  end
+
+  def SingletonNode(name)
+    if name.is_a?(String)
+      name = TypeName(name)
+    end
+
+    AncestorGraph::SingletonNode.new(type_name: name)
+  end
+
+  def test_graph
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class A
+end
+
+class B < A
+  include M
+  include _I
+end
+
+class C < B
+end
+
+module M
+end
+
+interface _I
+end
+
+interface _J
+  include _I
+end
+EOF
+
+      manager.build do |env|
+        graph = AncestorGraph.new(env: env)
+
+        assert_equal(
+          Set[InstanceNode("::Object"), InstanceNode("::Kernel"), InstanceNode("::BasicObject")],
+          graph.each_ancestor(InstanceNode("::A")).to_set
+        )
+        assert_equal(
+          Set[InstanceNode("::B"), InstanceNode("::C")],
+          graph.each_descendant(InstanceNode("::A")).to_set
+        )
+
+        assert_equal(
+          Set[InstanceNode("::M"), InstanceNode("::_I"), InstanceNode("::A"), InstanceNode("::Object"), InstanceNode("::Kernel"), InstanceNode("::BasicObject")],
+          graph.each_ancestor(InstanceNode("::B")).to_set
+        )
+        assert_equal(
+          Set[InstanceNode("::C")],
+          graph.each_descendant(InstanceNode("::B")).to_set
+        )
+
+        assert_equal(
+          Set[InstanceNode("::B"), InstanceNode("::M"), InstanceNode("::_I"), InstanceNode("::A"), InstanceNode("::Object"), InstanceNode("::Kernel"), InstanceNode("::BasicObject")],
+          graph.each_ancestor(InstanceNode("::C")).to_set
+        )
+        assert_equal(
+          Set[],
+          graph.each_descendant(InstanceNode("::C")).to_set
+        )
+
+        assert_equal(
+          Set[InstanceNode("::Object"), InstanceNode("::Kernel"), InstanceNode("::BasicObject")],
+          graph.each_ancestor(InstanceNode("::M")).to_set
+        )
+        assert_equal(
+          Set[InstanceNode("::B"), InstanceNode("::C")],
+          graph.each_descendant(InstanceNode("::M")).to_set
+        )
+
+        assert_equal(
+          Set[],
+          graph.each_ancestor(InstanceNode("::_I")).to_set
+        )
+        assert_equal(
+          Set[InstanceNode("::B"), InstanceNode("::C"), InstanceNode("::_J")],
+          graph.each_descendant(InstanceNode("::_I")).to_set
+        )
+
+        assert_equal(
+          Set[InstanceNode("::_I")],
+          graph.each_ancestor(InstanceNode("::_J")).to_set
+        )
+        assert_equal(
+          Set[],
+          graph.each_descendant(InstanceNode("::_J")).to_set
+        )
+      end
+    end
+  end
+end

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -384,4 +384,38 @@ module ::Enumerable[A]
 end
 RBS
   end
+
+  def test_reject
+    env = Environment.new
+
+    foo = RBS::Buffer.new(content: <<EOF, name: Pathname("foo.rbs"))
+class Hello < String
+  def hello: (String) -> Integer
+end
+EOF
+
+    RBS::Parser.parse_signature(foo).each do |decl|
+      env << decl
+    end
+
+    bar = RBS::Buffer.new(content: <<EOF, name: Pathname("bar.rbs"))
+class Hello
+  def world: () -> void
+end
+EOF
+
+    RBS::Parser.parse_signature(bar).each do |decl|
+      env << decl
+    end
+
+    assert env.buffers.any? {|buf| buf.name == Pathname("foo.rbs") }
+    assert env.buffers.any? {|buf| buf.name == Pathname("bar.rbs") }
+
+    env_ = env.reject do |decl|
+      decl.location.buffer.name == Pathname("foo.rbs")
+    end
+
+    assert env_.buffers.none? {|buf| buf.name == Pathname("foo.rbs") }
+    assert env_.buffers.any? {|buf| buf.name == Pathname("bar.rbs") }
+  end
 end

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -160,11 +160,14 @@ module Foo[X, in Y]      # Variance mismatch
 end
 EOF
 
-    # The GenericParameterMismatchError raises on #type_params call
     env << decls[0]
     env << decls[1]
     env << decls[2]
     env << decls[3]
+
+    assert_raises RBS::GenericParameterMismatchError do
+      env.validate_type_params()
+    end
   end
 
   def test_generic_class_error


### PR DESCRIPTION
Invalidating all of the caches -- definition builder cache, method builder cache, and ancestor cache -- makes interactive RBS access really slow. This pull request adds some features to implement partial cache invalidation.

* `AncestorGraph` allows descendant classes/modules/interfaces of a class/module/interface, that allows identifying a set of types to be invalidated.
* `Environment#reject` allows removing declarations from environments.