### PR TITLE
Fix `Array#{shuffle, shuffle!, sample}` takes random generator, not only for `Random`

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1584,8 +1584,8 @@ class Array[unchecked out Elem] < Object
   #     a.sample(random: Random.new(1))     #=> 6
   #     a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
   #
-  def sample: (?random: Random rng) -> Elem?
-            | (?int n, ?random: Random rng) -> ::Array[Elem]
+  def sample: (?random: _Rand rng) -> Elem?
+            | (?int n, ?random: _Rand rng) -> ::Array[Elem]
 
   # Returns a new array containing all elements of `ary` for which the given
   # `block` returns a true value.
@@ -1649,7 +1649,7 @@ class Array[unchecked out Elem] < Object
   #
   #     a.shuffle(random: Random.new(1))  #=> [1, 3, 2]
   #
-  def shuffle: (?random: Random rng) -> ::Array[Elem]
+  def shuffle: (?random: _Rand rng) -> ::Array[Elem]
 
   # Shuffles elements in `self` in place.
   #
@@ -1661,7 +1661,7 @@ class Array[unchecked out Elem] < Object
   #
   #     a.shuffle!(random: Random.new(1))  #=> [1, 3, 2]
   #
-  def shuffle!: (?random: Random rng) -> self
+  def shuffle!: (?random: _Rand rng) -> self
 
   alias size length
 
@@ -1995,6 +1995,10 @@ end
 
 interface _ToAry[T]
   def to_ary: () -> ::Array[T]
+end
+
+interface _Rand
+  def rand: (::Integer max) -> ::Integer
 end
 
 interface Array::_Pattern[T]

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -724,11 +724,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [], :sample
     assert_send_type "(random: Random) -> Integer",
                      [1,2,3], :sample, random: Random.new(1)
+    assert_send_type "(random: Rand) -> Integer",
+                     [1,2,3], :sample, random: Rand.new
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :sample, 2
     assert_send_type "(ToInt, random: Random) -> Array[Integer]",
                      [1,2,3], :sample, ToInt.new(2), random: Random.new(2)
+    assert_send_type "(ToInt, random: Rand) -> Array[Integer]",
+                     [1,2,3], :sample, ToInt.new(2), random: Rand.new
   end
 
   def test_select
@@ -759,6 +763,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :shuffle
     assert_send_type "(random: Random) -> Array[Integer]",
                      [1,2,3], :shuffle, random: Random.new(2)
+    assert_send_type "(random: Rand) -> Array[Integer]",
+                     [1,2,3], :shuffle, random: Rand.new
   end
 
   def test_shuffle!
@@ -766,6 +772,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :shuffle!
     assert_send_type "(random: Random) -> Array[Integer]",
                      [1,2,3], :shuffle!, random: Random.new(2)
+    assert_send_type "(random: Rand) -> Array[Integer]",
+                     [1,2,3], :shuffle!, random: Rand.new
   end
 
   def test_slice

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -357,6 +357,12 @@ end
 class ToJson
 end
 
+class Rand
+  def rand(max)
+    max - 1
+  end
+end
+
 class JsonWrite
   def write(_str)
   end


### PR DESCRIPTION
Behavior checking code
---

```ruby
fixed_random_generator = Object.new
class << fixed_random_generator
  def rand(limit)
    raise ArgumentError unless limit.instance_of?(Integer)
    p(limit - 1)
  end
end

puts 'Array#shuffle'
p %w[a b c d e].shuffle random: fixed_random_generator
puts 'Array#shuffle!'
p %w[a b c d e].shuffle! random: fixed_random_generator
puts 'Array#sample'
p %w[a b c d e].sample random: fixed_random_generator
```

It outputs 

```
Array#shuffle
4
3
2
1
0
["a", "b", "c", "d", "e"]
Array#shuffle!
4
3
2
1
0
["a", "b", "c", "d", "e"]
Array#sample
4
"e"
```

MRI implementations
---

`Array#sample`
https://github.com/ruby/ruby/blob/1f0e0dfb228fd14b3f6687539ba274ba6a2d1643/array.c#L6361-L6373

`Array#shuffle!`
https://github.com/ruby/ruby/blob/1f0e0dfb228fd14b3f6687539ba274ba6a2d1643/array.c#L6331-L6339

`RAND_UPTO` and `rb_random_ulong_limited`
https://github.com/ruby/ruby/blob/1f0e0dfb228fd14b3f6687539ba274ba6a2d1643/array.c#L6328
https://github.com/ruby/ruby/blob/1f0e0dfb228fd14b3f6687539ba274ba6a2d1643/random.c#L1127-L1144

