### PR TITLE
Fix RBS for Thread.new

### DIFF
--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -287,7 +287,21 @@ class Thread < Object
 
   def group: () -> ThreadGroup?
 
-  def initialize: (*untyped args) -> Thread
+  # Creates a new thread executing the given block.
+  #
+  # Any `args` given to ::new will be passed to the block:
+  #
+  #     arr = []
+  #     a, b, c = 1, 2, 3
+  #     Thread.new(a,b,c) { |d,e,f| arr << d << e << f }.join
+  #     arr #=> [1, 2, 3]
+  #
+  # A ThreadError exception is raised if ::new is called without a block.
+  #
+  # If you're going to subclass Thread, be sure to call super in your `initialize`
+  # method, otherwise a ThreadError will be raised.
+  def initialize: () { () -> untyped } -> void
+                | (*untyped) { (*untyped) -> untyped } -> void
 
   # The calling thread will suspend execution and run this `thr` .
   #

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -300,8 +300,7 @@ class Thread < Object
   #
   # If you're going to subclass Thread, be sure to call super in your `initialize`
   # method, otherwise a ThreadError will be raised.
-  def initialize: () { () -> untyped } -> void
-                | (*untyped) { (*untyped) -> untyped } -> void
+  def initialize: (*untyped) { (*untyped) -> void } -> void
 
   # The calling thread will suspend execution and run this `thr` .
   #

--- a/test/stdlib/Thread_test.rb
+++ b/test/stdlib/Thread_test.rb
@@ -1,0 +1,18 @@
+require_relative "test_helper"
+
+class ThreadSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::Thread)"
+
+  def test_new
+    assert_send_type  "() { () -> untyped } -> Thread",
+                      Thread, :new do 1 end
+    assert_send_type  "(Integer, nil) { (Integer, nil) -> untyped } -> Thread",
+                      Thread, :new, 1, nil do |a, b| [a, b] end
+
+    a_proc = proc { "do something..." }
+    assert_send_type  "() { () -> untyped } -> Thread",
+                      Thread, :new, &a_proc
+  end
+end


### PR DESCRIPTION
This change fixes RBS for the `Thread.new` method (actually `Thread#initialize`).
Also, this adds a missing test for `Thread` RBS.