### PR TITLE
No substitute `instance` types on `#build_singleton`

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -361,15 +361,10 @@ module RBS
         when Environment::ClassEntry, Environment::ModuleEntry
           ancestors = ancestor_builder.singleton_ancestors(type_name)
           self_type = Types::ClassSingleton.new(name: type_name, location: nil)
-          instance_type = Types::ClassInstance.new(
-            name: type_name,
-            args: entry.type_params.each.map { Types::Bases::Any.new(location: nil) },
-            location: nil
-          )
 
           Definition.new(type_name: type_name, entry: entry, self_type: self_type, ancestors: ancestors).tap do |definition|
             def0 = build_singleton0(type_name)
-            subst = Substitution.build([], [], instance_type: instance_type)
+            subst = Substitution.new
 
             merge_definition(src: def0, dest: definition, subst: subst, keep_super: true)
 

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -5,13 +5,17 @@ module RBS
       attr_reader :builder
       attr_reader :sample_size
       attr_reader :unchecked_classes
+      attr_reader :instance_class
+      attr_reader :class_class
 
       attr_reader :const_cache
 
       DEFAULT_SAMPLE_SIZE = 100
 
-      def initialize(self_class:, builder:, sample_size:, unchecked_classes:)
+      def initialize(self_class:, builder:, sample_size:, unchecked_classes:, instance_class: Object, class_class: Module)
         @self_class = self_class
+        @instance_class = instance_class
+        @class_class = class_class
         @builder = builder
         @sample_size = sample_size
         @unchecked_classes = unchecked_classes.uniq
@@ -237,9 +241,9 @@ module RBS
         when Types::Bases::Nil
           Test.call(val, IS_AP, ::NilClass)
         when Types::Bases::Class
-          Test.call(val, IS_AP, Class)
+          Test.call(val, IS_AP, class_class)
         when Types::Bases::Instance
-          Test.call(val, IS_AP, self_class)
+          Test.call(val, IS_AP, instance_class)
         when Types::ClassInstance
           klass = get_class(type.name) or return false
           case

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -854,6 +854,28 @@ EOF
     end
   end
 
+  def test_build_singleton_instance_with_class_instance
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Hello
+  def self?.foo: (instance) -> class
+end
+EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(TypeName("::Hello")).tap do |definition|
+          assert_equal ["(instance) -> class"], definition.methods[:foo].method_types.map(&:to_s)
+        end
+
+        builder.build_singleton(TypeName("::Hello")).tap do |definition|
+          assert_equal ["(instance) -> class"], definition.methods[:foo].method_types.map(&:to_s)
+        end
+      end
+    end
+  end
+
   def test_build_singleton_variables
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -69,6 +69,27 @@ EOF
     end
   end
 
+  def test_type_check_instance_class
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        typecheck = Test::TypeCheck.new(
+          self_class: Integer,
+          instance_class: Integer,
+          class_class: Integer.singleton_class,
+          builder: DefinitionBuilder.new(env: env),
+          sample_size: 100,
+          unchecked_classes: []
+        )
+
+        assert typecheck.value(30, parse_type("instance"))
+        refute typecheck.value("30", parse_type("instance"))
+
+        assert typecheck.value(Integer, parse_type("class"))
+        refute typecheck.value(String, parse_type("class"))
+      end
+    end
+  end
+
   def test_type_check_absent
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF


### PR DESCRIPTION
It seems like there is no reason to do so:

1. `build_instance` doesn't do that
2. `class` types are left
3. It makes `#build_singleton` much slower