### PR TITLE
Remove needless Gem::Version polyfill

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -6,6 +6,7 @@ target :lib do
 
   library "set", "pathname", "json", "logger", "monitor", "tsort"
   signature "stdlib/strscan/0/"
+  signature "stdlib/rubygems/0/"
 end
 
 # target :lib do

--- a/sig/polyfill.rbs
+++ b/sig/polyfill.rbs
@@ -3,20 +3,6 @@ module Kernel
 end
 
 module Gem
-  class Version
-    def self.correct?: (String) -> bool
-
-    def self.create: (String?) -> instance?
-
-    include Comparable
-
-    def prerelease?: () -> bool
-
-    def release: () -> self
-
-    def version: () -> String
-  end
-
   class Specification
     attr_reader version (): Version
 


### PR DESCRIPTION
The `Gem::Version` signature has been added with PR #610.
I think we now can remove the polyfill of `Gem::Version`.

Follow-up of <https://github.com/ruby/rbs/pull/610#issuecomment-785609744>