### PR TITLE
Improve signature for Gem::Version.create

### DIFF
--- a/stdlib/rubygems/0/version.rbs
+++ b/stdlib/rubygems/0/version.rbs
@@ -170,7 +170,8 @@ module Gem
     #     ver2 = Version.create(ver1)       # -> (ver1)
     #     ver3 = Version.create(nil)        # -> nil
     #
-    def self.create: (_ToS | Version | nil input) -> instance?
+    def self.create: (_ToS | Version input) -> instance
+                   | (nil input) -> nil
 
     # Constructs a Version from the `version` string.  A version string is a series
     # of digits or ASCII letters separated by dots.


### PR DESCRIPTION
This change aims to improve the signature for the `Gem::Version.create` method.

The current signature always returns a nil-able value, but this is not useful because nil-check is necessary.
I think we can improve the method signature via overloading because this method returns `nil` only when `nil` is passed.

See below:

```ruby
# a.rb
p(Gem::Version.create("2.3.4") >= Gem::Version.create("2.3.0"))
```

```console
$ bundle exec steep check a.rb
...
a.rb:1:31: [error] Type `(::Gem::Version | nil)` does not have method `>=`
│ Diagnostic ID: Ruby::NoMethod
│
└ p(Gem::Version.create("2.3.4") >= Gem::Version.create("2.3.0"))
                                 ~~
```

Environments:
- RBS 1.1.0
- Steep 0.42.0

Source code of the `create` method:
https://github.com/rubygems/rubygems/blob/v3.2.13/lib/rubygems/version.rb#L188-L196