### PR TITLE
Add signature for Gem::Requirement

### DIFF
--- a/stdlib/rubygems/0/requirement.rbs
+++ b/stdlib/rubygems/0/requirement.rbs
@@ -1,3 +1,85 @@
-class Gem::Requirement
-  # TODO: Add sinatures...
+module Gem
+  # A Requirement is a set of one or more version restrictions. It supports a few
+  # (`=, !=, >, <, >=, <=, ~>`) different restriction operators.
+  #
+  # See Gem::Version for a description on how versions and requirements work
+  # together in RubyGems.
+  #
+  class Requirement
+    type operator = "=" | "!=" | ">" | "<" | ">=" | "<=" | "~>"
+
+    # Raised when a bad requirement is encountered
+    #
+    class BadRequirementError < ArgumentError
+    end
+
+    # The default requirement matches any version
+    #
+    DefaultPrereleaseRequirement: [ operator, Gem::Version ]
+
+    # The default requirement matches any non-prerelease version
+    #
+    DefaultRequirement: [ operator, Gem::Version ]
+
+    # A regular expression that matches a requirement
+    #
+    PATTERN: Regexp
+
+    # Factory method to create a Gem::Requirement object.  Input may be a Version, a
+    # String, or nil.  Intended to simplify client code.
+    #
+    # If the input is "weird", the default version requirement is returned.
+    #
+    def self.create: (*(String | Gem::Version | Gem::Requirement | nil) inputs) -> instance
+
+    def self.default: () -> instance
+
+    def self.default_prerelease: () -> instance
+
+    # Parse `obj`, returning an `[op, version]` pair. `obj` can be a String or a
+    # Gem::Version.
+    #
+    # If `obj` is a String, it can be either a full requirement specification, like
+    # `">= 1.2"`, or a simple version number, like `"1.2"`.
+    #
+    #     parse("> 1.0")                 # => [">", Gem::Version.new("1.0")]
+    #     parse("1.0")                   # => ["=", Gem::Version.new("1.0")]
+    #     parse(Gem::Version.new("1.0")) # => ["=,  Gem::Version.new("1.0")]
+    #
+    def self.parse: (String | Gem::Version obj) -> [ operator, Gem::Version ]
+
+    # Constructs a requirement from `requirements`. Requirements can be Strings,
+    # Gem::Versions, or Arrays of those. `nil` and duplicate requirements are
+    # ignored. An empty set of `requirements` is the same as `">= 0"`.
+    #
+    def initialize: (*(String | Gem::Version) requirements) -> void
+
+    # Concatenates the `new` requirements onto this requirement.
+    #
+    def concat: (Array[String | Gem::Version] new) -> void
+
+    # true if the requirement is for only an exact version
+    #
+    def exact?: () -> bool
+
+    # true if this gem has no requirements.
+    #
+    def none?: () -> bool
+
+    # A requirement is a prerelease if any of the versions inside of it are
+    # prereleases
+    #
+    def prerelease?: () -> bool
+
+    # True if `version` satisfies this Requirement.
+    #
+    def satisfied_by?: (Gem::Version version) -> bool
+
+    alias === satisfied_by?
+    alias =~ satisfied_by?
+
+    # True if the requirement will not always match the latest version.
+    #
+    def specific?: () -> bool
+  end
 end

--- a/test/stdlib/rubygems/GemRequirement_test.rb
+++ b/test/stdlib/rubygems/GemRequirement_test.rb
@@ -1,0 +1,84 @@
+require_relative "../test_helper"
+
+class GemRequirementSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "rubygems"
+  testing "singleton(::Gem::Requirement)"
+
+  def test_create
+    assert_send_type  "() -> Gem::Requirement",
+                      Gem::Requirement, :create
+    assert_send_type  "(String, Gem::Version, Gem::Requirement, nil) -> Gem::Requirement",
+                      Gem::Requirement, :create, "1.0", Gem::Version.new("1.2"), Gem::Requirement.new, nil
+    assert_send_type  "(nil) -> Gem::Requirement",
+                      Gem::Requirement, :create, nil
+  end
+
+  def test_default
+    assert_send_type  "() -> Gem::Requirement",
+                      Gem::Requirement, :default
+  end
+
+  def test_default_prerelease
+    assert_send_type  "() -> Gem::Requirement",
+                      Gem::Requirement, :default_prerelease
+  end
+
+  def test_parse
+    assert_send_type  "(String) -> [ String, Gem::Version ]",
+                      Gem::Requirement, :parse, "1.0"
+    assert_send_type  "(Gem::Version) -> [ String, Gem::Version ]",
+                      Gem::Requirement, :parse, Gem::Version.new("1.0")
+  end
+
+  def test_new
+    assert_send_type  "() -> Gem::Requirement",
+                      Gem::Requirement, :new
+    assert_send_type  "(String, Gem::Version) -> Gem::Requirement",
+                      Gem::Requirement, :new, "1.0", Gem::Version.new("1.2")
+  end
+end
+
+class GemRequirementInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library "rubygems"
+  testing "::Gem::Requirement"
+
+  def test_concat
+    assert_send_type  "(Array[String | Gem::Version]) -> void",
+                      Gem::Requirement.new, :concat, ["1.0", Gem::Version.new("1.1")]
+  end
+
+  def test_exact?
+    assert_send_type  "() -> bool",
+                      Gem::Requirement.new, :exact?
+  end
+
+  def test_none?
+    assert_send_type  "() -> bool",
+                      Gem::Requirement.new, :none?
+  end
+
+  def test_prerelease?
+    assert_send_type  "() -> bool",
+                      Gem::Requirement.new, :prerelease?
+  end
+
+  def test_satisfied_by?
+    assert_send_type  "(Gem::Version) -> bool",
+                      Gem::Requirement.new, :satisfied_by?, Gem::Version.new("1.0")
+
+    # alias
+    assert_send_type  "(Gem::Version) -> bool",
+                      Gem::Requirement.new, :===, Gem::Version.new("1.0")
+    assert_send_type  "(Gem::Version) -> bool",
+                      Gem::Requirement.new, :=~, Gem::Version.new("1.0")
+  end
+
+  def test_specific?
+    assert_send_type  "() -> bool",
+                      Gem::Requirement.new, :specific?
+  end
+end


### PR DESCRIPTION
This change adds the signature for the `Gem::Requirement` class.

See also:
- https://github.com/rubygems/rubygems/blob/v3.2.14/lib/rubygems/requirement.rb
- https://ruby-doc.org/stdlib-3.0.0/libdoc/rubygems/rdoc/Gem/Requirement.html