### PR TITLE
adding + and - methods to numeric

### DIFF
--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -82,9 +82,19 @@ class Numeric
   #
   def %: (Numeric) -> Numeric
 
+  # Performs addition: the class of the resulting object depends on the class of
+  # `numeric`.
+  #
+  def +: (Numeric) -> Numeric
+
   # Unary Plus---Returns the receiver.
   #
   def +@: () -> Numeric
+
+  # Performs subtraction: the class of the resulting object depends on the class
+  # of `numeric`.
+  #
+  def -: (Numeric) -> Numeric
 
   # Unary Minus---Returns the receiver, negated.
   #


### PR DESCRIPTION
Fixes #609 

Allows signatures of the kind:

```ruby
def test: (Numeric a, Numeric b) -> Numeric
```

Where `a+b` happens.