### PR TITLE
Add Hash#except signature

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -450,6 +450,14 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   def eql?: (untyped) -> bool
 
+  # Returns a hash excluded given keys and the values.
+  #
+  #     h = { a: 100, b: 200, c: 300 }
+  #     h.except(:a)           #=> {:b=>200, :c=>300}
+  #     h.except(:b, :c, :d)   #=> {:a=>100}
+  #
+  def except: (*K) -> ::Hash[K, V]
+
   # Returns a value from the hash for the given key. If the key can't be found,
   # there are several options: With no other arguments, it will raise a KeyError
   # exception; if *default* is given, then that will be returned; if the optional

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -186,6 +186,7 @@ class HashTest < StdlibTest
   end
 
   def test_except
+    omit_if(!Hash.method_defined?(:except))
     { a: 100, b: 200, c: 300 }.except(:a)
     { a: 100, b: 200, c: 300 }.except(:b, :c, :d)
   end
@@ -385,6 +386,7 @@ class HashInstanceTest < Test::Unit::TestCase
   testing "::Hash[::Symbol, ::Integer]"
 
   def test_except
+    omit_if(!Hash.method_defined?(:except))
     assert_send_type "() -> ::Hash[::Symbol, ::Integer]",
                       { a: 100, b: 200, c: 300 }, :except
     assert_send_type "(*Symbol keys) -> ::Hash[::Symbol, ::Integer]",

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -185,6 +185,11 @@ class HashTest < StdlibTest
     { a: 2 }.eql?({ a: 1 })
   end
 
+  def test_except
+    { a: 100, b: 200, c: 300 }.except(:a)
+    { a: 100, b: 200, c: 300 }.except(:b, :c, :d)
+  end
+
   def test_fetch
     hash = { a: 1 }
     hash.fetch(:a)
@@ -371,5 +376,18 @@ class HashTest < StdlibTest
     Hash.new
     Hash.new(10)
     Hash.new { |hash, key| key.to_s }
+  end
+end
+
+class HashInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Hash[::Symbol, ::Integer]"
+
+  def test_except
+    assert_send_type "() -> ::Hash[::Symbol, ::Integer]",
+                      { a: 100, b: 200, c: 300 }, :except
+    assert_send_type "(*Symbol keys) -> ::Hash[::Symbol, ::Integer]",
+                      { a: 100, b: 200, c: 300 }, :except, :a
   end
 end


### PR DESCRIPTION
ref: https://github.com/ruby/rbs/issues/613

I have tried to add missing `Hash#except` 😄 

🤔 
---

I don't know why existing `Hash` tests does not use `assert_send_type` as `Array` tests. So I have added both test cases in this PR.
