### PR TITLE
Fix Hash#slice signature

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -815,7 +815,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h.slice(:a)           #=> {:a=>100}
   #     h.slice(:b, :c, :d)   #=> {:b=>200, :c=>300}
   #
-  def slice: (*K) -> self
+  def slice: (*K) -> ::Hash[K, V]
 
   # ## Element Assignment
   #

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -323,6 +323,7 @@ class HashTest < StdlibTest
   def test_slice
     { a: 42, b: 43, c: 44 }.slice(:a)
     { a: 42, b: 43, c: 44 }.slice(:a, :b)
+    Class.new(Hash)[:a, 42].slice(:a)
   end
 
   def test_to_a


### PR DESCRIPTION
```sh
ruby -v -e 'class Foo < Hash; end; p Foo.new.slice.class'
```

outputs

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
Hash
```