### PR TITLE
Fix indent to remove warning

### DIFF
--- a/test/rbs/char_scanner_test.rb
+++ b/test/rbs/char_scanner_test.rb
@@ -11,5 +11,5 @@ class RBS::CharScannerTest < Test::Unit::TestCase
     scanner.scan(/.../)
     assert_equal 12, scanner.pos
     assert_equal 6, scanner.charpos
-end
+  end
 end


### PR DESCRIPTION
`bundle exec rake test` warns `/Users/kachick/repos/rbs/test/rbs/char_scanner_test.rb:14: warning: mismatched indentations at 'end' with 'def' at 4`

This PR fixes the warning.

My ruby version is `ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]`