### PR TITLE
Fix Hash#compact signature

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -256,7 +256,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h.compact     #=> { a: 1, b: false }
   #     h             #=> { a: 1, b: false, c: nil }
   #
-  def compact: () -> self
+  def compact: () -> ::Hash[K, V]
 
   # Removes all nil values from the hash. Returns nil if no changes were made,
   # otherwise returns the hash.

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -76,6 +76,7 @@ class HashTest < StdlibTest
     { a: nil }.compact
     { a: nil, b: 2 }.compact
     { b: 2 }.compact
+    Class.new(Hash)[:a, nil].compact
   end
 
   def test_compact!


### PR DESCRIPTION
```sh
ruby -v -e 'p Class.new(Hash)[:a, nil].compact.class'
```

outputs

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
Hash
```