### PR TITLE
Fix Hash#{filter, select} signature

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -498,8 +498,8 @@ class Hash[unchecked out K, unchecked out V] < Object
   #
   # Hash#filter is an alias for Hash#select.
   #
-  def filter: () { (K, V) -> boolish } -> self
-            | () -> ::Enumerator[[ K, V ], self]
+  def filter: () { (K, V) -> boolish } -> ::Hash[K, V]
+            | () -> ::Enumerator[[ K, V ], ::Hash[K, V]]
 
   # Equivalent to Hash#keep_if, but returns `nil` if no changes were made.
   #

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -202,9 +202,13 @@ class HashTest < StdlibTest
   def test_filter
     { a: 1, b: 2 }.filter
     { a: 1, b: 2 }.filter { |k, v| v == 1 }
+    Class.new(Hash)[:a, nil].filter.each { |k, v| k }
+    Class.new(Hash)[:a, nil].filter { |k, v| k }
 
     { a: 1, b: 2 }.select
     { a: 1, b: 2 }.select { |k, v| v == 1 }
+    Class.new(Hash)[:a, nil].select.each { |k, v| k }
+    Class.new(Hash)[:a, nil].select { |k, v| k }
   end
 
   def test_filter!


### PR DESCRIPTION
Actual behaviors
---

```sh
ruby -v
ruby -e 'p Class.new(Hash)[:a, nil].filter { |k, v| k }.class'
ruby -e 'p Class.new(Hash)[:a, nil].filter.each { |k, v| k }.class'
ruby -e 'p Class.new(Hash)[:a, nil].select { |k, v| k }.class'
ruby -e 'p Class.new(Hash)[:a, nil].select.each { |k, v| k }.class'
```

outputs

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
Hash
Hash
Hash
Hash
```