### PR TITLE
Fix Hash#to_hash signature

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -857,7 +857,7 @@ class Hash[unchecked out K, unchecked out V] < Object
 
   # Returns `self`.
   #
-  def to_hash: () -> ::Hash[K, V]
+  def to_hash: () -> self
 
   # Returns a Proc which maps keys to values.
   #

--- a/test/stdlib/Hash_test.rb
+++ b/test/stdlib/Hash_test.rb
@@ -334,6 +334,11 @@ class HashTest < StdlibTest
     { a: 42 }.to_h { |k, v| [k.to_s, v.to_f] }
   end
 
+  def test_to_hash
+    { a: 42 }.to_hash
+    Class.new(Hash)[:a, 42].to_hash
+  end
+
   def test_to_proc
     { a: 1 }.to_proc.call(:a)
     { a: 1 }.to_proc.call(:b)


### PR DESCRIPTION
```sh
ruby -v -e 'p Class.new(Hash)[:a, nil].to_hash.class'
```

outputs

```
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
#<Class:0x00007ffc6988ec18>
```