### PR TITLE
[Doc] Add how to test specific stdlib with the path

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -60,6 +60,8 @@ You may find the *Good for first contributor* column where you can find some cla
   Validate the syntax and some of the semantics.
 * `rake generate:stdlib_test[String]`
   Scaffold the stdlib test.
+* `rake test/stdlib/Array_test.rb`
+  Run specific stdlib test with the path.
 
 ## Standard STDLIB Members Order
 


### PR DESCRIPTION
I am using this way since faced https://github.com/ruby/rbs/issues/641.
The rake tasks looks defined at https://github.com/ruby/rbs/blob/4a911a9a8e3de24c1f08c697d7f6f54345c23ea7/Rakefile#L59-L64

It works enough and does not show warnings. So useful to me.
How about to add it to this document? Or it should be an unofficial feature from some reasons?