### PR TITLE
Fix Array#concat signature on subclasses

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -682,7 +682,7 @@ class Array[unchecked out Elem] < Object
   #
   # See also Array#+.
   #
-  def concat: (*::Array[Elem] arrays) -> ::Array[Elem]
+  def concat: (*::Array[Elem] arrays) -> self
 
   # Returns the number of elements.
   #

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -217,6 +217,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_concat
     assert_send_type "(Array[Integer], Array[Integer]) -> Array[Integer]",
                      [1,2,3], :concat, [4,5,6], [7,8,9]
+    assert_send_type "(Array[Integer], Array[Integer]) -> self",
+                     Class.new(Array).new, :concat, [4,5,6], [7,8,9]
   end
 
   def test_count


### PR DESCRIPTION
```console
$ ruby -v -e 'p Class.new(Array).new.concat.class'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
#<Class:0x00007ff93307abf0>
```

```console
$ ruby -v -e 'p Class.new(Array).new.concat.class'
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]
#<Class:0x00007faa0010d2e8>
```