### PR TITLE
Token locations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require "rbconfig"
 
+$LOAD_PATH << File.join(__dir__, "test")
+
 ruby = ENV["RUBY"] || RbConfig.ruby
 racc = ENV.fetch("RACC", "racc")
 rbs = File.join(__dir__, "exe/rbs")

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -7,7 +7,7 @@ module RBS
       class ModuleTypeParams
         attr_reader :params
 
-        TypeParam = _ = Struct.new(:name, :variance, :skip_validation, keyword_init: true) do
+        TypeParam = _ = Struct.new(:name, :variance, :skip_validation, :location, keyword_init: true) do
           # @implements TypeParam
 
           def to_json(state = _ = nil)
@@ -16,6 +16,19 @@ module RBS
               variance: variance,
               skip_validation: skip_validation,
             }.to_json(state)
+          end
+
+          def ==(other)
+            other.is_a?(TypeParam) &&
+              other.name == name &&
+              other.variance == variance &&
+              other.skip_validation == skip_validation
+          end
+
+          alias eql? ==
+
+          def hash
+            self.class.hash ^ name.hash ^ variance.hash ^ skip_validation.hash
           end
         end
 
@@ -82,7 +95,7 @@ module RBS
           ModuleTypeParams.new().tap do |params|
             names.each.with_index do |new_name, index|
               param = self.params[index]
-              params.add(TypeParam.new(name: new_name, variance: param.variance, skip_validation: param.skip_validation))
+              params.add(TypeParam.new(name: new_name, variance: param.variance, skip_validation: param.skip_validation, location: param.location))
             end
           end
         end

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -659,10 +659,12 @@ module RBS
       class Param
         attr_reader :type
         attr_reader :name
+        attr_reader :location
 
-        def initialize(type:, name:)
+        def initialize(type:, name:, location: nil)
           @type = type
           @name = name
+          @location = location
         end
 
         def ==(other)
@@ -677,7 +679,7 @@ module RBS
 
         def map_type(&block)
           if block
-            Param.new(name: name, type: yield(type))
+            Param.new(name: name, type: yield(type), location: location)
           else
             enum_for :map_type
           end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -267,8 +267,10 @@ module RBS
       end
 
       if member.overload
-        string << padding
-        string << "|"
+        if member.types.size > 0
+          string << padding
+          string << "|"
+        end
         string << " ...\n"
       end
 

--- a/sig/declarations.rbs
+++ b/sig/declarations.rbs
@@ -10,11 +10,21 @@ module RBS
 
       class ModuleTypeParams
         class TypeParam
+          # Key
+          # ^^^ name
+          #
+          # unchecked out Elem
+          # ^^^^^^^^^          unchecked
+          #           ^^^      variance
+          #               ^^^^ name
+          type loc = Location::WithChildren[:name, :variance | :unchecked]
+
           attr_reader name: Symbol
           attr_reader variance: variance
           attr_reader skip_validation: bool
+          attr_reader location: loc?
 
-          def initialize: (name: Symbol, variance: variance, skip_validation: boolish) -> void
+          def initialize: (name: Symbol, variance: variance, skip_validation: boolish, location: loc?) -> void
 
           include _ToJson
         end
@@ -68,18 +78,41 @@ module RBS
       end
 
       class Class < Base
-        type member = Members::t | t
-
         class Super
+          # String
+          # ^^^^^^  name
+          #
+          # Array[String]
+          # ^^^^^         name
+          #      ^^^^^^^^ args
+          #
+          type loc = Location::WithChildren[:name, :args]
+
           attr_reader name: TypeName
           attr_reader args: Array[Types::t]
-          attr_reader location: Location?
+          attr_reader location: loc?
 
-          def initialize: (name: TypeName, args: Array[Types::t], location: Location?) -> void
+          def initialize: (name: TypeName, args: Array[Types::t], location: loc?) -> void
 
           include _HashEqual
           include _ToJson
         end
+
+        type member = Members::t | t
+
+        # class Foo end
+        # ^^^^^         keyword
+        #       ^^^     name
+        #           ^^^ end
+        #
+        # class Foo[A] < String end
+        # ^^^^^                     keyword
+        #       ^^^                 name
+        #          ^^^              type_params
+        #              ^            lt
+        #                       ^^^ end
+        #
+        type loc = Location::WithChildren[:keyword | :name | :end, :type_params | :lt]
 
         include NestedDeclarationHelper
         include MixinHelper
@@ -89,24 +122,28 @@ module RBS
         attr_reader members: Array[member]
         attr_reader super_class: Super?
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], super_class: Super?, annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], super_class: Super?, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson
       end
 
       class Module < Base
-        type member = Members::t | t
-
         class Self
+          # _Each[String]
+          # ^^^^^         name
+          #      ^^^^^^^^ args
+          #
+          type loc = Location::WithChildren[:name, :args]
+
           attr_reader name: TypeName
           attr_reader args: Array[Types::t]
-          attr_reader location: Location?
+          attr_reader location: loc?
 
-          def initialize: (name: TypeName, args: Array[Types::t], location: Location?) -> void
+          def initialize: (name: TypeName, args: Array[Types::t], location: loc?) -> void
 
           include _HashEqual
           include _ToJson
@@ -114,18 +151,35 @@ module RBS
           def to_s: () -> String
         end
 
+        type member = Members::t | t
+
+        # module Foo end
+        # ^^^^^^         keyword
+        #        ^^^     name
+        #            ^^^ end
+        #
+        # module Foo[A] : BasicObject end
+        # ^^^^^^                          keyword
+        #        ^^^                      name
+        #           ^^^                   type_params
+        #               ^                 colon
+        #                 ^^^^^^^^^^^     self_types
+        #                             ^^^ end
+        #
+        type loc = Location::WithChildren[:keyword | :name | :end, :type_params | :colon | :self_types]
+
         include NestedDeclarationHelper
         include MixinHelper
 
         attr_reader name: TypeName
         attr_reader type_params: ModuleTypeParams
         attr_reader members: Array[member]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader annotations: Array[Annotation]
         attr_reader self_types: Array[Self]
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], location: Location?, annotations: Array[Annotation], self_types: Array[Self], comment: Comment?) -> void
+        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], location: loc?, annotations: Array[Annotation], self_types: Array[Self], comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson
@@ -134,14 +188,27 @@ module RBS
       class Interface
         type member = Members::t
 
+        # interface _Foo end
+        # ^^^^^^^^^          keyword
+        #           ^^^^     name
+        #                ^^^ end
+        #
+        # interface _Bar[A, B] end
+        # ^^^^^^^^^                keyword
+        #           ^^^^           name
+        #               ^^^^^^     type_params
+        #                      ^^^ end
+        #
+        type loc = Location::WithChildren[:name | :keyword | :end, :type_params]
+
         attr_reader name: TypeName
         attr_reader type_params: ModuleTypeParams
         attr_reader members: Array[member]
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (name: TypeName, type_params: ModuleTypeParams, members: Array[member], annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include MixinHelper
 
@@ -150,37 +217,55 @@ module RBS
       end
 
       class Alias < Base
+        # type loc = Location
+        # ^^^^                keyword
+        #      ^^^            name
+        #          ^          eq
+        type loc = Location::WithChildren[:keyword | :name | :eq, bot]
+
         attr_reader name: TypeName
         attr_reader type: Types::t
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type: Types::t, annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (name: TypeName, type: Types::t, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson
       end
 
       class Constant < Base
+        # VERSION: String
+        # ^^^^^^^         name
+        #        ^        colon
+        #
+        type loc = Location::WithChildren[:name | :colon, bot]
+
         attr_reader name: TypeName
         attr_reader type: Types::t
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type: Types::t, location: Location?, comment: Comment?) -> void
+        def initialize: (name: TypeName, type: Types::t, location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson
       end
 
       class Global < Base
+        # $SIZE: String
+        # ^^^^^         name
+        #      ^        colon
+        #
+        type loc = Location::WithChildren[:name | :colon, bot]
+
         attr_reader name: Symbol
         attr_reader type: Types::t
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: Symbol, type: Types::t, location: Location?, comment: Comment?) -> void
+        def initialize: (name: Symbol, type: Types::t, location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson

--- a/sig/location.rbs
+++ b/sig/location.rbs
@@ -13,40 +13,121 @@ module RBS
 
     def initialize: (buffer: Buffer, start_pos: Integer, end_pos: Integer) -> void
 
-    def inspect: () -> ::String
+    def inspect: () -> String
 
+    # Returns the name of the buffer.
     def name: () -> untyped
 
+    # Line of the `start_pos` (1 origin)
     def start_line: () -> Integer
 
+    # Column of the `start_pos` (0 origin)
     def start_column: () -> Integer
 
+    # Line of the `end_pos` (1 origin)
     def end_line: () -> Integer
 
+    # Column of the `end_pos` (0 origin)
     def end_column: () -> Integer
 
     def start_loc: () -> Buffer::loc
 
     def end_loc: () -> Buffer::loc
 
+    def range: () -> Range[Integer]
+
+    # A substring of buffer associated to the location.
     def source: () -> String
 
     def to_s: () -> String
 
+    # Returns a string representation suitable for terminal output.
+    #
+    #     Location.to_string(loc)  # => a.rb:1:0...3:4
+    #     Location.to_string(nil)  # => *:*:*..*:*
+    #
     def self.to_string: (Location? location, ?default: ::String default) -> String
 
     def ==: (untyped other) -> bool
 
+    # Returns a new location with starting positionof `self` and ending position of `other`.
+    #
+    #     l1 = Location.new(buffer: buffer, start_pos: 0, end_pox: x)
+    #     l2 = Location.new(buffer: buffer, start_pos: y, end_pos: 20)
+    #     l1 + l2  # => Location.new(buffer: buffer, start_pos: 0, end_pos: 20)
+    #
     def +: (Location other) -> Location
 
+    # Returns true if `loc` is exact predecessor of `self`.
+    #
+    #     l1 = Location.new(...)    # 0..10
+    #     l2 = Location.new(...)    # 10..13
+    #     l3 = Location.new(...)    # 13..20
+    #
+    #     l1.pred?(l2)       # => true
+    #     l2.pred?(l3)       # => true
+    #     l1.pred?(l3)       # => false
+    #
     def pred?: (Location loc) -> bool
 
     include _ToJson
 
     # `<<` locations given as argument.
+    #
     def concat: (*Location?) -> Location
 
-    # Append given location destructively.
+    # Inplace version of `+`.
+    #
     def <<: (Location?) -> Location
+
+    # Returns WithChildren instance with given children.
+    #
+    #     location.with_children(
+    #       required: { name: name.location },
+    #       optional: { args: nil }
+    #     )
+    #
+    def with_children: [R, O](?required: Hash[R, Range[Integer] | Location], ?optional: Hash[O, Range[Integer] | Location | nil]) -> WithChildren[R, O]
+
+    # Location::WithChildren contains _child_ locations.
+    #
+    #     # Array[String]
+    #     # ^^^^^          <= name
+    #     #      ^^^^^^^^  <= args
+    #     #
+    #     # @type var loc: Location::WithChildren[:name, :args]
+    #     loc = Location::WithChildren.new(buffer: buffer, start_pos: 0, end_pos: 13)
+    #     loc = loc.merge_required({ name: 1...5 })
+    #     loc = loc.merge_optional({ args: 5...13 })
+    #
+    #     loc[:name]      # => Location instance for `Array`
+    #     loc[:args]      # => Location instance for `[String]`
+    #
+    class WithChildren[RequiredChildKeys, OptionalChildKeys] < Location
+      attr_reader required_children: Hash[RequiredChildKeys, Range[Integer]]
+
+      attr_reader optional_children: Hash[OptionalChildKeys, Range[Integer]?]
+
+      def initialize: ...
+
+      def initialize_copy: ...
+
+      # Returns `Location` instance for given _child_ name.
+      #
+      #     # @type var loc: Location::WithChildren[:name, :args]
+      #     loc[:name]      # => Location
+      #     loc[:args]      # => may be nil
+      #
+      # Note that passing unknown symbol raises an error even if the child is _optional_.
+      # You need explicitly set `nil` for absent optional children.
+      #
+      def []: (RequiredChildKeys) -> Location
+            | (OptionalChildKeys) -> Location?
+            | (Symbol) -> Location?
+
+      def merge_required: (Hash[RequiredChildKeys, Range[Integer] | Location]) -> self
+
+      def merge_optional: (Hash[OptionalChildKeys, Range[Integer] | Location | nil]) -> self
+    end
   end
 end

--- a/sig/members.rbs
+++ b/sig/members.rbs
@@ -15,15 +15,27 @@ module RBS
       class MethodDefinition < Base
         type kind = :instance | :singleton | :singleton_instance
 
+        # def foo: () -> void
+        # ^^^                    keyword
+        #     ^^^                name
+        #
+        # def self.bar: () -> void | ...
+        # ^^^                              keyword
+        #     ^^^^^                        kind
+        #          ^^^                     name
+        #                            ^^^   overload
+        #
+        type loc = Location::WithChildren[:keyword | :name, :kind | :overload]
+
         attr_reader name: Symbol
         attr_reader kind: kind
         attr_reader types: Array[MethodType]
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
         attr_reader overload: bool
 
-        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: Location?, comment: Comment?, overload: boolish) -> void
+        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: loc?, comment: Comment?, overload: boolish) -> void
 
         include _HashEqual
         include _ToJson
@@ -34,16 +46,27 @@ module RBS
 
         def overload?: () -> bool
 
-        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: Location?, ?comment: Comment?, ?overload: boolish) -> MethodDefinition
+        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?, ?overload: boolish) -> MethodDefinition
       end
 
       module Var
+        # @foo: String
+        # ^^^^            name
+        #     ^           colon
+        #
+        # self.@all: Array[String]
+        # ^^^^^                        kind
+        #      ^^^^                    name
+        #          ^                   colon
+        #
+        type loc = Location::WithChildren[:name | :colon, :kind]
+
         attr_reader name: Symbol
         attr_reader type: Types::t
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: Symbol, type: Types::t, location: Location?, comment: Comment?) -> void
+        def initialize: (name: Symbol, type: Types::t, location: loc?, comment: Comment?) -> void
 
         include _HashEqual
       end
@@ -64,13 +87,25 @@ module RBS
       end
 
       module Mixin
+        # include Foo
+        # ^^^^^^^       keyword
+        #         ^^^   name
+        #
+        # include Array[String]
+        # ^^^^^^^                keyword
+        #         ^^^^^          name
+        #              ^         arg_open
+        #                     ^  arg_close
+        #
+        type loc = Location::WithChildren[:name | :keyword, :args]
+
         attr_reader name: TypeName
         attr_reader args: Array[Types::t]
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, args: Array[Types::t], annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (name: TypeName, args: Array[Types::t], annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
       end
@@ -93,19 +128,34 @@ module RBS
       module Attribute
         type kind = :instance | :singleton
 
+        # attr_reader name: String
+        # ^^^^^^^^^^^                  keyword
+        #             ^^^^             name
+        #                 ^            colon
+        #
+        # attr_accessor self.name (@foo) : String
+        # ^^^^^^^^^^^^^                             keyword
+        #               ^^^^^                       kind
+        #                    ^^^^                   name
+        #                         ^^^^^^            ivar
+        #                          ^^^^             ivar_name
+        #                                ^          colon
+        #
+        type loc = Location::WithChildren[:keyword | :name | :colon, :kind | :ivar | :ivar_name]
+
         attr_reader name: Symbol
         attr_reader type: Types::t
         attr_reader kind: kind
         attr_reader ivar_name: Symbol | false | nil
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: Symbol, type: Types::t, ivar_name: Symbol | false | nil, kind: kind, annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (name: Symbol, type: Types::t, ivar_name: Symbol | false | nil, kind: kind, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
 
-        def update: (?name: Symbol, ?type: Types::t, ?ivar_name: Symbol | false | nil, ?kind: kind, ?annotations: Array[Annotation], ?location: Location?, ?comment: Comment?) -> instance
+        def update: (?name: Symbol, ?type: Types::t, ?ivar_name: Symbol | false | nil, ?kind: kind, ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?) -> instance
       end
 
       class AttrReader < Base
@@ -144,14 +194,28 @@ module RBS
       class Alias < Base
         type kind = :instance | :singleton
 
+        # alias foo bar
+        # ^^^^^           keyword
+        #       ^^^       new_name
+        #           ^^^   old_name
+        #
+        # alias self.foo self.bar
+        # ^^^^^                      keyword
+        #       ^^^^^                new_kind
+        #            ^^^             new_name
+        #                ^^^^^       old_kind
+        #                     ^^^    old_name
+        #
+        type loc = Location::WithChildren[:keyword | :new_name | :old_name, :new_kind | :old_kind]
+
         attr_reader new_name: Symbol
         attr_reader old_name: Symbol
         attr_reader kind: kind
         attr_reader annotations: Array[Annotation]
-        attr_reader location: Location?
+        attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (new_name: Symbol, old_name: Symbol, kind: kind, annotations: Array[Annotation], location: Location?, comment: Comment?) -> void
+        def initialize: (new_name: Symbol, old_name: Symbol, kind: kind, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -260,10 +260,13 @@ module RBS
 
     class Function
       class Param
+        type loc = Location::WithChildren[bot, :name]
+
         attr_reader type: t
         attr_reader name: Symbol?
+        attr_reader location: loc?
 
-        def initialize: (type: t, name: Symbol?) -> void
+        def initialize: (type: t, name: Symbol?, ?location: loc?) -> void
 
         def map_type: { (t) -> t } -> Param
                     | -> Enumerator[t, Param]


### PR DESCRIPTION
This PR is to store token-level locations in AST locations. It introduces `Location::WithChildren` class which saves _child_ locations inside a location.

```ruby
loc = Location::WithChildren.new(buffer: buffer, start_pos: 0, end_pos: 13)
loc = loc.merge_required({ name: 1...5 })
loc = loc.merge_optional({ args: 5...13 })

loc[:name]      # => Location instance for `Array`
loc[:args]      # => Location instance for `[String]`
```

AST now stores locations for its name tokens and some of the keyword tokens.