### PR TITLE
Add RBS::Locator

### DIFF
--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -43,6 +43,7 @@ require "rbs/validator"
 require "rbs/factory"
 require "rbs/repository"
 require "rbs/ancestor_graph"
+require "rbs/locator"
 
 begin
   require "rbs/parser"

--- a/lib/rbs/locator.rb
+++ b/lib/rbs/locator.rb
@@ -1,0 +1,205 @@
+module RBS
+  class Locator
+    attr_reader :decls
+
+    def initialize(decls:)
+      @decls = decls
+    end
+
+    def buffer
+      decls[0].location&.buffer or raise
+    end
+
+    def find(line:, column:)
+      pos = buffer.loc_to_pos([line, column])
+
+      decls.each do |decl|
+        array = []
+        find_in_decl(pos, decl: decl, array: array) and return array
+      end
+
+      []
+    end
+
+    def find2(line:, column:)
+      path = find(line: line, column: column)
+
+      return if path.empty?
+
+      hd, *tl = path
+      if hd.is_a?(Symbol)
+        [hd, tl]
+      else
+        [nil, path]
+      end
+    end
+
+    def find_in_decl(pos, decl:, array:)
+      if test_loc(pos, location: decl.location)
+        array.unshift(decl)
+
+        case decl
+        when AST::Declarations::Class
+          decl.type_params.each do |param|
+            if test_loc(pos, location: param.location)
+              array.unshift(param)
+              find_in_loc(pos, array: array, location: param.location)
+              return true
+            end
+          end
+
+          if super_class = decl.super_class
+            if test_loc(pos, location: super_class.location)
+              array.unshift(super_class)
+              find_in_loc(pos, array: array, location: super_class.location)
+              return true
+            end
+          end
+
+          decl.each_decl do |decl_|
+            find_in_decl(pos, decl: decl_, array: array) and return true
+          end
+
+          decl.each_member do |member|
+            find_in_member(pos, array: array, member: member) and return true
+          end
+
+        when AST::Declarations::Module
+          decl.type_params.each do |param|
+            if test_loc(pos, location: param.location)
+              array.unshift(param)
+              find_in_loc(pos, array: array, location: param.location)
+              return true
+            end
+          end
+
+          decl.self_types.each do |self_type|
+            if test_loc(pos, location: self_type.location)
+              array.unshift(self_type)
+              find_in_loc(pos, array: array, location: self_type.location)
+              return true
+            end
+          end
+
+          decl.each_decl do |decl_|
+            find_in_decl(pos, decl: decl_, array: array) and return true
+          end
+
+          decl.each_member do |member|
+            find_in_member(pos, array: array, member: member) and return true
+          end
+
+        when AST::Declarations::Interface
+          decl.type_params.each do |param|
+            if test_loc(pos, location: param.location)
+              array.unshift(param)
+              find_in_loc(pos, array: array, location: param.location)
+              return true
+            end
+          end
+
+          decl.members.each do |member|
+            find_in_member(pos, array: array, member: member) and return true
+          end
+
+        when AST::Declarations::Constant, AST::Declarations::Global
+          find_in_type(pos, array: array, type: decl.type) and return true
+
+        when AST::Declarations::Alias
+          find_in_type(pos, array: array, type: decl.type) and return true
+        end
+
+        find_in_loc(pos, location: decl.location, array: array)
+
+        true
+      else
+        false
+      end
+    end
+
+    def find_in_member(pos, member:, array:)
+      if test_loc(pos, location: member.location)
+        array.unshift(member)
+
+        case member
+        when AST::Members::MethodDefinition
+          member.types.each do |method_type|
+            find_in_method_type(pos, array: array, method_type: method_type) and return true
+          end
+        when AST::Members::InstanceVariable, AST::Members::ClassInstanceVariable, AST::Members::ClassVariable
+          find_in_type(pos, array: array, type: member.type) and return true
+        when AST::Members::AttrReader, AST::Members::AttrWriter, AST::Members::AttrAccessor
+          find_in_type(pos, array: array, type: member.type) and return true
+        end
+
+        find_in_loc(pos, location: member.location, array: array)
+
+        true
+      else
+        false
+      end
+    end
+
+    def find_in_method_type(pos, method_type:, array:)
+      if test_loc(pos, location: method_type.location)
+        array.unshift(method_type)
+
+        method_type.each_type do |type|
+          find_in_type(pos, array: array, type: type) and break
+        end
+
+        true
+      else
+        false
+      end
+    end
+
+    def find_in_type(pos, type:, array:)
+      if test_loc(pos, location: type.location)
+        array.unshift(type)
+
+        type.each_type do |type_|
+          find_in_type(pos, array: array, type: type_) and return true
+        end
+
+        find_in_loc(pos, array: array, location: type.location)
+
+        true
+      else
+        false
+      end
+    end
+
+    def find_in_loc(pos, location:, array:)
+      if test_loc(pos, location: location)
+        if location.is_a?(Location::WithChildren)
+          location.optional_children.each do |key, range|
+            if range === pos
+              array.unshift(key)
+              return true
+            end
+          end
+
+          location.required_children.each do |key, range|
+            if range === pos
+              array.unshift(key)
+              return true
+            end
+          end
+        end
+
+        true
+      else
+        false
+      end
+    end
+
+    def test_loc(pos, location:)
+      if location
+        location.range === pos
+      else
+        false
+      end
+    end
+  end
+end

--- a/lib/rbs/parser.rb
+++ b/lib/rbs/parser.rb
@@ -8,7 +8,7 @@ require 'racc/parser.rb'
 module RBS
   class Parser < Racc::Parser
 
-module_eval(<<'...end parser.y/module_eval...', 'parser.y', 1353)
+module_eval(<<'...end parser.y/module_eval...', 'parser.y', 1394)
 
 Types = RBS::Types
 Namespace = RBS::Namespace
@@ -2692,19 +2692,27 @@ module_eval(<<'.,.,', 'parser.y', 818)
 module_eval(<<'.,.,', 'parser.y', 838)
   def _reduce_153(val, _values, result)
             location = val[1].location + val[4].location
-        result = Declarations::Alias.new(name: val[2].value,
-                                         type: val[4],
-                                         annotations: val[0],
-                                         location: location,
-                                         comment: leading_comment(val[0].first&.location || location))
+        location = location.with_children(
+          required: { keyword: val[1].location, name: val[2].location, eq: val[3].location }
+        )
+        result = Declarations::Alias.new(
+          name: val[2].value,
+          type: val[4],
+          annotations: val[0],
+          location: location,
+          comment: leading_comment(val[0].first&.location || location)
+        )
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 848)
+module_eval(<<'.,.,', 'parser.y', 853)
   def _reduce_154(val, _values, result)
             location = val[0].location + val[2].location
+        location = location.with_children(
+          required: { name: val[0].location, colon: val[1].location }
+        )
         result = Declarations::Constant.new(name: val[0].value,
                                             type: val[2],
                                             location: location,
@@ -2714,9 +2722,16 @@ module_eval(<<'.,.,', 'parser.y', 848)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 855)
+module_eval(<<'.,.,', 'parser.y', 863)
   def _reduce_155(val, _values, result)
             location = (val[0] || val[1]).location + val[2].location
+
+        lhs_loc = (val[0] || val[1]).location + val[1].location
+        name_loc, colon_loc = split_kw_loc(lhs_loc)
+        location = location.with_children(
+          required: { name: name_loc, colon: colon_loc }
+        )
+
         name = TypeName.new(name: val[1].value, namespace: val[0]&.value || Namespace.empty)
         result = Declarations::Constant.new(name: name,
                                             type: val[2],
@@ -2727,9 +2742,12 @@ module_eval(<<'.,.,', 'parser.y', 855)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 865)
+module_eval(<<'.,.,', 'parser.y', 880)
   def _reduce_156(val, _values, result)
             location = val[0].location + val[2].location
+        location = location.with_children(
+          required: { name: val[0].location, colon: val[1].location }
+        )
         result = Declarations::Global.new(name: val[0].value.to_sym,
                                           type: val[2],
                                           location: location,
@@ -2741,7 +2759,7 @@ module_eval(<<'.,.,', 'parser.y', 865)
 
 # reduce 157 omitted
 
-module_eval(<<'.,.,', 'parser.y', 875)
+module_eval(<<'.,.,', 'parser.y', 893)
   def _reduce_158(val, _values, result)
             types = case l = val[0]
                 when Types::Union
@@ -2756,7 +2774,7 @@ module_eval(<<'.,.,', 'parser.y', 875)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 885)
+module_eval(<<'.,.,', 'parser.y', 903)
   def _reduce_159(val, _values, result)
             types = case l = val[0]
                 when Types::Intersection
@@ -2772,7 +2790,7 @@ module_eval(<<'.,.,', 'parser.y', 885)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 898)
+module_eval(<<'.,.,', 'parser.y', 916)
   def _reduce_160(val, _values, result)
             result = Types::Bases::Void.new(location: val[0].location)
 
@@ -2780,7 +2798,7 @@ module_eval(<<'.,.,', 'parser.y', 898)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 901)
+module_eval(<<'.,.,', 'parser.y', 919)
   def _reduce_161(val, _values, result)
             RBS.logger.warn "`any` type is deprecated. Use `untyped` instead. (#{val[0].location.to_s})"
         result = Types::Bases::Any.new(location: val[0].location)
@@ -2789,7 +2807,7 @@ module_eval(<<'.,.,', 'parser.y', 901)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 905)
+module_eval(<<'.,.,', 'parser.y', 923)
   def _reduce_162(val, _values, result)
             result = Types::Bases::Any.new(location: val[0].location)
 
@@ -2797,7 +2815,7 @@ module_eval(<<'.,.,', 'parser.y', 905)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 908)
+module_eval(<<'.,.,', 'parser.y', 926)
   def _reduce_163(val, _values, result)
             result = Types::Bases::Bool.new(location: val[0].location)
 
@@ -2805,7 +2823,7 @@ module_eval(<<'.,.,', 'parser.y', 908)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 911)
+module_eval(<<'.,.,', 'parser.y', 929)
   def _reduce_164(val, _values, result)
             result = Types::Bases::Nil.new(location: val[0].location)
 
@@ -2813,7 +2831,7 @@ module_eval(<<'.,.,', 'parser.y', 911)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 914)
+module_eval(<<'.,.,', 'parser.y', 932)
   def _reduce_165(val, _values, result)
             result = Types::Bases::Top.new(location: val[0].location)
 
@@ -2821,7 +2839,7 @@ module_eval(<<'.,.,', 'parser.y', 914)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 917)
+module_eval(<<'.,.,', 'parser.y', 935)
   def _reduce_166(val, _values, result)
             result = Types::Bases::Bottom.new(location: val[0].location)
 
@@ -2829,7 +2847,7 @@ module_eval(<<'.,.,', 'parser.y', 917)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 920)
+module_eval(<<'.,.,', 'parser.y', 938)
   def _reduce_167(val, _values, result)
             result = Types::Bases::Self.new(location: val[0].location)
 
@@ -2837,7 +2855,7 @@ module_eval(<<'.,.,', 'parser.y', 920)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 923)
+module_eval(<<'.,.,', 'parser.y', 941)
   def _reduce_168(val, _values, result)
             result = Types::Optional.new(type: Types::Bases::Self.new(location: val[0].location),
                                      location: val[0].location)
@@ -2846,7 +2864,7 @@ module_eval(<<'.,.,', 'parser.y', 923)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 927)
+module_eval(<<'.,.,', 'parser.y', 945)
   def _reduce_169(val, _values, result)
             result = Types::Bases::Instance.new(location: val[0].location)
 
@@ -2854,7 +2872,7 @@ module_eval(<<'.,.,', 'parser.y', 927)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 930)
+module_eval(<<'.,.,', 'parser.y', 948)
   def _reduce_170(val, _values, result)
             result = Types::Bases::Class.new(location: val[0].location)
 
@@ -2862,7 +2880,7 @@ module_eval(<<'.,.,', 'parser.y', 930)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 933)
+module_eval(<<'.,.,', 'parser.y', 951)
   def _reduce_171(val, _values, result)
             result = Types::Literal.new(literal: true, location: val[0].location)
 
@@ -2870,7 +2888,7 @@ module_eval(<<'.,.,', 'parser.y', 933)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 936)
+module_eval(<<'.,.,', 'parser.y', 954)
   def _reduce_172(val, _values, result)
             result = Types::Literal.new(literal: false, location: val[0].location)
 
@@ -2878,7 +2896,7 @@ module_eval(<<'.,.,', 'parser.y', 936)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 939)
+module_eval(<<'.,.,', 'parser.y', 957)
   def _reduce_173(val, _values, result)
             result = Types::Literal.new(literal: val[0].value, location: val[0].location)
 
@@ -2886,7 +2904,7 @@ module_eval(<<'.,.,', 'parser.y', 939)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 942)
+module_eval(<<'.,.,', 'parser.y', 960)
   def _reduce_174(val, _values, result)
             result = Types::Literal.new(literal: val[0].value, location: val[0].location)
 
@@ -2894,7 +2912,7 @@ module_eval(<<'.,.,', 'parser.y', 942)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 945)
+module_eval(<<'.,.,', 'parser.y', 963)
   def _reduce_175(val, _values, result)
             result = Types::Literal.new(literal: val[0].value, location: val[0].location)
 
@@ -2902,7 +2920,7 @@ module_eval(<<'.,.,', 'parser.y', 945)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 948)
+module_eval(<<'.,.,', 'parser.y', 966)
   def _reduce_176(val, _values, result)
             name = val[0].value
         args = []
@@ -2913,11 +2931,23 @@ module_eval(<<'.,.,', 'parser.y', 948)
           if is_bound_variable?(name.name)
             result = Types::Variable.new(name: name.name, location: location)
           else
+            location = location.with_children(
+              required: { name: val[0].location },
+              optional: { args: nil }
+            )
             result = Types::ClassInstance.new(name: name, args: args, location: location)
           end
         when name.alias?
+          location = location.with_children(
+            required: { name: val[0].location },
+            optional: { args: nil }
+          )
           result = Types::Alias.new(name: name, location: location)
         when name.interface?
+          location = location.with_children(
+            required: { name: val[0].location },
+            optional: { args: nil }
+          )
           result = Types::Interface.new(name: name, args: args, location: location)
         end
 
@@ -2925,7 +2955,7 @@ module_eval(<<'.,.,', 'parser.y', 948)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 966)
+module_eval(<<'.,.,', 'parser.y', 996)
   def _reduce_177(val, _values, result)
             name = val[0].value
         args = val[2]
@@ -2936,8 +2966,16 @@ module_eval(<<'.,.,', 'parser.y', 966)
           if is_bound_variable?(name.name)
             raise SemanticsError.new("#{name.name} is type variable and cannot be applied", subject: name, location: location)
           end
+          location = location.with_children(
+            required: { name: val[0].location },
+            optional: { args: val[1].location + val[3].location }
+          )
           result = Types::ClassInstance.new(name: name, args: args, location: location)
         when name.interface?
+          location = location.with_children(
+            required: { name: val[0].location },
+            optional: { args: val[1].location + val[3].location }
+          )
           result = Types::Interface.new(name: name, args: args, location: location)
         else
           raise SyntaxError.new(token_str: "kLBRACKET", error_value: val[1])
@@ -2947,7 +2985,7 @@ module_eval(<<'.,.,', 'parser.y', 966)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 983)
+module_eval(<<'.,.,', 'parser.y', 1021)
   def _reduce_178(val, _values, result)
             location = val[0].location + val[1].location
         result = Types::Tuple.new(types: [], location: location)
@@ -2956,7 +2994,7 @@ module_eval(<<'.,.,', 'parser.y', 983)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 987)
+module_eval(<<'.,.,', 'parser.y', 1025)
   def _reduce_179(val, _values, result)
             location = val[0].location + val[3].location
         types = val[1]
@@ -2966,7 +3004,7 @@ module_eval(<<'.,.,', 'parser.y', 987)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 992)
+module_eval(<<'.,.,', 'parser.y', 1030)
   def _reduce_180(val, _values, result)
             type = val[1].dup
         type.instance_eval do
@@ -2978,16 +3016,19 @@ module_eval(<<'.,.,', 'parser.y', 992)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 999)
+module_eval(<<'.,.,', 'parser.y', 1037)
   def _reduce_181(val, _values, result)
-            result = Types::ClassSingleton.new(name: val[2].value,
-                                           location: val[0].location + val[3].location)
+            location = val[0].location + val[3].location
+        location = location.with_children(
+          required: { name: val[2].location }
+        )
+        result = Types::ClassSingleton.new(name: val[2].value, location: location)
 
     result
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1003)
+module_eval(<<'.,.,', 'parser.y', 1044)
   def _reduce_182(val, _values, result)
             type, block = val[1].value
         result = Types::Proc.new(type: type, block: block, location: val[0].location + val[1].location)
@@ -2996,7 +3037,7 @@ module_eval(<<'.,.,', 'parser.y', 1003)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1007)
+module_eval(<<'.,.,', 'parser.y', 1048)
   def _reduce_183(val, _values, result)
             result = Types::Optional.new(type: val[0], location: val[0].location + val[1].location)
 
@@ -3006,7 +3047,7 @@ module_eval(<<'.,.,', 'parser.y', 1007)
 
 # reduce 184 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1013)
+module_eval(<<'.,.,', 'parser.y', 1054)
   def _reduce_185(val, _values, result)
             result = [val[0]]
 
@@ -3014,7 +3055,7 @@ module_eval(<<'.,.,', 'parser.y', 1013)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1016)
+module_eval(<<'.,.,', 'parser.y', 1057)
   def _reduce_186(val, _values, result)
             result = val[0] + [val[2]]
 
@@ -3022,7 +3063,7 @@ module_eval(<<'.,.,', 'parser.y', 1016)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1021)
+module_eval(<<'.,.,', 'parser.y', 1062)
   def _reduce_187(val, _values, result)
             result = Types::Record.new(
           fields: val[1],
@@ -3033,7 +3074,7 @@ module_eval(<<'.,.,', 'parser.y', 1021)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1029)
+module_eval(<<'.,.,', 'parser.y', 1070)
   def _reduce_188(val, _values, result)
             result = val[0]
 
@@ -3041,7 +3082,7 @@ module_eval(<<'.,.,', 'parser.y', 1029)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1032)
+module_eval(<<'.,.,', 'parser.y', 1073)
   def _reduce_189(val, _values, result)
             result = val[0].merge!(val[2])
 
@@ -3049,7 +3090,7 @@ module_eval(<<'.,.,', 'parser.y', 1032)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1037)
+module_eval(<<'.,.,', 'parser.y', 1078)
   def _reduce_190(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3057,7 +3098,7 @@ module_eval(<<'.,.,', 'parser.y', 1037)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1040)
+module_eval(<<'.,.,', 'parser.y', 1081)
   def _reduce_191(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3065,7 +3106,7 @@ module_eval(<<'.,.,', 'parser.y', 1040)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1043)
+module_eval(<<'.,.,', 'parser.y', 1084)
   def _reduce_192(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3073,7 +3114,7 @@ module_eval(<<'.,.,', 'parser.y', 1043)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1046)
+module_eval(<<'.,.,', 'parser.y', 1087)
   def _reduce_193(val, _values, result)
             result = { val[0].value => val[1] }
 
@@ -3081,7 +3122,7 @@ module_eval(<<'.,.,', 'parser.y', 1046)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1049)
+module_eval(<<'.,.,', 'parser.y', 1090)
   def _reduce_194(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3089,7 +3130,7 @@ module_eval(<<'.,.,', 'parser.y', 1049)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1052)
+module_eval(<<'.,.,', 'parser.y', 1093)
   def _reduce_195(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3097,7 +3138,7 @@ module_eval(<<'.,.,', 'parser.y', 1052)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1055)
+module_eval(<<'.,.,', 'parser.y', 1096)
   def _reduce_196(val, _values, result)
             result = { val[0].value => val[2] }
 
@@ -3107,7 +3148,7 @@ module_eval(<<'.,.,', 'parser.y', 1055)
 
 # reduce 197 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1061)
+module_eval(<<'.,.,', 'parser.y', 1102)
   def _reduce_198(val, _values, result)
             result = val[0]
 
@@ -3123,7 +3164,7 @@ module_eval(<<'.,.,', 'parser.y', 1061)
 
 # reduce 202 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1068)
+module_eval(<<'.,.,', 'parser.y', 1109)
   def _reduce_203(val, _values, result)
             location = (val[0] || val[1] || val[2]).location + val[3].location
 
@@ -3148,7 +3189,7 @@ module_eval(<<'.,.,', 'parser.y', 1068)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1088)
+module_eval(<<'.,.,', 'parser.y', 1129)
   def _reduce_204(val, _values, result)
             result = LocatedValue.new(value: [val[0].value, nil], location: val[0].location)
 
@@ -3156,7 +3197,7 @@ module_eval(<<'.,.,', 'parser.y', 1088)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1093)
+module_eval(<<'.,.,', 'parser.y', 1134)
   def _reduce_205(val, _values, result)
             location = val[0].location + val[4].location
         type = Types::Function.new(
@@ -3176,7 +3217,7 @@ module_eval(<<'.,.,', 'parser.y', 1093)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1108)
+module_eval(<<'.,.,', 'parser.y', 1149)
   def _reduce_206(val, _values, result)
             location = val[0].location + val[1].location
         type = Types::Function.new(
@@ -3196,7 +3237,7 @@ module_eval(<<'.,.,', 'parser.y', 1108)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1125)
+module_eval(<<'.,.,', 'parser.y', 1166)
   def _reduce_207(val, _values, result)
             result = val[2]
         result[0].unshift(val[0])
@@ -3205,7 +3246,7 @@ module_eval(<<'.,.,', 'parser.y', 1125)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1129)
+module_eval(<<'.,.,', 'parser.y', 1170)
   def _reduce_208(val, _values, result)
             result = empty_params_result
         result[0].unshift(val[0])
@@ -3216,7 +3257,7 @@ module_eval(<<'.,.,', 'parser.y', 1129)
 
 # reduce 209 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1136)
+module_eval(<<'.,.,', 'parser.y', 1177)
   def _reduce_210(val, _values, result)
             result = val[2]
         result[1].unshift(val[0])
@@ -3225,7 +3266,7 @@ module_eval(<<'.,.,', 'parser.y', 1136)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1140)
+module_eval(<<'.,.,', 'parser.y', 1181)
   def _reduce_211(val, _values, result)
             result = empty_params_result
         result[1].unshift(val[0])
@@ -3236,7 +3277,7 @@ module_eval(<<'.,.,', 'parser.y', 1140)
 
 # reduce 212 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1147)
+module_eval(<<'.,.,', 'parser.y', 1188)
   def _reduce_213(val, _values, result)
             result = val[2]
         result[2] = val[0]
@@ -3245,7 +3286,7 @@ module_eval(<<'.,.,', 'parser.y', 1147)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1151)
+module_eval(<<'.,.,', 'parser.y', 1192)
   def _reduce_214(val, _values, result)
             result = empty_params_result
         result[2] = val[0]
@@ -3256,7 +3297,7 @@ module_eval(<<'.,.,', 'parser.y', 1151)
 
 # reduce 215 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1158)
+module_eval(<<'.,.,', 'parser.y', 1199)
   def _reduce_216(val, _values, result)
             result = val[2]
         result[3].unshift(val[0])
@@ -3265,7 +3306,7 @@ module_eval(<<'.,.,', 'parser.y', 1158)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1162)
+module_eval(<<'.,.,', 'parser.y', 1203)
   def _reduce_217(val, _values, result)
             result = empty_params_result
         result[3].unshift(val[0])
@@ -3276,7 +3317,7 @@ module_eval(<<'.,.,', 'parser.y', 1162)
 
 # reduce 218 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1169)
+module_eval(<<'.,.,', 'parser.y', 1210)
   def _reduce_219(val, _values, result)
             result = empty_params_result
 
@@ -3284,7 +3325,7 @@ module_eval(<<'.,.,', 'parser.y', 1169)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1172)
+module_eval(<<'.,.,', 'parser.y', 1213)
   def _reduce_220(val, _values, result)
             result = val[2]
         result[4].merge!(val[0])
@@ -3293,7 +3334,7 @@ module_eval(<<'.,.,', 'parser.y', 1172)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1176)
+module_eval(<<'.,.,', 'parser.y', 1217)
   def _reduce_221(val, _values, result)
             result = empty_params_result
         result[4].merge!(val[0])
@@ -3302,7 +3343,7 @@ module_eval(<<'.,.,', 'parser.y', 1176)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1180)
+module_eval(<<'.,.,', 'parser.y', 1221)
   def _reduce_222(val, _values, result)
             result = val[2]
         result[5].merge!(val[0])
@@ -3311,7 +3352,7 @@ module_eval(<<'.,.,', 'parser.y', 1180)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1184)
+module_eval(<<'.,.,', 'parser.y', 1225)
   def _reduce_223(val, _values, result)
             result = empty_params_result
         result[5].merge!(val[0])
@@ -3320,7 +3361,7 @@ module_eval(<<'.,.,', 'parser.y', 1184)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1188)
+module_eval(<<'.,.,', 'parser.y', 1229)
   def _reduce_224(val, _values, result)
             result = empty_params_result
         result[6] = val[0]
@@ -3329,7 +3370,7 @@ module_eval(<<'.,.,', 'parser.y', 1188)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1194)
+module_eval(<<'.,.,', 'parser.y', 1235)
   def _reduce_225(val, _values, result)
             loc = val[0].location
         if var_name = val[1]
@@ -3347,7 +3388,7 @@ module_eval(<<'.,.,', 'parser.y', 1194)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1209)
+module_eval(<<'.,.,', 'parser.y', 1250)
   def _reduce_226(val, _values, result)
             loc = val[0].location + val[1].location
         if var_name = val[2]
@@ -3365,7 +3406,7 @@ module_eval(<<'.,.,', 'parser.y', 1209)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1224)
+module_eval(<<'.,.,', 'parser.y', 1265)
   def _reduce_227(val, _values, result)
             loc = val[0].location + val[1].location
         if var_name = val[2]
@@ -3383,7 +3424,7 @@ module_eval(<<'.,.,', 'parser.y', 1224)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1239)
+module_eval(<<'.,.,', 'parser.y', 1280)
   def _reduce_228(val, _values, result)
             loc = val[0].location + val[1].location
         if var_name = val[2]
@@ -3403,7 +3444,7 @@ module_eval(<<'.,.,', 'parser.y', 1239)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1256)
+module_eval(<<'.,.,', 'parser.y', 1297)
   def _reduce_229(val, _values, result)
             loc = val[0].location + val[2].location
         if var_name = val[3]
@@ -3423,7 +3464,7 @@ module_eval(<<'.,.,', 'parser.y', 1256)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1273)
+module_eval(<<'.,.,', 'parser.y', 1314)
   def _reduce_230(val, _values, result)
             loc = val[0].location + val[1].location
         if var_name = val[2]
@@ -3450,7 +3491,7 @@ module_eval(<<'.,.,', 'parser.y', 1273)
 
 # reduce 234 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1292)
+module_eval(<<'.,.,', 'parser.y', 1333)
   def _reduce_235(val, _values, result)
             namespace = val[0]&.value || Namespace.empty
         name = val[1].value.to_sym
@@ -3468,7 +3509,7 @@ module_eval(<<'.,.,', 'parser.y', 1292)
 
 # reduce 238 omitted
 
-module_eval(<<'.,.,', 'parser.y', 1304)
+module_eval(<<'.,.,', 'parser.y', 1345)
   def _reduce_239(val, _values, result)
             namespace = val[0]&.value || Namespace.empty
         name = val[1].value.to_sym
@@ -3480,7 +3521,7 @@ module_eval(<<'.,.,', 'parser.y', 1304)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1313)
+module_eval(<<'.,.,', 'parser.y', 1354)
   def _reduce_240(val, _values, result)
             namespace = val[0]&.value || Namespace.empty
         name = val[1].value.to_sym
@@ -3492,7 +3533,7 @@ module_eval(<<'.,.,', 'parser.y', 1313)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1322)
+module_eval(<<'.,.,', 'parser.y', 1363)
   def _reduce_241(val, _values, result)
             namespace = val[0]&.value || Namespace.empty
         name = val[1].value.to_sym
@@ -3504,7 +3545,7 @@ module_eval(<<'.,.,', 'parser.y', 1322)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1332)
+module_eval(<<'.,.,', 'parser.y', 1373)
   def _reduce_242(val, _values, result)
             result = nil
 
@@ -3512,7 +3553,7 @@ module_eval(<<'.,.,', 'parser.y', 1332)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1335)
+module_eval(<<'.,.,', 'parser.y', 1376)
   def _reduce_243(val, _values, result)
             result = LocatedValue.new(value: Namespace.root, location: val[0].location)
 
@@ -3520,7 +3561,7 @@ module_eval(<<'.,.,', 'parser.y', 1335)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1338)
+module_eval(<<'.,.,', 'parser.y', 1379)
   def _reduce_244(val, _values, result)
             namespace = Namespace.parse(val[1].value).absolute!
         result = LocatedValue.new(value: namespace, location: val[0].location + val[1].location)
@@ -3529,7 +3570,7 @@ module_eval(<<'.,.,', 'parser.y', 1338)
   end
 .,.,
 
-module_eval(<<'.,.,', 'parser.y', 1342)
+module_eval(<<'.,.,', 'parser.y', 1383)
   def _reduce_245(val, _values, result)
             namespace = Namespace.parse(val[0].value)
         result = LocatedValue.new(value: namespace, location: val[0].location)

--- a/sig/locator.rbs
+++ b/sig/locator.rbs
@@ -1,0 +1,44 @@
+module RBS
+  # Locator helps finding RBS elements based on locations in the RBS source text.
+  #
+  class Locator
+    type component = Symbol
+                   | Types::t
+                   | MethodType
+                   | AST::Declarations::t
+                   | AST::Members::t
+                   | AST::Declarations::ModuleTypeParams::TypeParam
+                   | AST::Declarations::Class::Super
+                   | AST::Declarations::Module::Self
+
+    # Array of _top-level_ declarations.
+    #
+    attr_reader decls: Array[AST::Declarations::t]
+
+    def initialize: (decls: Array[AST::Declarations::t]) -> void
+
+    def buffer: () -> Buffer
+
+    # Returns list of components.
+    # Inner component comes first.
+    #
+    def find: (line: Integer, column: Integer) -> Array[component]
+
+    # Returns pair of the inner most symbol and outer components.
+    # It ensures the array starts with a AST/type component.
+    #
+    def find2: (line: Integer, column: Integer) -> [Symbol?, Array[component]]?
+
+    def find_in_decl: (Integer pos, decl: AST::Declarations::t, array: Array[component]) -> bool
+
+    def find_in_member: (Integer pos, member: AST::Members::t, array: Array[component]) -> bool
+
+    def find_in_method_type: (Integer pos, method_type: MethodType, array: Array[component]) -> bool
+
+    def find_in_type: (Integer pos, type: Types::t, array: Array[component]) -> bool
+
+    def find_in_loc: (Integer pos, location: Location::WithChildren[untyped, untyped] | Location | nil, array: Array[component]) -> bool
+
+    def test_loc: (Integer pos, location: Location?) -> bool
+  end
+end

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -3,11 +3,6 @@ module RBS
     # _TypeBase interface represents the operations common to all of the types.
     #
     interface _TypeBase
-      # Location for types in the RBS source code.
-      # `nil` means there is no RBS source code for the type.
-      #
-      def location: () -> Location?
-
       # Returns names of free variables of a type.
       # You can pass a Set instance to add the free variables to the set to avoid Set object allocation.
       #
@@ -70,6 +65,8 @@ module RBS
       class Base
         include _TypeBase
 
+        attr_reader location: Location?
+
         def initialize: (location: Location?) -> void
 
         def ==: (untyped other) -> bool
@@ -119,11 +116,12 @@ module RBS
       @@count: Integer
 
       include _TypeBase
-
       include NoTypeName
       include EmptyEachType
 
       def initialize: (name: Symbol, location: Location?) -> void
+
+      attr_reader location: Location?
 
       def ==: (untyped other) -> bool
 
@@ -144,21 +142,26 @@ module RBS
     end
 
     class ClassSingleton
+      # singleton(::Foo)
+      #           ^^^^^  => name
+      type loc = Location::WithChildren[:name, bot]
+
+      def initialize: (name: TypeName, location: loc?) -> void
+
       attr_reader name: TypeName
 
-      include _TypeBase
+      attr_reader location: loc?
 
-      def initialize: (name: TypeName, location: Location?) -> void
+      include _TypeBase
+      include NoFreeVariables
+      include NoSubst
+      include EmptyEachType
 
       def ==: (untyped other) -> bool
 
       alias eql? ==
 
       def hash: () -> Integer
-
-      include NoFreeVariables
-      include NoSubst
-      include EmptyEachType
     end
 
     module Application
@@ -180,11 +183,20 @@ module RBS
     end
 
     class Interface
+      # _Foo
+      # ^^^^ => name
+      #
+      # _Foo[Bar, Baz]
+      # ^^^^           => name
+      #     ^^^^^^^^^^ => args
+      type loc = Location::WithChildren[:name, :args]
+
+      def initialize: (name: TypeName, args: Array[t], location: loc?) -> void
+
       include Application
-
-      def initialize: (name: TypeName, args: Array[t], location: Location?) -> void
-
       include _TypeBase
+
+      attr_reader location: loc?
     end
 
     # ClassInstance represents a type of an instance of a class.
@@ -196,7 +208,17 @@ module RBS
     class ClassInstance
       include Application
 
-      def initialize: (name: TypeName, args: Array[t], location: Location?) -> void
+      # Foo
+      # ^^^ => name
+      #
+      # Foo[Bar, Baz]
+      # ^^^           => name
+      #    ^^^^^^^^^^ => args
+      type loc = Location::WithChildren[:name, :args]
+
+      def initialize: (name: TypeName, args: Array[t], location: loc?) -> void
+
+      attr_reader location: loc?
 
       include _TypeBase
     end
@@ -210,6 +232,8 @@ module RBS
       include NoFreeVariables
       include NoSubst
       include EmptyEachType
+
+      attr_reader location: Location?
     end
 
     class Tuple
@@ -218,6 +242,8 @@ module RBS
       def initialize: (types: Array[t], location: Location?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
     end
 
     class Record
@@ -226,6 +252,8 @@ module RBS
       def initialize: (fields: Hash[Symbol, t], location: Location?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
     end
 
     class Optional
@@ -234,6 +262,8 @@ module RBS
       def initialize: (type: t, location: Location?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
     end
 
     class Union
@@ -242,6 +272,8 @@ module RBS
       def initialize: (types: Array[t], location: Location?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
 
       def map_type: () { (t) -> t } -> Union
                   | () -> Enumerator[t, Union]
@@ -253,6 +285,8 @@ module RBS
       def initialize: (types: Array[t], location: Location?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
 
       def map_type: () { (t) -> t } -> Intersection
                   | () -> Enumerator[t, Intersection]
@@ -353,6 +387,8 @@ module RBS
       def initialize: (location: Location?, type: Function, block: Block?) -> void
 
       include _TypeBase
+
+      attr_reader location: Location?
     end
 
     class Literal
@@ -367,6 +403,8 @@ module RBS
       include NoSubst
       include EmptyEachType
       include NoTypeName
+
+      attr_reader location: Location?
     end
   end
 end

--- a/test/rbs/locator_test.rb
+++ b/test/rbs/locator_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class RBS::LocatorTest < Test::Unit::TestCase
+  include RBS
+  include TestHelper
+
+  def locator(src)
+    decls = Parser.parse_signature(src)
+    Locator.new(decls: decls)
+  end
+
+  def test_find_class
+    locator = locator(<<RBS)
+class Foo[A] < Array[A]
+
+end
+RBS
+
+    locator.find(line: 2, column: 0).tap do |cs|
+      assert_equal 1, cs.size
+      assert_instance_of AST::Declarations::Class, cs[0]
+    end
+
+    locator.find(line: 1, column: 2).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :keyword, cs[0]
+      assert_instance_of AST::Declarations::Class, cs[1]
+    end
+
+    locator.find(line: 1, column: 8).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::Class, cs[1]
+    end
+
+    locator.find(line: 1, column: 9).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :type_params, cs[0]
+      assert_instance_of AST::Declarations::Class, cs[1]
+    end
+
+    locator.find(line: 1, column: 10).tap do |cs|
+      assert_equal 3, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::ModuleTypeParams::TypeParam, cs[1]
+      assert_instance_of AST::Declarations::Class, cs[2]
+    end
+
+    locator.find(line: 1, column: 18).tap do |cs|
+      assert_equal 3, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::Class::Super, cs[1]
+      assert_instance_of AST::Declarations::Class, cs[2]
+    end
+  end
+
+  def test_find_module
+    locator = locator(<<RBS)
+module Foo[A] : Array[A], _Foo
+
+end
+RBS
+
+    locator.find(line: 2, column: 0).tap do |cs|
+      assert_equal 1, cs.size
+      assert_instance_of AST::Declarations::Module, cs[0]
+    end
+
+    locator.find(line: 1, column: 1).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :keyword, cs[0]
+      assert_instance_of AST::Declarations::Module, cs[1]
+    end
+
+    locator.find(line: 1, column: 8).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::Module, cs[1]
+    end
+
+    locator.find(line: 1, column: 11).tap do |cs|
+      assert_equal 3, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::ModuleTypeParams::TypeParam, cs[1]
+      assert_instance_of AST::Declarations::Module, cs[2]
+    end
+
+    locator.find(line: 1, column: 25).tap do |cs|
+      assert_equal 2, cs.size
+      assert_equal :self_types, cs[0]
+      assert_instance_of AST::Declarations::Module, cs[1]
+    end
+
+    locator.find(line: 1, column: 27).tap do |cs|
+      assert_equal 3, cs.size
+      assert_equal :name, cs[0]
+      assert_instance_of AST::Declarations::Module::Self, cs[1]
+      assert_instance_of AST::Declarations::Module, cs[2]
+    end
+  end
+end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -1701,4 +1701,47 @@ end
       end
     end
   end
+
+  def test_constant_global_location
+    Parser.parse_signature(<<-EOF).tap do |decls|
+X: String
+A::B : String
+$B: Integer
+    EOF
+      decls[0].tap do |decl|
+        assert_instance_of Location::WithChildren, decl.location
+
+        assert_equal "X", decl.location[:name].source
+        assert_equal ":", decl.location[:colon].source
+      end
+
+      decls[1].tap do |decl|
+        assert_instance_of Location::WithChildren, decl.location
+
+        assert_equal "A::B", decl.location[:name].source
+        assert_equal ":", decl.location[:colon].source
+      end
+
+      decls[2].tap do |decl|
+        assert_instance_of Location::WithChildren, decl.location
+
+        assert_equal "$B", decl.location[:name].source
+        assert_equal ":", decl.location[:colon].source
+      end
+    end
+  end
+
+  def test_type_alias_location
+    Parser.parse_signature(<<-EOF).tap do |decls|
+type foo = Integer
+    EOF
+      decls[0].tap do |decl|
+        assert_instance_of Location::WithChildren, decl.location
+
+        assert_equal "type", decl.location[:keyword].source
+        assert_equal "foo", decl.location[:name].source
+        assert_equal "=", decl.location[:eq].source
+      end
+    end
+  end
 end

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -634,4 +634,47 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
     Parser.parse_type('{ `日本語`: Integer }')
     Parser.parse_type('{ `🌼`: Integer }')
   end
+
+  def test_location_children
+    Parser.parse_type("_Foo").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "_Foo", type.location[:name].source
+      assert_nil type.location[:args]
+    end
+
+    Parser.parse_type("_Foo[untyped]").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "_Foo", type.location[:name].source
+      assert_equal "[untyped]", type.location[:args].source
+    end
+
+    Parser.parse_type("Foo").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "Foo", type.location[:name].source
+      assert_nil type.location[:args]
+    end
+
+    Parser.parse_type("Foo[untyped]").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "Foo", type.location[:name].source
+      assert_equal "[untyped]", type.location[:args].source
+    end
+
+    Parser.parse_type("foo").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "foo", type.location[:name].source
+      assert_nil type.location[:args]
+    end
+
+    Parser.parse_type("singleton(::Foo)").yield_self do |type|
+      assert_instance_of RBS::Location::WithChildren, type.location
+
+      assert_equal "::Foo", type.location[:name].source
+    end
+  end
 end


### PR DESCRIPTION
`Locator` is a class to translate a pair of integers that represents line and column to a list of values that represents a position in the declaration tree.

```rbs
class Foo
       ^ line = 1, column = 7
end
```

The position will be translated to a list of:

1. `:name` (The symbol tells the position in the class declaration)
2. A class declaration of `::Foo`

So that we can find that the cursor in a text file is at the _name_ of a class declaration. This is essential to implement some features which work with text files (== a language server).
