### PR TITLE
Expand how to set `pathname`

### DIFF
--- a/docs/sigs.md
+++ b/docs/sigs.md
@@ -134,6 +134,9 @@ The default is `-I sig`.
 RBS_TEST_OPT='-r set -r pathname -I sig'
 ```
 
+Replacing `pathname` with the `stdlib` you want to include. For example, if you need to load `BigDecimal` in `stdlib`, you would need to set `RBS_TEST_OPT='-r set -r bigdecimal -I sig'`
+
+
 `RBS_TEST_LOGLEVEL` can be used to configure log level. Defaults to `info`.
 
 `RBS_TEST_RAISE` may help to debug the type signatures.

--- a/docs/sigs.md
+++ b/docs/sigs.md
@@ -136,7 +136,6 @@ RBS_TEST_OPT='-r pathname -I sig'
 
 Replacing `pathname` with the `stdlib` you want to include. For example, if you need to load `Set` and `BigDecimal` in `stdlib`, you would need to have `RBS_TEST_OPT='-r set -r bigdecimal -I sig'`
 
-
 `RBS_TEST_LOGLEVEL` can be used to configure log level. Defaults to `info`.
 
 `RBS_TEST_RAISE` may help to debug the type signatures.

--- a/docs/sigs.md
+++ b/docs/sigs.md
@@ -131,10 +131,10 @@ You may need to specify `-r` or `-I` to load signatures.
 The default is `-I sig`.
 
 ```
-RBS_TEST_OPT='-r set -r pathname -I sig'
+RBS_TEST_OPT='-r pathname -I sig'
 ```
 
-Replacing `pathname` with the `stdlib` you want to include. For example, if you need to load `BigDecimal` in `stdlib`, you would need to set `RBS_TEST_OPT='-r set -r bigdecimal -I sig'`
+Replacing `pathname` with the `stdlib` you want to include. For example, if you need to load `Set` and `BigDecimal` in `stdlib`, you would need to have `RBS_TEST_OPT='-r set -r bigdecimal -I sig'`
 
 
 `RBS_TEST_LOGLEVEL` can be used to configure log level. Defaults to `info`.


### PR DESCRIPTION
It's not obvious what pathname should be set to include 
some classes in stdlib.