### PR TITLE
Do not allow including/prepending/extending a class constant

### DIFF
--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -321,7 +321,7 @@ module RBS
 
             case
             when member.name.class? && included_modules
-              InvalidMixinClassError.check!(mixin_name: "include", env: env, member: member)
+              MixinClassError.check!(env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               included_modules << ancestor
             when member.name.interface? && included_interfaces
@@ -331,7 +331,7 @@ module RBS
 
           when AST::Members::Prepend
             if prepended_modules
-              InvalidMixinClassError.check!(mixin_name: "perpend", env: env, member: member)
+              MixinClassError.check!(env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
 
               module_name = member.name
@@ -347,7 +347,7 @@ module RBS
 
             case
             when member.name.class? && extended_modules
-              InvalidMixinClassError.check!(mixin_name: "extend", env: env, member: member)
+              MixinClassError.check!(env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               extended_modules << ancestor
             when member.name.interface? && extended_interfaces

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -237,6 +237,7 @@ module RBS
         end
 
         mixin_ancestors(entry,
+                        type_name,
                         included_modules: ancestors.included_modules,
                         included_interfaces: ancestors.included_interfaces,
                         prepended_modules: ancestors.prepended_modules,
@@ -284,6 +285,7 @@ module RBS
         end
 
         mixin_ancestors(entry,
+                        type_name,
                         included_modules: nil,
                         included_interfaces: nil,
                         prepended_modules: nil,
@@ -301,6 +303,7 @@ module RBS
 
             OneAncestors.interface(type_name: type_name, params: params).tap do |ancestors|
               mixin_ancestors0(entry.decl,
+                               type_name,
                                align_params: nil,
                                included_modules: nil,
                                included_interfaces: ancestors.included_interfaces,
@@ -311,7 +314,7 @@ module RBS
           end
       end
 
-      def mixin_ancestors0(decl, align_params:, included_modules:, included_interfaces:, extended_modules:, prepended_modules:, extended_interfaces:)
+      def mixin_ancestors0(decl, type_name, align_params:, included_modules:, included_interfaces:, extended_modules:, prepended_modules:, extended_interfaces:)
         decl.each_mixin do |member|
           case member
           when AST::Members::Include
@@ -321,7 +324,7 @@ module RBS
 
             case
             when member.name.class? && included_modules
-              MixinClassError.check!(env: env, member: member)
+              MixinClassError.check!(type_name: type_name, env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               included_modules << ancestor
             when member.name.interface? && included_interfaces
@@ -331,7 +334,7 @@ module RBS
 
           when AST::Members::Prepend
             if prepended_modules
-              MixinClassError.check!(env: env, member: member)
+              MixinClassError.check!(type_name: type_name, env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
 
               module_name = member.name
@@ -347,7 +350,7 @@ module RBS
 
             case
             when member.name.class? && extended_modules
-              MixinClassError.check!(env: env, member: member)
+              MixinClassError.check!(type_name: type_name, env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               extended_modules << ancestor
             when member.name.interface? && extended_interfaces
@@ -358,7 +361,7 @@ module RBS
         end
       end
 
-      def mixin_ancestors(entry, included_modules:, included_interfaces:, extended_modules:, prepended_modules:, extended_interfaces:)
+      def mixin_ancestors(entry, type_name, included_modules:, included_interfaces:, extended_modules:, prepended_modules:, extended_interfaces:)
         entry.decls.each do |d|
           decl = d.decl
 
@@ -368,6 +371,7 @@ module RBS
           )
 
           mixin_ancestors0(decl,
+                           type_name,
                            align_params: align_params,
                            included_modules: included_modules,
                            included_interfaces: included_interfaces,

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -321,6 +321,7 @@ module RBS
 
             case
             when member.name.class? && included_modules
+              InvalidMixinClassError.check!(mixin_name: "include", env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               included_modules << ancestor
             when member.name.interface? && included_interfaces
@@ -330,6 +331,7 @@ module RBS
 
           when AST::Members::Prepend
             if prepended_modules
+              InvalidMixinClassError.check!(mixin_name: "perpend", env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
 
               module_name = member.name
@@ -345,6 +347,7 @@ module RBS
 
             case
             when member.name.class? && extended_modules
+              InvalidMixinClassError.check!(mixin_name: "extend", env: env, member: member)
               NoMixinFoundError.check!(member.name, env: env, member: member)
               extended_modules << ancestor
             when member.name.interface? && extended_interfaces

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -350,4 +350,29 @@ module RBS
       original.location
     end
   end
+
+  class InvalidMixinClassError < DefinitionError
+    attr_reader :type_name
+    attr_reader :member
+
+    def initialize(mixin_name:, member:)
+      @type_name = member.name
+      @member = member
+
+      super "#{Location.to_string location}: Not allow to #{mixin_name} #{type_name} class"
+    end
+
+    def location
+      member.location
+    end
+
+    def self.check!(mixin_name:, env:, member:)
+      if member.name.class? && env.class_decls.key?(member.name)
+        case env.class_decls[member.name]
+        when Environment::ClassEntry
+          raise new(mixin_name: mixin_name, member: member)
+        end
+      end
+    end
+  end
 end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -351,27 +351,40 @@ module RBS
     end
   end
 
-  class InvalidMixinClassError < DefinitionError
+  class MixinClassError < DefinitionError
     attr_reader :type_name
     attr_reader :member
 
-    def initialize(mixin_name:, member:)
+    def initialize(member:)
       @type_name = member.name
       @member = member
 
-      super "#{Location.to_string location}: Not allow to #{mixin_name} #{type_name} class"
+      super "Cannot #{mixin_name} a class #{member.name} in the definition of #{type_name}"
     end
 
     def location
       member.location
     end
 
-    def self.check!(mixin_name:, env:, member:)
-      if member.name.class? && env.class_decls.key?(member.name)
+    def self.check!(env:, member:)
+      if member.name.class?
         case env.class_decls[member.name]
         when Environment::ClassEntry
-          raise new(mixin_name: mixin_name, member: member)
+          raise new(member: member)
         end
+      end
+    end
+
+    private
+
+    def mixin_name
+      case member
+      when AST::Members::Prepend
+        "prepend"
+      when AST::Members::Include
+        "include"
+      when AST::Members::Extend
+        "extend"
       end
     end
   end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -359,7 +359,7 @@ module RBS
       @type_name = member.name
       @member = member
 
-      super "Cannot #{mixin_name} a class `#{member.name}` in the definition of `#{type_name}`"
+      super "#{Location.to_string member.location}: Cannot #{mixin_name} a class `#{member.name}` in the definition of `#{type_name}`"
     end
 
     def location

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -355,8 +355,8 @@ module RBS
     attr_reader :type_name
     attr_reader :member
 
-    def initialize(member:)
-      @type_name = member.name
+    def initialize(type_name:, member:)
+      @type_name = type_name
       @member = member
 
       super "#{Location.to_string member.location}: Cannot #{mixin_name} a class `#{member.name}` in the definition of `#{type_name}`"
@@ -366,12 +366,10 @@ module RBS
       member.location
     end
 
-    def self.check!(env:, member:)
-      if member.name.class?
-        case env.class_decls[member.name]
-        when Environment::ClassEntry
-          raise new(member: member)
-        end
+    def self.check!(type_name:, env:, member:)
+      case env.class_decls[member.name]
+      when Environment::ClassEntry
+        raise new(type_name: type_name, member: member)
       end
     end
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -359,7 +359,7 @@ module RBS
       @type_name = member.name
       @member = member
 
-      super "Cannot #{mixin_name} a class #{member.name} in the definition of #{type_name}"
+      super "Cannot #{mixin_name} a class `#{member.name}` in the definition of `#{type_name}`"
     end
 
     def location

--- a/sig/ancestor_builder.rbs
+++ b/sig/ancestor_builder.rbs
@@ -80,6 +80,7 @@ module RBS
       def interface_ancestors: (TypeName, ?building_ancestors: Array[Definition::Ancestor::t]) -> Definition::InstanceAncestors
 
       def mixin_ancestors: (Environment::ClassEntry | Environment::ModuleEntry,
+                            TypeName,
                             included_modules: Array[Definition::Ancestor::Instance]?,
                          included_interfaces:Array[Definition::Ancestor::Instance]?,
                            prepended_modules: Array[Definition::Ancestor::Instance]?,
@@ -87,6 +88,7 @@ module RBS
                          extended_interfaces: Array[Definition::Ancestor::Instance]?) -> void
 
       def mixin_ancestors0: (AST::Declarations::Class | AST::Declarations::Module | AST::Declarations::Interface,
+                             TypeName,
                              align_params: Substitution?,
                          included_modules: Array[Definition::Ancestor::Instance]?,
                       included_interfaces:Array[Definition::Ancestor::Instance]?,

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -181,4 +181,19 @@ module RBS
 
     def location: () -> Location?
   end
+
+  class MixinClassError < DefinitionError
+    type member = AST::Members::Include | AST::Members::Prepend | AST::Members::Extend
+
+    attr_reader type_name: TypeName
+    attr_reader member: member
+
+    def initialize: (type_name: TypeName, member: member) -> void
+
+    def location: () -> Location?
+
+    def self.check!: (TypeName, env: Environment, member: member) -> void
+
+    def mixin_name: () -> String
+  end
 end

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -192,7 +192,7 @@ module RBS
 
     def location: () -> Location?
 
-    def self.check!: (TypeName, env: Environment, member: member) -> void
+    def self.check!: (type_name: TypeName, env: Environment, member: member) -> void
 
     def mixin_name: () -> String
   end

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -14,6 +14,7 @@ class RBS::AncestorBuilderTest < Test::Unit::TestCase
   InvalidTypeApplicationError = RBS::InvalidTypeApplicationError
   RecursiveAncestorError = RBS::RecursiveAncestorError
   SuperclassMismatchError = RBS::SuperclassMismatchError
+  InvalidMixinClassError = RBS::InvalidMixinClassError
 
   def test_one_ancestors_class
     SignatureManager.new(system_builtin: true) do |manager|
@@ -502,6 +503,75 @@ EOF
 
         assert_raises InvalidTypeApplicationError do
           builder.singleton_ancestors(type_name("::C"))
+        end
+      end
+    end
+  end
+
+  def test_invalid_mixin_include
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Foo
+  def foo: () -> untyped
+end
+
+class Qux
+  include Foo
+end
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+        assert_raises InvalidMixinClassError do
+          builder.instance_ancestors(type_name("::Qux"))
+        end
+      end
+    end
+  end
+
+  def test_invalid_mixin_perpend
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Foo
+  def foo: () -> untyped
+end
+
+class Qux
+  prepend Foo
+end
+EOF
+
+  manager.build do |env|
+        manager.build do |env|
+          builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+          assert_raises InvalidMixinClassError do
+            builder.instance_ancestors(type_name("::Qux"))
+          end
+        end
+      end
+    end
+  end
+
+  def test_invalid_mixin_extend
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+class Foo
+  def foo: () -> untyped
+end
+
+class Qux
+  extend Foo
+end
+EOF
+
+  manager.build do |env|
+        manager.build do |env|
+          builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+          assert_raises InvalidMixinClassError do
+            builder.one_singleton_ancestors(type_name("::Qux"))
+          end
         end
       end
     end

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -14,7 +14,7 @@ class RBS::AncestorBuilderTest < Test::Unit::TestCase
   InvalidTypeApplicationError = RBS::InvalidTypeApplicationError
   RecursiveAncestorError = RBS::RecursiveAncestorError
   SuperclassMismatchError = RBS::SuperclassMismatchError
-  InvalidMixinClassError = RBS::InvalidMixinClassError
+  MixinClassError = RBS::MixinClassError
 
   def test_one_ancestors_class
     SignatureManager.new(system_builtin: true) do |manager|
@@ -522,7 +522,7 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder::AncestorBuilder.new(env: env)
 
-        assert_raises InvalidMixinClassError do
+        assert_raises MixinClassError do
           builder.instance_ancestors(type_name("::Qux"))
         end
       end
@@ -545,7 +545,7 @@ EOF
         manager.build do |env|
           builder = DefinitionBuilder::AncestorBuilder.new(env: env)
 
-          assert_raises InvalidMixinClassError do
+          assert_raises MixinClassError do
             builder.instance_ancestors(type_name("::Qux"))
           end
         end
@@ -569,7 +569,7 @@ EOF
         manager.build do |env|
           builder = DefinitionBuilder::AncestorBuilder.new(env: env)
 
-          assert_raises InvalidMixinClassError do
+          assert_raises MixinClassError do
             builder.one_singleton_ancestors(type_name("::Qux"))
           end
         end


### PR DESCRIPTION
Fix https://github.com/ruby/rbs/issues/657
now it should throw an error 
```ruby
class Foo
  def foo: () -> untyped
end

class Qux
  include Foo
end
```