### PR TITLE
Handle Mutex#sleep change planned in Ruby 3.1

### DIFF
--- a/stdlib/mutex_m/0/mutex_m.rbs
+++ b/stdlib/mutex_m/0/mutex_m.rbs
@@ -59,7 +59,7 @@ module Mutex_m
 
   # See Mutex#sleep
   #
-  def sleep: (?Numeric timeout) -> Integer
+  def sleep: (?Numeric timeout) -> Integer?
 
   alias locked? mu_locked?
   alias lock mu_lock

--- a/test/stdlib/Mutex_m_test.rb
+++ b/test/stdlib/Mutex_m_test.rb
@@ -47,10 +47,9 @@ class Mutex_mInstanceTest < Test::Unit::TestCase
   def test_sleep
     mu = mu()
     mu.lock
-    return_type = "Integer#{'?' if RUBY_VERSION >= '3.1'}"
-    assert_send_type "(Integer) -> #{return_type}",
+    assert_send_type "(Integer) -> Integer?",
                      mu, :sleep, 0
-    assert_send_type "(Float) -> #{return_type}",
+    assert_send_type "(Float) -> Integer?",
                      mu, :sleep, 0.1
   end
 end

--- a/test/stdlib/Mutex_m_test.rb
+++ b/test/stdlib/Mutex_m_test.rb
@@ -47,9 +47,10 @@ class Mutex_mInstanceTest < Test::Unit::TestCase
   def test_sleep
     mu = mu()
     mu.lock
-    assert_send_type "(Integer) -> Integer",
+    return_type = "Integer#{'?' if RUBY_VERSION >= '3.1'}"
+    assert_send_type "(Integer) -> #{return_type}",
                      mu, :sleep, 0
-    assert_send_type "(Float) -> Integer",
+    assert_send_type "(Float) -> #{return_type}",
                      mu, :sleep, 0.1
   end
 end


### PR DESCRIPTION
Mutex#sleep in Ruby 3.1 will return nil if not interrupted. This
change is needed so that ruby/ruby PR 4256 can be merged, in order
to fix Ruby bug 16608.