### PR TITLE
Ignore steep/.bundle/ directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/steep/.bundle/
 /.yardoc
 /_yardoc/
 /coverage/
@@ -9,3 +10,4 @@
 /lib/rbs/parser.output
 /vendor/sigs
 /Gemfile.lock
+


### PR DESCRIPTION
The directory is generated by `bin/setup` (`bundle install --jobs 4 --retry 3 --gemfile=steep/Gemfile`), but it is not necessary to git