### PR TITLE
Validate #library call

### DIFF
--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -122,6 +122,10 @@ module TypeAssertions
     attr_reader :target
 
     def library(*libs)
+      if @libs
+        raise "Multiple #library calls are not allowed"
+      end
+
       @libs = libs
       @env = nil
       @target = nil


### PR DESCRIPTION
Make multiple `#library` calls in test an error to prevent a confusion like https://github.com/ruby/rbs/pull/686#discussion_r658479391.