### PR TITLE
Do not check parser.rb diff on ruby-master

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,11 @@ jobs:
         job:
         - test
         - stdlib_test
-        - rubocop validate test_doc build test_generate_stdlib confirm_parser
+        - rubocop validate test_doc build test_generate_stdlib
+        - confirm_parser
+        exclude:
+        - container_tag: master-nightly-focal
+          job: confirm_parser
     container:
       image: rubylang/ruby:${{ matrix.container_tag }}
     steps:


### PR DESCRIPTION
To fix build failure. For example: https://github.com/ruby/rbs/pull/689/checks?check_run_id=2921271817
Racc can have unreleased change on Ruby's master branch, so skip
`confirm_parser` rake task on ruby master.