### PR TITLE
Add optparse signature

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -7,6 +7,7 @@ target :lib do
   library "set", "pathname", "json", "logger", "monitor", "tsort"
   signature "stdlib/strscan/0/"
   signature "stdlib/rubygems/0/"
+  signature "stdlib/optparse/0/"
 end
 
 # target :lib do

--- a/sig/polyfill.rbs
+++ b/sig/polyfill.rbs
@@ -11,24 +11,6 @@ module Gem
   end
 end
 
-class OptionParser
-  def initialize: () ?{ (instance) -> void } -> void
-
-  def on: [T] (*String) { (T) -> void } -> void
-
-  attr_accessor version: String
-
-  attr_accessor banner: String
-
-  def order!: (Array[String]) -> void
-
-  def parse!: (Array[String]) -> void
-
-  def ver: () -> String
-
-  def help: () -> String
-end
-
 module Enumerable[unchecked out Elem]
   def flat_map: [U] () { (Elem) -> Array[U] } -> Array[U]
               | [U] () { (Elem) -> U } -> Array[U]

--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -1,0 +1,410 @@
+class OptionParser
+  def self.accept: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  def self.getopts: (*untyped args) -> untyped
+
+  def self.inc: (untyped arg, ?untyped default) -> untyped
+
+  def self.reject: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  def self.terminate: (?untyped arg) -> untyped
+
+  def self.top: () -> untyped
+
+  def self.with: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  public
+
+  def abort: (?untyped mesg) -> untyped
+
+  def accept: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  def add_officious: () -> untyped
+
+  def additional_message: (untyped typ, untyped opt) -> untyped
+
+  def banner: () -> untyped
+
+  def banner=: (untyped) -> untyped
+
+  def base: () -> untyped
+
+  def candidate: (untyped word) -> untyped
+
+  def compsys: (untyped to, ?untyped name) -> untyped
+
+  alias def_head_option define_head
+
+  alias def_option define
+
+  alias def_tail_option define_tail
+
+  def default_argv: () -> untyped
+
+  def default_argv=: (untyped) -> untyped
+
+  def define: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def define_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def define_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def environment: (?untyped env) -> untyped
+
+  def getopts: (*untyped args) -> untyped
+
+  def help: () -> untyped
+
+  def inc: (*untyped args) -> untyped
+
+  def load: (?untyped filename) -> untyped
+
+  def make_switch: (untyped opts, ?untyped block) -> untyped
+
+  def new: () -> untyped
+
+  def on: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def on_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def on_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
+
+  def order: (*untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
+
+  def order!: (?untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
+
+  def parse: (*untyped argv, ?into: untyped) -> untyped
+
+  def parse!: (?untyped argv, ?into: untyped) -> untyped
+
+  def permute: (*untyped argv, ?into: untyped) -> untyped
+
+  def permute!: (?untyped argv, ?into: untyped) -> untyped
+
+  def program_name: () -> untyped
+
+  def program_name=: (untyped) -> untyped
+
+  def reject: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  def release: () -> untyped
+
+  def release=: (untyped) -> untyped
+
+  def remove: () -> untyped
+
+  def require_exact: () -> untyped
+
+  def require_exact=: (untyped) -> untyped
+
+  def separator: (untyped string) -> untyped
+
+  alias set_banner banner=
+
+  alias set_program_name program_name=
+
+  alias set_summary_indent summary_indent=
+
+  alias set_summary_width summary_width=
+
+  def summarize: (?untyped to, ?untyped width, ?untyped max, ?untyped indent) { (*untyped) -> untyped } -> untyped
+
+  def summary_indent: () -> untyped
+
+  def summary_indent=: (untyped) -> untyped
+
+  def summary_width: () -> untyped
+
+  def summary_width=: (untyped) -> untyped
+
+  def terminate: (?untyped arg) -> untyped
+
+  def to_a: () -> untyped
+
+  alias to_s help
+
+  def top: () -> untyped
+
+  def ver: () -> untyped
+
+  def version: () -> untyped
+
+  def version=: (untyped) -> untyped
+
+  def warn: (?untyped mesg) -> untyped
+
+  private
+
+  def complete: (untyped typ, untyped opt, ?untyped icase, *untyped pat) -> untyped
+
+  def initialize: (?untyped banner, ?untyped width, ?untyped indent) -> void
+
+  def notwice: (untyped obj, untyped prv, untyped msg) -> untyped
+
+  def parse_in_order: (?untyped argv, ?untyped setter) { (*untyped) -> untyped } -> untyped
+
+  def search: (untyped id, untyped key) -> untyped
+
+  def visit: (untyped id, *untyped args) { (*untyped) -> untyped } -> untyped
+end
+
+OptionParser::ArgumentStyle: Hash[untyped, untyped]
+
+OptionParser::COMPSYS_HEADER: String
+
+OptionParser::DecimalInteger: Regexp
+
+OptionParser::DecimalNumeric: Regexp
+
+OptionParser::DefaultList: OptionParser::List
+
+OptionParser::NO_ARGUMENT: Symbol
+
+OptionParser::NoArgument: Array[untyped]
+
+OptionParser::OPTIONAL_ARGUMENT: Symbol
+
+OptionParser::OctalInteger: Regexp
+
+OptionParser::Officious: Hash[untyped, untyped]
+
+OptionParser::OptionalArgument: Array[untyped]
+
+OptionParser::REQUIRED_ARGUMENT: Symbol
+
+OptionParser::RequiredArgument: Array[untyped]
+
+OptionParser::SPLAT_PROC: Proc
+
+OptionParser::Version: String
+
+module OptionParser::Acceptables
+end
+
+OptionParser::Acceptables::DecimalInteger: Regexp
+
+OptionParser::Acceptables::DecimalNumeric: Regexp
+
+OptionParser::Acceptables::OctalInteger: Regexp
+
+class OptionParser::AmbiguousArgument < OptionParser::InvalidArgument
+end
+
+OptionParser::AmbiguousArgument::Reason: String
+
+class OptionParser::AmbiguousOption < OptionParser::ParseError
+end
+
+OptionParser::AmbiguousOption::Reason: String
+
+module OptionParser::Arguable
+  def self.extend_object: (untyped obj) -> untyped
+
+  public
+
+  def getopts: (*untyped args) -> untyped
+
+  def options: () -> untyped
+
+  def options=: (untyped opt) -> untyped
+
+  def order!: () { (*untyped) -> untyped } -> untyped
+
+  def parse!: () -> untyped
+
+  def permute!: () -> untyped
+
+  private
+
+  def initialize: (*untyped args) -> void
+end
+
+class OptionParser::CompletingHash < Hash[untyped, untyped]
+  include Completion
+
+  public
+
+  def match: (untyped key) -> untyped
+end
+
+module OptionParser::Completion
+  def self.candidate: (untyped key, ?untyped icase, ?untyped pat) { (*untyped) -> untyped } -> untyped
+
+  def self.regexp: (untyped key, untyped icase) -> untyped
+
+  public
+
+  def candidate: (untyped key, ?untyped icase, ?untyped pat) -> untyped
+
+  def complete: (untyped key, ?untyped icase, ?untyped pat) -> untyped
+
+  def convert: (?untyped opt, ?untyped val, *untyped) -> untyped
+end
+
+class OptionParser::InvalidArgument < OptionParser::ParseError
+end
+
+OptionParser::InvalidArgument::Reason: String
+
+class OptionParser::InvalidOption < OptionParser::ParseError
+end
+
+OptionParser::InvalidOption::Reason: String
+
+class OptionParser::List
+  public
+
+  def accept: (untyped t, ?untyped pat) { (*untyped) -> untyped } -> untyped
+
+  def add_banner: (untyped to) -> untyped
+
+  def append: (*untyped args) -> untyped
+
+  def atype: () -> untyped
+
+  def complete: (untyped id, untyped opt, ?untyped icase, *untyped pat) { (*untyped) -> untyped } -> untyped
+
+  def compsys: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  def each_option: () { (*untyped) -> untyped } -> untyped
+
+  def get_candidates: (untyped id) -> untyped
+
+  def list: () -> untyped
+
+  def long: () -> untyped
+
+  def prepend: (*untyped args) -> untyped
+
+  def reject: (untyped t) -> untyped
+
+  def search: (untyped id, untyped key) -> untyped
+
+  def short: () -> untyped
+
+  def summarize: (*untyped args) { (*untyped) -> untyped } -> untyped
+
+  private
+
+  def initialize: () -> void
+
+  def update: (untyped sw, untyped sopts, untyped lopts, ?untyped nsw, ?untyped nlopts) -> untyped
+end
+
+class OptionParser::MissingArgument < OptionParser::ParseError
+end
+
+OptionParser::MissingArgument::Reason: String
+
+class OptionParser::NeedlessArgument < OptionParser::ParseError
+end
+
+OptionParser::NeedlessArgument::Reason: String
+
+class OptionParser::OptionMap < Hash[untyped, untyped]
+  include Completion
+end
+
+class OptionParser::ParseError < RuntimeError
+  def self.filter_backtrace: (untyped array) -> untyped
+
+  public
+
+  def additional: () -> untyped
+
+  def additional=: (untyped) -> untyped
+
+  def args: () -> untyped
+
+  def inspect: () -> untyped
+
+  def message: () -> untyped
+
+  def reason: () -> untyped
+
+  def reason=: (untyped) -> untyped
+
+  def recover: (untyped argv) -> untyped
+
+  def set_backtrace: (untyped array) -> untyped
+
+  def set_option: (untyped opt, untyped eq) -> untyped
+
+  alias to_s message
+
+  private
+
+  def initialize: (*untyped args, ?additional: untyped) -> void
+end
+
+OptionParser::ParseError::Reason: String
+
+class OptionParser::Switch
+  def self.guess: (untyped arg) -> untyped
+
+  def self.incompatible_argument_styles: (untyped arg, untyped t) -> untyped
+
+  def self.pattern: () -> untyped
+
+  public
+
+  def add_banner: (untyped to) -> untyped
+
+  def arg: () -> untyped
+
+  def block: () -> untyped
+
+  def compsys: (untyped sdone, untyped ldone) -> untyped
+
+  def conv: () -> untyped
+
+  def desc: () -> untyped
+
+  def long: () -> untyped
+
+  def match_nonswitch?: (untyped str) -> untyped
+
+  def pattern: () -> untyped
+
+  def short: () -> untyped
+
+  def summarize: (?untyped sdone, ?untyped ldone, ?untyped width, ?untyped max, ?untyped indent) -> untyped
+
+  def switch_name: () -> untyped
+
+  private
+
+  def conv_arg: (untyped arg, ?untyped val) -> untyped
+
+  def initialize: (?untyped pattern, ?untyped conv, ?untyped short, ?untyped long, ?untyped arg, ?untyped desc, ?untyped block) { (*untyped) -> untyped } -> void
+
+  def parse_arg: (untyped arg) -> untyped
+end
+
+class OptionParser::Switch::NoArgument < OptionParser::Switch
+  def self.incompatible_argument_styles: (*untyped) -> untyped
+
+  def self.pattern: () -> untyped
+
+  public
+
+  def parse: (untyped arg, untyped argv) -> untyped
+end
+
+class OptionParser::Switch::OptionalArgument < OptionParser::Switch
+  public
+
+  def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
+end
+
+class OptionParser::Switch::PlacedArgument < OptionParser::Switch
+  public
+
+  def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
+end
+
+class OptionParser::Switch::RequiredArgument < OptionParser::Switch
+  public
+
+  def parse: (untyped arg, untyped argv) -> untyped
+end

--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -371,37 +371,38 @@
 # The above examples should be enough to learn how to use this class.  If you
 # have any questions, file a ticket at http://bugs.ruby-lang.org.
 class OptionParser
+  interface _Pattern
+    def match: (untyped other) -> boolish
+  end
+
+  interface _Intoable
+    def []=: (Symbol, untyped) -> untyped
+  end
+
+  interface _LtLtString
+    def <<: (String) -> untyped
+  end
+
   # See #accept.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     accept(*args, &blk)
-  #
-  def self.accept: (*untyped args) { (*untyped) -> untyped } -> untyped
+  def self.accept: (Class t, ?_Pattern pat) ?{ (*untyped) -> untyped } -> void
 
   # See #getopts.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     getopts(*args)
-  #
-  def self.getopts: (*untyped args) -> untyped
+  def self.getopts: (*String options) -> Hash[String, untyped]
+                  | (Array[String] args, *String options) -> Hash[String, untyped]
 
   # Returns an incremented value of `default` according to `arg`.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     inc(arg, default = nil)
-  #
-  def self.inc: (untyped arg, ?untyped default) -> untyped
+  def self.inc: (untyped arg, ?_ToI default) -> Integer?
 
   # See #reject.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     reject(*args, &blk)
-  #
-  def self.reject: (*untyped args) { (*untyped) -> untyped } -> untyped
+  def self.reject: (Class t) -> void
 
-  def self.terminate: (?untyped arg) -> untyped
+  def self.terminate: (?String arg) -> bot
 
-  def self.top: () -> untyped
+  def self.top: () -> OptionParser::List
 
   # Initializes a new instance and evaluates the optional block in context of the
   # instance. Arguments `args` are passed to #new, see there for description of
@@ -410,14 +411,11 @@ class OptionParser
   # This method is **deprecated**, its behavior corresponds to the older #new
   # method.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     with(*args, &block)
-  #
-  def self.with: (*untyped args) { (*untyped) -> untyped } -> untyped
+  def self.with: (?String banner, ?Integer width, ?String indent) ?{ (instance opts) -> void } -> instance
 
   public
 
-  def abort: (?untyped mesg) -> untyped
+  def abort: (?_ToS mesg) -> bot
 
   # Directs to accept specified class `t`. The argument string is passed to the
   # block in which it should be converted to the desired class.
@@ -430,57 +428,35 @@ class OptionParser
   #
   #     accept(t, pat, &block)
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     accept(*args, &blk)
-  #
-  def accept: (*untyped args) { (*untyped) -> untyped } -> untyped
+  def accept: (Class t, ?_Pattern pat) ?{ (*untyped) -> untyped } -> void
 
-  def add_officious: () -> untyped
+  def add_officious: () -> void
 
   # Returns additional info.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     additional_message(typ, opt)
-  #
-  def additional_message: (untyped typ, untyped opt) -> untyped
+  def additional_message: (untyped typ, untyped opt) -> String?
 
   # Heading banner preceding summary.
   #
-  def banner: () -> untyped
-
-  def banner=: (untyped) -> untyped
+  attr_accessor banner: String
 
   # Subject of #on_tail.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     base()
-  #
-  def base: () -> untyped
+  def base: () -> List
 
-  def candidate: (untyped word) -> untyped
+  def candidate: (String word) -> Array[untyped]
 
   def compsys: (untyped to, ?untyped name) -> untyped
 
-  # # arglists 💪👽🚨 << Delete this section
-  #     def_head_option(*opts, &block)
-  #
   alias def_head_option define_head
 
-  # # arglists 💪👽🚨 << Delete this section
-  #     def_option(*opts, &block)
-  #
   alias def_option define
 
-  # # arglists 💪👽🚨 << Delete this section
-  #     def_tail_option(*opts, &block)
-  #
   alias def_tail_option define_tail
 
   # Strings to be parsed in default.
   #
-  def default_argv: () -> untyped
-
-  def default_argv=: (untyped) -> untyped
+  attr_accessor default_argv: Array[String]
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -490,10 +466,10 @@ class OptionParser
   # given for the option, if any. See [Option
   # Handlers](./option_params_rdoc.html#label-Option+Handlers).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     define(*params, &block)
-  #
-  def define: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def define: (*String params) ?{ (*untyped) -> untyped } -> untyped
+            | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> untyped
+            | (*String params, Proc | Method handler) -> untyped
+            | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> untyped
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -503,10 +479,10 @@ class OptionParser
   # given for the option, if any. See [Option
   # Handlers](./option_params_rdoc.html#label-Option+Handlers).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     define_head(*params, &block)
-  #
-  def define_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def define_head: (*String params) ?{ (*untyped) -> untyped } -> untyped
+                 | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> untyped
+                 | (*String params, Proc | Method handler) -> untyped
+                 | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> untyped
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -516,20 +492,17 @@ class OptionParser
   # given for the option, if any. See [Option
   # Handlers](./option_params_rdoc.html#label-Option+Handlers).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     define_tail(*params, &block)
-  #
-  def define_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def define_tail: (*String params) ?{ (*untyped) -> untyped } -> untyped
+                 | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> untyped
+                 | (*String params, Proc | Method handler) -> untyped
+                 | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> untyped
 
   # Parses environment variable `env` or its uppercase with splitting like a
   # shell.
   #
   # `env` defaults to the basename of the program.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     environment(env = File.basename($0, '.*'))
-  #
-  def environment: (?untyped env) -> untyped
+  def environment: (?String env) -> Array[String]?
 
   # Wrapper method for getopts.rb.
   #
@@ -540,17 +513,12 @@ class OptionParser
   #     # params["bar"] = "x"  # --bar x
   #     # params["zot"] = "z"  # --zot Z
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     getopts(*args)
-  #
-  def getopts: (*untyped args) -> untyped
+  def getopts: (*String options) -> Hash[String, untyped]
+               | (Array[String] args, *String options) -> Hash[String, untyped]
 
   # Returns option summary string.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     help()
-  #
-  def help: () -> untyped
+  def help: () -> String
 
   def inc: (*untyped args) -> untyped
 
@@ -561,10 +529,7 @@ class OptionParser
   # ~/.options, then the basename with '.options' suffix under XDG and Haiku
   # standard places.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     load(filename = nil)
-  #
-  def load: (?untyped filename) -> untyped
+  def load: (?String filename) -> bool
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -574,17 +539,12 @@ class OptionParser
   # given for the option, if any. See [Option
   # Handlers](./option_params_rdoc.html#label-Option+Handlers).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     make_switch(params, block = nil)
-  #
-  def make_switch: (untyped opts, ?untyped block) -> untyped
+  def make_switch: (Array[untyped] opts, ?Proc block) -> [untyped, untyped, untyped, untyped, untyped]
 
   # Pushes a new List.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     new() { |self| ... }
-  #
-  def new: () -> untyped
+  def new: () -> self
+         | [T] () { (self) -> T } -> T
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -594,10 +554,11 @@ class OptionParser
   # given for the option, if any. See [Option
   # Handlers](./option_params_rdoc.html#label-Option+Handlers).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     on(*params, &block)
-  #
-  def on: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def on: (*String params) ?{ (*untyped) -> untyped } -> self
+        | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+        | (*String params, Proc | Method handler) -> self
+        | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
+
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -609,10 +570,10 @@ class OptionParser
   #
   # The new option is added at the head of the summary.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     on_head(*params, &block)
-  #
-  def on_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def on_head: (*String params) ?{ (*untyped) -> untyped } -> self
+             | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+             | (*String params, Proc | Method handler) -> self
+             | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
 
   # Creates an option from the given parameters `params`. See [Parameters for New
   # Options](./option_params_rdoc.html).
@@ -624,10 +585,10 @@ class OptionParser
   #
   # The new option is added at the tail of the summary.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     on_tail(*params, &block)
-  #
-  def on_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
+  def on_tail: (*String params) ?{ (*untyped) -> untyped } -> self
+             | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+             | (*String params, Proc | Method handler) -> self
+             | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
 
   # Parses command line arguments `argv` in order. When a block is given, each
   # non-option argument is yielded. When optional `into` keyword argument is
@@ -636,61 +597,44 @@ class OptionParser
   #
   # Returns the rest of `argv` left unparsed.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     order(*argv, into: nil, &nonopt)
-  #
-  def order: (*untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
+  def order: (*String argv, ?into: _Intoable) ?{ (String) -> void } -> Array[String]
+           | (Array[String] argv, ?into: _Intoable) ?{ (String) -> void } -> Array[String]
 
   # Same as #order, but removes switches destructively. Non-option arguments
   # remain in `argv`.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     order!(argv = default_argv, into: nil, &nonopt)
-  #
-  def order!: (?untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
+  def order!: (?Array[String] argv, ?into: _Intoable) ?{ (String) -> void } -> Array[String]
 
   # Parses command line arguments `argv` in order when environment variable
   # POSIXLY_CORRECT is set, and in permutation mode otherwise. When optional
   # `into` keyword argument is provided, the parsed option values are stored there
   # via `[]=` method (so it can be Hash, or OpenStruct, or other similar object).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse(*argv, into: nil)
-  #
-  def parse: (*untyped argv, ?into: untyped) -> untyped
+  def parse: (*String argv, ?into: _Intoable) -> Array[String]
+           | (Array[String] argv, ?into: _Intoable) -> Array[String]
 
   # Same as #parse, but removes switches destructively. Non-option arguments
   # remain in `argv`.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse!(argv = default_argv, into: nil)
-  #
-  def parse!: (?untyped argv, ?into: untyped) -> untyped
+  def parse!: (?Array[String] argv, ?into: _Intoable) -> Array[String]
 
   # Parses command line arguments `argv` in permutation mode and returns list of
   # non-option arguments. When optional `into` keyword argument is provided, the
   # parsed option values are stored there via `[]=` method (so it can be Hash, or
   # OpenStruct, or other similar object).
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     permute(*argv, into: nil)
-  #
-  def permute: (*untyped argv, ?into: untyped) -> untyped
+  def permute: (*String argv, ?into: _Intoable) -> Array[String]
+             | (Array[String] argv, ?into: _Intoable) -> Array[String]
 
   # Same as #permute, but removes switches destructively. Non-option arguments
   # remain in `argv`.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     permute!(argv = default_argv, into: nil)
-  #
-  def permute!: (?untyped argv, ?into: untyped) -> untyped
+  def permute!: (?Array[String] argv, ?into: _Intoable) -> Array[String]
 
   # Program name to be emitted in error message and default banner, defaults to
   # $0.
   #
-  def program_name: () -> untyped
-
-  def program_name=: (untyped) -> untyped
+  attr_accessor program_name: String
 
   # Directs to reject specified class argument.
   #
@@ -700,10 +644,7 @@ class OptionParser
   #
   #     reject(t)
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     reject(*args, &blk)
-  #
-  def reject: (*untyped args) { (*untyped) -> untyped } -> untyped
+  def reject: (Class t) -> void
 
   # Release code
   #
@@ -713,24 +654,16 @@ class OptionParser
 
   # Removes the last List.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     remove()
-  #
-  def remove: () -> untyped
+  def remove: () -> List?
 
   # Whether to require that options match exactly (disallows providing abbreviated
   # long option as short option).
   #
-  def require_exact: () -> untyped
-
-  def require_exact=: (untyped) -> untyped
+  attr_accessor require_exact: boolish
 
   # Add separator in summary.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     separator(string)
-  #
-  def separator: (untyped string) -> untyped
+  def separator: (String string) -> void
 
   # Heading banner preceding summary.
   #
@@ -762,64 +695,40 @@ class OptionParser
   # :   Indentation, defaults to @summary_indent.
   #
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     summarize(to = [], width = @summary_width, max = width - 1, indent = @summary_indent, &blk)
-  #
-  def summarize: (?untyped to, ?untyped width, ?untyped max, ?untyped indent) { (*untyped) -> untyped } -> untyped
+  def summarize: (?_LtLtString to, ?Integer width, ?Integer max, ?String indent) ?{ (String line) -> void } -> _LtLtString
 
   # Indentation for summary. Must be String (or have + String method).
   #
-  def summary_indent: () -> untyped
-
-  def summary_indent=: (untyped) -> untyped
+  attr_accessor summary_indent: String
 
   # Width for option list portion of summary. Must be Numeric.
   #
-  def summary_width: () -> untyped
-
-  def summary_width=: (untyped) -> untyped
+  attr_accessor summary_width: Integer
 
   # Terminates option parsing. Optional parameter `arg` is a string pushed back to
   # be the first non-option argument.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     terminate(arg = nil)
-  #
-  def terminate: (?untyped arg) -> untyped
+  def terminate: (?String arg) -> bot
 
   # Returns option summary list.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     to_a()
-  #
-  def to_a: () -> untyped
+  def to_a: () -> Array[String]
 
-  # # arglists 💪👽🚨 << Delete this section
-  #     to_s()
-  #
   alias to_s help
 
   # Subject of #on / #on_head, #accept / #reject
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     top()
-  #
-  def top: () -> untyped
+  def top: () -> List
 
   # Returns version string from program_name, version and release.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     ver()
-  #
-  def ver: () -> untyped
+  def ver: () -> String?
 
   # Version
   #
-  def version: () -> untyped
+  attr_accessor version: String?
 
-  def version=: (untyped) -> untyped
-
-  def warn: (?untyped mesg) -> untyped
+  def warn: (?_ToS mesg) -> void
 
   private
 
@@ -836,9 +745,6 @@ class OptionParser
   # :   Optional pattern for completion.
   #
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     complete(typ, opt, icase = false, *pat)
-  #
   def complete: (untyped typ, untyped opt, ?untyped icase, *untyped pat) -> untyped
 
   # Initializes the instance and yields itself if called with a block.
@@ -851,10 +757,7 @@ class OptionParser
   # :   Summary indent.
   #
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     new(banner = nil, width = 32, indent = ' ' * 4) { |self| ... }
-  #
-  def initialize: (?untyped banner, ?untyped width, ?untyped indent) -> void
+  def initialize: (?String banner, ?Integer width, ?String indent) ?{ (OptionParser) -> void } -> void
 
   # Checks if an argument is given twice, in which case an ArgumentError is
   # raised. Called from OptionParser#switch only.
@@ -867,24 +770,15 @@ class OptionParser
   # :   Exception message.
   #
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     notwice(obj, prv, msg)
-  #
   def notwice: (untyped obj, untyped prv, untyped msg) -> untyped
 
   def parse_in_order: (?untyped argv, ?untyped setter) { (*untyped) -> untyped } -> untyped
 
   # Searches `key` in @stack for `id` hash and returns or yields the result.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     search(id, key) { |k| ... }
-  #
   def search: (untyped id, untyped key) -> untyped
 
   # Traverses @stack, sending each element method `id` with `args` and `block`.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     visit(id, *args, &block)
   #
   def visit: (untyped id, *untyped args) { (*untyped) -> untyped } -> untyped
 end
@@ -904,7 +798,7 @@ OptionParser::DefaultList: OptionParser::List
 
 OptionParser::NO_ARGUMENT: Symbol
 
-OptionParser::NoArgument: Array[untyped]
+OptionParser::NoArgument: [:NONE, nil]
 
 OptionParser::OPTIONAL_ARGUMENT: Symbol
 
@@ -951,9 +845,6 @@ OptionParser::AmbiguousOption::Reason: String
 module OptionParser::Arguable
   # Initializes instance variable.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     extend_object(obj)
-  #
   def self.extend_object: (untyped obj) -> untyped
 
   public
@@ -967,10 +858,7 @@ module OptionParser::Arguable
   #     rescue OptionParser::ParseError
   #     end
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     getopts(*args)
-  #
-  def getopts: (*untyped args) -> untyped
+  def getopts: (*String args) -> Hash[String, untyped]
 
   # Actual OptionParser object, automatically created if nonexistent.
   #
@@ -978,60 +866,39 @@ module OptionParser::Arguable
   # of the block. If an OptionParser::ParseError exception occurs in the block, it
   # is rescued, a error message printed to STDERR and `nil` returned.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     options() { |optparse| ... }
-  #
-  def options: () -> untyped
+  def options: () -> OptionParser
+             | [T] () { (OptionParser) -> T } -> T?
 
   # Sets OptionParser object, when `opt` is `false` or `nil`, methods
   # OptionParser::Arguable#options and OptionParser::Arguable#options= are
   # undefined. Thus, there is no ways to access the OptionParser object via the
   # receiver object.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     options=(opt)
-  #
-  def options=: (untyped opt) -> untyped
+  def options=: (OptionParser? opt) -> untyped
 
   # Parses `self` destructively in order and returns `self` containing the rest
   # arguments left unparsed.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     order!(&blk)
-  #
-  def order!: () { (*untyped) -> untyped } -> untyped
+  def order!: () ?{ (String) -> void } -> Array[String]
 
   # Parses `self` destructively and returns `self` containing the rest arguments
   # left unparsed.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse!()
-  #
-  def parse!: () -> untyped
+  def parse!: () -> Array[String]
 
   # Parses `self` destructively in permutation mode and returns `self` containing
   # the rest arguments left unparsed.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     permute!()
-  #
-  def permute!: () -> untyped
-
-  private
-
-  def initialize: (*untyped args) -> void
+  def permute!: () -> Array[String]
 end
 
 # Hash with completion search feature. See OptionParser::Completion.
 class OptionParser::CompletingHash < Hash[untyped, untyped]
-  include Completion
+  include OptionParser::Completion
 
   public
 
   # Completion for hash key.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     match(key)
   #
   def match: (untyped key) -> untyped
 end
@@ -1072,9 +939,6 @@ class OptionParser::List
 
   # See OptionParser.accept.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     accept(t, pat = /.*/m, &block)
-  #
   def accept: (untyped t, ?untyped pat) { (*untyped) -> untyped } -> untyped
 
   def add_banner: (untyped to) -> untyped
@@ -1094,9 +958,6 @@ class OptionParser::List
   #
   #     append(switch, short_opts, long_opts, nolong_opts)
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     append(*args)
-  #
   def append: (*untyped args) -> untyped
 
   # Map from acceptable argument types to pattern and converter pairs.
@@ -1107,17 +968,11 @@ class OptionParser::List
   # If `icase` is true, the search is case insensitive. The result is returned or
   # yielded if a block is given. If it isn't found, nil is returned.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     complete(id, opt, icase = false, *pat, &block)
-  #
   def complete: (untyped id, untyped opt, ?untyped icase, *untyped pat) { (*untyped) -> untyped } -> untyped
 
   def compsys: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   # Iterates over each option, passing the option to the `block`.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     each_option(&block)
   #
   def each_option: () { (*untyped) -> untyped } -> untyped
 
@@ -1146,23 +1001,14 @@ class OptionParser::List
   #
   #     prepend(switch, short_opts, long_opts, nolong_opts)
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     prepend(*args)
-  #
   def prepend: (*untyped args) -> untyped
 
   # See OptionParser.reject.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     reject(t)
   #
   def reject: (untyped t) -> untyped
 
   # Searches `key` in `id` list. The result is returned or yielded if a block is
   # given. If it isn't found, nil is returned.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     search(id, key) { |val| ... }
   #
   def search: (untyped id, untyped key) -> untyped
 
@@ -1174,17 +1020,11 @@ class OptionParser::List
   # The arguments `args` are passed along to the summarize method which is called
   # on every option.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     summarize(*args, &block)
-  #
   def summarize: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   private
 
   # Just initializes all instance variables.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     new()
   #
   def initialize: () -> void
 
@@ -1199,9 +1039,6 @@ class OptionParser::List
   # `nlopts`
   # :   Negated long style options list.
   #
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     update(sw, sopts, lopts, nsw = nil, nlopts = nil)
   #
   def update: (untyped sw, untyped sopts, untyped lopts, ?untyped nsw, ?untyped nlopts) -> untyped
 end
@@ -1220,7 +1057,7 @@ OptionParser::NeedlessArgument::Reason: String
 
 # Map from option/keyword string to object with completion.
 class OptionParser::OptionMap < Hash[untyped, untyped]
-  include Completion
+  include OptionParser::Completion
 end
 
 # Base class of exceptions from OptionParser.
@@ -1239,10 +1076,7 @@ class OptionParser::ParseError < RuntimeError
 
   # Default stringizing method to emit standard error message.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     message()
-  #
-  def message: () -> untyped
+  def message: () -> String
 
   def reason: () -> untyped
 
@@ -1250,18 +1084,12 @@ class OptionParser::ParseError < RuntimeError
 
   # Pushes back erred argument(s) to `argv`.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     recover(argv)
-  #
   def recover: (untyped argv) -> untyped
 
   def set_backtrace: (untyped array) -> untyped
 
   def set_option: (untyped opt, untyped eq) -> untyped
 
-  # # arglists 💪👽🚨 << Delete this section
-  #     to_s()
-  #
   alias to_s message
 
   private
@@ -1279,9 +1107,6 @@ OptionParser::ParseError::Reason: String
 class OptionParser::Switch
   # Guesses argument style from `arg`.  Returns corresponding OptionParser::Switch
   # class (OptionalArgument, etc.).
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     guess(arg)
   #
   def self.guess: (untyped arg) -> untyped
 
@@ -1327,15 +1152,9 @@ class OptionParser::Switch
   # :   Prefix string indents all summarized lines.
   #
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     summarize(sdone = {}, ldone = {}, width = 1, max = width - 1, indent = "") { |indent| ... }
-  #
   def summarize: (?untyped sdone, ?untyped ldone, ?untyped width, ?untyped max, ?untyped indent) -> untyped
 
   # Main name of the switch.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     switch_name()
   #
   def switch_name: () -> untyped
 
@@ -1344,18 +1163,12 @@ class OptionParser::Switch
   # Parses argument, converts and returns `arg`, `block` and result of conversion.
   # Yields at semi-error condition instead of raising an exception.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     conv_arg(arg, val = [])
-  #
   def conv_arg: (untyped arg, ?untyped val) -> untyped
 
   def initialize: (?untyped pattern, ?untyped conv, ?untyped short, ?untyped long, ?untyped arg, ?untyped desc, ?untyped block) { (*untyped) -> untyped } -> void
 
   # Parses `arg` and returns rest of `arg` and matched portion to the argument
   # pattern. Yields when the pattern doesn't match substring.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse_arg(arg) { |InvalidArgument, arg| ... }
   #
   def parse_arg: (untyped arg) -> untyped
 end
@@ -1370,9 +1183,6 @@ class OptionParser::Switch::NoArgument < OptionParser::Switch
 
   # Raises an exception if any arguments given.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse(arg, argv) { |NeedlessArgument, arg| ... }
-  #
   def parse: (untyped arg, untyped argv) -> untyped
 end
 
@@ -1381,9 +1191,6 @@ class OptionParser::Switch::OptionalArgument < OptionParser::Switch
   public
 
   # Parses argument if given, or uses default value.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse(arg, argv, &error)
   #
   def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
 end
@@ -1394,9 +1201,6 @@ class OptionParser::Switch::PlacedArgument < OptionParser::Switch
 
   # Returns nil if argument is not present or begins with '-'.
   #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse(arg, argv, &error)
-  #
   def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
 end
 
@@ -1405,9 +1209,6 @@ class OptionParser::Switch::RequiredArgument < OptionParser::Switch
   public
 
   # Raises an exception if argument is not present.
-  #
-  # # arglists 💪👽🚨 << Delete this section
-  #     parse(arg, argv)
   #
   def parse: (untyped arg, untyped argv) -> untyped
 end

--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -1,132 +1,820 @@
+# ## OptionParser
+#
+# ### Introduction
+#
+# OptionParser is a class for command-line option analysis.  It is much more
+# advanced, yet also easier to use, than GetoptLong, and is a more Ruby-oriented
+# solution.
+#
+# ### Features
+#
+# 1.  The argument specification and the code to handle it are written in the
+#     same place.
+# 2.  It can output an option summary; you don't need to maintain this string
+#     separately.
+# 3.  Optional and mandatory arguments are specified very gracefully.
+# 4.  Arguments can be automatically converted to a specified class.
+# 5.  Arguments can be restricted to a certain set.
+#
+#
+# All of these features are demonstrated in the examples below.  See
+# #make_switch for full documentation.
+#
+# ### Minimal example
+#
+#     require 'optparse'
+#
+#     options = {}
+#     OptionParser.new do |parser|
+#       parser.banner = "Usage: example.rb [options]"
+#
+#       parser.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+#         options[:verbose] = v
+#       end
+#     end.parse!
+#
+#     p options
+#     p ARGV
+#
+# ### Generating Help
+#
+# OptionParser can be used to automatically generate help for the commands you
+# write:
+#
+#     require 'optparse'
+#
+#     Options = Struct.new(:name)
+#
+#     class Parser
+#       def self.parse(options)
+#         args = Options.new("world")
+#
+#         opt_parser = OptionParser.new do |parser|
+#           parser.banner = "Usage: example.rb [options]"
+#
+#           parser.on("-nNAME", "--name=NAME", "Name to say hello to") do |n|
+#             args.name = n
+#           end
+#
+#           parser.on("-h", "--help", "Prints this help") do
+#             puts parser
+#             exit
+#           end
+#         end
+#
+#         opt_parser.parse!(options)
+#         return args
+#       end
+#     end
+#     options = Parser.parse %w[--help]
+#
+#     #=>
+#        # Usage: example.rb [options]
+#        #     -n, --name=NAME                  Name to say hello to
+#        #     -h, --help                       Prints this help
+#
+# ### Required Arguments
+#
+# For options that require an argument, option specification strings may include
+# an option name in all caps. If an option is used without the required
+# argument, an exception will be raised.
+#
+#     require 'optparse'
+#
+#     options = {}
+#     OptionParser.new do |parser|
+#       parser.on("-r", "--require LIBRARY",
+#                 "Require the LIBRARY before executing your script") do |lib|
+#         puts "You required #{lib}!"
+#       end
+#     end.parse!
+#
+# Used:
+#
+#     $ ruby optparse-test.rb -r
+#     optparse-test.rb:9:in `<main>': missing argument: -r (OptionParser::MissingArgument)
+#     $ ruby optparse-test.rb -r my-library
+#     You required my-library!
+#
+# ### Type Coercion
+#
+# OptionParser supports the ability to coerce command line arguments into
+# objects for us.
+#
+# OptionParser comes with a few ready-to-use kinds of  type coercion. They are:
+#
+# *   Date  -- Anything accepted by `Date.parse`
+# *   DateTime -- Anything accepted by `DateTime.parse`
+# *   Time -- Anything accepted by `Time.httpdate` or `Time.parse`
+# *   URI  -- Anything accepted by `URI.parse`
+# *   Shellwords -- Anything accepted by `Shellwords.shellwords`
+# *   String -- Any non-empty string
+# *   Integer -- Any integer. Will convert octal. (e.g. 124, -3, 040)
+# *   Float -- Any float. (e.g. 10, 3.14, -100E+13)
+# *   Numeric -- Any integer, float, or rational (1, 3.4, 1/3)
+# *   DecimalInteger -- Like `Integer`, but no octal format.
+# *   OctalInteger -- Like `Integer`, but no decimal format.
+# *   DecimalNumeric -- Decimal integer or float.
+# *   TrueClass --  Accepts '+, yes, true, -, no, false' and defaults as `true`
+# *   FalseClass -- Same as `TrueClass`, but defaults to `false`
+# *   Array -- Strings separated by ',' (e.g. 1,2,3)
+# *   Regexp -- Regular expressions. Also includes options.
+#
+#
+# We can also add our own coercions, which we will cover below.
+#
+# #### Using Built-in Conversions
+#
+# As an example, the built-in `Time` conversion is used. The other built-in
+# conversions behave in the same way. OptionParser will attempt to parse the
+# argument as a `Time`. If it succeeds, that time will be passed to the handler
+# block. Otherwise, an exception will be raised.
+#
+#     require 'optparse'
+#     require 'optparse/time'
+#     OptionParser.new do |parser|
+#       parser.on("-t", "--time [TIME]", Time, "Begin execution at given time") do |time|
+#         p time
+#       end
+#     end.parse!
+#
+# Used:
+#
+#     $ ruby optparse-test.rb  -t nonsense
+#     ... invalid argument: -t nonsense (OptionParser::InvalidArgument)
+#     $ ruby optparse-test.rb  -t 10-11-12
+#     2010-11-12 00:00:00 -0500
+#     $ ruby optparse-test.rb  -t 9:30
+#     2014-08-13 09:30:00 -0400
+#
+# #### Creating Custom Conversions
+#
+# The `accept` method on OptionParser may be used to create converters. It
+# specifies which conversion block to call whenever a class is specified. The
+# example below uses it to fetch a `User` object before the `on` handler
+# receives it.
+#
+#     require 'optparse'
+#
+#     User = Struct.new(:id, :name)
+#
+#     def find_user id
+#       not_found = ->{ raise "No User Found for id #{id}" }
+#       [ User.new(1, "Sam"),
+#         User.new(2, "Gandalf") ].find(not_found) do |u|
+#         u.id == id
+#       end
+#     end
+#
+#     op = OptionParser.new
+#     op.accept(User) do |user_id|
+#       find_user user_id.to_i
+#     end
+#
+#     op.on("--user ID", User) do |user|
+#       puts user
+#     end
+#
+#     op.parse!
+#
+# Used:
+#
+#     $ ruby optparse-test.rb --user 1
+#     #<struct User id=1, name="Sam">
+#     $ ruby optparse-test.rb --user 2
+#     #<struct User id=2, name="Gandalf">
+#     $ ruby optparse-test.rb --user 3
+#     optparse-test.rb:15:in `block in find_user': No User Found for id 3 (RuntimeError)
+#
+# ### Store options to a Hash
+#
+# The `into` option of `order`, `parse` and so on methods stores command line
+# options into a Hash.
+#
+#     require 'optparse'
+#
+#     options = {}
+#     OptionParser.new do |parser|
+#       parser.on('-a')
+#       parser.on('-b NUM', Integer)
+#       parser.on('-v', '--verbose')
+#     end.parse!(into: options)
+#
+#     p options
+#
+# Used:
+#
+#     $ ruby optparse-test.rb -a
+#     {:a=>true}
+#     $ ruby optparse-test.rb -a -v
+#     {:a=>true, :verbose=>true}
+#     $ ruby optparse-test.rb -a -b 100
+#     {:a=>true, :b=>100}
+#
+# ### Complete example
+#
+# The following example is a complete Ruby program.  You can run it and see the
+# effect of specifying various options.  This is probably the best way to learn
+# the features of `optparse`.
+#
+#     require 'optparse'
+#     require 'optparse/time'
+#     require 'ostruct'
+#     require 'pp'
+#
+#     class OptparseExample
+#       Version = '1.0.0'
+#
+#       CODES = %w[iso-2022-jp shift_jis euc-jp utf8 binary]
+#       CODE_ALIASES = { "jis" => "iso-2022-jp", "sjis" => "shift_jis" }
+#
+#       class ScriptOptions
+#         attr_accessor :library, :inplace, :encoding, :transfer_type,
+#                       :verbose, :extension, :delay, :time, :record_separator,
+#                       :list
+#
+#         def initialize
+#           self.library = []
+#           self.inplace = false
+#           self.encoding = "utf8"
+#           self.transfer_type = :auto
+#           self.verbose = false
+#         end
+#
+#         def define_options(parser)
+#           parser.banner = "Usage: example.rb [options]"
+#           parser.separator ""
+#           parser.separator "Specific options:"
+#
+#           # add additional options
+#           perform_inplace_option(parser)
+#           delay_execution_option(parser)
+#           execute_at_time_option(parser)
+#           specify_record_separator_option(parser)
+#           list_example_option(parser)
+#           specify_encoding_option(parser)
+#           optional_option_argument_with_keyword_completion_option(parser)
+#           boolean_verbose_option(parser)
+#
+#           parser.separator ""
+#           parser.separator "Common options:"
+#           # No argument, shows at tail.  This will print an options summary.
+#           # Try it and see!
+#           parser.on_tail("-h", "--help", "Show this message") do
+#             puts parser
+#             exit
+#           end
+#           # Another typical switch to print the version.
+#           parser.on_tail("--version", "Show version") do
+#             puts Version
+#             exit
+#           end
+#         end
+#
+#         def perform_inplace_option(parser)
+#           # Specifies an optional option argument
+#           parser.on("-i", "--inplace [EXTENSION]",
+#                     "Edit ARGV files in place",
+#                     "(make backup if EXTENSION supplied)") do |ext|
+#             self.inplace = true
+#             self.extension = ext || ''
+#             self.extension.sub!(/\A\.?(?=.)/, ".")  # Ensure extension begins with dot.
+#           end
+#         end
+#
+#         def delay_execution_option(parser)
+#           # Cast 'delay' argument to a Float.
+#           parser.on("--delay N", Float, "Delay N seconds before executing") do |n|
+#             self.delay = n
+#           end
+#         end
+#
+#         def execute_at_time_option(parser)
+#           # Cast 'time' argument to a Time object.
+#           parser.on("-t", "--time [TIME]", Time, "Begin execution at given time") do |time|
+#             self.time = time
+#           end
+#         end
+#
+#         def specify_record_separator_option(parser)
+#           # Cast to octal integer.
+#           parser.on("-F", "--irs [OCTAL]", OptionParser::OctalInteger,
+#                     "Specify record separator (default \\0)") do |rs|
+#             self.record_separator = rs
+#           end
+#         end
+#
+#         def list_example_option(parser)
+#           # List of arguments.
+#           parser.on("--list x,y,z", Array, "Example 'list' of arguments") do |list|
+#             self.list = list
+#           end
+#         end
+#
+#         def specify_encoding_option(parser)
+#           # Keyword completion.  We are specifying a specific set of arguments (CODES
+#           # and CODE_ALIASES - notice the latter is a Hash), and the user may provide
+#           # the shortest unambiguous text.
+#           code_list = (CODE_ALIASES.keys + CODES).join(', ')
+#           parser.on("--code CODE", CODES, CODE_ALIASES, "Select encoding",
+#                     "(#{code_list})") do |encoding|
+#             self.encoding = encoding
+#           end
+#         end
+#
+#         def optional_option_argument_with_keyword_completion_option(parser)
+#           # Optional '--type' option argument with keyword completion.
+#           parser.on("--type [TYPE]", [:text, :binary, :auto],
+#                     "Select transfer type (text, binary, auto)") do |t|
+#             self.transfer_type = t
+#           end
+#         end
+#
+#         def boolean_verbose_option(parser)
+#           # Boolean switch.
+#           parser.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+#             self.verbose = v
+#           end
+#         end
+#       end
+#
+#       #
+#       # Return a structure describing the options.
+#       #
+#       def parse(args)
+#         # The options specified on the command line will be collected in
+#         # *options*.
+#
+#         @options = ScriptOptions.new
+#         @args = OptionParser.new do |parser|
+#           @options.define_options(parser)
+#           parser.parse!(args)
+#         end
+#         @options
+#       end
+#
+#       attr_reader :parser, :options
+#     end  # class OptparseExample
+#
+#     example = OptparseExample.new
+#     options = example.parse(ARGV)
+#     pp options # example.options
+#     pp ARGV
+#
+# ### Shell Completion
+#
+# For modern shells (e.g. bash, zsh, etc.), you can use shell completion for
+# command line options.
+#
+# ### Further documentation
+#
+# The above examples should be enough to learn how to use this class.  If you
+# have any questions, file a ticket at http://bugs.ruby-lang.org.
 class OptionParser
+  # See #accept.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     accept(*args, &blk)
+  #
   def self.accept: (*untyped args) { (*untyped) -> untyped } -> untyped
 
+  # See #getopts.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     getopts(*args)
+  #
   def self.getopts: (*untyped args) -> untyped
 
+  # Returns an incremented value of `default` according to `arg`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     inc(arg, default = nil)
+  #
   def self.inc: (untyped arg, ?untyped default) -> untyped
 
+  # See #reject.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     reject(*args, &blk)
+  #
   def self.reject: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   def self.terminate: (?untyped arg) -> untyped
 
   def self.top: () -> untyped
 
+  # Initializes a new instance and evaluates the optional block in context of the
+  # instance. Arguments `args` are passed to #new, see there for description of
+  # parameters.
+  #
+  # This method is **deprecated**, its behavior corresponds to the older #new
+  # method.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     with(*args, &block)
+  #
   def self.with: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   public
 
   def abort: (?untyped mesg) -> untyped
 
+  # Directs to accept specified class `t`. The argument string is passed to the
+  # block in which it should be converted to the desired class.
+  #
+  # `t`
+  # :   Argument class specifier, any object including Class.
+  # `pat`
+  # :   Pattern for argument, defaults to `t` if it responds to match.
+  #
+  #
+  #     accept(t, pat, &block)
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     accept(*args, &blk)
+  #
   def accept: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   def add_officious: () -> untyped
 
+  # Returns additional info.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     additional_message(typ, opt)
+  #
   def additional_message: (untyped typ, untyped opt) -> untyped
 
+  # Heading banner preceding summary.
+  #
   def banner: () -> untyped
 
   def banner=: (untyped) -> untyped
 
+  # Subject of #on_tail.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     base()
+  #
   def base: () -> untyped
 
   def candidate: (untyped word) -> untyped
 
   def compsys: (untyped to, ?untyped name) -> untyped
 
+  # # arglists 💪👽🚨 << Delete this section
+  #     def_head_option(*opts, &block)
+  #
   alias def_head_option define_head
 
+  # # arglists 💪👽🚨 << Delete this section
+  #     def_option(*opts, &block)
+  #
   alias def_option define
 
+  # # arglists 💪👽🚨 << Delete this section
+  #     def_tail_option(*opts, &block)
+  #
   alias def_tail_option define_tail
 
+  # Strings to be parsed in default.
+  #
   def default_argv: () -> untyped
 
   def default_argv=: (untyped) -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     define(*params, &block)
+  #
   def define: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     define_head(*params, &block)
+  #
   def define_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     define_tail(*params, &block)
+  #
   def define_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Parses environment variable `env` or its uppercase with splitting like a
+  # shell.
+  #
+  # `env` defaults to the basename of the program.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     environment(env = File.basename($0, '.*'))
+  #
   def environment: (?untyped env) -> untyped
 
+  # Wrapper method for getopts.rb.
+  #
+  #     params = ARGV.getopts("ab:", "foo", "bar:", "zot:Z;zot option")
+  #     # params["a"] = true   # -a
+  #     # params["b"] = "1"    # -b1
+  #     # params["foo"] = "1"  # --foo
+  #     # params["bar"] = "x"  # --bar x
+  #     # params["zot"] = "z"  # --zot Z
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     getopts(*args)
+  #
   def getopts: (*untyped args) -> untyped
 
+  # Returns option summary string.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     help()
+  #
   def help: () -> untyped
 
   def inc: (*untyped args) -> untyped
 
+  # Loads options from file names as `filename`. Does nothing when the file is not
+  # present. Returns whether successfully loaded.
+  #
+  # `filename` defaults to basename of the program without suffix in a directory
+  # ~/.options, then the basename with '.options' suffix under XDG and Haiku
+  # standard places.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     load(filename = nil)
+  #
   def load: (?untyped filename) -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     make_switch(params, block = nil)
+  #
   def make_switch: (untyped opts, ?untyped block) -> untyped
 
+  # Pushes a new List.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     new() { |self| ... }
+  #
   def new: () -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     on(*params, &block)
+  #
   def on: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # The new option is added at the head of the summary.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     on_head(*params, &block)
+  #
   def on_head: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Creates an option from the given parameters `params`. See [Parameters for New
+  # Options](./option_params_rdoc.html).
+  #
+  # The block, if given, is the handler for the created option. When the option is
+  # encountered during command-line parsing, the block is called with the argument
+  # given for the option, if any. See [Option
+  # Handlers](./option_params_rdoc.html#label-Option+Handlers).
+  #
+  # The new option is added at the tail of the summary.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     on_tail(*params, &block)
+  #
   def on_tail: (*untyped opts) { (*untyped) -> untyped } -> untyped
 
+  # Parses command line arguments `argv` in order. When a block is given, each
+  # non-option argument is yielded. When optional `into` keyword argument is
+  # provided, the parsed option values are stored there via `[]=` method (so it
+  # can be Hash, or OpenStruct, or other similar object).
+  #
+  # Returns the rest of `argv` left unparsed.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     order(*argv, into: nil, &nonopt)
+  #
   def order: (*untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
 
+  # Same as #order, but removes switches destructively. Non-option arguments
+  # remain in `argv`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     order!(argv = default_argv, into: nil, &nonopt)
+  #
   def order!: (?untyped argv, ?into: untyped) { (*untyped) -> untyped } -> untyped
 
+  # Parses command line arguments `argv` in order when environment variable
+  # POSIXLY_CORRECT is set, and in permutation mode otherwise. When optional
+  # `into` keyword argument is provided, the parsed option values are stored there
+  # via `[]=` method (so it can be Hash, or OpenStruct, or other similar object).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse(*argv, into: nil)
+  #
   def parse: (*untyped argv, ?into: untyped) -> untyped
 
+  # Same as #parse, but removes switches destructively. Non-option arguments
+  # remain in `argv`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse!(argv = default_argv, into: nil)
+  #
   def parse!: (?untyped argv, ?into: untyped) -> untyped
 
+  # Parses command line arguments `argv` in permutation mode and returns list of
+  # non-option arguments. When optional `into` keyword argument is provided, the
+  # parsed option values are stored there via `[]=` method (so it can be Hash, or
+  # OpenStruct, or other similar object).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     permute(*argv, into: nil)
+  #
   def permute: (*untyped argv, ?into: untyped) -> untyped
 
+  # Same as #permute, but removes switches destructively. Non-option arguments
+  # remain in `argv`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     permute!(argv = default_argv, into: nil)
+  #
   def permute!: (?untyped argv, ?into: untyped) -> untyped
 
+  # Program name to be emitted in error message and default banner, defaults to
+  # $0.
+  #
   def program_name: () -> untyped
 
   def program_name=: (untyped) -> untyped
 
+  # Directs to reject specified class argument.
+  #
+  # `t`
+  # :   Argument class specifier, any object including Class.
+  #
+  #
+  #     reject(t)
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     reject(*args, &blk)
+  #
   def reject: (*untyped args) { (*untyped) -> untyped } -> untyped
 
+  # Release code
+  #
   def release: () -> untyped
 
   def release=: (untyped) -> untyped
 
+  # Removes the last List.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     remove()
+  #
   def remove: () -> untyped
 
+  # Whether to require that options match exactly (disallows providing abbreviated
+  # long option as short option).
+  #
   def require_exact: () -> untyped
 
   def require_exact=: (untyped) -> untyped
 
+  # Add separator in summary.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     separator(string)
+  #
   def separator: (untyped string) -> untyped
 
+  # Heading banner preceding summary.
+  #
   alias set_banner banner=
 
+  # Program name to be emitted in error message and default banner, defaults to
+  # $0.
+  #
   alias set_program_name program_name=
 
+  # Indentation for summary. Must be String (or have + String method).
+  #
   alias set_summary_indent summary_indent=
 
+  # Width for option list portion of summary. Must be Numeric.
+  #
   alias set_summary_width summary_width=
 
+  # Puts option summary into `to` and returns `to`. Yields each line if a block is
+  # given.
+  #
+  # `to`
+  # :   Output destination, which must have method <<. Defaults to [].
+  # `width`
+  # :   Width of left side, defaults to @summary_width.
+  # `max`
+  # :   Maximum length allowed for left side, defaults to `width` - 1.
+  # `indent`
+  # :   Indentation, defaults to @summary_indent.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     summarize(to = [], width = @summary_width, max = width - 1, indent = @summary_indent, &blk)
+  #
   def summarize: (?untyped to, ?untyped width, ?untyped max, ?untyped indent) { (*untyped) -> untyped } -> untyped
 
+  # Indentation for summary. Must be String (or have + String method).
+  #
   def summary_indent: () -> untyped
 
   def summary_indent=: (untyped) -> untyped
 
+  # Width for option list portion of summary. Must be Numeric.
+  #
   def summary_width: () -> untyped
 
   def summary_width=: (untyped) -> untyped
 
+  # Terminates option parsing. Optional parameter `arg` is a string pushed back to
+  # be the first non-option argument.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     terminate(arg = nil)
+  #
   def terminate: (?untyped arg) -> untyped
 
+  # Returns option summary list.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     to_a()
+  #
   def to_a: () -> untyped
 
+  # # arglists 💪👽🚨 << Delete this section
+  #     to_s()
+  #
   alias to_s help
 
+  # Subject of #on / #on_head, #accept / #reject
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     top()
+  #
   def top: () -> untyped
 
+  # Returns version string from program_name, version and release.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     ver()
+  #
   def ver: () -> untyped
 
+  # Version
+  #
   def version: () -> untyped
 
   def version=: (untyped) -> untyped
@@ -135,16 +823,69 @@ class OptionParser
 
   private
 
+  # Completes shortened long style option switch and returns pair of canonical
+  # switch and switch descriptor OptionParser::Switch.
+  #
+  # `typ`
+  # :   Searching table.
+  # `opt`
+  # :   Searching key.
+  # `icase`
+  # :   Search case insensitive if true.
+  # `pat`
+  # :   Optional pattern for completion.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     complete(typ, opt, icase = false, *pat)
+  #
   def complete: (untyped typ, untyped opt, ?untyped icase, *untyped pat) -> untyped
 
+  # Initializes the instance and yields itself if called with a block.
+  #
+  # `banner`
+  # :   Banner message.
+  # `width`
+  # :   Summary width.
+  # `indent`
+  # :   Summary indent.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     new(banner = nil, width = 32, indent = ' ' * 4) { |self| ... }
+  #
   def initialize: (?untyped banner, ?untyped width, ?untyped indent) -> void
 
+  # Checks if an argument is given twice, in which case an ArgumentError is
+  # raised. Called from OptionParser#switch only.
+  #
+  # `obj`
+  # :   New argument.
+  # `prv`
+  # :   Previously specified argument.
+  # `msg`
+  # :   Exception message.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     notwice(obj, prv, msg)
+  #
   def notwice: (untyped obj, untyped prv, untyped msg) -> untyped
 
   def parse_in_order: (?untyped argv, ?untyped setter) { (*untyped) -> untyped } -> untyped
 
+  # Searches `key` in @stack for `id` hash and returns or yields the result.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     search(id, key) { |k| ... }
+  #
   def search: (untyped id, untyped key) -> untyped
 
+  # Traverses @stack, sending each element method `id` with `args` and `block`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     visit(id, *args, &block)
+  #
   def visit: (untyped id, *untyped args) { (*untyped) -> untyped } -> untyped
 end
 
@@ -152,8 +893,11 @@ OptionParser::ArgumentStyle: Hash[untyped, untyped]
 
 OptionParser::COMPSYS_HEADER: String
 
+# Decimal integer format, to be converted to Integer.
 OptionParser::DecimalInteger: Regexp
 
+# Decimal integer/float number format, to be converted to Integer for integer
+# format, Float for float format.
 OptionParser::DecimalNumeric: Regexp
 
 OptionParser::DefaultList: OptionParser::List
@@ -164,6 +908,8 @@ OptionParser::NoArgument: Array[untyped]
 
 OptionParser::OPTIONAL_ARGUMENT: Symbol
 
+# Ruby/C like octal/hexadecimal/binary integer format, to be converted to
+# Integer.
 OptionParser::OctalInteger: Regexp
 
 OptionParser::Officious: Hash[untyped, untyped]
@@ -178,6 +924,8 @@ OptionParser::SPLAT_PROC: Proc
 
 OptionParser::Version: String
 
+# Acceptable argument classes. Now contains DecimalInteger, OctalInteger and
+# DecimalNumeric. See Acceptable argument classes (in source code).
 module OptionParser::Acceptables
 end
 
@@ -187,31 +935,86 @@ OptionParser::Acceptables::DecimalNumeric: Regexp
 
 OptionParser::Acceptables::OctalInteger: Regexp
 
+# Raises when the given argument word can't be completed uniquely.
 class OptionParser::AmbiguousArgument < OptionParser::InvalidArgument
 end
 
 OptionParser::AmbiguousArgument::Reason: String
 
+# Raises when ambiguously completable string is encountered.
 class OptionParser::AmbiguousOption < OptionParser::ParseError
 end
 
 OptionParser::AmbiguousOption::Reason: String
 
+# Extends command line arguments array (ARGV) to parse itself.
 module OptionParser::Arguable
+  # Initializes instance variable.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     extend_object(obj)
+  #
   def self.extend_object: (untyped obj) -> untyped
 
   public
 
+  # Substitution of getopts is possible as follows. Also see OptionParser#getopts.
+  #
+  #     def getopts(*args)
+  #       ($OPT = ARGV.getopts(*args)).each do |opt, val|
+  #         eval "$OPT_#{opt.gsub(/[^A-Za-z0-9_]/, '_')} = val"
+  #       end
+  #     rescue OptionParser::ParseError
+  #     end
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     getopts(*args)
+  #
   def getopts: (*untyped args) -> untyped
 
+  # Actual OptionParser object, automatically created if nonexistent.
+  #
+  # If called with a block, yields the OptionParser object and returns the result
+  # of the block. If an OptionParser::ParseError exception occurs in the block, it
+  # is rescued, a error message printed to STDERR and `nil` returned.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     options() { |optparse| ... }
+  #
   def options: () -> untyped
 
+  # Sets OptionParser object, when `opt` is `false` or `nil`, methods
+  # OptionParser::Arguable#options and OptionParser::Arguable#options= are
+  # undefined. Thus, there is no ways to access the OptionParser object via the
+  # receiver object.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     options=(opt)
+  #
   def options=: (untyped opt) -> untyped
 
+  # Parses `self` destructively in order and returns `self` containing the rest
+  # arguments left unparsed.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     order!(&blk)
+  #
   def order!: () { (*untyped) -> untyped } -> untyped
 
+  # Parses `self` destructively and returns `self` containing the rest arguments
+  # left unparsed.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse!()
+  #
   def parse!: () -> untyped
 
+  # Parses `self` destructively in permutation mode and returns `self` containing
+  # the rest arguments left unparsed.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     permute!()
+  #
   def permute!: () -> untyped
 
   private
@@ -219,14 +1022,22 @@ module OptionParser::Arguable
   def initialize: (*untyped args) -> void
 end
 
+# Hash with completion search feature. See OptionParser::Completion.
 class OptionParser::CompletingHash < Hash[untyped, untyped]
   include Completion
 
   public
 
+  # Completion for hash key.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     match(key)
+  #
   def match: (untyped key) -> untyped
 end
 
+# Keyword completion module.  This allows partial arguments to be specified and
+# resolved against a list of acceptable values.
 module OptionParser::Completion
   def self.candidate: (untyped key, ?untyped icase, ?untyped pat) { (*untyped) -> untyped } -> untyped
 
@@ -241,70 +1052,178 @@ module OptionParser::Completion
   def convert: (?untyped opt, ?untyped val, *untyped) -> untyped
 end
 
+# Raises when the given argument does not match required format.
 class OptionParser::InvalidArgument < OptionParser::ParseError
 end
 
 OptionParser::InvalidArgument::Reason: String
 
+# Raises when switch is undefined.
 class OptionParser::InvalidOption < OptionParser::ParseError
 end
 
 OptionParser::InvalidOption::Reason: String
 
+# Simple option list providing mapping from short and/or long option string to
+# OptionParser::Switch and mapping from acceptable argument to matching pattern
+# and converter pair. Also provides summary feature.
 class OptionParser::List
   public
 
+  # See OptionParser.accept.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     accept(t, pat = /.*/m, &block)
+  #
   def accept: (untyped t, ?untyped pat) { (*untyped) -> untyped } -> untyped
 
   def add_banner: (untyped to) -> untyped
 
+  # Appends `switch` at the tail of the list, and associates short, long and
+  # negated long options. Arguments are:
+  #
+  # `switch`
+  # :   OptionParser::Switch instance to be inserted.
+  # `short_opts`
+  # :   List of short style options.
+  # `long_opts`
+  # :   List of long style options.
+  # `nolong_opts`
+  # :   List of long style options with "no-" prefix.
+  #
+  #
+  #     append(switch, short_opts, long_opts, nolong_opts)
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     append(*args)
+  #
   def append: (*untyped args) -> untyped
 
+  # Map from acceptable argument types to pattern and converter pairs.
+  #
   def atype: () -> untyped
 
+  # Searches list `id` for `opt` and the optional patterns for completion `pat`.
+  # If `icase` is true, the search is case insensitive. The result is returned or
+  # yielded if a block is given. If it isn't found, nil is returned.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     complete(id, opt, icase = false, *pat, &block)
+  #
   def complete: (untyped id, untyped opt, ?untyped icase, *untyped pat) { (*untyped) -> untyped } -> untyped
 
   def compsys: (*untyped args) { (*untyped) -> untyped } -> untyped
 
+  # Iterates over each option, passing the option to the `block`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     each_option(&block)
+  #
   def each_option: () { (*untyped) -> untyped } -> untyped
 
   def get_candidates: (untyped id) -> untyped
 
+  # List of all switches and summary string.
+  #
   def list: () -> untyped
 
+  # Map from long style option switches to actual switch objects.
+  #
   def long: () -> untyped
 
+  # Inserts `switch` at the head of the list, and associates short, long and
+  # negated long options. Arguments are:
+  #
+  # `switch`
+  # :   OptionParser::Switch instance to be inserted.
+  # `short_opts`
+  # :   List of short style options.
+  # `long_opts`
+  # :   List of long style options.
+  # `nolong_opts`
+  # :   List of long style options with "no-" prefix.
+  #
+  #
+  #     prepend(switch, short_opts, long_opts, nolong_opts)
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     prepend(*args)
+  #
   def prepend: (*untyped args) -> untyped
 
+  # See OptionParser.reject.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     reject(t)
+  #
   def reject: (untyped t) -> untyped
 
+  # Searches `key` in `id` list. The result is returned or yielded if a block is
+  # given. If it isn't found, nil is returned.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     search(id, key) { |val| ... }
+  #
   def search: (untyped id, untyped key) -> untyped
 
+  # Map from short style option switches to actual switch objects.
+  #
   def short: () -> untyped
 
+  # Creates the summary table, passing each line to the `block` (without newline).
+  # The arguments `args` are passed along to the summarize method which is called
+  # on every option.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     summarize(*args, &block)
+  #
   def summarize: (*untyped args) { (*untyped) -> untyped } -> untyped
 
   private
 
+  # Just initializes all instance variables.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     new()
+  #
   def initialize: () -> void
 
+  # Adds `sw` according to `sopts`, `lopts` and `nlopts`.
+  #
+  # `sw`
+  # :   OptionParser::Switch instance to be added.
+  # `sopts`
+  # :   Short style option list.
+  # `lopts`
+  # :   Long style option list.
+  # `nlopts`
+  # :   Negated long style options list.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     update(sw, sopts, lopts, nsw = nil, nlopts = nil)
+  #
   def update: (untyped sw, untyped sopts, untyped lopts, ?untyped nsw, ?untyped nlopts) -> untyped
 end
 
+# Raises when a switch with mandatory argument has no argument.
 class OptionParser::MissingArgument < OptionParser::ParseError
 end
 
 OptionParser::MissingArgument::Reason: String
 
+# Raises when there is an argument for a switch which takes no argument.
 class OptionParser::NeedlessArgument < OptionParser::ParseError
 end
 
 OptionParser::NeedlessArgument::Reason: String
 
+# Map from option/keyword string to object with completion.
 class OptionParser::OptionMap < Hash[untyped, untyped]
   include Completion
 end
 
+# Base class of exceptions from OptionParser.
 class OptionParser::ParseError < RuntimeError
   def self.filter_backtrace: (untyped array) -> untyped
 
@@ -318,18 +1237,31 @@ class OptionParser::ParseError < RuntimeError
 
   def inspect: () -> untyped
 
+  # Default stringizing method to emit standard error message.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     message()
+  #
   def message: () -> untyped
 
   def reason: () -> untyped
 
   def reason=: (untyped) -> untyped
 
+  # Pushes back erred argument(s) to `argv`.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     recover(argv)
+  #
   def recover: (untyped argv) -> untyped
 
   def set_backtrace: (untyped array) -> untyped
 
   def set_option: (untyped opt, untyped eq) -> untyped
 
+  # # arglists 💪👽🚨 << Delete this section
+  #     to_s()
+  #
   alias to_s message
 
   private
@@ -337,9 +1269,20 @@ class OptionParser::ParseError < RuntimeError
   def initialize: (*untyped args, ?additional: untyped) -> void
 end
 
+# Reason which caused the error.
 OptionParser::ParseError::Reason: String
 
+# Individual switch class.  Not important to the user.
+#
+# Defined within Switch are several Switch-derived classes: NoArgument,
+# RequiredArgument, etc.
 class OptionParser::Switch
+  # Guesses argument style from `arg`.  Returns corresponding OptionParser::Switch
+  # class (OptionalArgument, etc.).
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     guess(arg)
+  #
   def self.guess: (untyped arg) -> untyped
 
   def self.incompatible_argument_styles: (untyped arg, untyped t) -> untyped
@@ -368,19 +1311,56 @@ class OptionParser::Switch
 
   def short: () -> untyped
 
+  # Produces the summary text. Each line of the summary is yielded to the block
+  # (without newline).
+  #
+  # `sdone`
+  # :   Already summarized short style options keyed hash.
+  # `ldone`
+  # :   Already summarized long style options keyed hash.
+  # `width`
+  # :   Width of left side (option part). In other words, the right side
+  #     (description part) starts after `width` columns.
+  # `max`
+  # :   Maximum width of left side -> the options are filled within `max` columns.
+  # `indent`
+  # :   Prefix string indents all summarized lines.
+  #
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     summarize(sdone = {}, ldone = {}, width = 1, max = width - 1, indent = "") { |indent| ... }
+  #
   def summarize: (?untyped sdone, ?untyped ldone, ?untyped width, ?untyped max, ?untyped indent) -> untyped
 
+  # Main name of the switch.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     switch_name()
+  #
   def switch_name: () -> untyped
 
   private
 
+  # Parses argument, converts and returns `arg`, `block` and result of conversion.
+  # Yields at semi-error condition instead of raising an exception.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     conv_arg(arg, val = [])
+  #
   def conv_arg: (untyped arg, ?untyped val) -> untyped
 
   def initialize: (?untyped pattern, ?untyped conv, ?untyped short, ?untyped long, ?untyped arg, ?untyped desc, ?untyped block) { (*untyped) -> untyped } -> void
 
+  # Parses `arg` and returns rest of `arg` and matched portion to the argument
+  # pattern. Yields when the pattern doesn't match substring.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse_arg(arg) { |InvalidArgument, arg| ... }
+  #
   def parse_arg: (untyped arg) -> untyped
 end
 
+# Switch that takes no arguments.
 class OptionParser::Switch::NoArgument < OptionParser::Switch
   def self.incompatible_argument_styles: (*untyped) -> untyped
 
@@ -388,23 +1368,46 @@ class OptionParser::Switch::NoArgument < OptionParser::Switch
 
   public
 
+  # Raises an exception if any arguments given.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse(arg, argv) { |NeedlessArgument, arg| ... }
+  #
   def parse: (untyped arg, untyped argv) -> untyped
 end
 
+# Switch that can omit argument.
 class OptionParser::Switch::OptionalArgument < OptionParser::Switch
   public
 
+  # Parses argument if given, or uses default value.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse(arg, argv, &error)
+  #
   def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
 end
 
+# Switch that takes an argument, which does not begin with '-'.
 class OptionParser::Switch::PlacedArgument < OptionParser::Switch
   public
 
+  # Returns nil if argument is not present or begins with '-'.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse(arg, argv, &error)
+  #
   def parse: (untyped arg, untyped argv) { (*untyped) -> untyped } -> untyped
 end
 
+# Switch that takes an argument.
 class OptionParser::Switch::RequiredArgument < OptionParser::Switch
   public
 
+  # Raises an exception if argument is not present.
+  #
+  # # arglists 💪👽🚨 << Delete this section
+  #     parse(arg, argv)
+  #
   def parse: (untyped arg, untyped argv) -> untyped
 end

--- a/test/stdlib/OptionParser_test.rb
+++ b/test/stdlib/OptionParser_test.rb
@@ -1,0 +1,262 @@
+require_relative "test_helper"
+require "optparse"
+
+class OptionParserSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+  library "optparse"
+  testing "singleton(::OptionParser)"
+
+  def test_accept
+    assert_send_type "(Class t) -> void", OptionParser, :accept, Class.new
+    assert_send_type "(Class t, Regexp pat) -> void", OptionParser, :accept, Class.new, /xxx/
+    assert_send_type "(Class t) { (*untyped) -> untyped } -> void", OptionParser, :accept, Class.new do end
+  end
+
+  def test_getopts
+    assert_send_type "(*String) -> Hash[String, untyped]", OptionParser, :getopts, "ab:", "foo", "bar:", "zot:Z;zot option"
+    assert_send_type "(Array[String], *String) -> Hash[String, untyped]", OptionParser, :getopts, ['-a'], "ab:", "foo", "bar:", "zot:Z;zot option"
+  end
+
+  def test_inc
+    assert_send_type "(Integer) -> Integer", OptionParser, :inc, 1
+    assert_send_type "(Integer) -> nil", OptionParser, :inc, 0
+    assert_send_type "(nil) -> Integer", OptionParser, :inc, nil
+    assert_send_type "(nil, Integer) -> Integer", OptionParser, :inc, nil, 10
+  end
+
+  def test_reject
+    assert_send_type '(Class) -> void', OptionParser, :reject, Class.new
+  end
+
+  def test_top
+    assert_send_type '() -> OptionParser::List', OptionParser, :top
+  end
+
+  def test_new
+    assert_send_type "() -> OptionParser", OptionParser, :new
+    assert_send_type "() { (OptionParser) -> void } -> OptionParser", OptionParser, :new do end
+    assert_send_type "(String) -> OptionParser", OptionParser, :new, 'banner'
+    assert_send_type "(String, Integer) -> OptionParser", OptionParser, :new, 'banner', 42
+    assert_send_type "(String, Integer, String) -> OptionParser", OptionParser, :new, 'banner', 42, '  '
+  end
+end
+
+class OptionParserTest < Test::Unit::TestCase
+  include TypeAssertions
+  library "optparse"
+  testing "::OptionParser"
+
+  def test_accept
+    assert_send_type "(Class t) -> void", opt, :accept, Class.new
+    assert_send_type "(Class t, Regexp pat) -> void", opt, :accept, Class.new, /xxx/
+    assert_send_type "(Class t) { (*untyped) -> untyped } -> void", opt, :accept, Class.new do end
+  end
+
+  def test_banner
+    assert_send_type "() -> String", opt, :banner
+  end
+
+  def test_banner=
+    assert_send_type "(String) -> String", opt, :banner=, 'foo'
+  end
+
+  def test_default_argv
+    assert_send_type "() -> Array[String]", opt, :default_argv
+  end
+
+  def test_default_argv=
+    assert_send_type "(Array[String]) -> Array[String]", opt, :default_argv=, ['a', 'b', 'c']
+  end
+
+  def test_define
+    assert_send_type "(*String) -> void", opt, :define, '-a'
+    assert_send_type "(String, Class) -> void", opt, :define, '-a', Array
+    assert_send_type "(String, Class, String) -> void", opt, :define, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> void", opt, :define, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> void", opt, :define, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> void", opt, :define, '-a', /foo/
+    assert_send_type "(*String, Proc) -> void", opt, :define, '-a', proc {}
+  end
+
+  def test_define_head
+    assert_send_type "(*String) -> void", opt, :define_head, '-a'
+    assert_send_type "(String, Class) -> void", opt, :define_head, '-a', Array
+    assert_send_type "(String, Class, String) -> void", opt, :define_head, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> void", opt, :define_head, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> void", opt, :define_head, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> void", opt, :define_head, '-a', /foo/
+    assert_send_type "(*String, Proc) -> void", opt, :define_head, '-a', proc {}
+  end
+
+  def test_define_tail
+    assert_send_type "(*String) -> void", opt, :define_tail, '-a'
+    assert_send_type "(String, Class) -> void", opt, :define_tail, '-a', Array
+    assert_send_type "(String, Class, String) -> void", opt, :define_tail, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> void", opt, :define_tail, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> void", opt, :define_tail, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> void", opt, :define_tail, '-a', /foo/
+    assert_send_type "(*String, Proc) -> void", opt, :define_tail, '-a', proc {}
+  end
+
+  def test_environment
+    env = ENV.to_h
+    assert_send_type '(String) -> nil', opt, :environment, 'not-exist-env'
+    ENV['FOOBAROPT'] = '--foo v'
+    assert_send_type '(String) -> Array[String]', opt, :environment, 'FOOBAROPT'
+  ensure
+    ENV.replace(env) if env
+  end
+
+  def test_getopts
+    assert_send_type "(*String) -> Hash[String, untyped]", opt, :getopts, "ab:", "foo", "bar:", "zot:Z;zot option"
+    assert_send_type "(Array[String], *String) -> Hash[String, untyped]", opt, :getopts, ['-a'], "ab:", "foo", "bar:", "zot:Z;zot option"
+  end
+
+  def test_help
+    assert_send_type "() -> String", opt, :help
+  end
+
+  def test_on
+    assert_send_type "(*String) -> self", opt, :on, '-a'
+    assert_send_type "(String, Class) -> self", opt, :on, '-a', Array
+    assert_send_type "(String, Class, String) -> self", opt, :on, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> self", opt, :on, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> self", opt, :on, '-a', /foo/
+    assert_send_type "(*String, Proc) -> self", opt, :on, '-a', proc {}
+  end
+
+  def test_on_head
+    assert_send_type "(*String) -> self", opt, :on_head, '-a'
+    assert_send_type "(String, Class) -> self", opt, :on_head, '-a', Array
+    assert_send_type "(String, Class, String) -> self", opt, :on_head, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> self", opt, :on_head, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on_head, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> self", opt, :on_head, '-a', /foo/
+    assert_send_type "(*String, Proc) -> self", opt, :on_head, '-a', proc {}
+  end
+
+  def test_on_tail
+    assert_send_type "(*String) -> self", opt, :on_tail, '-a'
+    assert_send_type "(String, Class) -> self", opt, :on_tail, '-a', Array
+    assert_send_type "(String, Class, String) -> self", opt, :on_tail, '-a', Array, 'description'
+    assert_send_type "(String, Array[String]) -> self", opt, :on_tail, '-a', ['foo', 'bar']
+    assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on_tail, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, Regexp) -> self", opt, :on_tail, '-a', /foo/
+    assert_send_type "(*String, Proc) -> self", opt, :on_tail, '-a', proc {}
+  end
+
+  def test_order
+    assert_send_type "(*String) -> Array[String]", opt, :order, '--foo', '42'
+    assert_send_type "(*String, into: Hash[untyped, untyped]) -> Array[String]", opt, :order, '--foo', '42', into: {}
+    assert_send_type "(*String) { (String) -> void } -> Array[String]", opt, :order, '--foo', '42' do end
+    assert_send_type "(Array[String]) -> Array[String]", opt, :order, %w[--foo 42]
+  end
+
+  def test_order!
+    assert_send_type "(Array[String]) -> Array[String]", opt, :order!, %w[--foo 42]
+    assert_send_type "(Array[String], into: Hash[untyped, untyped]) -> Array[String]", opt, :order!, %w[--foo 42], into: {}
+    assert_send_type "(Array[String]) { (String) -> void } -> Array[String]", opt, :order!, %w[--foo 42] do end
+  end
+
+  def test_parse
+    assert_send_type "(*String) -> Array[String]", opt, :parse, '--foo', '42'
+    assert_send_type "(*String, into: Hash[untyped, untyped]) -> Array[String]", opt, :parse, '--foo', '42', into: {}
+    assert_send_type "(Array[String]) -> Array[String]", opt, :parse, %w[--foo 42]
+  end
+
+  def test_parse!
+    assert_send_type "(Array[String]) -> Array[String]", opt, :parse!, %w[--foo 42]
+    assert_send_type "(Array[String], into: Hash[untyped, untyped]) -> Array[String]", opt, :parse!, %w[--foo 42], into: {}
+  end
+
+  def test_permute
+    assert_send_type "(*String) -> Array[String]", opt, :permute, '--foo', '42'
+    assert_send_type "(*String, into: Hash[untyped, untyped]) -> Array[String]", opt, :permute, '--foo', '42', into: {}
+    assert_send_type "(Array[String]) -> Array[String]", opt, :permute, %w[--foo 42]
+  end
+
+  def test_permute!
+    assert_send_type "(Array[String]) -> Array[String]", opt, :permute!, %w[--foo 42]
+    assert_send_type "(Array[String], into: Hash[untyped, untyped]) -> Array[String]", opt, :permute!, %w[--foo 42], into: {}
+  end
+
+  def test_program_name
+    assert_send_type "() -> String", opt, :program_name
+  end
+
+  def test_program_name=
+    assert_send_type "(String) -> String", opt, :program_name=, 'foo'
+  end
+
+  def test_reject
+    assert_send_type '(Class) -> void', opt, :reject, Class.new
+  end
+
+  def test_summarize
+    assert_send_type '() -> Array[String]', opt, :summarize
+    assert_send_type '(Array[String]) -> Array[String]', opt, :summarize, []
+    assert_send_type '(Array[String], Integer) -> Array[String]', opt, :summarize, [], 100
+    assert_send_type '(Array[String], Integer, Integer) -> Array[String]', opt, :summarize, [], 100, 99
+    assert_send_type '(Array[String], Integer, Integer, String) -> Array[String]', opt, :summarize, [], 100, 99, '  '
+    assert_send_type '() { (String) -> void } -> Array[String]', opt, :summarize do end
+  end
+
+  def test_to_a
+    assert_send_type '() -> Array[String]', opt, :to_a
+  end
+
+  def test_top
+    assert_send_type '() -> OptionParser::List', opt, :top
+  end
+
+  def opt
+    OptionParser.new do |opt|
+      opt.on('--foo value')
+    end
+  end
+end
+
+class OptionParserArguableTest < Test::Unit::TestCase
+  class Target < Array
+    include OptionParser::Arguable
+  end
+
+  include TypeAssertions
+  library "optparse"
+  testing "::OptionParser::Arguable"
+
+  def test_getopts
+    assert_send_type '(*String) -> Hash[String, untyped]', subject, :getopts, 'ab:'
+  end
+
+  def test_options
+    assert_send_type '() -> OptionParser', subject, :options
+    assert_send_type '() { (OptionParser) -> String } -> String', subject, :options do "foo" end
+  end
+
+  def test_options=
+    assert_send_type '(OptionParser) -> untyped', subject, :options=, OptionParser.new
+    assert_send_type '(nil) -> untyped', subject, :options=, nil
+  end
+
+  def test_order!
+    subject.options.on('-a')
+    assert_send_type "() -> Array[String]", subject, :order!
+    assert_send_type "() { (String) -> void } -> Array[String]", subject, :order! do end
+  end
+
+  def test_parse!
+    subject.options.on('-a')
+    assert_send_type "() -> Array[String]", subject, :parse!
+  end
+
+  def test_permute!
+    subject.options.on('-a')
+    assert_send_type "() -> Array[String]", subject, :permute!
+  end
+
+  def subject
+    @subject ||= Target.new(%w[-a 42])
+  end
+end


### PR DESCRIPTION
This pull request adds OptionParser RBSs.




Note that I kept `untyped` for internal APIs and private methods. Typing them will be hard work but only a few benefits.


`optparse` library has files that is needed to require explicitly. For example, `optparse/ac` file.
But this pull request doesn't add types for them.

