### PR TITLE
changing IO.select timeout into a numeric

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -746,7 +746,7 @@ class IO < Object
 
   def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> ::Array[String]
 
-  def self.select: (::Array[io]? read_array, ?::Array[io]? write_array, ?::Array[io]? error_array, ?Integer? timeout) -> ::Array[::Array[io]]?
+  def self.select: (::Array[io]? read_array, ?::Array[io]? write_array, ?::Array[io]? error_array, ?Numeric? timeout) -> ::Array[::Array[io]]?
 
   def self.sysopen: (String path, ?String mode, ?String perm) -> Integer
 


### PR DESCRIPTION
`IO.select` actually can receive floats, and I've tried it with rationals as well.