### PR TITLE
Fix race condition for multi-thread support

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -774,26 +774,10 @@ module RBS
     end
 
     def try_cache(type_name, cache:, key: type_name)
-      # @type var cc: Hash[untyped, Definition | false | nil]
+      # @type var cc: Hash[untyped, Definition | nil]
       cc = _ = cache
-      cached = cc[key]
 
-      case cached
-      when Definition
-        cached
-      when false
-        raise
-      when nil
-        cc[key] = false
-        begin
-          cc[key] = yield
-        rescue => ex
-          cc.delete(key)
-          raise ex
-        end
-      else
-        raise
-      end
+      cc[key] ||= yield
     end
 
     def expand_alias(type_name)


### PR DESCRIPTION
Inside DefinitionBuilder, access to caches happens recursively, where
set operations mark the field in the cache with false. This breaks
sometimes when used in a threaded context, such as a minitest parallel
run.

This patch fixes it by making cache accesses mutex-aware, while also
allowing recursive sets on the same cache.

Fixes #695