### PR TITLE
fixed signature of caller

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -13,8 +13,8 @@
 module Kernel : BasicObject
   private
 
-  def self?.caller: (?Integer start_or_range, ?Integer length) -> ::Array[String]?
-            | (?::Range[Integer] start_or_range) -> ::Array[String]?
+  def self?.caller: (Integer start_or_range, ?Integer length) -> ::Array[String]?
+            | (::Range[Integer] start_or_range) -> ::Array[String]?
             | () -> ::Array[String]
 
   def self?.caller_locations: (?Integer start_or_range, ?Integer length) -> ::Array[Thread::Backtrace::Location]?


### PR DESCRIPTION
`Kernel.caller` signatures were overriding the case of no arguments, leading to the steep errors when performing `ex.set_backtrace(caller)`