### PR TITLE
Avoid redundant overloading of Array#shift

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1637,7 +1637,7 @@ class Array[unchecked out Elem] < Object
   #     args           #=> ["filename"]
   #
   def shift: () -> Elem?
-           | (?int n) -> ::Array[Elem]
+           | (int n) -> ::Array[Elem]
 
   # Returns a new array with elements of `self` shuffled.
   #


### PR DESCRIPTION
It returns an array of elements only when the length argument is
specified.