### PR TITLE
Enumerable#flat_map

### DIFF
--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -48,7 +48,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
              | () -> ::Enumerator[Elem, ::Array[untyped]]
 
-  def collect_concat: [U] () { (Elem arg0) -> ::Enumerator[U, untyped] } -> ::Array[U]
+  alias collect_concat flat_map
 
   # Returns the number of items in `enum` through enumeration. If an
   # argument is given, the number of items in `enum` that are equal to

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -334,7 +334,15 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
           | [T] (_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
           | [T] (_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
 
-  def flat_map: [U] () { (Elem) -> (Array[U] | U) } -> Array[U]
+  # Returns a new array with the concatenated results of running *block* once for
+  # every element in *enum*.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
+  #     [1, 2, 3, 4].flat_map { |e| [e, -e] } #=> [1, -1, 2, -2, 3, -3, 4, -4]
+  #     [[1, 2], [3, 4]].flat_map { |e| e + [100] } #=> [1, 2, 100, 3, 4, 100]
+  #
+  def flat_map: [U] () { (Elem obj) -> Array[U] } -> Array[U]
               | () -> ::Enumerator[Elem, Array[untyped]]
 
   def map: [U] () { (Elem arg0) -> U } -> ::Array[U]


### PR DESCRIPTION
Drops object version from `Enumerable#flat_map`, because it usually expects the block value is an `Array`

```ruby
[1,2,3].flat_map {|x| [x] }    # OK because the block returns an Array.
[1,2,3].flat_map {|x| x+1 }    # Type error with this type signature update, because the non-array block type is dropped.
```