### PR TITLE
Skip test of `...` with Ruby 3.1

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -231,7 +231,7 @@ end
     assert(true) # nothing raised above
   end
 
-  if RUBY_VERSION >= '2.7'
+  if RUBY_VERSION >= '2.7' && RUBY_VERSION <= '3.0'
     class TestForArgumentForwarding
       eval <<~RUBY
         def foo(...)


### PR DESCRIPTION
Skip testing `...` with Ruby 3.1 because we plan to change the behavior for https://bugs.ruby-lang.org/issues/18011.
