### PR TITLE
Fix duplicated range warning in parser.y

### DIFF
--- a/lib/rbs/parser.rb
+++ b/lib/rbs/parser.rb
@@ -340,7 +340,7 @@ def next_token
     new_token(:tLIDENT)
   when input.scan(/_[a-z]\w*\b/)
     new_token(:tUNDERSCOREIDENT)
-  when input.scan(/_[\w_]*\b/)
+  when input.scan(/_\w*\b/)
     new_token(:tPARAMNAME)
   when input.scan(/"(\\"|[^"])*"/)
     s = input.matched.yield_self {|s| s[1, s.length - 2] }

--- a/lib/rbs/parser.y
+++ b/lib/rbs/parser.y
@@ -1722,7 +1722,7 @@ def next_token
     new_token(:tLIDENT)
   when input.scan(/_[a-z]\w*\b/)
     new_token(:tUNDERSCOREIDENT)
-  when input.scan(/_[\w_]*\b/)
+  when input.scan(/_\w*\b/)
     new_token(:tPARAMNAME)
   when input.scan(/"(\\"|[^"])*"/)
     s = input.matched.yield_self {|s| s[1, s.length - 2] }


### PR DESCRIPTION
This PR fixes the following warning.

```
parser.y:1725: warning: character class has duplicated range: /_[\w_]*\b/
```


