### PR TITLE
Fix resolv test

### DIFF
--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -177,7 +177,7 @@ class Resolv::DNS
   # `address` must be a Resolv::IPv4, Resolv::IPv6 or a String.  Retrieved names
   # will be Resolv::DNS::Name instances.
   #
-  def getnames: (ip_address | dns_name address) -> [Resolv::DNS::Name]
+  def getnames: (ip_address | dns_name address) -> Array[Resolv::DNS::Name]
 
   # Look up the `typeclass` DNS resource of `name`.
   #

--- a/test/stdlib/resolv/DNS_test.rb
+++ b/test/stdlib/resolv/DNS_test.rb
@@ -196,7 +196,7 @@ class ResolvDNSConfigInstanceTest < Test::Unit::TestCase
   end
 
   def test_single?
-    assert_send_type '() -> [String, Integer]',
+    assert_send_type '() -> [String, Integer]?',
       dns_config, :single?
   end
 

--- a/test/stdlib/resolv/DNS_test.rb
+++ b/test/stdlib/resolv/DNS_test.rb
@@ -36,7 +36,6 @@ class ResolvDNSSingletonTest < Test::Unit::TestCase
   end
 end
 
-
 class ResolvDNSinstanceTest < Test::Unit::TestCase
   include TypeAssertions
   library 'resolv'
@@ -86,10 +85,12 @@ class ResolvDNSinstanceTest < Test::Unit::TestCase
   end
 
   def test_getaddress
-    assert_send_type "(String) -> (Resolv::IPv4 | Resolv::IPv6)",
-      resolv_dns, :getaddress, "localhost"
-    assert_send_type "(Resolv::DNS::Name) -> (Resolv::IPv4 | Resolv::IPv6)",
-      resolv_dns, :getaddress, Resolv::DNS::Name.create("localhost")
+    allows_error(Resolv::ResolvError) do
+      assert_send_type "(String) -> (Resolv::IPv4 | Resolv::IPv6)",
+                       resolv_dns, :getaddress, "localhost"
+      assert_send_type "(Resolv::DNS::Name) -> (Resolv::IPv4 | Resolv::IPv6)",
+                       resolv_dns, :getaddress, Resolv::DNS::Name.create("localhost")
+    end
   end
 
   def test_getaddresses
@@ -100,12 +101,14 @@ class ResolvDNSinstanceTest < Test::Unit::TestCase
   end
 
   def test_getname
-    assert_send_type "(String) -> Resolv::DNS::Name",
-      resolv_dns, :getname, "127.0.0.1"
-    assert_send_type "(Resolv::IPv4) -> Resolv::DNS::Name",
-      resolv_dns, :getname, Resolv::IPv4.create("127.0.0.1")
-    assert_send_type "(Resolv::DNS::Name) -> Resolv::DNS::Name",
-      resolv_dns, :getname, Resolv::IPv4.create("127.0.0.1").to_name
+    allows_error(Resolv::ResolvError) do
+      assert_send_type "(String) -> Resolv::DNS::Name",
+        resolv_dns, :getname, "127.0.0.1"
+      assert_send_type "(Resolv::IPv4) -> Resolv::DNS::Name",
+        resolv_dns, :getname, Resolv::IPv4.create("127.0.0.1")
+      assert_send_type "(Resolv::DNS::Name) -> Resolv::DNS::Name",
+        resolv_dns, :getname, Resolv::IPv4.create("127.0.0.1").to_name
+    end
   end
 
   def test_getnames
@@ -114,8 +117,10 @@ class ResolvDNSinstanceTest < Test::Unit::TestCase
   end
 
   def test_getresource
-    assert_send_type "(String, singleton(Resolv::DNS::Query)) -> Resolv::DNS::Resource",
-      resolv_dns, :getresource, "localhost", Resolv::DNS::Resource::IN::A
+    allows_error(Resolv::ResolvError) do
+      assert_send_type "(String, singleton(Resolv::DNS::Query)) -> Resolv::DNS::Resource",
+        resolv_dns, :getresource, "localhost", Resolv::DNS::Resource::IN::A
+    end
   end
 
   def test_getresources

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -336,6 +336,12 @@ module TypeAssertions
       definition.methods[method].method_types
     end
   end
+
+  def allows_error(*errors)
+    yield
+  rescue *errors => exn
+    notify "Error allowed: #{exn.inspect}"
+  end
 end
 
 class ToInt


### PR DESCRIPTION
The test related to resolv library causes CI failures of `ruby/ruby` because the testing environment doesn't allow DNS name resolution of `localhost`/`127.0.0.1`.

* https://github.com/ruby/actions/runs/3174954841?check_suite_focus=true#step:16:1643

This PR is to fix some method types and the test.