### PR TITLE
Generate included modules with complete name

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -87,7 +87,7 @@ module RBS
             unless const_name(mix)
               RBS.logger.warn("Skipping anonymous module #{mix} included in #{mod}")
             else
-              module_name = module_full_name = to_type_name(const_name(mix))
+              module_name = module_full_name = to_type_name(const_name(mix), full_name: true)
               if module_full_name.namespace == type_name.namespace
                 module_name = TypeName.new(name: module_full_name.name, namespace: Namespace.empty)
               end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -59,9 +59,9 @@ module RBS
       end
 
       class Test < String
-        include Foo
+        include RBS::RuntimePrototypeTest::TestTargets::Foo
 
-        extend Bar
+        extend RBS::RuntimePrototypeTest::TestTargets::Bar
 
         def self.b: () -> untyped
 
@@ -123,9 +123,9 @@ module RBS
       end
 
       class Test < String
-        include Foo
+        include RBS::RuntimePrototypeTest::TestTargets::Foo
 
-        extend Bar
+        extend RBS::RuntimePrototypeTest::TestTargets::Bar
 
         def self.b: () -> untyped
 
@@ -290,7 +290,7 @@ end
             module RuntimePrototypeTest
               module TestForOverrideModuleName
                 class C
-                  include M
+                  include RBS::RuntimePrototypeTest::TestForOverrideModuleName::M
 
                   def self.name: () -> untyped
 


### PR DESCRIPTION
# Description
- As @pocke sir mentioned in his [comment](https://github.com/ruby/rbs/issues/729#issuecomment-893261119), it is possible to generate included modules with complete name
- This PR contains a minor change to enable generating RBS with included modules being written out with their namespace

# Example
![image](https://user-images.githubusercontent.com/57192414/128397786-9ec42e42-e2c1-476c-8129-3ba2c2001045.png)
