### PR TITLE
Allow Array#[] to receive Range of optional Integer

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -452,7 +452,7 @@ class Array[unchecked out Elem] < Object
   #
   def []: (int index) -> Elem
         | (int start, int length) -> ::Array[Elem]?
-        | (::Range[::Integer] range) -> ::Array[Elem]?
+        | (::Range[::Integer?] range) -> ::Array[Elem]?
 
   # Element Assignment --- Sets the element at `index`, or replaces a subarray
   # from the `start` index for `length` elements, or replaces a subarray specified
@@ -486,9 +486,9 @@ class Array[unchecked out Elem] < Object
          | (int start, int length, Elem obj) -> Elem
          | (int start, int length, ::Array[Elem]) -> ::Array[Elem]
          | (int start, int length, nil) -> nil
-         | (::Range[::Integer], Elem obj) -> Elem
-         | (::Range[::Integer], ::Array[Elem]) -> ::Array[Elem]
-         | (::Range[::Integer], nil) -> nil
+         | (::Range[::Integer?], Elem obj) -> Elem
+         | (::Range[::Integer?], ::Array[Elem]) -> ::Array[Elem]
+         | (::Range[::Integer?], nil) -> nil
 
   # See also Enumerable#all?
   #

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -102,6 +102,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :[], 0...1
     assert_send_type "(Range[Integer]) -> nil",
                      [1,2,3], :[], 5..8
+    assert_send_type "(Range[Integer?]) -> Array[Integer]",
+                     [1,2,3], :[], 0...nil
   end
 
   def test_aupdate
@@ -121,6 +123,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :[]=, 0...2, [-1]
     assert_send_type "(Range[Integer], nil) -> nil",
                      [1,2,3], :[]=, 0...2, nil
+    assert_send_type "(Range[Integer?], Integer) -> Integer",
+                     [1,2,3], :[]=, 0..nil, -1
   end
 
   def test_all?


### PR DESCRIPTION
`Array#[]` and `Array#[]=` accept a Range of optional Integer as the argument in Ruby, but the RBS doesn't allow it unexpectedly.


By the way, `String#[]` already accepts it.