### PR TITLE
fixing hash yielding of field and value

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -113,6 +113,7 @@ module Kernel : BasicObject
   def self?.Array: (NilClass x) -> [ ]
            | [T] (::Array[T] x) -> ::Array[T]
            | [T] (::Range[T] x) -> ::Array[T]
+           | [T] (_Each[T] x) -> ::Array[T]
            | [K, V] (::Hash[K, V] x) -> ::Array[[K, V]]
            | [T] (T x) -> ::Array[T]
 


### PR DESCRIPTION
This generates steep errors on hash each yields, as field and value are
spread, and not yielded as a tuple.

Also fixing Array() when called with an enumerable, for which it can
also generate an array.
