### PR TITLE
fix set_backtrace signature when passing nil value

### DIFF
--- a/core/exception.rbs
+++ b/core/exception.rbs
@@ -185,6 +185,7 @@ class Exception < Object
   def message: () -> String
 
   def set_backtrace: (String | ::Array[String] arg0) -> ::Array[String]
+                   | (nil) -> nil
 
   # Returns exception’s message (or the name of the exception if no message
   # is set).


### PR DESCRIPTION
```ruby
irb(main):001:0> e = StandardError.new
=> #<StandardError: StandardError>
irb(main):002:0> e.set_backtrace nil
=> nil
irb(main):003:0> e.set_backtrace "bang"
=> ["bang"]
```

without this change, there are steep errors everywhere where the following idiommatic ruby expression is used:

```ruby
def raise_another(error)
  ex =  StandardError.new
  ex.set_backtrace(error.backtrace)
  raise ex
end
```

because `error.backtrace` can be nil.