### PR TITLE
Fix error when multi assign with const

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -319,9 +319,16 @@ module RBS
                          const_to_name(node.children[0])
                        end
 
+          value_node = node.children.last
+          type = if value_node.nil?
+                  # Give up type prediction when node is MASGN.
+                  Types::Bases::Any.new(location: nil)
+                else
+                  node_type(value_node)
+                end
           decls << AST::Declarations::Constant.new(
             name: const_name,
-            type: node_type(node.children.last),
+            type: type,
             location: nil,
             comment: comments[node.first_lineno - 1]
           )

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -573,6 +573,28 @@ end
     EOF
   end
 
+  def test_const_with_multi_assign
+    parser = RB.new
+
+    rb = <<-EOR
+module Foo
+  MAJOR, MINOR, PATCH = ['0', '1', '1']
+end
+    EOR
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<-EOF
+module Foo
+  MAJOR: untyped
+
+  MINOR: untyped
+
+  PATCH: untyped
+end
+    EOF
+  end
+
   def test_literal_types
     parser = RB.new
 


### PR DESCRIPTION
Fixed an error that occurred when loading code with multi-assigned constants in `rbs prototype rb`.
If the value is a single value, the type is predicted, but if the value is multi-assigned, it is given up.

## Demo

t.rb
```rb
module Foo
  MAJOR, MINOR, PATCH = ['0', '1', '1']
end
```

### Before

```
$ rbs prototype rb t.rb
/Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:654:in `node_type': undefined method `type' for nil:NilClass (NoMethodError)
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:324:in `process'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:336:in `block in process_children'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:371:in `block in each_node'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:369:in `each'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:369:in `each_node'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:377:in `each_child'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:335:in `process_children'
	from /Users/ksss/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rbs-1.3.3/lib/rbs/prototype/rb.rb:330:in `process'
```

### After

```
$ rbs prototype rb t.rb
module Foo
  MAJOR: untyped

  MINOR: untyped

  PATCH: untyped
end
```
