### PR TITLE
allow uris to merge with anythig coercing to string

### DIFF
--- a/stdlib/uri/0/generic.rbs
+++ b/stdlib/uri/0/generic.rbs
@@ -706,7 +706,7 @@ module URI
     #   uri.merge!("/main.rbx?page=1")
     #   uri.to_s  # => "http://my.example.com/main.rbx?page=1"
     #
-    def merge!: (String oth) -> String
+    def merge!: (string oth) -> String
 
     #
     # == Args
@@ -726,7 +726,7 @@ module URI
     #   uri.merge("/main.rbx?page=1")
     #   # => "http://my.example.com/main.rbx?page=1"
     #
-    def merge: (String oth) -> URI::Generic
+    def merge: (string oth) -> URI::Generic
 
     # :stopdoc:
     def route_from_path: (String src, String dst) -> String


### PR DESCRIPTION
```ruby
a = URI("http://google.com")
a.merge("/path")
=> #<URI::HTTP http://google.com/path>
irb(main):004:0> a.merge(URI("/path"))
=> #<URI::HTTP http://google.com/path>
irb(main):005:0> a.merge(URI("http://cdn.com/path"))
=> #<URI::HTTP http://cdn.com/path>
irb(main):006:-> a.merge(:"http://cdn.com/path"))
class A
  def to_str
    "/path"
  end
end
a.merge(A.new)
=> #<URI::HTTP http://google.com/path>
```