### PR TITLE
Fix test failure of use_gemdeps with RubyGems v3.2.26

### DIFF
--- a/stdlib/rubygems/0/rubygems.rbs
+++ b/stdlib/rubygems/0/rubygems.rbs
@@ -685,7 +685,7 @@ module Gem
   # NOTE: Enabling automatic discovery on multiuser systems can lead to execution
   # of arbitrary code when used from directories outside your control.
   #
-  def self.use_gemdeps: (?String path) -> Array[Specification]?
+  def self.use_gemdeps: (?String path) -> void
 
   # Use the `home` and `paths` values for Gem.dir and Gem.path.  Used mainly by
   # the unit tests to provide environment isolation.

--- a/test/stdlib/rubygems/Gem_test.rb
+++ b/test/stdlib/rubygems/Gem_test.rb
@@ -561,7 +561,7 @@ class GemSingletonTest < Test::Unit::TestCase
   end
 
   def test_use_gemdeps
-    assert_send_type  "() -> nil",
+    assert_send_type  "() -> void",
                       Gem, :use_gemdeps
 
     Dir.mktmpdir do |dir|
@@ -570,7 +570,7 @@ class GemSingletonTest < Test::Unit::TestCase
         File.write(gemfile_path, <<GEMFILE)
 source "https://rubygems.org"
 GEMFILE
-        assert_send_type  "(String) -> Array[Gem::Specification]",
+        assert_send_type  "(String) -> void",
                           Gem, :use_gemdeps, "-"
       end
     end


### PR DESCRIPTION
This PR fixes test failure for `use_gemdeps` with RubyGems v3.2.26, which was released today. https://github.com/rubygems/rubygems/releases/tag/v3.2.26

`use_gemdeps`'s returned value has been changed since v3.2.26.
I think it doesn't expect to use the returned value, so the type should be `void`.


The test failure is reproduced with `gem update --system` and `bundle exec ruby -Ilib bin/test_runner.rb test/stdlib/rubygems/Gem_test.rb`.
example: https://github.com/ruby/rbs/pull/589/checks?check_run_id=3352074807


