### PR TITLE
fixing _Reader interface implementations to what's expected

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -31,7 +31,7 @@ interface _Each[out A]
 end
 
 interface _Reader
-  def read: (?int length, ?string outbuf) -> String?
+  def read: (?int? length, ?string outbuf) -> String?
 end
 
 interface _ReaderPartial

--- a/core/file.rbs
+++ b/core/file.rbs
@@ -1042,7 +1042,7 @@ class File::Stat < Object
 
   def rdev_minor: () -> Integer
 
-  def read: (?Integer length, ?String outbuf) -> String
+  def read: (?int? length, ?string outbuf) -> String?
 
   def readable?: () -> bool
 

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -532,10 +532,10 @@ class IO < Object
   # need the behavior like a single read(2) system call, consider #readpartial,
   # #read_nonblock, and #sysread.
   #
-  def read: (?Integer? length, ?String outbuf) -> String?
+  def read: (?int? length, ?string outbuf) -> String?
 
-  def read_nonblock: (Integer len, ?String buf, ?exception: true) -> String
-                   | (Integer len, ?String buf, exception: false) -> (String | :wait_readable | nil)
+  def read_nonblock: (int len, ?string buf, ?exception: true) -> String
+                   | (int len, ?string buf, exception: false) -> (String | :wait_readable | nil)
 
   # Reads a byte as with `IO#getbyte`, but raises an `EOFError` on end of
   # file.
@@ -611,7 +611,7 @@ class IO < Object
   # on the situation IO#sysread causes Errno::EWOULDBLOCK as if the fd is blocking
   # mode.
   #
-  def readpartial: (Integer maxlen, ?String outbuf) -> String
+  def readpartial: (int maxlen, ?string outbuf) -> String
 
   def reopen: (IO other_IO_or_path) -> IO
             | (String other_IO_or_path, ?String mode_str) -> IO

--- a/core/string_io.rbs
+++ b/core/string_io.rbs
@@ -164,10 +164,9 @@ class StringIO
 
   # See IO#read.
   #
-  def read: (?Integer length, ?String outbuf) -> String?
+  def read: (?int? length, ?string outbuf) -> String?
 
-  def read_nonblock: (Integer len) -> String
-                   | (Integer len, ?String buf) -> String
+  def read_nonblock: (int len, ?string buf) -> String
 
   def readbyte: () -> Integer
 
@@ -179,8 +178,7 @@ class StringIO
   #
   def readlines: (?String sep, ?Integer limit, ?chomp: boolish) -> ::Array[String]
 
-  def readpartial: (Integer maxlen) -> String
-                 | (Integer maxlen, ?String outbuf) -> String
+  def readpartial: (int maxlen, ?string outbuf) -> String
 
   # Reinitializes the stream with the given *other_StrIO* or *string* and *mode*
   # (see StringIO#new).


### PR DESCRIPTION
in all #read family implementations, length is anything coerced to
integer, and the same applies to buffer (anything coercing to string).

The APIs also allow nil in some cases (i.e. `io.read nil, nil`).

One particular thing which I couldn't narrow down in the interface is
the following (quoting the docs):

> When this method is called at end of file, it returns nil or "",
> depending on length: read, read(nil), and read(0) return "",
> read(positive_integer) returns nil.

I suspect that this should also be defined in the API, as length will
rarely be 0 or nil in most practical cases.