### PR TITLE
Fix global_variables.rbs

### DIFF
--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -48,7 +48,7 @@ $-a: bool
 $-d: bool
 
 # In in-place-edit mode, this variable holds the extension, otherwise +nil+.
-$-i: bool
+$-i: String?
 
 # True if option <tt>-l</tt> is set. Read-only variable.
 $-l: bool

--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -74,7 +74,7 @@ $.: Integer
 # The input record separator, newline by default. Aliased to $-0.
 $/: String | nil
 
-# The same as $!.backtrace.
+# Contains the name of the script being executed. May be assignable.
 $0: String
 
 # The Nth group of the last successful match. May be > 1.
@@ -149,7 +149,7 @@ $LOADED_FEATURES: Array[String]
 # the path the original Kernel#require method would load.
 $LOAD_PATH: Array[String]
 
-# The same as $!.backtrace.
+# Contains the name of the script being executed. May be assignable.
 $PROGRAM_NAME: String
 
 # The verbose flag, which is set by the <tt>-w</tt> or <tt>-v</tt> switch.


### PR DESCRIPTION
This PR contains two fixes to global_variables.rbs, which is introduced in #749.


* Fix `$-i` type, it stores String or a nil
* Fix `$0` and `$PROGRAM_NAME` document.
  * I brought the doc from https://github.com/ruby/ruby/blob/95aff214687a5e12c3eb57d056665741e734c188/doc/globals.rdoc