### PR TITLE
[io/wait] Add RBS for "io/wait"

### DIFF
--- a/core/io/wait.rbs
+++ b/core/io/wait.rbs
@@ -1,0 +1,33 @@
+class IO
+  # Returns number of bytes that can be read without blocking. Returns zero if no
+  # information available.
+  #
+  def nread: () -> Integer
+
+  # Returns `true` if input available without blocking, or `false`.
+  #
+  def ready?: () -> boolish
+
+  # Waits until the IO becomes ready for the specified events and returns the
+  # subset of events that become ready, or `false` when times out.
+  #
+  # The events can be a bit mask of `IO::READABLE`, `IO::WRITABLE` or
+  # `IO::PRIORITY`.
+  #
+  # Returns `true` immediately when buffered data is available.
+  #
+  # Optional parameter `mode` is one of `:read`, `:write`, or `:read_write`
+  # (deprecated).
+  #
+  def wait: (Integer events, ?Numeric timeout) -> self?
+          | (Integer timeout, ?(:read | :write | :read_write) mode) -> self?
+
+  # Waits until IO is readable and returns `true`, or `false` when times out.
+  # Returns `true` immediately when buffered data is available.
+  #
+  def wait_readable: (?Numeric timeout) -> self?
+
+  # Waits until IO is writable and returns `true` or `false` when times out.
+  #
+  def wait_writable: (?Numeric timeout) -> self?
+end

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -1,4 +1,5 @@
 require_relative "test_helper"
+require "io/wait"
 
 class IOSingletonTest < Test::Unit::TestCase
   include TypeAssertions
@@ -240,4 +241,32 @@ class IOInstanceTest < Test::Unit::TestCase
                        io, :sync
     end
   end
+end
+
+class IOWaitTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::IO"
+
+  def test_wait
+    r, w = IO.pipe
+    assert_send_type "() -> Integer",
+      r, :nread
+    assert_send_type "() -> nil",
+      r, :ready?
+    assert_send_type "(Float) -> nil",
+      r, :wait_readable, 0.2
+    assert_send_type "(Integer, Float) -> nil",
+      r, :wait, IO::READABLE, 0.2
+    assert_send_type "(Float) -> IO",
+      w, :wait_writable, 0.2
+    w.write("a")
+    assert_send_type "(Float) -> IO",
+      r, :wait_readable, 0.2
+    assert_send_type "() -> IO",
+      r, :ready?
+  ensure
+    r.close
+    w.close
+  end if RUBY_VERSION >= "3.0.0"
 end


### PR DESCRIPTION
Picking up the work left in https://github.com/ruby/rbs/pull/563.

The most controversial part is the mismatch between what documentation
says about return types and what actually gets returned (doc says bool,
but IO or nil are actually returned).