### PR TITLE
[digest] Add missing root level Digest method

### DIFF
--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -399,8 +399,6 @@ end
 class Digest::SHA512 < Digest::Base
 end
 
-# https://github.com/seattlerb/minitest/blob/13c48a03d84a2a87855a4de0c959f968001
-# 00357/lib/minitest/mock.rb#L192
 # Object is the default root of all Ruby objects.  Object inherits from
 # BasicObject which allows creating alternate object hierarchies.  Methods on
 # Object are available to all classes unless explicitly overridden.

--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -399,20 +399,6 @@ end
 class Digest::SHA512 < Digest::Base
 end
 
-# Object is the default root of all Ruby objects.  Object inherits from
-# BasicObject which allows creating alternate object hierarchies.  Methods on
-# Object are available to all classes unless explicitly overridden.
-#
-# Object mixes in the Kernel module, making the built-in kernel functions
-# globally accessible.  Although the instance methods of Object are defined by
-# the Kernel module, we have chosen to document them here for clarity.
-#
-# When referencing constants in classes inheriting from Object you do not need
-# to use the full namespace.  For example, referencing `File` inside `YourClass`
-# will find the top-level File class.
-#
-# In the descriptions of Object's methods, the parameter *symbol* refers to a
-# symbol, which is either a quoted string or a Symbol (such as `:name`).
 class Object
   # Returns a Digest subclass by `name` in a thread-safe manner even when
   # on-demand loading is involved.

--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -398,3 +398,37 @@ end
 
 class Digest::SHA512 < Digest::Base
 end
+
+# https://github.com/seattlerb/minitest/blob/13c48a03d84a2a87855a4de0c959f968001
+# 00357/lib/minitest/mock.rb#L192
+# Object is the default root of all Ruby objects.  Object inherits from
+# BasicObject which allows creating alternate object hierarchies.  Methods on
+# Object are available to all classes unless explicitly overridden.
+#
+# Object mixes in the Kernel module, making the built-in kernel functions
+# globally accessible.  Although the instance methods of Object are defined by
+# the Kernel module, we have chosen to document them here for clarity.
+#
+# When referencing constants in classes inheriting from Object you do not need
+# to use the full namespace.  For example, referencing `File` inside `YourClass`
+# will find the top-level File class.
+#
+# In the descriptions of Object's methods, the parameter *symbol* refers to a
+# symbol, which is either a quoted string or a Symbol (such as `:name`).
+class Object
+  # Returns a Digest subclass by `name` in a thread-safe manner even when
+  # on-demand loading is involved.
+  #
+  #     require 'digest'
+  #
+  #     Digest("MD5")
+  #     # => Digest::MD5
+  #
+  #     Digest(:SHA256)
+  #     # => Digest::SHA256
+  #
+  #     Digest(:Foo)
+  #     # => LoadError: library not found for class Digest::Foo -- digest/foo
+  #
+  def Digest: (String | Symbol name) -> singleton(::Digest::Base)
+end

--- a/test/stdlib/digest/Digest_test.rb
+++ b/test/stdlib/digest/Digest_test.rb
@@ -58,3 +58,48 @@ class DigestInstanceTest < Test::Unit::TestCase
                      :hexencode, '_hexencode_'
   end
 end
+
+class DigestRootTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library 'digest'
+  testing '::Object'
+
+  def test_digest
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :SHA1
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'SHA1'
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :MD5
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'MD5'
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :RMD160
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'RMD160'
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :SHA256
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'SHA256'
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :SHA384
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'SHA384'
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, :SHA512
+
+    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
+                      ::Digest, :Digest, 'SHA512'
+  end
+end


### PR DESCRIPTION
In regards to this pull request (#744), I forgot to add the root level Digest method.