### PR TITLE
Make repo take precedence over sig/ in gem package

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -78,10 +78,10 @@ module RBS
         end
 
         case
-        when from_gem = self.class.gem_sig_path(lib.name, lib.version)
-          yield lib, from_gem[1]
         when from_repo = repository.lookup(lib.name, lib.version)
           yield lib, from_repo
+        when from_gem = self.class.gem_sig_path(lib.name, lib.version)
+          yield lib, from_gem[1]
         end
       end
 


### PR DESCRIPTION
This PR changes loading priority between gem_repo and sig/ in gem package. Repo will take precedence over sig/.


Currently sig/ in gem package takes precedence over gem_repo. It means if there're RBSs in both of gem_repo and sig/, sig/ is used.
It is not a useful behavior. We can modify gem_repo's content easily, especially if we use `rbs collection`. But we need to fork the gem to modify sig/ directory in the gem package.
So, overriding RBS in sig/ with gem_repo is useful, but the opposite isn't.

I propose this PR to enable the overriding. 


-----


By the way, I'm wondering if EnvironmentLoader can receive the sources of RBS, which are gem_repo, sig/, or stdlibs.
I guess this PR is ok in most cases, but we need to specify the source to EnvLoader to make 100% sure that the loader loads RBS from expected places. I'll consider this problem :thinking: 