### PR TITLE
Fix bundler related test for test-bundled-gems

### DIFF
--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -333,6 +333,7 @@ singleton(::BasicObject)
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
+        dir.join('Gemfile').write('')
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/
@@ -403,6 +404,7 @@ singleton(::BasicObject)
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
+        dir.join('Gemfile').write('')
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -6,6 +6,8 @@ require "test_helper"
 # so the test generate and check the generated lockfile
 
 class RBS::Collection::ConfigTest < Test::Unit::TestCase
+  include TestHelper
+
   CONFIG = <<~YAML
     sources:
       - name: ruby/gem_rbs_collection
@@ -280,6 +282,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
   end
 
   def test_generate_lock_from_rubygems
+    omit unless has_gem?("rbs-amber")
+
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
@@ -288,13 +292,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
         GEM
           remote: https://rubygems.org/
           specs:
-            strong_json (2.1.2)
+            rbs-amber (1.0.0)
 
         PLATFORMS
           x86_64-linux
 
         DEPENDENCIES
-          strong_json
+          rbs-amber
 
         BUNDLED WITH
            2.2.0
@@ -312,8 +316,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
             repo_dir: gems
         path: "/path/to/somewhere"
         gems:
-          - name: strong_json
-            version: "2.1.2"
+          - name: rbs-amber
+            version: "1.0.0"
             source:
               type: rubygems
       YAML

--- a/test/rbs/collection/installer_test.rb
+++ b/test/rbs/collection/installer_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RBS::Collection::InstallerTest < Test::Unit::TestCase
+  include TestHelper
+
   def test_install_from_git
     mktmpdir do |tmpdir|
       lockfile_path = tmpdir.join('rbs_collection.lock.yaml')
@@ -66,6 +68,8 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
   end
 
   def test_install_from_gem_sig_dir
+    omit unless has_gem?("rbs-amber")
+
     mktmpdir do |tmpdir|
       lockfile_path = tmpdir.join('rbs_collection.lock.yaml')
       dest = tmpdir / 'gem_rbs_collection'
@@ -73,8 +77,8 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
         sources: []
         path: "#{dest}"
         gems:
-          - name: strong_json
-            version: "2.1.2"
+          - name: rbs-amber
+            version: "1.0.0"
             source:
               type: rubygems
       YAML
@@ -83,7 +87,7 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
       RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
 
       assert dest.glob('*').empty? # because rubygems installer does nothing
-      assert_match(%r!Using strong_json:2.1.2 \(.+/strong_json-2\.1\.2/sig\)!, stdout.string)
+      assert_match(%r!Using rbs-amber:1.0.0 \(.+/rbs/test/assets/test-gem/sig\)!, stdout.string)
       assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
     end
   end

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -67,11 +67,10 @@ RUBY
           "RBS_TEST_TARGET" => "::Hello",
           "RBS_TEST_OPT" => "-I./foo.rbs"
         }
-        ruby = ENV['RUBY'] || RbConfig.ruby
-        command_line = if defined?(Bundler)
-                         [ruby, "-rbundler/setup", "-rrbs/test/setup", "sample.rb"]
+        command_line = if ENV['RUBY']
+                         [ENV['RUBY'], "-I#{__dir__}/../../../lib", "-EUTF-8", "-rrbs/test/setup", "sample.rb"]
                        else
-                         [ruby, "-I#{__dir__}/../../../lib", "-EUTF-8", "-rrbs/test/setup", "sample.rb"]
+                         [RbConfig.ruby, "-rbundler/setup", "-rrbs/test/setup", "sample.rb"]
                        end
 
         _out, err, status = Open3.capture3(env.merge(other_env), *command_line, chdir: path.to_s)


### PR DESCRIPTION
This PR fixes bundler related tests fro test-bundled-gems.


The RBS's tests fail on ruby/ruby's CI. https://github.com/ruby/ruby/pull/4809/checks?check_run_id=3516979076

The following three tests fail


* runtime test
  * rbs collection does `require 'bundler'` always, so `if defined?(Bundler)` is not appropriate solution to detect availability of `bunder/setup`.
* cli test for collection
  * `Bundler::LockfileParser` needs `Gemfile` in the current directory to detect `Bundler.root`, but the CLI test doesn't put `Gemfile`.
  * The problem is concealed if the test runs on Bundler environment because it sets `BUNDLE_GEMFILE` env var.
* test with strong_json
  * The test failed if strong_json gem is not available.
  * The problem is concealed on the Bundler environment because strong_json is installed with `bundle install` as a dependency of goodcheck gem.
  * I replaced strong_json with `rbs-amber`.

