### PR TITLE
Fix stdlib test for Resolv::Hosts by removing /etc/hosts dependency

### DIFF
--- a/test/stdlib/resolv/Hosts_test.rb
+++ b/test/stdlib/resolv/Hosts_test.rb
@@ -6,37 +6,55 @@ class ResolvHostsInstanceTest < Test::Unit::TestCase
   library 'resolv'
   testing '::Resolv::Hosts'
 
-  def hosts
-    Resolv::Hosts.new
+  def with_hosts
+    Tempfile.create do |f|
+      f.write(<<~HOSTS)
+        127.0.0.1 localhost
+      HOSTS
+      f.close
+      yield Resolv::Hosts.new(f.path)
+    end
   end
 
   def test_each_address
-    assert_send_type "(String) { (String) -> void } -> void",
-      hosts, :each_address, "localhost" do |c| c end
+    with_hosts do |hosts|
+      assert_send_type "(String) { (String) -> void } -> void",
+        hosts, :each_address, "localhost" do |c| c end
+    end
   end
 
   def test_each_name
-    assert_send_type "(String) { (String) -> void } -> void",
-      hosts, :each_name, "127.0.0.1"  do |c| c end
+    with_hosts do |hosts|
+      assert_send_type "(String) { (String) -> void } -> void",
+        hosts, :each_name, "127.0.0.1"  do |c| c end
+    end
   end
 
   def test_getaddress
-    assert_send_type "(String) -> String",
-      hosts, :getaddress, "localhost"
+    with_hosts do |hosts|
+      assert_send_type "(String) -> String",
+        hosts, :getaddress, "localhost"
+    end
   end
 
   def test_getaddresses
-    assert_send_type "(String) -> Array[String]",
-      hosts, :getaddresses, "localhost"
+    with_hosts do |hosts|
+      assert_send_type "(String) -> Array[String]",
+        hosts, :getaddresses, "localhost"
+    end
   end
 
   def test_getname
-    assert_send_type "(String) -> String",
-      hosts, :getname, "127.0.0.1"
+    with_hosts do |hosts|
+      assert_send_type "(String) -> String",
+        hosts, :getname, "127.0.0.1"
+    end
   end
 
   def test_getnames
-    assert_send_type "(String) -> Array[String]",
-      hosts, :getnames, "127.0.0.1"
+    with_hosts do |hosts|
+      assert_send_type "(String) -> Array[String]",
+        hosts, :getnames, "127.0.0.1"
+    end
   end
 end


### PR DESCRIPTION
This PR removes dependency to `/etc/hosts` content from `Resolv::Hosts` stdlib test.

# Problem

`Resolv::Hosts` test depended on `/etc/hosts` content. The test failed on my environment because `/etc/hosts` is empty.


```console
$ cat /etc/hosts
# Static table lookup for hostnames.
# See hosts(5) for details.

$ bundle exec ruby -Ilib bin/test_runner.rb test/stdlib/resolv/Hosts_test.rb
⚠️⚠️⚠️⚠️ stdlib test assumes Ruby 3.0 but RUBY_VERSION==3.1.0 ⚠️⚠️⚠️⚠️
Loaded suite bin/test_runner
Started
..E
===============================================================================
Error: test_getaddress(ResolvHostsInstanceTest): Resolv::ResolvError: /etc/hosts has no name: localhost
/home/pocke/.rbenv/versions/trunk/lib/ruby/3.1.0/resolv.rb:220:in `getaddress'
/home/pocke/ghq/github.com/ruby/rbs/test/stdlib/test_helper.rb:84:in `block (2 levels) in wrapped_object'
/home/pocke/ghq/github.com/ruby/rbs/test/stdlib/test_helper.rb:247:in `assert_send_type'
test/stdlib/resolv/Hosts_test.rb:24:in `test_getaddress'
     21:   end
     22: 
     23:   def test_getaddress
  => 24:     assert_send_type "(String) -> String",
     25:       hosts, :getaddress, "localhost"
     26:   end
     27: 
===============================================================================
.E
===============================================================================
Error: test_getname(ResolvHostsInstanceTest): Resolv::ResolvError: /etc/hosts has no address: 127.0.0.1
/home/pocke/.rbenv/versions/trunk/lib/ruby/3.1.0/resolv.rb:245:in `getname'
/home/pocke/ghq/github.com/ruby/rbs/test/stdlib/test_helper.rb:84:in `block (2 levels) in wrapped_object'
/home/pocke/ghq/github.com/ruby/rbs/test/stdlib/test_helper.rb:247:in `assert_send_type'
test/stdlib/resolv/Hosts_test.rb:34:in `test_getname'
     31:   end
     32: 
     33:   def test_getname
  => 34:     assert_send_type "(String) -> String",
     35:       hosts, :getname, "127.0.0.1"
     36:   end
     37: 
===============================================================================
.
Finished in 0.003496298 seconds.
-------------------------------------------------------------------------------
6 tests, 12 assertions, 0 failures, 2 errors, 0 pendings, 0 omissions, 0 notifications
66.6667% passed
-------------------------------------------------------------------------------
1716.10 tests/s, 3432.20 assertions/s
```


# Solution


`Resolv::Hosts.new` receives a path to the hosts file, the default is `/etc/hosts`. This patch creates a tempfile instead of `/etc/hosts`. 