### PR TITLE
Add `chomp` option to IO.readlines

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -749,7 +749,7 @@ class IO < Object
 
   def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> String
 
-  def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> ::Array[String]
+  def self.readlines: (String name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) -> ::Array[String]
 
   def self.select: [X, Y, Z] (::Array[X & io]? read_array, ?::Array[Y & io]? write_array, ?::Array[Z & io]? error_array) -> [Array[X], Array[Y], Array[Z]]
                  | [X, Y, Z] (::Array[X & io]? read_array, ?::Array[Y & io]? write_array, ?::Array[Z & io]? error_array, Numeric? timeout) -> [Array[X], Array[Y], Array[Z]]?


### PR DESCRIPTION
This PR adds the `chomp` option of the `IO.readlines` method signature.

```console
$ irb
irb(main):001:0> IO.write 'foo.txt', [1, 2, 3].join("\n")
=> 5
irb(main):002:0> IO.readlines 'foo.txt'
=> ["1\n", "2\n", "3"]
irb(main):003:0> IO.readlines 'foo.txt', chomp: true
=> ["1", "2", "3"]
irb(main):004:0> IO.readlines 'foo.txt', chomp: false
=> ["1\n", "2\n", "3"]
irb(main):005:0> IO.readlines 'foo.txt', chomp: nil
=> ["1\n", "2\n", "3"]
```

See also <https://ruby-doc.org/core-3.0.2/IO.html#readlines-method>