### PR TITLE
Set XDG_CACHE_HOME during test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,12 +3,24 @@ require "rbs"
 require "tmpdir"
 require "stringio"
 require "open3"
+
+unless ENV["XDG_CACHE_HOME"]
+  tmpdir = Dir.mktmpdir("rbs-test-")
+  ENV["XDG_CACHE_HOME"] = tmpdir
+
+  at_exit do
+    FileUtils.rmtree(tmpdir)
+    ENV.delete("XDG_CACHE_HOME")
+  end
+end
+
 require "test/unit"
 
 begin
   require "amber"
 rescue LoadError
 end
+
 
 module TestHelper
   def has_gem?(*gems)


### PR DESCRIPTION
To ensure the cache dir is writable and fix following test failures:

* https://github.com/ruby/actions/runs/3527326828?check_suite_focus=true#step:17:278