### PR TITLE
Add stdlib sigs for io/console and io/console/size

### DIFF
--- a/stdlib/io-console/0/io-console.rbs
+++ b/stdlib/io-console/0/io-console.rbs
@@ -11,7 +11,7 @@ class IO
   # result will be returned instead of the console IO itself.
   def self.console: () -> File?
                   | (:close) -> nil
-                  | (Symbol sym, *untyped args) -> top
+                  | (Symbol sym, *untyped args) -> untyped
 
   # returns console window size
   #

--- a/stdlib/io-console/0/io-console.rbs
+++ b/stdlib/io-console/0/io-console.rbs
@@ -1,8 +1,8 @@
 class IO
   class ConsoleMode
-    def echo=: ((true | false)) -> (true | false)
-    def raw: (?min: int, ?time: int, ?intr: (true | false)) -> self
-    def raw!: (?min: int, ?time: int, ?intr: (true | false)) -> self
+    def echo=: (bool) -> bool
+    def raw: (?min: int, ?time: int, ?intr: bool) -> self
+    def raw!: (?min: int, ?time: int, ?intr: bool) -> self
   end
 
   # Returns an File instance opened console.
@@ -56,10 +56,10 @@ class IO
 
   # Enables/disables echo back. On some platforms, all combinations of this flags
   # and raw/cooked mode may not be valid.
-  def echo=: ((true | false) flag) -> (true | false)
+  def echo=: (bool flag) -> bool
 
   # Returns `true` if echo back is enabled.
-  def echo?: () -> (true | false)
+  def echo?: () -> bool
 
   def erase_line: (0 | 1 | 2 | nil) -> self
   def erase_screen: (0 | 1 | 2 | 3 | nil) -> self
@@ -67,7 +67,7 @@ class IO
   # Reads and returns a character in raw mode.
   #
   # See IO#raw for details on the parameters.
-  def getch: (?min: int, ?time: int, ?intr: (true | false)) -> String
+  def getch: (?min: int, ?time: int, ?intr: bool) -> String
 
   # Reads and returns a line without echo back.
   # Prints +prompt+ unless it is +nil+.
@@ -115,14 +115,14 @@ class IO
   # special characters.
   #
   # Refer to the manual page of termios for further details.
-  def raw: [T] (?min: int, ?time: int, ?intr: (true | false)) { (self) -> T } -> T
+  def raw: [T] (?min: int, ?time: int, ?intr: bool) { (self) -> T } -> T
 
   # Enables raw mode, and returns `io`.
   #
   # If the terminal mode needs to be back, use `io.raw { ... }`.
   #
   # See IO#raw for details on the parameters.
-  def raw!: (?min: int, ?time: int, ?intr: (true | false)) -> self
+  def raw!: (?min: int, ?time: int, ?intr: bool) -> self
 
   def scroll_backward: (int) -> self
   def scroll_forward: (int) -> self

--- a/stdlib/io-console/0/io-console.rbs
+++ b/stdlib/io-console/0/io-console.rbs
@@ -1,0 +1,137 @@
+class IO
+  class ConsoleMode
+    def echo=: ((true | false)) -> (true | false)
+    def raw: (?min: int, ?time: int, ?intr: (true | false)) -> self
+    def raw!: (?min: int, ?time: int, ?intr: (true | false)) -> self
+  end
+
+  # Returns an File instance opened console.
+  #
+  # If `sym` is given, it will be sent to the opened console with `args` and the
+  # result will be returned instead of the console IO itself.
+  def self.console: () -> File?
+                  | (:close) -> nil
+                  | (Symbol sym, *untyped args) -> top
+
+  # returns console window size
+  #
+  # You must require 'io/console/size' to use this method.
+  def self.console_size: () -> [Integer, Integer]
+
+  # fallback to console window size
+  #
+  # You must require 'io/console/size' to use this method.
+  def self.default_console_size: -> [Integer, Integer]
+
+  def beep: () -> self
+
+  def check_winsize_changed: () { () -> void } -> self
+  def clear_screen: () -> self
+
+  # Returns a data represents the current console mode.
+  def console_mode: () -> IO::ConsoleMode
+
+  # Sets the console mode to `mode`.
+  def console_mode=: (IO::ConsoleMode mode) -> IO::ConsoleMode
+
+  # Yields `self` within cooked mode.
+  #
+  #     STDIN.cooked(&:gets)
+  #
+  # will read and return a line with echo back and line editing.
+  def cooked: () { (self) -> void } -> void
+
+  # Enables cooked mode.
+  #
+  # If the terminal mode needs to be back, use io.cooked { ... }.
+  def cooked!: () -> self
+
+  def cursor: () -> [Integer, Integer]
+  def cursor=: ([Integer, Integer]) -> [Integer, Integer]
+
+  def cursor_down: (int) -> self
+  def cursor_left: (int) -> self
+  def cursor_right: (int) -> self
+  def cursor_up: (int) -> self
+
+  # Enables/disables echo back. On some platforms, all combinations of this flags
+  # and raw/cooked mode may not be valid.
+  def echo=: ((true | false) flag) -> (true | false)
+
+  # Returns `true` if echo back is enabled.
+  def echo?: () -> (true | false)
+
+  def erase_line: (0 | 1 | 2 | nil) -> self
+  def erase_screen: (0 | 1 | 2 | 3 | nil) -> self
+
+  # Reads and returns a character in raw mode.
+  #
+  # See IO#raw for details on the parameters.
+  def getch: (?min: int, ?time: int, ?intr: (true | false)) -> String
+
+  # Reads and returns a line without echo back.
+  # Prints +prompt+ unless it is +nil+.
+  #
+  # The newline character that terminates the
+  # read line is removed from the returned string,
+  # see String#chomp!.
+  def getpass: (?String) -> String
+
+  def goto: (int, int) -> self
+
+  def goto_column: (int) -> self
+
+  # Flushes input buffer in kernel.
+  def iflush: () -> self
+
+  # Flushes input and output buffers in kernel.
+  def ioflush: () -> self
+
+  # Yields `self` with disabling echo back.
+  #
+  #     STDIN.noecho(&:gets)
+  #
+  # will read and return a line without echo back.
+  def noecho: () { (self) -> void } -> void
+
+  # Flushes output buffer in kernel.
+  def oflush: () -> self
+
+  def pressed?: (Integer | Symbol | String) -> bool
+
+  # Yields `self` within raw mode, and returns the result of the block.
+  #
+  #     STDIN.raw(&:gets)
+  #
+  # will read and return a line without echo back and line editing.
+  #
+  # The parameter `min` specifies the minimum number of bytes that should be
+  # received when a read operation is performed. (default: 1)
+  #
+  # The parameter `time` specifies the timeout in *seconds* with a precision of
+  # 1/10 of a second. (default: 0)
+  #
+  # If the parameter `intr` is `true`, enables break, interrupt, quit, and suspend
+  # special characters.
+  #
+  # Refer to the manual page of termios for further details.
+  def raw: (?min: int, ?time: int, ?intr: (true | false)) { (self) -> void } -> void
+
+  # Enables raw mode, and returns `io`.
+  #
+  # If the terminal mode needs to be back, use `io.raw { ... }`.
+  #
+  # See IO#raw for details on the parameters.
+  def raw!: (?min: int, ?time: int, ?intr: (true | false)) -> self
+
+  def scroll_backward: (int) -> self
+  def scroll_forward: (int) -> self
+
+  # Returns console size.
+  def winsize: () -> [Integer, Integer]
+
+  # Tries to set console size.  The effect depends on the platform and the running
+  # environment.
+  def winsize=: ([Integer, Integer]) -> [Integer, Integer]
+              | ([Integer, Integer, Integer, Integer]) -> [Integer, Integer, Integer, Integer]
+end

--- a/stdlib/io-console/0/io-console.rbs
+++ b/stdlib/io-console/0/io-console.rbs
@@ -39,7 +39,7 @@ class IO
   #     STDIN.cooked(&:gets)
   #
   # will read and return a line with echo back and line editing.
-  def cooked: () { (self) -> void } -> void
+  def cooked: [T] () { (self) -> T } -> T
 
   # Enables cooked mode.
   #
@@ -92,7 +92,7 @@ class IO
   #     STDIN.noecho(&:gets)
   #
   # will read and return a line without echo back.
-  def noecho: () { (self) -> void } -> void
+  def noecho: [T] () { (self) -> T } -> T
 
   # Flushes output buffer in kernel.
   def oflush: () -> self
@@ -115,7 +115,7 @@ class IO
   # special characters.
   #
   # Refer to the manual page of termios for further details.
-  def raw: (?min: int, ?time: int, ?intr: (true | false)) { (self) -> void } -> void
+  def raw: [T] (?min: int, ?time: int, ?intr: (true | false)) { (self) -> T } -> T
 
   # Enables raw mode, and returns `io`.
   #

--- a/test/stdlib/IO_console_test.rb
+++ b/test/stdlib/IO_console_test.rb
@@ -1,0 +1,95 @@
+require_relative "test_helper"
+require "io/console"
+require "io/console/size"
+require 'pty'
+
+class IOConsoleSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library 'io-console'
+  testing "singleton(::IO)"
+
+  def test_io_console
+    assert_send_type "() -> File?",
+                     IO, :console
+    assert_send_type "(:close) -> nil",
+                     IO, :console, :close
+  end
+
+  def test_io_console_size
+    assert_send_type "() -> [Integer, Integer]",
+                     IO, :console_size
+  end
+
+  def test_io_default_console_size
+    assert_send_type "() -> [Integer, Integer]",
+                     IO, :default_console_size
+  end
+end
+
+class IOConsoleTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  library 'io-console'
+  testing "::IO"
+
+  def helper
+    m, s = PTY.open
+  rescue RuntimeError
+    puts "no pty"
+  else
+    yield m, s
+  ensure
+    m.close if m
+    s.close if s
+  end
+
+  def test_io_console_mode
+    helper { |m, s|
+      assert_send_type "() -> IO::ConsoleMode",
+                       s, :console_mode
+    }
+  end
+
+  def test_io_console_mode_set
+    helper { |m, s|
+      assert_send_type "(IO::ConsoleMode mode) -> IO::ConsoleMode",
+                       s, :console_mode=, s.console_mode
+    }
+  end
+
+  def test_io_cooked
+    helper { |m, s|
+      assert_send_type "() { (self) -> void } -> void",
+                       s, :cooked do end
+    }
+  end
+
+  def test_io_echo_p
+    helper { |m, s|
+      assert_send_type "() -> bool",
+                       s, :echo?
+    }
+  end
+
+  def test_io_noecho
+    helper { |m, s|
+      assert_send_type "() { (self) -> void } -> void",
+                       s, :noecho do end
+    }
+  end
+
+  def test_io_raw
+    helper { |m, s|
+      assert_send_type "() { (self) -> void } -> void",
+                       s, :raw do end
+    }
+  end
+
+  def test_io_winsize
+    helper { |m, s|
+      assert_send_type "() -> [Integer, Integer]",
+                       s, :winsize
+    }
+  end
+end

--- a/test/stdlib/IO_console_test.rb
+++ b/test/stdlib/IO_console_test.rb
@@ -33,10 +33,10 @@ class IOConsoleTest < Test::Unit::TestCase
   library 'io-console'
   testing "::IO"
 
-  def helper
+  private def helper
     m, s = PTY.open
   rescue RuntimeError
-    puts "no pty"
+    omit $!
   else
     yield m, s
   ensure


### PR DESCRIPTION
I've written rbs for the `io/console` and `io/console/size` library.

ref: https://github.com/ruby/io-console