### PR TITLE
[collection] Fix copying symlink from gem_rbs_collection

### DIFF
--- a/test/rbs/collection/installer_test.rb
+++ b/test/rbs/collection/installer_test.rb
@@ -31,6 +31,14 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
               remote: https://github.com/ruby/gem_rbs_collection.git
               revision: b4d3b346d9657543099a35a1fd20347e75b8c523
               repo_dir: gems
+          - name: activerecord # To test symlink
+            version: "6.1"
+            source:
+              type: git
+              name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: 51880bed87fbc3dc8076fedb5cf798be05148220
+              repo_dir: gems
       YAML
 
       stdout = StringIO.new
@@ -38,9 +46,17 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
 
       assert dest.join('ast/2.4/ast.rbs').file?
       assert dest.join('rainbow/3.0/rainbow.rbs').file?
+      assert dest.join('activerecord/6.1/activerecord-6.1.rbs').file?
+      assert dest.join('activerecord/6.1/activerecord.rbs').file?
+
+      refute dest.join('ast/2.4/_test').exist?
+      refute dest.join('rainbow/3.0/_src').exist?
+      refute dest.join('activerecord/6.1/_test').exist?
+
       assert_match('Installing ast:2.4 (ast@b4d3b346d96)', stdout.string)
       assert_match('Installing rainbow:3.0 (rainbow@b4d3b346d96)', stdout.string)
-      assert_match("It's done! 2 gems' RBSs now installed.", stdout.string)
+      assert_match('Installing activerecord:6.1 (activerecord@51880bed87f)', stdout.string)
+      assert_match("It's done! 3 gems' RBSs now installed.", stdout.string)
     end
   end
 


### PR DESCRIPTION
`ruby/gem_rbs_collection` introduced symlinks since https://github.com/ruby/gem_rbs_collection/pull/49 but `rbs collection install` doesn't work well on a symlink.

This patch fixes the problem by copying symlink's content correctly.
It also stops copying files starts with `_`, such as `_test/` due to unnecessary.