### PR TITLE
Clarify Goodcheck's justification message for "bool"

### DIFF
--- a/goodcheck.yml
+++ b/goodcheck.yml
@@ -40,7 +40,7 @@ rules:
     glob:
       - "**/*.rbs"
     justification:
-      - When you strictly want `true | false`.
+      - When you strictly want `true | false`. Use `bool` in this case.
     pass:
       - "(arg: boolish)"
       - "{ () -> boolish }"


### PR DESCRIPTION
Clarify the Goodcheck's message to use `bool`.
ref: https://github.com/ruby/rbs/pull/783#discussion_r706765887

By the way, I think we can improve CONTRIBUTING.md also. https://github.com/ruby/rbs/blob/5144bebb1bb31f66ce235d05098d63c1d5e0e9f2/docs/CONTRIBUTING.md For example, we can add a section to Sider to CONTRIBUTING.md.
We need to re-organize CONTRIBUTING.md before adding the section because it focuses on stdlib but CONTRIBUTING.md should focus on all kinds of contributions. I don't have time for re-organization today so I skipped updating CONTRIBUTING.md.