### PR TITLE
Ignore `vendor/bundle/` directories from Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.bundle/
+/vendor/bundle/
 /steep/.bundle/
+/steep/vendor/bundle/
 /.yardoc
 /_yardoc/
 /coverage/


### PR DESCRIPTION
When setting `BUNDLE_PATH: "vendor/bundle"` in the `.bundle/config` file,
I'd like to ignore `vendor/bundle/` directories from Git.