### PR TITLE
Fix `Tempfile.new` method not found

### DIFF
--- a/stdlib/tempfile/0/tempfile.rbs
+++ b/stdlib/tempfile/0/tempfile.rbs
@@ -220,8 +220,6 @@ class Tempfile < File
     def initialize: (::Tempfile tmpfile) -> void
   end
 
-  private
-
   # Creates a temporary file with permissions 0600 (= only readable and writable
   # by the owner) and opens it with mode "w+".
   #


### PR DESCRIPTION
Currently, Steep cannot find the `Tempfile.new` method.
I think the cause is that the method is marked as *private*, so this change just removes `private` from the method.

See the following reproduction.

```ruby
# Gemfile
source "https://rubygems.org"
gem "rbs", github: "ruby/rbs", ref: "029e2b56c8edcc2658882b7b1fa1b0a841312dbd"
gem "steep", "0.46.0"

# Steepfile
target :lib do
  check "*.rb"
  library "tempfile"
end

# a.rb
require "tempfile"
p Tempfile.new
```

Run `bundle exec steep check`:

```
a.rb:2:11: [error] Type `singleton(::Tempfile)` does not have method `new`
│ Diagnostic ID: Ruby::NoMethod
│
└ p Tempfile.new
             ~~~
```