### PR TITLE
Allow tuple `basename` for `Tempfile.{new,create}` methods

### DIFF
--- a/stdlib/tempfile/0/tempfile.rbs
+++ b/stdlib/tempfile/0/tempfile.rbs
@@ -95,8 +95,8 @@ class Tempfile < File
   #        # ... do something with f ...
   #     end
   #
-  def self.create: (?String basename, ?String? tmpdir, ?mode: Integer, **untyped) -> File
-                 | [A] (?String basename, ?String? tmpdir, ?mode: Integer, **untyped) { (File) -> A } -> A
+  def self.create: (?(String | [String, String]) basename, ?String? tmpdir, ?mode: Integer, **untyped) -> File
+                 | [A] (?(String | [String, String]) basename, ?String? tmpdir, ?mode: Integer, **untyped) { (File) -> A } -> A
 
   # Creates a new Tempfile.
   #
@@ -265,6 +265,6 @@ class Tempfile < File
   # If Tempfile.new cannot find a unique filename within a limited number of
   # tries, then it will raise an exception.
   #
-  def self.new: (?String basename, ?String? tmpdir, ?mode: Integer, **untyped) -> instance
-              | [A] (?String basename, ?String? tmpdir, ?mode: Integer, **untyped) { (instance) -> A } -> A
+  def self.new: (?(String | [String, String]) basename, ?String? tmpdir, ?mode: Integer, **untyped) -> instance
+              | [A] (?(String | [String, String]) basename, ?String? tmpdir, ?mode: Integer, **untyped) { (instance) -> A } -> A
 end

--- a/test/stdlib/tempfile/Tempfile_test.rb
+++ b/test/stdlib/tempfile/Tempfile_test.rb
@@ -20,17 +20,21 @@ class TempfileSingletonTest < Test::Unit::TestCase
   def test_new
     assert_send_type "(?::String basename, ?::String? tmpdir, ?mode: ::Integer, **untyped) -> ::Tempfile",
                      Tempfile, :new, 'README.md', '/tmp', mode: 0
+
+    assert_send_type "([::String, ::String]) -> ::Tempfile",
+                     Tempfile, :new, ['foo', '.txt']
   end
 
   def test_create
     assert_send_type "(::String basename, ::String? tmpdir, mode: ::Integer) -> ::File",
                      Tempfile, :create, 'README.md', '/tmp', mode: 0
 
+    assert_send_type "([::String, ::String]) -> ::File",
+                     Tempfile, :create, ['foo', '.txt']
+
     assert_send_type "() { (::File) -> Integer } -> Integer",
-                     Tempfile, :create do |file|
-                      123
-                     end
-end
+                     Tempfile, :create do |file| 123 end
+  end
 
   def test_initialize
     assert_send_type "(?::String basename, ?::String? tmpdir, ?mode: ::Integer, **untyped) -> void",


### PR DESCRIPTION
This change allows the `basename` parameter receives a 2-strings tuple for the `Tempfile.new` and `Tempfile.create` methods.

The `Tempfile.new` doc says:

> The `basename` parameter is used to determine the name of the temporary file.
> You can either pass a String or an Array with 2 String elements. In the former
> form, the temporary file's base name will begin with the given string. In the
> latter form, the temporary file's base name will begin with the array's first
> element, and end with the second element. For example: