### PR TITLE
Fix unexpected CollectionNotAvailable without gems from `git` source

### DIFF
--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -11,6 +11,7 @@ module RBS
 
       def install_from_lockfile
         install_to = lockfile.repo_path
+        install_to.mkpath
         lockfile.gems.each do |config_entry|
           source_for(config_entry).install(dest: install_to, config_entry: config_entry, stdout: stdout)
         end

--- a/test/rbs/collection/installer_test.rb
+++ b/test/rbs/collection/installer_test.rb
@@ -77,6 +77,7 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
       stdout = StringIO.new
       RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
 
+      assert dest.directory?
       assert dest.glob('*').empty? # because stdlib installer does nothing
       assert_match(%r!Using csv:0 \(.+/stdlib/csv/0\)!, stdout.string)
       assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
@@ -102,6 +103,7 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
       stdout = StringIO.new
       RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
 
+      assert dest.directory?
       assert dest.glob('*').empty? # because rubygems installer does nothing
       assert_match(%r!Using rbs-amber:1.0.0 \(.+/rbs/test/assets/test-gem/sig\)!, stdout.string)
       assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)


### PR DESCRIPTION
This PR fixes the unexpected CollectionNotAvailable error when the lockfile only has non-`git` source gems.

Currently the collection installer makes `.gem_rbs_collection` directory if `git` source gems exist. And `Config#check_rbs_availability!` method checks the directory existence. Then the error is raised.

This patch makes sure that the directory is created by `rbs collection install` even if `git` source gem does not exist.