### PR TITLE
define_singleton_method accepts a Proc

### DIFF
--- a/core/object.rbs
+++ b/core/object.rbs
@@ -98,7 +98,7 @@ class Object < BasicObject
   #     guy.define_singleton_method(:hello) { "#{self}: Hello there!" }
   #     guy.hello    #=>  "Bob: Hello there!"
   #
-  def define_singleton_method: (Symbol, Method | UnboundMethod) -> Symbol
+  def define_singleton_method: (Symbol, Method | UnboundMethod | ^(*untyped) -> untyped) -> Symbol
                              | (Symbol) { (*untyped) -> untyped } -> Symbol
 
   # Prints *obj* on the given port (default `$>`). Equivalent to:


### PR DESCRIPTION
According to doc of `Object#define_singleton_method`,  it accepts a Proc as a second argument. but its rbs, `core/object.rbs` does not represent. 

- [Object#define_singleton_method (Ruby 3.0.0 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/latest/method/Object/i/define_singleton_method.html)

This pull-request provides a patch to fix it.