### PR TITLE
Use partial clone for rbs collection installer

### DIFF
--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -102,7 +102,12 @@ module RBS
               git 'fetch', 'origin'
             end
           else
-            git 'clone', remote, git_dir.to_s
+            begin
+              # git v2.27.0 or greater
+              git 'clone', '--filter=blob:none', remote, git_dir.to_s
+            rescue CommandError
+              git 'clone', remote, git_dir.to_s
+            end
           end
 
           begin


### PR DESCRIPTION
This PR avoids full cloning gem_rbs_collection repository by `rbs collection install` by using partial clone instead.

It will improve performance if gem_rbs_collection grows.


Note that partial clone was introduced in Git v2.27.0, and the release date is 2020-01-01.
https://github.com/git/git/blob/ddb1055343948e0d0bc81f8d20245f1ada6430a0/Documentation/RelNotes/2.27.0.txt#L175-L176
However, Ruby 2.6, the oldest supported Ruby by RBS, was released 2018-12-25.
I think we should support Git < v2.27.0 for now.