### PR TITLE
Fix return type of Set.[] and Set#flatten

### DIFF
--- a/stdlib/set/0/set.rbs
+++ b/stdlib/set/0/set.rbs
@@ -61,7 +61,7 @@ class Set[A]
   #     Set[1, 2, 1]                # => #<Set: {1, 2}>
   #     Set[1, 'c', :s]             # => #<Set: {1, "c", :s}>
   #
-  def self.[]: [X] (*X) -> Set[X]
+  def self.[]: [X] (*X) -> instance
 
   # Returns a new set containing elements common to the set and the given
   # enumerable object.
@@ -225,7 +225,7 @@ class Set[A]
   # Returns a new set that is a copy of the set, flattening each containing set
   # recursively.
   #
-  def flatten: () -> Set[untyped]
+  def flatten: () -> self
 
   # Returns true if the set and the given set have at least one element in common.
   #


### PR DESCRIPTION
The following types are currently a mismatch.

t.rbs
```rb
class FooSet < Set[Integer]
  def self.gen: (*Integer) -> FooSet
end
```

t.rb
```rb
class FooSet < Set
  def self.gen(*arg)
    FooSet[*arg]
  end
end
```

steep check
```
t.rb:2:11:[error] Cannot allow method body have type `::Set[::Integer]` because declared as type `::FooSet`
│   ::Set[::Integer] <: ::FooSet
│     ::Object <: ::FooSet
│       ::BasicObject <: ::FooSet
│
│ Diagnostic ID: Ruby::MethodBodyTypeMismatch
│
└   def self.gen(*arg)
```

This PR fix this issue.

`Set.[]` and `Set#flatten` return instance of inherited class.
I adapted return type to this behavior.

```rb
class FooSet < Set
end

FooSet[1, 2, 3]
#=> #<FooSet: {1, 2, 3}>

FooSet[1, 2, FooSet[3]].flatten
#=> #<FooSet: {1, 2, 3}>
```