### PR TITLE
Polish argument type of `#clone`

### DIFF
--- a/core/binding.rbs
+++ b/core/binding.rbs
@@ -31,6 +31,8 @@
 class Binding
   public
 
+  def clone: () -> self
+
   # Evaluates the Ruby expression(s) in *string*, in the *binding*'s context.  If
   # the optional *filename* and *lineno* parameters are present, they will be used
   # when reporting syntax errors.

--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -165,8 +165,6 @@ class Complex < Numeric
 
   def ceil: (*untyped) -> bot
 
-  def clone: (?freeze: bool) -> self
-
   def coerce: (Numeric) -> [ Complex, Complex ]
 
   # Returns the complex conjugate.

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -171,8 +171,6 @@ class Float < Numeric
   def ceil: () -> Integer
           | (int digits) -> (Integer | Float)
 
-  def clone: (?freeze: bool) -> self
-
   # Returns an array with both `numeric` and `float` represented as Float objects.
   #
   # This is achieved by converting `numeric` to a Float.

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -272,8 +272,6 @@ class Integer < Numeric
   #
   def chr: (?encoding) -> String
 
-  def clone: (?freeze: bool) -> self
-
   # Returns an array with both a `numeric` and a `big` represented as Bignum
   # objects.
   #

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -416,4 +416,11 @@ class Numeric
   # Returns `true` if `num` has a zero value.
   #
   def zero?: () -> bool
+
+  # Returns +self+.
+  #
+  # Raises an exception if the value for +freeze+ is neither +true+ nor +nil+.
+  #
+  # Related: Numeric#dup.
+  def clone: (?freeze: true?) -> self
 end

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -76,7 +76,7 @@ class Object < BasicObject
   # This method may have class-specific behavior.  If so, that behavior will be
   # documented under the #`initialize_copy` method of the class.
   #
-  def clone: (?freeze: bool) -> self
+  def clone: (?freeze: bool?) -> self
 
   # Defines a singleton method in the receiver. The *method* parameter can be a
   # `Proc`, a `Method` or an `UnboundMethod` object. If a block is specified, it

--- a/core/proc.rbs
+++ b/core/proc.rbs
@@ -210,6 +210,8 @@
 #     {test: 1}.to_proc.call(:test)       #=> 1
 #     %i[test many keys].map(&{test: 1})  #=> [1, nil, nil]
 class Proc < Object
+  def clone: () -> self
+
   # Returns the number of mandatory arguments. If the block is declared to
   # take no arguments, returns 0. If the block is known to take exactly n
   # arguments, returns n. If the block has optional arguments, returns -n-1,

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -175,8 +175,6 @@ class Rational < Numeric
   def ceil: () -> Integer
           | (Integer digits) -> (Integer | Rational)
 
-  def clone: (?freeze: bool) -> self
-
   def coerce: (Numeric) -> [Numeric, Numeric]
 
   def conj: () -> Rational

--- a/core/unbound_method.rbs
+++ b/core/unbound_method.rbs
@@ -45,6 +45,19 @@
 #     um.bind(t).call   #=> :original
 #
 class UnboundMethod
+  # Returns a clone of this method.
+  #
+  #   class A
+  #     def foo
+  #       return "bar"
+  #     end
+  #   end
+  #
+  #   m = A.new.method(:foo)
+  #   m.call # => "bar"
+  #   n = m.clone.call # => "bar"
+  def clone: () -> self
+
   # Returns an indication of the number of arguments accepted by a method. Returns
   # a nonnegative integer for methods that take a fixed number of arguments. For
   # Ruby methods that take a variable number of arguments, returns -n-1, where n


### PR DESCRIPTION
- Should define `Numeric#clone` and shuold remove method on inherited class
- `Numeric#clone` allow only `true` or `nil` by freeze option
- `Object#clone` should allow `nil` on freeze option
- `Proc`,`Method`,`UnboundMethod` and `Binding` `#clone` should not have freeze option