### PR TITLE
Special consts should't allow clone(freeze: false)

### DIFF
--- a/core/false_class.rbs
+++ b/core/false_class.rbs
@@ -37,4 +37,6 @@ class FalseClass
   def |: (nil) -> false
        | (false) -> false
        | (untyped obj) -> true
+
+  def clone: (?freeze: true?) -> self
 end

--- a/core/nil_class.rbs
+++ b/core/nil_class.rbs
@@ -79,4 +79,6 @@ class NilClass
   def |: (nil) -> false
        | (false) -> false
        | (untyped obj) -> bool
+
+  def clone: (?freeze: true?) -> self
 end

--- a/core/symbol.rbs
+++ b/core/symbol.rbs
@@ -226,4 +226,6 @@ class Symbol
             | (:ascii | :lithuanian | :turkic) -> Symbol
             | (:lithuanian, :turkic) -> Symbol
             | (:turkic, :lithuanian) -> Symbol
+
+  def clone: (?freeze: true?) -> self
 end

--- a/core/true_class.rbs
+++ b/core/true_class.rbs
@@ -43,4 +43,6 @@ class TrueClass
   #     or
   #
   def |: (untyped obj) -> true
+
+  def clone: (?freeze: true?) -> self
 end


### PR DESCRIPTION
In some special classes, we cannot effectively pass `false` for freeze option, even though it calls `Object#clone`.

https://github.com/ruby/ruby/blob/185c5738211e16f289aa7448823f678348597bb5/test/ruby/test_object.rb#L81-L84
https://github.com/ruby/ruby/blob/185c5738211e16f289aa7448823f678348597bb5/object.c#L354

ref: https://github.com/ruby/rbs/pull/811