### PR TITLE
Check the argument type with the generator type

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -699,7 +699,7 @@ class Array[unchecked out Elem] < Object
   #     ary.count {|x| x%2 == 0}   #=> 3
   #
   def count: () -> ::Integer
-           | (untyped obj) -> ::Integer
+           | (Elem) -> ::Integer
            | () { (Elem) -> boolish } -> ::Integer
 
   # Calls the given block for each element `n` times or forever if `nil` is given.

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -63,7 +63,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   # ary.count{ |x| x%2==0 } #=> 3
   # ```
   def count: () -> Integer
-           | (?untyped) -> Integer
+           | (Elem) -> Integer
            | () { (Elem) -> boolish } -> Integer
 
   def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass


### PR DESCRIPTION
The following typo argument errors cannot be detected if `untyped`.

```rb
# typo
[1,2,3].count(:odd?)

# expect
[1,2,3].count(&:odd?)
```

I defined the argument type as generator type to solve this problem.