### PR TITLE
Remove a call to undefined function "pp" from C extension

### DIFF
--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -87,7 +87,6 @@ bool parser_typevar_member(parserstate *state, ID id) {
 }
 
 void print_parser(parserstate *state) {
-  pp(state->buffer);
   printf("  current_token = %s (%d...%d)\n", token_type_str(state->current_token.type), state->current_token.range.start.char_pos, state->current_token.range.end.char_pos);
   printf("     next_token = %s (%d...%d)\n", token_type_str(state->next_token.type), state->next_token.range.start.char_pos, state->next_token.range.end.char_pos);
   printf("    next_token2 = %s (%d...%d)\n", token_type_str(state->next_token2.type), state->next_token2.range.start.char_pos, state->next_token2.range.end.char_pos);

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -41,6 +41,4 @@ VALUE rbs_type_name(VALUE namespace, VALUE name);
 VALUE rbs_union(VALUE types, VALUE location);
 VALUE rbs_variable(VALUE name, VALUE location);
 
-void pp(VALUE object);
-
 #endif


### PR DESCRIPTION
It is just for debugging, and it does not build on MinGW
```
linking shared-object rbs_extension.so
C:/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: parserstate.o:parserstate.c:(.text+0x2e2): undefined reference to `pp'
collect2.exe: error: ld returned 1 exit status
```