### PR TITLE
Prevent two GCC warnings

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1487,6 +1487,8 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
   case INSTANCE_SINGLETON_KIND:
     k = ID2SYM(rb_intern("singleton_instance"));
     break;
+  default:
+    rbs_abort();
   }
 
   VALUE location = rbs_new_location(state->buffer, member_range);

--- a/ext/rbs_extension/rbs_extension.h
+++ b/ext/rbs_extension/rbs_extension.h
@@ -37,4 +37,4 @@ VALUE rbs_unquote_string(parserstate *state, range rg, int offset_bytes);
  * foo.rbs:11:21...11:25: Syntax error: {message}, token=`{tok source}` ({tok type})
  * ```
  * */
-NORETURN(void) raise_syntax_error(parserstate *state, token tok, const char *fmt, ...);
+PRINTF_ARGS(NORETURN(void) raise_syntax_error(parserstate *state, token tok, const char *fmt, ...), 3, 4);


### PR DESCRIPTION
The following warning can be prevented by using `PRINTF_ARGS` macro that
is provided by ruby header files.

```
../../../../ext/rbs_extension/parser.c:90:3: warning: function ‘raise_syntax_error’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
```

The following one is preveted by adding `rbs_abort()` to an impossible
case.

```
../../../../ext/rbs_extension/parser.c:1499:10: warning: ‘k’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```