### PR TITLE
Generic type alias

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -414,7 +414,6 @@ These work only as _statements_, not per-method specifier.
 _decl_ ::= _class-decl_                         # Class declaration
          | _module-decl_                        # Module declaration
          | _interface-decl_                     # Interface declaration
-         | _extension-decl_                     # Extension declaration
          | _type-alias-decl_                    # Type alias declaration
          | _const-decl_                         # Constant declaration
          | _global-decl_                        # Global declaration
@@ -433,8 +432,6 @@ _interface-decl_ ::= `interface` _interface-name_ _module-type-parameters_ _inte
 _interface-members_ ::= _method-member_              # Method
                       | _include-member_             # Mixin (include)
                       | _alias-member_               # Alias
-
-_extension-decl_ ::= `extension` _class-name_ _type-parameters_ `(` _extension-name_ `)` _members_ `end`
 
 _type-alias-decl_ ::= `type` _alias-name_ _module-type-parameters_ `=` _type_
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -5,14 +5,14 @@
 ```markdown
 _type_ ::= _class-name_ _type-arguments_                (Class instance type)
          | _interface-name_ _type-arguments_            (Interface type)
+         | _alias-name_ _type-arguments_                (Alias type)
          | `singleton(` _class-name_ `)`                (Class singleton type)
-         | _alias-name_                                 (Alias type)
          | _literal_                                    (Literal type)
          | _type_ `|` _type_                            (Union type)
          | _type_ `&` _type_                            (Intersection type)
          | _type_ `?`                                   (Optional type)
-         | `{` _record-name_ `:` _type_ `,` etc. `}`     (Record type)
-         | `[]` | `[` _type_ `,` etc. `]`                (Tuples)
+         | `{` _record-name_ `:` _type_ `,` etc. `}`    (Record type)
+         | `[]` | `[` _type_ `,` etc. `]`               (Tuples)
          | _type-variable_                              (Type variables)
          | `^(` _parameters_ `) ->` _type_              (Proc type)
          | `self`
@@ -35,8 +35,8 @@ _namespace_ ::=                                         (Empty namespace)
               | `::`                                    (Root)
               | _namespace_ /[A-Z]\w*/ `::`             (Namespace)
 
-_type-arguments_ ::=                                    (No application)
-                   | `[` _type_ `,` etc. `]`             (Type application)
+_type-arguments_ ::=                                    (No type arguments)
+                   | `[` _type_ `,` etc. `]`            (Type arguments)
 
 _literal_ ::= _string-literal_
             | _symbol-literal_
@@ -64,6 +64,18 @@ _ToS                          # _ToS interface
 ::MyApp::_Each[String]        # Interface name with namespace and type application
 ```
 
+### Alias type
+
+Alias type denotes an alias declared with _alias declaration_.
+
+The name of type aliases starts with lowercase `[a-z]`.
+
+```
+name
+::JSON::t                    # Alias name with namespace
+list[Integer]                # Type alias can be generic
+```
+
 ### Class singleton type
 
 Class singleton type denotes _the type of a singleton object of a class_.
@@ -71,18 +83,6 @@ Class singleton type denotes _the type of a singleton object of a class_.
 ```
 singleton(String)
 singleton(::Hash)            # Class singleton type cannot be parametrized.
-```
-
-### Alias type
-
-Alias type denotes an alias declared with _alias declaration_.
-
-The name of type aliases starts with lowercase `[a-z]`.
-
-
-```
-name
-::JSON::t                    # Alias name with namespace
 ```
 
 ### Literal type
@@ -155,7 +155,7 @@ Elem
 ```
 
 Type variables cannot be distinguished from _class instance types_.
-They are scoped in _class/module/interface declaration_ or _generic method types_.
+They are scoped in _class/module/interface/alias declaration_ or _generic method types_.
 
 ```
 class Ref[T]              # Object is scoped in the class declaration.
@@ -436,7 +436,7 @@ _interface-members_ ::= _method-member_              # Method
 
 _extension-decl_ ::= `extension` _class-name_ _type-parameters_ `(` _extension-name_ `)` _members_ `end`
 
-_type-alias-decl_ ::= `type` _alias-name_ `=` _type_
+_type-alias-decl_ ::= `type` _alias-name_ _module-type-parameters_ `=` _type_
 
 _const-decl_ ::= _const-name_ `:` _type_
 
@@ -534,6 +534,12 @@ You can declare an alias of types.
 ```
 type subject = Attendee | Speaker
 type JSON::t = Integer | TrueClass | FalseClass | String | Hash[Symbol, t] | Array[t]
+```
+
+Type alias can be generic like class, module, and interface.
+
+```
+type list[out T] = [T, list[T]] | nil
 ```
 
 ### Constant type declaration

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -815,6 +815,8 @@ static VALUE parse_simple(parserstate *state) {
   }
   case tULIDENT:
     // fallthrough
+  case tLIDENT:
+    // fallthrough
   case pCOLON2: {
     range name_range;
     range args_range;
@@ -857,18 +859,10 @@ static VALUE parse_simple(parserstate *state) {
     } else if (kind == INTERFACE_NAME) {
       return rbs_interface(typename, types, location);
     } else if (kind == ALIAS_NAME) {
-      return rbs_alias(typename, location);
+      return rbs_alias(typename, types, location);
     } else {
       return Qnil;
     }
-  }
-  case tLIDENT: {
-    VALUE location = rbs_location_current_token(state);
-    rbs_loc *loc = rbs_check_location(location);
-    rbs_loc_add_required_child(loc, rb_intern("name"), state->current_token.range);
-    rbs_loc_add_optional_child(loc, rb_intern("args"), NULL_RANGE);
-    VALUE typename = parse_type_name(state, ALIAS_NAME, NULL);
-    return rbs_alias(typename, location);
   }
   case kSINGLETON: {
     range name_range;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1094,97 +1094,6 @@ VALUE parse_const_decl(parserstate *state) {
 }
 
 /*
-  type_decl ::= {kTYPE} alias_name `=` <type>
-*/
-VALUE parse_type_decl(parserstate *state, position comment_pos, VALUE annotations) {
-  range decl_range;
-  range keyword_range, name_range, eq_range;
-
-  decl_range.start = state->current_token.range.start;
-  comment_pos = nonnull_pos_or(comment_pos, decl_range.start);
-
-  keyword_range = state->current_token.range;
-
-  parser_advance(state);
-  VALUE typename = parse_type_name(state, ALIAS_NAME, &name_range);
-
-  parser_advance_assert(state, pEQ);
-  eq_range = state->current_token.range;
-
-  VALUE type = parse_type(state);
-  decl_range.end = state->current_token.range.end;
-
-  VALUE location = rbs_new_location(state->buffer, decl_range);
-  rbs_loc *loc = rbs_check_location(location);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
-
-  return rbs_ast_decl_alias(
-    typename,
-    type,
-    annotations,
-    location,
-    get_comment(state, comment_pos.line)
-  );
-}
-
-/*
-  annotation ::= {<tANNOTATION>}
-*/
-VALUE parse_annotation(parserstate *state) {
-  VALUE content = rb_funcall(state->buffer, rb_intern("content"), 0);
-  rb_encoding *enc = rb_enc_get(content);
-
-  range rg = state->current_token.range;
-
-  int offset_bytes = rb_enc_codelen('%', enc) + rb_enc_codelen('a', enc);
-
-  unsigned int open_char = rb_enc_mbc_to_codepoint(
-    RSTRING_PTR(state->lexstate->string) + rg.start.byte_pos + offset_bytes,
-    RSTRING_END(state->lexstate->string),
-    enc
-  );
-
-  unsigned int close_char;
-
-  switch (open_char) {
-  case '{':
-    close_char = '}';
-    break;
-  case '(':
-    close_char = ')';
-    break;
-  case '[':
-    close_char = ']';
-    break;
-  case '<':
-    close_char = '>';
-    break;
-  case '|':
-    close_char = '|';
-    break;
-  default:
-    rbs_abort();
-  }
-
-  int open_bytes = rb_enc_codelen(open_char, enc);
-  int close_bytes = rb_enc_codelen(close_char, enc);
-
-  char *buffer = RSTRING_PTR(state->lexstate->string) + rg.start.byte_pos + offset_bytes + open_bytes;
-  VALUE string = rb_enc_str_new(
-    buffer,
-    rg.end.byte_pos - rg.start.byte_pos - offset_bytes - open_bytes - close_bytes,
-    enc
-  );
-  rb_funcall(string, rb_intern("strip!"), 0);
-
-  VALUE location = rbs_location_current_token(state);
-
-  return rbs_ast_annotation(string, location);
-}
-
-/*
   module_type_params ::= {} `[` module_type_param `,` ... <`]`>
                        | {<>}
 
@@ -1266,6 +1175,105 @@ VALUE parse_module_type_params(parserstate *state, range *rg) {
   }
 
   return params;
+}
+
+/*
+  type_decl ::= {kTYPE} alias_name `=` <type>
+*/
+VALUE parse_type_decl(parserstate *state, position comment_pos, VALUE annotations) {
+  range decl_range;
+  range keyword_range, name_range, params_range, eq_range;
+
+  parser_push_typevar_table(state, true);
+
+  decl_range.start = state->current_token.range.start;
+  comment_pos = nonnull_pos_or(comment_pos, decl_range.start);
+
+  keyword_range = state->current_token.range;
+
+  parser_advance(state);
+  VALUE typename = parse_type_name(state, ALIAS_NAME, &name_range);
+
+  VALUE type_params = parse_module_type_params(state, &params_range);
+
+  parser_advance_assert(state, pEQ);
+  eq_range = state->current_token.range;
+
+  VALUE type = parse_type(state);
+  decl_range.end = state->current_token.range.end;
+
+  VALUE location = rbs_new_location(state->buffer, decl_range);
+  rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
+  rbs_loc_add_optional_child(loc, rb_intern("type_params"), params_range);
+  rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
+
+  parser_pop_typevar_table(state);
+
+  return rbs_ast_decl_alias(
+    typename,
+    type_params,
+    type,
+    annotations,
+    location,
+    get_comment(state, comment_pos.line)
+  );
+}
+
+/*
+  annotation ::= {<tANNOTATION>}
+*/
+VALUE parse_annotation(parserstate *state) {
+  VALUE content = rb_funcall(state->buffer, rb_intern("content"), 0);
+  rb_encoding *enc = rb_enc_get(content);
+
+  range rg = state->current_token.range;
+
+  int offset_bytes = rb_enc_codelen('%', enc) + rb_enc_codelen('a', enc);
+
+  unsigned int open_char = rb_enc_mbc_to_codepoint(
+    RSTRING_PTR(state->lexstate->string) + rg.start.byte_pos + offset_bytes,
+    RSTRING_END(state->lexstate->string),
+    enc
+  );
+
+  unsigned int close_char;
+
+  switch (open_char) {
+  case '{':
+    close_char = '}';
+    break;
+  case '(':
+    close_char = ')';
+    break;
+  case '[':
+    close_char = ']';
+    break;
+  case '<':
+    close_char = '>';
+    break;
+  case '|':
+    close_char = '|';
+    break;
+  default:
+    rbs_abort();
+  }
+
+  int open_bytes = rb_enc_codelen(open_char, enc);
+  int close_bytes = rb_enc_codelen(close_char, enc);
+
+  char *buffer = RSTRING_PTR(state->lexstate->string) + rg.start.byte_pos + offset_bytes + open_bytes;
+  VALUE string = rb_enc_str_new(
+    buffer,
+    rg.end.byte_pos - rg.start.byte_pos - offset_bytes - open_bytes - close_bytes,
+    enc
+  );
+  rb_funcall(string, rb_intern("strip!"), 0);
+
+  VALUE location = rbs_location_current_token(state);
+
+  return rbs_ast_annotation(string, location);
 }
 
 /*

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -339,10 +339,10 @@ VALUE rbs_ast_decl_global(VALUE name, VALUE type, VALUE location, VALUE comment)
   );
 }
 
-VALUE rbs_ast_decl_alias(VALUE name, VALUE type, VALUE annotations, VALUE location, VALUE comment) {
+VALUE rbs_ast_decl_alias(VALUE name, VALUE type_params, VALUE type, VALUE annotations, VALUE location, VALUE comment) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("name")), name);
-  rb_hash_aset(args, ID2SYM(rb_intern("type_params")), rbs_ast_decl_module_type_params());
+  rb_hash_aset(args, ID2SYM(rb_intern("type_params")), type_params);
   rb_hash_aset(args, ID2SYM(rb_intern("type")), type);
   rb_hash_aset(args, ID2SYM(rb_intern("annotations")), annotations);
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -70,15 +70,16 @@ VALUE rbs_class_singleton(VALUE typename, VALUE location) {
   );
 }
 
-VALUE rbs_alias(VALUE typename, VALUE location) {
-  VALUE args = rb_hash_new();
-  rb_hash_aset(args, ID2SYM(rb_intern("name")), typename);
-  rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
+VALUE rbs_alias(VALUE typename, VALUE args, VALUE location) {
+  VALUE kwargs = rb_hash_new();
+  rb_hash_aset(kwargs, ID2SYM(rb_intern("name")), typename);
+  rb_hash_aset(kwargs, ID2SYM(rb_intern("args")), args);
+  rb_hash_aset(kwargs, ID2SYM(rb_intern("location")), location);
 
   return CLASS_NEW_INSTANCE(
     RBS_Types_Alias,
     1,
-    &args
+    &kwargs
   );
 }
 

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -342,6 +342,7 @@ VALUE rbs_ast_decl_global(VALUE name, VALUE type, VALUE location, VALUE comment)
 VALUE rbs_ast_decl_alias(VALUE name, VALUE type, VALUE annotations, VALUE location, VALUE comment) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("name")), name);
+  rb_hash_aset(args, ID2SYM(rb_intern("type_params")), rbs_ast_decl_module_type_params());
   rb_hash_aset(args, ID2SYM(rb_intern("type")), type);
   rb_hash_aset(args, ID2SYM(rb_intern("annotations")), annotations);
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -3,7 +3,7 @@
 
 #include "ruby.h"
 
-VALUE rbs_alias(VALUE typename, VALUE location);
+VALUE rbs_alias(VALUE typename, VALUE args, VALUE location);
 VALUE rbs_ast_annotation(VALUE string, VALUE location);
 VALUE rbs_ast_comment(VALUE string, VALUE location);
 VALUE rbs_ast_decl_alias(VALUE name, VALUE type_params, VALUE type, VALUE annotations, VALUE location, VALUE comment);

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -6,7 +6,7 @@
 VALUE rbs_alias(VALUE typename, VALUE location);
 VALUE rbs_ast_annotation(VALUE string, VALUE location);
 VALUE rbs_ast_comment(VALUE string, VALUE location);
-VALUE rbs_ast_decl_alias(VALUE name, VALUE type, VALUE annotations, VALUE location, VALUE comment);
+VALUE rbs_ast_decl_alias(VALUE name, VALUE type_params, VALUE type, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_decl_class_super(VALUE name, VALUE args, VALUE location);
 VALUE rbs_ast_decl_class(VALUE name, VALUE type_params, VALUE super_class, VALUE members, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_decl_constant(VALUE name, VALUE type, VALUE location, VALUE comment);

--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -45,6 +45,7 @@ require "rbs/repository"
 require "rbs/ancestor_graph"
 require "rbs/locator"
 require "rbs/type_alias_dependency"
+require "rbs/type_alias_regularity"
 require "rbs/collection"
 
 require "rbs_extension"

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -362,13 +362,15 @@ module RBS
 
       class Alias < Base
         attr_reader :name
+        attr_reader :type_params
         attr_reader :type
         attr_reader :annotations
         attr_reader :location
         attr_reader :comment
 
-        def initialize(name:, type:, annotations:, location:, comment:)
+        def initialize(name:, type_params:, type:, annotations:, location:, comment:)
           @name = name
+          @type_params = type_params
           @type = type
           @annotations = annotations
           @location = location
@@ -378,19 +380,21 @@ module RBS
         def ==(other)
           other.is_a?(Alias) &&
             other.name == name &&
+            other.type_params == type_params &&
             other.type == type
         end
 
         alias eql? ==
 
         def hash
-          self.class.hash ^ name.hash ^ type.hash
+          self.class.hash ^ name.hash ^ type_params.hash ^ type.hash
         end
 
         def to_json(state = _ = nil)
           {
             declaration: :alias,
             name: name,
+            type_params: type_params,
             type: type,
             annotations: annotations,
             location: location,

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -460,7 +460,7 @@ EOU
 
       env.alias_decls.each do |name, decl|
         stdout.puts "Validating alias: `#{name}`..."
-        builder.expand_alias(name).tap do |type|
+        builder.expand_alias1(name).tap do |type|
           validator.validate_type type, context: [Namespace.root]
         end
         validator.validate_type_alias(entry: decl)

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -782,6 +782,10 @@ module RBS
 
     def expand_alias(type_name)
       entry = env.alias_decls[type_name] or raise "Unknown name for expand_alias: #{type_name}"
+      unless entry.decl.type_params.empty?
+        raise "Use #expand_alias2 for generic type aliases: type_name=#{type_name}"
+      end
+
       ensure_namespace!(type_name.namespace, location: entry.decl.location)
       entry.decl.type
     end

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -319,6 +319,7 @@ module RBS
       when AST::Declarations::Alias
         AST::Declarations::Alias.new(
           name: decl.name.with_prefix(prefix),
+          type_params: decl.type_params,
           type: absolute_type(resolver, decl.type, context: context),
           location: decl.location,
           annotations: decl.annotations,

--- a/lib/rbs/environment_walker.rb
+++ b/lib/rbs/environment_walker.rb
@@ -57,7 +57,7 @@ module RBS
             end
           end
         when name.alias?
-          each_type_node builder.expand_alias(name), &block
+          each_type_node builder.expand_alias1(name), &block
         else
           raise "Unexpected TypeNameNode with type_name=#{name}"
         end
@@ -126,6 +126,9 @@ module RBS
         end
       when RBS::Types::Alias
         yield TypeNameNode.new(type_name: type.name)
+        type.args.each do |ty|
+          each_type_node(ty, &block)
+        end
       when RBS::Types::Union, RBS::Types::Intersection, RBS::Types::Tuple
         type.types.each do |ty|
           each_type_node ty, &block

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -431,4 +431,16 @@ module RBS
       @alias_names.map(&:name).join(', ')
     end
   end
+
+  class NonregularTypeAliasError < LoadingError
+    attr_reader :diagnostic
+    attr_reader :location
+
+    def initialize(diagnostic:, location:)
+      @diagnostic = diagnostic
+      @location = location
+
+      super "#{Location.to_string location}: Nonregular generic type alias is prohibited: #{diagnostic.type_name}, #{diagnostic.nonregular_type}"
+    end
+  end
 end

--- a/lib/rbs/type_alias_regularity.rb
+++ b/lib/rbs/type_alias_regularity.rb
@@ -1,0 +1,115 @@
+module RBS
+  class TypeAliasRegularity
+    class Diagnostic
+      attr_reader :type_name, :nonregular_type
+
+      def initialize(type_name:, nonregular_type:)
+        @type_name = type_name
+        @nonregular_type = nonregular_type
+      end
+    end
+
+    attr_reader :env, :builder, :diagnostics
+
+    def initialize(env:)
+      @env = env
+      @builder = DefinitionBuilder.new(env: env)
+      @diagnostics = {}
+    end
+
+    def validate
+      diagnostics.clear
+
+      each_mutual_alias_defs do |names|
+        # Find the first generic type alias in strongly connected component.
+        # This is to skip the regularity check when the alias is not generic.
+        names.each do |name|
+          # @type break: nil
+          if type = build_alias_type(name)
+            # Running validation only once from the first generic type is enough, because they are mutual recursive definition.
+            validate_alias_type(type, names, {})
+            break
+          end
+        end
+      end
+    end
+
+    def validate_alias_type(alias_type, names, types)
+      if names.include?(alias_type.name)
+        if ex_type = types[alias_type.name]
+          unless compatible_args?(ex_type.args, alias_type.args)
+            diagnostics[alias_type.name] ||=
+              Diagnostic.new(type_name: alias_type.name, nonregular_type: alias_type)
+          end
+
+          return
+        else
+          types[alias_type.name] = alias_type
+        end
+
+        expanded = builder.expand_alias2(alias_type.name, alias_type.args)
+        each_alias_type(expanded) do |at|
+          validate_alias_type(at, names, types)
+        end
+      end
+    end
+
+    def build_alias_type(name)
+      entry = env.alias_decls[name] or raise "Unknown alias name: #{name}"
+      unless entry.decl.type_params.empty?
+        as = entry.decl.type_params.each.map {|param| Types::Variable.new(name: param.name, location: nil) }
+        Types::Alias.new(name: name, args: as, location: nil)
+      end
+    end
+
+    def compatible_args?(args1, args2)
+      if args1.size == args2.size
+        args1.zip(args2).all? do |t1, t2|
+          t1.is_a?(Types::Bases::Any) ||
+            t2.is_a?(Types::Bases::Any) ||
+            t1 == t2
+        end
+      end
+    end
+
+    def nonregular?(type_name)
+      diagnostics[type_name]
+    end
+
+    def each_mutual_alias_defs(&block)
+      # @type var each_node: TSort::_EachNode[TypeName]
+      each_node = __skip__ = -> (&block) do
+        env.alias_decls.each_value do |decl|
+          block[decl.name]
+        end
+      end
+      # @type var each_child: TSort::_EachChild[TypeName]
+      each_child = __skip__ = -> (name, &block) do
+        type = builder.expand_alias1(name)
+        each_alias_type(type) do |ty|
+          block[ty.name]
+        end
+      end
+
+      TSort.each_strongly_connected_component(each_node, each_child) do |names|
+        yield Set.new(names)
+      end
+    end
+
+    def each_alias_type(type, &block)
+      if type.is_a?(RBS::Types::Alias)
+        yield type
+      end
+
+      type.each_type do |ty|
+        each_alias_type(ty, &block)
+      end
+    end
+
+    def self.validate(env:)
+      self.new(env: env).tap do |validator|
+        validator.validate()
+      end
+    end
+  end
+end

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -295,39 +295,27 @@ module RBS
 
     class Alias
       attr_reader :location
-      attr_reader :name
 
-      def initialize(name:, location:)
+      include Application
+
+      def initialize(name:, args:, location:)
         @name = name
+        @args = args
         @location = location
       end
 
-      def ==(other)
-        other.is_a?(Alias) && other.name == name
-      end
-
-      alias eql? ==
-
-      def hash
-        self.class.hash ^ name.hash
-      end
-
-      include NoFreeVariables
-      include NoSubst
-
       def to_json(state = _ = nil)
-        { class: :alias, name: name, location: location }.to_json(state)
+        { class: :alias, name: name, args: args, location: location }.to_json(state)
       end
 
-      def to_s(level = 0)
-        name.to_s
+      def sub(s)
+        Alias.new(name: name, args: args.map {|ty| ty.sub(s) }, location: location)
       end
 
-      include EmptyEachType
-
-      def map_type_name
+      def map_type_name(&block)
         Alias.new(
           name: yield(name, location, self),
+          args: args.map {|arg| arg.map_type_name(&block) },
           location: location
         )
       end

--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -54,6 +54,21 @@ module RBS
           false
         end
       end
+
+      def incompatible?(params)
+        # @type set: Hash[Symbol]
+        set = Set[]
+
+        params.each do |param|
+          unless compatible?(param.name, with_annotation: param.variance)
+            set << param.name
+          end
+        end
+
+        unless set.empty?
+          set
+        end
+      end
     end
 
     attr_reader :builder
@@ -69,18 +84,11 @@ module RBS
     def in_method_type(method_type:, variables:)
       result = Result.new(variables: variables)
 
-      method_type.type.each_param do |param|
-        type(param.type, result: result, context: :contravariant)
-      end
+      function(method_type.type, result: result, context: :covariant)
 
       if block = method_type.block
-        block.type.each_param do |param|
-          type(param.type, result: result, context: :covariant)
-        end
-        type(block.type.return_type, result: result, context: :contravariant)
+        function(block.type, result: result, context: :contravariant)
       end
-
-      type(method_type.type.return_type, result: result, context: :covariant)
 
       result
     end
@@ -97,6 +105,14 @@ module RBS
       end
     end
 
+    def in_type_alias(name:)
+      decl = env.alias_decls[name].decl or raise
+      variables = decl.type_params.each.map(&:name)
+      Result.new(variables: variables).tap do |result|
+        type(decl.type, result: result, context: :covariant)
+      end
+    end
+
     def type(type, result:, context:)
       case type
       when Types::Variable
@@ -110,7 +126,7 @@ module RBS
             result.invariant(type.name)
           end
         end
-      when Types::ClassInstance, Types::Interface
+      when Types::ClassInstance, Types::Interface, Types::Alias
         NoTypeFoundError.check!(type.name,
                                 env: env,
                                 location: type.location)
@@ -120,6 +136,8 @@ module RBS
                         env.class_decls[type.name].type_params
                       when Types::Interface
                         env.interface_decls[type.name].decl.type_params
+                      when Types::Alias
+                        env.alias_decls[type.name].decl.type_params
                       end
 
         type.args.each.with_index do |ty, i|
@@ -130,25 +148,35 @@ module RBS
           when :covariant
             type(ty, result: result, context: context)
           when :contravariant
-            # @type var con: variance
-            con = case context
-                  when :invariant
-                    :invariant
-                  when :covariant
-                    :contravariant
-                  when :contravariant
-                    :covariant
-                  else
-                    raise
-                  end
-            type(ty, result: result, context: con)
+            type(ty, result: result, context: negate(context))
           end
         end
-      when Types::Tuple, Types::Record, Types::Union, Types::Intersection
-        # Covariant types
+      when Types::Proc
+        function(type.type, result: result, context: context)
+      else
         type.each_type do |ty|
           type(ty, result: result, context: context)
         end
+      end
+    end
+
+    def function(type, result:, context:)
+      type.each_param do |param|
+        type(param.type, result: result, context: negate(context))
+      end
+      type(type.return_type, result: result, context: context)
+    end
+
+    def negate(variance)
+      case variance
+      when :invariant
+        :invariant
+      when :covariant
+        :contravariant
+      when :contravariant
+        :covariant
+      else
+        raise
       end
     end
   end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -119,7 +119,7 @@ module RBS
       when AST::Declarations::Alias
         write_comment decl.comment
         write_annotation decl.annotations
-        puts "type #{decl.name} = #{decl.type}"
+        puts "type #{name_and_params(decl.name, decl.type_params)} = #{decl.type}"
 
       when AST::Declarations::Interface
         write_comment decl.comment

--- a/schema/decls.json
+++ b/schema/decls.json
@@ -12,6 +12,18 @@
         "name": {
           "type": "string"
         },
+        "type_params": {
+          "type": "object",
+          "properties": {
+            "params": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/moduleTypeParam"
+              }
+            }
+          },
+          "required": ["params"]
+        },
         "type": {
           "$ref": "types.json"
         },
@@ -28,7 +40,7 @@
           "$ref": "comment.json"
         }
       },
-      "required": ["declaration", "name", "type", "annotations", "location", "comment"]
+      "required": ["declaration", "name", "type_params", "type", "annotations", "location", "comment"]
     },
     "constant": {
       "title": "Constant declaration: `VERSION: String`, ...",

--- a/schema/types.json
+++ b/schema/types.json
@@ -106,7 +106,7 @@
       "required": ["class", "name", "args", "location"]
     },
     "alias": {
-      "title": "Type alias: `u`, `ty`, `json`, ...",
+      "title": "Type alias: `u`, `ty`, `json`, `list[Integer]`, ...",
       "type": "object",
       "properties": {
         "class": {
@@ -116,11 +116,17 @@
         "name": {
           "type": "string"
         },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#"
+          }
+        },
         "location": {
           "$ref": "location.json"
         }
       },
-      "required": ["class", "name", "location"]
+      "required": ["class", "name", "args", "location"]
     },
     "tuple": {
       "title": "Tuple type: `[Foo, bar]`, ...",

--- a/sig/declarations.rbs
+++ b/sig/declarations.rbs
@@ -217,19 +217,22 @@ module RBS
       end
 
       class Alias < Base
-        # type loc = Location
-        # ^^^^                keyword
-        #      ^^^            name
-        #          ^          eq
-        type loc = Location[:keyword | :name | :eq, bot]
+        # type loc[T] = Location[T, bot]
+        # ^^^^                            keyword
+        #      ^^^                        name
+        #         ^^^                     type_params
+        #             ^                      eq
+        #
+        type loc = Location[:keyword | :name | :eq, :type_params]
 
         attr_reader name: TypeName
+        attr_reader type_params: ModuleTypeParams
         attr_reader type: Types::t
         attr_reader annotations: Array[Annotation]
         attr_reader location: loc?
         attr_reader comment: Comment?
 
-        def initialize: (name: TypeName, type: Types::t, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
+        def initialize: (name: TypeName, type_params: ModuleTypeParams, type: Types::t, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
         include _HashEqual
         include _ToJson

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -43,9 +43,36 @@ module RBS
 
     def define_methods: (Definition, interface_methods: Hash[Symbol, Definition::Method], methods: MethodBuilder::Methods, super_interface_method: bool) -> void
 
+    # Expand a type alias of given name without type arguments.
+    # Raises an error if the type alias requires arguments.
+    #
+    # Assume `type foo[T] = [T, T]`:
+    #
+    # ```
+    # expand_alias("::foo")   # => error
+    # ```
+    #
     def expand_alias: (TypeName) -> Types::t
 
-    def expand_alias2: (TypeName, args: Array[Types::t]) -> Types::t
+    # Expand a type alias of given name with arguments of `untyped`.
+    #
+    # Assume `type foo[T] = [T, T]`:
+    #
+    # ```
+    # expand_alias1("::foo")   # => [untyped, untyped]
+    # ```
+    #
+    def expand_alias1: (TypeName) -> Types::t
+
+    # Expand a type alias of given name with `args`.
+    #
+    # Assume `type foo[T] = [T, T]`:
+    #
+    # ```
+    # expand_alias2("::foo", ["::Integer"])   # => [::Integer, ::Integer]
+    # ```
+    #
+    def expand_alias2: (TypeName, Array[Types::t] args) -> Types::t
 
     def update: (env: Environment, ancestor_builder: AncestorBuilder, except: _Each[TypeName]) -> DefinitionBuilder
   end

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -45,6 +45,8 @@ module RBS
 
     def expand_alias: (TypeName) -> Types::t
 
+    def expand_alias2: (TypeName, args: Array[Types::t]) -> Types::t
+
     def update: (env: Environment, ancestor_builder: AncestorBuilder, except: _Each[TypeName]) -> DefinitionBuilder
   end
 end

--- a/sig/environment_walker.rbs
+++ b/sig/environment_walker.rbs
@@ -1,4 +1,28 @@
 module RBS
+  # EnvironmentWalker provides topological sort of class/module definitions.
+  #
+  # If a method, attribute, or ancestor in a class definition have a reference to another class, it is dependency.
+  #
+  # ```rb
+  # walker = EnvironmentWalker.new(env: env)
+  #
+  # walker.each_strongly_connected_component do |scc|
+  #   # Yields an array of strongly connected components.
+  # end
+  # ```
+  #
+  # The `#only_ancestors!` method limits the dependency only to ancestors.
+  # Only super classes and included modules are dependencies with the option.
+  # This is useful to calculate the dependencies of class hierarchy.
+  #
+  # ```rb
+  # walker = EnvironmentWalker.new(env: env).only_ancestors!
+  #
+  # walker.each_strongly_connected_component do |scc|
+  #   # Yields an array of strongly connected components.
+  # end
+  # ```
+  #
   class EnvironmentWalker
     class InstanceNode
       attr_reader type_name: TypeName
@@ -31,6 +55,8 @@ module RBS
     def tsort_each_node: () { (node) -> void } -> void
 
     def tsort_each_child: (node) { (node) -> void } -> void
+
+    private
 
     def each_type_name: (Types::t) { (TypeName) -> void } -> void
 

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -220,4 +220,14 @@ module RBS
 
     def name: () -> String
   end
+
+  class NonregularTypeAliasError < LoadingError
+    # Diagnostic reported from `TypeAliasRegularity`.
+    attr_reader diagnostic: TypeAliasRegularity::Diagnostic
+
+    # Location of the definition.
+    attr_reader location: Location[untyped, untyped]?
+
+    def initialize: (diagnostic: TypeAliasRegularity::Diagnostic, location: Location[untyped, untyped]?) -> void
+  end
 end

--- a/sig/type_alias_regularity.rbs
+++ b/sig/type_alias_regularity.rbs
@@ -1,0 +1,92 @@
+module RBS
+  # `TypeAliasRegularity` validates if a type alias is regular or not.
+  #
+  # Generic and recursive type alias cannot be polymorphic in their definitions.
+  #
+  # ```rbs
+  # type foo[T] = Integer
+  #             | foo[T]?     # Allowed. The type argument of `foo` doesn't change.
+  #
+  # type bar[T] = Integer
+  #             | foo[T]
+  #             | foo[Array[T]]  # Allowed. There are two type arguments `T` and `Array[T]` of `foo`, but it's not definition of `foo`.
+  #
+  # type baz[T] = Integer
+  #             | baz[Array[T]]  # Error. Recursive definition of `baz` has different type argument from the definition.
+  # ```
+  #
+  # The `#nonregular?` method can be used to test if given type name is regular or not.
+  #
+  # ```rb
+  # validator = RBS::TypeAliasRegularity.validate(env: env)
+  #
+  # validator.nonregular?(TypeName("::foo"))    # => nil
+  # validator.nonregular?(TypeName("::bar"))    # => nil
+  # validator.nonregular?(TypeName("::baz"))    # => TypeAliasRegularity::Diagnostic
+  # ```
+  #
+  # A special case is when the type argument is `untyped`.
+  #
+  # ```rbs
+  # type foo[T] = Integer | foo[untyped]    # This is allowed.
+  # ```
+  #
+  class TypeAliasRegularity
+    attr_reader env: Environment
+
+    attr_reader builder: DefinitionBuilder
+
+    attr_reader diagnostics: Hash[TypeName, Diagnostic]
+
+    # `Diagnostic` represents an non-regular type alias declaration error.
+    # It consists of the name of the alias type and a type on which the nonregularity is detected.
+    #
+    # ```rbs
+    # type t[T] = Integer | t[T?]
+    # ```
+    #
+    # The type `t` is nonregular because it contains `t[T?]` on it's right hand side.
+    #
+    # ```
+    # diagnostic = validator.nonregular?(TypeName("::t"))
+    # diagnostic.type_name         # => TypeName("::t")
+    # diagnostic.nonregular_type   # => t[T?]
+    # ```
+    #
+    class Diagnostic
+      attr_reader type_name: TypeName
+
+      attr_reader nonregular_type: Types::Alias
+
+      def initialize: (type_name: TypeName, nonregular_type: Types::Alias) -> void
+    end
+
+    # Returns new instance which already run `#validate`.
+    #
+    def self.validate: (env: Environment) -> TypeAliasRegularity
+
+    def initialize: (env: Environment) -> void
+
+    # Returns `Diagnostic` instance if the alias type is nonregular.
+    # Regurns `nil` if the alias type is regular.
+    #
+    def nonregular?: (TypeName) -> Diagnostic?
+
+    def validate: () -> void
+
+    private
+
+    def validate_alias_type: (Types::Alias, Set[TypeName], Hash[TypeName, Types::Alias]) -> void
+
+    # Returns alias type for given type name, if the alias is generic.
+    # Returns nil if the type alias is not generic.
+    #
+    def build_alias_type: (TypeName) -> Types::Alias?
+
+    def compatible_args?: (Array[Types::t], Array[Types::t]) -> boolish
+
+    def each_alias_type: (Types::t) { (Types::Alias) -> void } -> void
+
+    def each_mutual_alias_defs: () { (Set[TypeName]) -> void } -> void
+  end
+end

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -227,18 +227,21 @@ module RBS
     end
 
     class Alias
-      attr_reader name: TypeName
-
-      type loc = Location[bot, bot]
-
-      def initialize: (name: TypeName, location: loc?) -> void
-
-      include _TypeBase
-      include NoFreeVariables
-      include NoSubst
-      include EmptyEachType
+      # foo
+      # ^^^ => name
+      #
+      # foo[bar, baz]
+      # ^^^           => name
+      #    ^^^^^^^^^^ => args
+      #
+      type loc = Location[:name, :args]
 
       attr_reader location: loc?
+
+      def initialize: (name: TypeName, args: Array[t], location: loc?) -> void
+
+      include _TypeBase
+      include Application
     end
 
     class Tuple

--- a/sig/validator.rbs
+++ b/sig/validator.rbs
@@ -4,6 +4,8 @@ module RBS
 
     attr_reader resolver: TypeNameResolver
 
+    attr_reader definition_builder: DefinitionBuilder
+
     attr_reader type_alias_dependency: TypeAliasDependency
 
     attr_reader type_alias_regularity: TypeAliasRegularity

--- a/sig/validator.rbs
+++ b/sig/validator.rbs
@@ -1,7 +1,12 @@
 module RBS
   class Validator
     attr_reader env: Environment
+
     attr_reader resolver: TypeNameResolver
+
+    attr_reader type_alias_dependency: TypeAliasDependency
+
+    attr_reader type_alias_regularity: TypeAliasRegularity
 
     def initialize: (env: Environment, resolver: TypeNameResolver) -> void
 

--- a/sig/variance_calculator.rbs
+++ b/sig/variance_calculator.rbs
@@ -1,7 +1,47 @@
 module RBS
+  # Calculate the use variances of type variables in declaration.
+  #
+  # ```rb
+  # calculator = VarianceCalculator.new(builder: builder)
+  #
+  # # Calculates variances in a method type
+  # result = calculator.in_method_type(method_type: method_type, variables: variables)
+  #
+  # # Calculates variances in a inheritance/mixin/...
+  # result = calculator.in_inherit(name: name, args: args, variables: variables)
+  #
+  # # Calculates variances in a type alias
+  # result = calculator.in_type_alias(name: name, args: args, variables: variables)
+  # ```
+  #
+  # See `RBS::VarianceCaluculator::Result` for information recorded in the `Result` object.
+  #
   class VarianceCalculator
     type variance = :unused | :covariant | :contravariant | :invariant
 
+    # Result contains the set of type variables and it's variance in a occurrence.
+    #
+    # ```rb
+    # # Enumerates recorded type variables
+    # result.each do |name, variance|
+    #   # name is the name of a type variable
+    #   # variance is one of :unused | :covariant | :contravariant | :invariant
+    # end
+    # ```
+    #
+    # You can test with `compatible?` method if the type variable occurrences are compatible with specified (annotated) variance.
+    #
+    # ```rb
+    # # When T is declared as `out T`
+    # result.compatible?(:T, with_annotation: :covariant)
+    #
+    # # When T is declared as `in T`
+    # result.compatible?(:T, with_annotation: :contravariant)
+    #
+    # # When T is declared as `T`
+    # result.compatible?(:T, with_annotation: :invariant)
+    # ```
+    #
     class Result
       attr_reader result: Hash[Symbol, variance]
 
@@ -18,6 +58,8 @@ module RBS
       def include?: (Symbol) -> bool
 
       def compatible?: (Symbol, with_annotation: variance) -> bool
+
+      def incompatible?: (AST::Declarations::ModuleTypeParams) -> Set[Symbol]?
     end
 
     attr_reader builder: DefinitionBuilder
@@ -30,6 +72,14 @@ module RBS
 
     def in_inherit: (name: TypeName, args: Array[Types::t], variables: Array[Symbol]) -> Result
 
+    def in_type_alias: (name: TypeName) -> Result
+
+    private
+
     def type: (Types::t, result: Result, context: variance) -> void
+
+    def function: (Types::Function, result: Result, context: variance) -> void
+
+    def negate: (variance) -> variance
   end
 end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1969,4 +1969,35 @@ end
       end
     end
   end
+
+  def test_expand_alias2
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+type opt[T] = T | nil
+type pair[S, T] = [S, T]
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        assert_equal(
+          parse_type("::Integer | nil"),
+          builder.expand_alias2(type_name("::opt"), [parse_type("::Integer")])
+        )
+
+        assert_equal(
+          parse_type("[::String, bool]"),
+          builder.expand_alias2(type_name("::pair"), [parse_type("::String"), parse_type("bool")])
+        )
+
+        assert_raises do
+          builder.expand_alias2(type_name("::opt"), [])
+        end
+
+        assert_raises do
+          builder.expand_alias2(type_name("::opt"), [parse_type("bool"), parse_type("top")])
+        end
+end
+    end
+  end
 end

--- a/test/rbs/schema_test.rb
+++ b/test/rbs/schema_test.rb
@@ -124,6 +124,7 @@ class RBS::SchemaTest < Test::Unit::TestCase
 
   def test_decls
     assert_decl RBS::Parser.parse_signature("type Steep::foo = untyped")[0], :alias
+    assert_decl RBS::Parser.parse_signature("type Steep::foo[A] = A")[0], :alias
 
     assert_decl RBS::Parser.parse_signature('Steep::VERSION: "1.2.3"')[0], :constant
 

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -21,6 +21,7 @@ class RBS::SignatureParsingTest < Test::Unit::TestCase
 
       assert_instance_of Declarations::Alias, type_decl
       assert_equal TypeName.new(name: :foo, namespace: Namespace.parse("Steep")), type_decl.name
+      assert_equal [], type_decl.type_params.each.map(&:name)
       assert_equal Types::Bases::Any.new(location: nil), type_decl.type
       assert_equal "type Steep::foo = untyped", type_decl.location.source
     end
@@ -29,6 +30,36 @@ class RBS::SignatureParsingTest < Test::Unit::TestCase
       Parser.parse_signature(<<~RBS)
         type Foo = untyped
       RBS
+    end
+  end
+
+  def test_type_alias_generic
+    Parser.parse_signature(<<RBS).yield_self do |decls|
+type optional[A] = A?
+RBS
+      assert_equal 1, decls.size
+
+      type_decl = decls[0]
+
+      assert_instance_of Declarations::Alias, type_decl
+      assert_equal TypeName("optional"), type_decl.name
+      assert_equal [:A], type_decl.type_params.each.map(&:name)
+      assert_equal parse_type("A?", variables: [:A]), type_decl.type
+      assert_equal "[A]", type_decl.location[:type_params].source
+    end
+
+    Parser.parse_signature(<<RBS).yield_self do |decls|
+class Foo[A]
+  type bar = B
+end
+RBS
+      decls[0].members[0].tap do |type_decl|
+        assert_instance_of Declarations::Alias, type_decl
+        assert_equal TypeName("bar"), type_decl.name
+        assert_equal [], type_decl.type_params.each.map(&:name)
+        assert_instance_of Types::ClassInstance, type_decl.type
+        assert_nil type_decl.location[:type_params]
+      end
     end
   end
 

--- a/test/rbs/type_alias_regulartiry_test.rb
+++ b/test/rbs/type_alias_regulartiry_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class TypeAliasRegularityTest < Test::Unit::TestCase
+  include RBS
+  include TestHelper
+
+  def test_validate
+    SignatureManager.new do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+type foo = Integer
+
+type bar[T] = [bar[T], T, bar[T]]
+            | nil
+
+type baz[T] = baz[bar[T]]
+            | nil
+      EOF
+
+      manager.build do |env|
+        validator = TypeAliasRegularity.validate(env: env)
+
+        refute_operator validator, :nonregular?, TypeName("::foo")
+        refute_operator validator, :nonregular?, TypeName("::bar")
+
+        assert_operator validator, :nonregular?, TypeName("::baz")
+        assert_equal(
+          parse_type("::baz[::bar[T]]", variables: [:T]),
+          validator.nonregular?(TypeName("::baz")).nonregular_type
+        )
+      end
+    end
+  end
+
+  def test_validate_mutual
+    SignatureManager.new do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+type foo[T] = bar[T]
+
+type bar[T] = baz[String | T]
+
+type baz[T] = foo[Array[T]]
+      EOF
+
+      manager.build do |env|
+        validator = TypeAliasRegularity.validate(env: env)
+
+        assert_operator validator, :nonregular?, TypeName("::foo")
+        assert_equal(
+          parse_type("::foo[Array[::String | T]]", variables: [:T]),
+          validator.nonregular?(TypeName("::foo")).nonregular_type
+        )
+      end
+    end
+  end
+end

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -123,8 +123,12 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal "::Foo::foo", type.location.source
     end
 
-    assert_raises RBS::ParsingError do
-      Parser.parse_type("foo[untyped]")
+    Parser.parse_type("foo[untyped]").yield_self do |type|
+      assert_instance_of Types::Alias, type
+      assert_equal TypeName.new(namespace: Namespace.empty, name: :foo), type.name
+      assert_equal "foo[untyped]", type.location.source
+      assert_equal "foo", type.location[:name].source
+      assert_equal "[untyped]", type.location[:args].source
     end
   end
 

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -133,6 +133,12 @@ end
     SIG
   end
 
+  def test_generic_alias
+    assert_writer <<-SIG
+type foo[Bar] = Baz
+    SIG
+  end
+
   def test_overload
     assert_writer <<-SIG
 class Foo

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -122,6 +122,8 @@ type record = { foo: record }
 type foo[T] = [T, foo[T]]
 
 type bar[T] = [bar[T?]]
+
+type baz[out T] = ^(T) -> void
       EOF
 
       manager.build do |env|
@@ -132,6 +134,10 @@ type bar[T] = [bar[T?]]
 
         assert_raises RBS::NonregularTypeAliasError do
           validator.validate_type_alias(entry: env.alias_decls[type_name("::bar")])
+        end
+
+        assert_raises RBS::InvalidVarianceAnnotationError do
+          validator.validate_type_alias(entry: env.alias_decls[type_name("::baz")])
         end
       end
     end


### PR DESCRIPTION
This PR adds the key feature for RBS 1.8, _generic type alias_!

You can now define generic type aliases like:

```rbs
type list[T] = [T, list[T]] | nil  # Defines linked list of `T`

type int_list = list[Integer]      # List of Integer
type object_list = list[Object]    # List of Object
```

We also provide new `DefinitionBuilder#expand_alias` variants to _unfold_ a type alias: `#expand_alias1` and `#expand_alias2`. 

```rb
builder.expand_alias2(list, [integer])   # Unfold type alias one step with application => [integer, list[integer]] | nil
builder.expand_alias1(list)              # Unfold type alias one step with `untyped` type arguments => [untyped, list[untyped]] | nil
builder.expand_alias(list)               # Raises a runtime error because `::list` type requires one type argument
```

So, the type checkers will continue working if no generic type alias is used in the application. Or, you can just replace your `#expand_alias` calls with `#expand_alias1` for the minimal support.

Generic type alias also supports variance annotations.

```rbs
# The type parameter `T` is covariant: list[Integer] <: list[Object]
type list[out T] = [T, list[T]] | nil
```

One limitation of defining generic type alias is the regularity. It prohibits polymorphic recursion. You cannot use a type alias polymorphic in its declaration.

```rbs
type foo[T] = foo[Array[T]] | nil      # This is prohibited.
```

* [x] Update `syntax.md`