### PR TITLE
Thread#value can't determine the type.

### DIFF
--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -554,7 +554,7 @@ class Thread < Object
   # b = Thread.new { raise 'something went wrong' }
   # b.value   #=> RuntimeError: something went wrong
   # ```
-  def value: () -> Object
+  def value: () -> untyped
 
   # Marks a given thread as eligible for scheduling, however it may still
   # remain blocked on I/O.


### PR DESCRIPTION
For example, in the case of code that accesses multiple URLs in concurrent and parses the responses as JSON, suppose I wrote the following.

```rb
ts = urls.map { |url| Thread.new { client.get(url).body.read } }
ts.map(&:value).map do |content|
  JSON.parse(content)
end
```

However, the following type error will occur. (steep)

```
[error] Cannot pass a value of type `::Object` as an argument of type `::string`
│   ::Object <: ::string
│     ::Object <: (::String | ::_ToStr)
│       ::Object <: ::String
│         ::BasicObject <: ::String
│
│ Diagnostic ID: Ruby::ArgumentTypeMismatch
│
└         JSON.parse(content)
```

It seems to be difficult to determine the type of `Thread#value`, so I set it as `untyped`.