### PR TITLE
Remove ruby/signature.rb

### DIFF
--- a/lib/ruby/signature.rb
+++ b/lib/ruby/signature.rb
@@ -1,7 +1,0 @@
-STDERR.puts "🚨🚨 ruby-signature is renamed to rbs. require 'rbs' instead of 'ruby/signature'. 🚨🚨"
-
-require "rbs"
-
-module Ruby
-  Signature = RBS
-end


### PR DESCRIPTION
This patch removes `lib/ruby/signature.rb`.


This file has been deprecated since over a year ago, so I guess anyone doesn't use it.

