### PR TITLE
Unquote parameter name

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -273,7 +273,7 @@ static VALUE parse_function_param(parserstate *state) {
     param_range.start = type_range.start;
     param_range.end = name_range.end;
 
-    VALUE name = ID2SYM(INTERN_TOKEN(state, state->current_token));
+    VALUE name = rb_to_symbol(rbs_unquote_string(state, state->current_token.range, 0));
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_add_optional_child(loc, rb_intern("name"), name_range);

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -690,7 +690,7 @@ module RBS
 
         def to_s
           if name
-            if Parser::KEYWORDS.include?(name)
+            if Parser::KEYWORDS.include?(name.to_s)
               "#{type} `#{name}`"
             else
               "#{type} #{name}"

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -312,7 +312,7 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal "^(untyped, void) -> void", type.location.source
     end
 
-    Parser.parse_type("^(untyped x, void _y) -> void").yield_self do |type|
+    Parser.parse_type("^(untyped x, void _y, bool `type`) -> void").yield_self do |type|
       assert_instance_of Types::Proc, type
 
       fun = type.type
@@ -320,6 +320,7 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal [
                      Types::Function::Param.new(type: Types::Bases::Any.new(location: nil), name: :x),
                      Types::Function::Param.new(type: Types::Bases::Void.new(location: nil), name: :_y),
+                     Types::Function::Param.new(type: Types::Bases::Bool.new(location: nil), name: :type),
                    ], fun.required_positionals
       assert_equal [], fun.optional_positionals
       assert_nil fun.rest_positionals
@@ -328,7 +329,7 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal({}, fun.optional_keywords)
       assert_nil fun.rest_keywords
 
-      assert_equal "^(untyped x, void _y) -> void", type.location.source
+      assert_equal "^(untyped x, void _y, bool `type`) -> void", type.location.source
     end
 
     Parser.parse_type("^(untyped x, ?void, ?nil y) -> void").yield_self do |type|


### PR DESCRIPTION
This PR fixes quoted parameter names.


# Problem


The C parser parses quoted parameter names incorrectly.

```ruby
require 'rbs'

pp RBS::Parser.parse_method_type('(untyped `class`) -> void')
```

With RBS v1.6.2:

```
#<RBS::MethodType:0x00007feec0127210
 @block=nil,
 @location=
  #<RBS::Location:820 @buffer=, @pos=0...25, source='(untyped `class`) -> void', start_line=1, start_column=0>,
 @type=
  #<RBS::Types::Function:0x00007feec0127580
   @optional_keywords={},
   @optional_positionals=[],
   @required_keywords={},
   @required_positionals=
    [#<RBS::Types::Function::Param:0x00007feec0127f58
      @location=
       #<RBS::Location::WithChildren:840 @buffer=, @pos=1...16, source='untyped `class`', start_line=1, start_column=1>,
      @name=:class, # ← it is ok 🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆🙆
      @type=
       #<RBS::Types::Bases::Any:0x00007feec0128610
        @location=
         #<RBS::Location:860 @buffer=, @pos=1...8, source='untyped', start_line=1, start_column=1>>>],
   @rest_keywords=nil,
   @rest_positionals=nil,
   @return_type=
    #<RBS::Types::Bases::Void:0x00007feec0127850
     @location=
      #<RBS::Location:880 @buffer=, @pos=21...25, source='void', start_line=1, start_column=21>>,
   @trailing_positionals=[]>,
 @type_params=[]>
```

With RBS v1.7.0:

```
#<RBS::MethodType:0x00007f8710568b98
 @block=nil,
 @location=
  #<RBS::Location:820 buffer=a.rbs, start=1:0, pos=0...25, children= source='(untyped `class`) -> void'>,
 @type=
  #<RBS::Types::Function:0x00007f8710568d78
   @optional_keywords={},
   @optional_positionals=[],
   @required_keywords={},
   @required_positionals=
    [#<RBS::Types::Function::Param:0x00007f8710568f30
      @location=
       #<RBS::Location:840 buffer=a.rbs, start=1:1, pos=1...16, children=?name source='untyped `class`'>,
      @name=:"`class`", # ← it is quoted unexpectedly 🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔🤔
      @type=
       #<RBS::Types::Bases::Any:0x00007f8710569098
        @location=
         #<RBS::Location:860 buffer=a.rbs, start=1:1, pos=1...8, children= source='untyped'>>>],
   @rest_keywords=nil,
   @rest_positionals=nil,
   @return_type=
    #<RBS::Types::Bases::Void:0x00007f8710568df0
     @location=
      #<RBS::Location:880 buffer=a.rbs, start=1:21, pos=21...25, children= source='void'>>,
   @trailing_positionals=[]>,
 @type_params=[]>
```


# Solution

Unquote the parameter name correctly.

This patch also fixes `Function::Param#to_s` to quote keywords correctly.







-----


By the way, method name also accepts quoted name, and it is unquoted correctly already.
