### PR TITLE
Use "untyped" as an exceptation of return value of IO#ready?

### DIFF
--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -252,9 +252,11 @@ class IOWaitTest < Test::Unit::TestCase
 
   def test_readyp
     if_ruby3 do
+      # This method returns true|false in Ruby 2.7, nil|IO in 3.0, and true|false in 3.1.
+
       IO.pipe.tap do |r, w|
         assert_send_type(
-          "() -> nil",
+          "() -> untyped",
           r, :ready?
         )
       end
@@ -263,7 +265,7 @@ class IOWaitTest < Test::Unit::TestCase
         w.write("hello")
 
         assert_send_type(
-          "() -> IO",
+          "() -> untyped",
           r, :ready?
         )
       end


### PR DESCRIPTION
In Ruby 2.7, the method returns true|false.
In Ruby 3.0, it returns nil|IO.
Now in Ruby 3.1.0-dev, it returns true|false again.

The CI of ruby/ruby repository now fails due to the type test of the
method, so I'd like to disable the test tentatively.