### PR TITLE
Support Complex and BigDecimal for Date#{+,-}

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -6,6 +6,10 @@ interface _ToInt
   def to_int: -> Integer
 end
 
+interface _ToR
+  def to_r: () -> Rational
+end
+
 interface _ToS
   def to_s: -> String
 end

--- a/stdlib/date/0/date.rbs
+++ b/stdlib/date/0/date.rbs
@@ -446,7 +446,7 @@ class Date
   #     DateTime.jd(0,12) + DateTime.new(2001,2,3).ajd
   #                               #=> #<DateTime: 2001-02-03T00:00:00+00:00 ...>
   #
-  def +: (Integer | Rational other) -> Date
+  def +: ((Numeric & _ToR) other) -> Date
 
   # Returns the difference between the two dates if the other is a date object.
   # If the other is a numeric value, returns a date object pointing `other` days
@@ -461,7 +461,7 @@ class Date
   #     DateTime.new(2001,2,3) - DateTime.new(2001,2,2,12)
   #                              #=> (1/2)
   #
-  def -: (Integer | Rational other) -> Date
+  def -: ((Numeric & _ToR) other) -> Date
        | (Date other) -> Rational
 
   # Returns a date object pointing `n` months before self. The argument `n` should


### PR DESCRIPTION
Date#{+,-} allows to pass an object with numeric argument and `to_r` method.

https://github.com/ruby/ruby/blob/6d540c1b9844a5832846618b53ce35d12d64deac/ext/date/date_core.c#L5785-L5786

For example, `Complex` and `BigDecimal` can be passed.

```rb
Date.today + Complex(1, 0)
#=> Date

Date.today + BigDecimal("1")
#=> Date
```

To achieve this behavior, the `_ToR` interface was introduced.

And `Integer`, `Rational`, and even `Float` are removed because they satisfy the condition of `(Numeric & _ToR)`.