### PR TITLE
Strict include/delete element types

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -699,7 +699,7 @@ class Array[unchecked out Elem] < Object
   #     ary.count {|x| x%2 == 0}   #=> 3
   #
   def count: () -> ::Integer
-           | (untyped obj) -> ::Integer
+           | (Elem obj) -> ::Integer
            | () { (Elem) -> boolish } -> ::Integer
 
   # Calls the given block for each element `n` times or forever if `nil` is given.
@@ -733,7 +733,7 @@ class Array[unchecked out Elem] < Object
   #     a.delete("z")                   #=> nil
   #     a.delete("z") {"not found"}     #=> "not found"
   #
-  def delete: (untyped obj) -> Elem?
+  def delete: (Elem obj) -> Elem?
             | [S, T] (S obj) { (S) -> T } -> (Elem | T)
 
   # Deletes the element at the specified `index`, returning that element, or `nil`
@@ -1029,7 +1029,7 @@ class Array[unchecked out Elem] < Object
   #     a.include?("b")   #=> true
   #     a.include?("z")   #=> false
   #
-  def include?: (untyped object) -> bool
+  def include?: (Elem object) -> bool
 
   # Returns the *index* of the first object in `ary` such that the object is `==`
   # to `obj`.

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -63,7 +63,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   # ary.count{ |x| x%2==0 } #=> 3
   # ```
   def count: () -> Integer
-           | (?untyped) -> Integer
+           | (Elem) -> Integer
            | () { (Elem) -> boolish } -> Integer
 
   def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
@@ -130,7 +130,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   def group_by: [U] () { (Elem arg0) -> U } -> ::Hash[U, ::Array[Elem]]
               | () -> ::Enumerator[Elem, ::Array[Elem]]
 
-  def `include?`: (untyped arg0) -> bool
+  def `include?`: (Elem arg0) -> bool
 
   def inject: (untyped init, Symbol method) -> untyped
             | (Symbol method) -> untyped
@@ -341,7 +341,7 @@ module Enumerable[unchecked out Elem]: _Each[Elem]
   def map: [U] () { (Elem arg0) -> U } -> ::Array[U]
          | () -> ::Enumerator[Elem, ::Array[untyped]]
 
-  def member?: (untyped arg0) -> bool
+  def member?: (Elem arg0) -> bool
 
   alias reduce inject
 

--- a/stdlib/set/0/set.rbs
+++ b/stdlib/set/0/set.rbs
@@ -122,7 +122,7 @@ class Set[A]
   #
   # See also Enumerable#include?
   #
-  def include?: (untyped) -> bool
+  def include?: (A) -> bool
 
   alias member? include?
 
@@ -168,12 +168,12 @@ class Set[A]
   # Deletes the given object from the set and returns self.  Use `subtract` to
   # delete many items at once.
   #
-  def delete: (untyped) -> self
+  def delete: (A) -> self
 
   # Deletes the given object from the set and returns self.  If the object is not
   # in the set, returns nil.
   #
-  def delete?: (untyped) -> self?
+  def delete?: (A) -> self?
 
   # Deletes every element of the set for which block evaluates to true, and
   # returns self. Returns an enumerator if no block is given.

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -256,8 +256,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_delete
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :delete, 2
-    assert_send_type "(String) -> nil",
-                     [1,2,3], :delete, ""
 
     assert_send_type "(Integer) { (Integer) -> String } -> Integer",
                      [1,2,3], :delete, 2 do "" end
@@ -441,8 +439,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_include?
     assert_send_type "(Integer) -> bool",
                      [1,2,3], :include?, 1
-    assert_send_type "(String) -> bool",
-                     [1,2,3], :include?, ""
   end
 
   def test_index


### PR DESCRIPTION
RBS has provided a method type of `include?`/`delete` with `untyped`.

```rbs
class Array[Elem]
  def include?: (untyped) -> bool   # Allows passing object of unrelated types.
end
```

This is more compatible with Ruby runtime behavior.

```rb
a = [1, 2, 3]      # RBS assumes the `a` has type of `Array[Integer]`
a.include?("1")    # Ruby evaluates this line without an error, but returns false.
```

I have found that limiting the type of argument here makes more sense to find possible bugs, and want to change the type.

[This](https://github.com/ruby/rbs/pull/834/files#diff-af649a561a0fc1f8255ec6690d893ecf223fb2b409449790da1bb33fc48cba60L436) is an example of the type error: `Parser::KEYWORDS` is `Hash[String, bot]`, and passing a Symbol to `include?` always returns `false`, which is not what I want to do here.