### PR TITLE
[collection] Allow a relative path as git remote

### DIFF
--- a/sig/collection/collections.rbs
+++ b/sig/collection/collections.rbs
@@ -62,9 +62,9 @@ module RBS
 
         def resolve_revision: () -> String
 
-        def git: (*String cmd) -> String
+        def git: (*String cmd, **untyped opt) -> String
 
-        def sh!: (*String cmd) -> String
+        def sh!: (*String cmd, **untyped opt) -> String
 
         def format_config_entry: (Config::gem_entry) -> String
       end


### PR DESCRIPTION


`rbs collection` didn't allow a relative path as a git remote. For example:

```yaml
# rbs_collection.yaml
sources:
  - name: ruby/gem_rbs_collection
    remote: ../../path/to/gem_rbs_collection/
    revision: main
    repo_dir: gems
```

I need to specify relative paths for test of ruby/gems_rbs_collection repo. In this repository, I'd like to refer to the repository itself for the test.

So this patch makes a relative path available as git remote. 