### PR TITLE
Validate `extend` arguments

### DIFF
--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -27,18 +27,16 @@ module RBS
           end
         end
 
+        definition_builder.validate_type_name(type.name, type.location)
+
         type_params = case type
                       when Types::ClassInstance
-                        env.class_decls[type.name]&.type_params
+                        env.class_decls[type.name].type_params
                       when Types::Interface
-                        env.interface_decls[type.name]&.decl&.type_params
+                        env.interface_decls[type.name].decl.type_params
                       when Types::Alias
-                        env.alias_decls[type.name]&.decl&.type_params
+                        env.alias_decls[type.name].decl.type_params
                       end
-
-        unless type_params
-          raise NoTypeFoundError.new(type_name: type.name, location: type.location)
-        end
 
         InvalidTypeApplicationError.check!(
           type_name: type.name,
@@ -48,9 +46,7 @@ module RBS
         )
 
       when Types::ClassSingleton
-        # @type var type: Types::ClassSingleton
-        type = _ = absolute_type(type, context: context) { type.name.absolute! }
-        NoTypeFoundError.check!(type.name, env: env, location: type.location)
+        definition_builder.validate_type_presence(type)
       end
 
       type.each_type do |type|

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -43,6 +43,13 @@ module RBS
 
     def define_methods: (Definition, interface_methods: Hash[Symbol, Definition::Method], methods: MethodBuilder::Methods, super_interface_method: bool) -> void
 
+    # Validates presence of type names recursively.
+    # Assumes the type names are already resolved.
+    #
+    def validate_type_presence: (Types::t) -> void
+
+    def validate_type_name: (TypeName, Location[untyped, untyped]?) -> void
+
     # Expand a type alias of given name without type arguments.
     # Raises an error if the type alias requires arguments.
     #

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -183,6 +183,25 @@ singleton(::BasicObject)
         assert_equal "::Hello", error.type_name.to_s
       end
     end
+
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        class Foo[A]
+          extend Bar[A]
+        end
+
+        module Bar[B]
+        end
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+
+        assert_equal "::A", error.type_name.to_s
+      end
+    end
   end
 
   def test_constant


### PR DESCRIPTION
There was no explicit validation on `extend` arguments, which resulted in a false-negative as reported in #838. Adding a validation of the arguments solves the issue.