### PR TITLE
Fix URI signatures

### DIFF
--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -268,7 +268,7 @@ module URI
   # It's recommended to first ::escape the provided `uri_str` if there are any
   # invalid URI characters.
   #
-  def self.parse: (String uri) -> URI::Generic
+  def self.parse: (_ToStr uri) -> (File | HTTP | HTTPS | LDAP | LDAPS | Generic)
 
   # ## Synopsis
   #

--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -308,6 +308,11 @@ module URI
   #
   def self.scheme_list: () -> Hash[String, Class]
 
+  # Construct a URI instance, using the scheme to detect the appropriate class
+  # from +URI.scheme_list+.
+  #
+  def self.for: (String scheme, *untyped arguments, ?default: Class) -> (File | HTTP | HTTPS | LDAP | LDAPS | Generic)
+
   # ## Synopsis
   #
   #     URI::split(uri)

--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -268,7 +268,7 @@ module URI
   # It's recommended to first ::escape the provided `uri_str` if there are any
   # invalid URI characters.
   #
-  def self.parse: (_ToStr uri) -> (File | HTTP | HTTPS | LDAP | LDAPS | Generic)
+  def self.parse: (_ToStr uri) -> (File | FTP | HTTP | HTTPS | LDAP | LDAPS | MailTo | WS | WSS | Generic)
 
   # ## Synopsis
   #
@@ -311,7 +311,7 @@ module URI
   # Construct a URI instance, using the scheme to detect the appropriate class
   # from +URI.scheme_list+.
   #
-  def self.for: (String scheme, *untyped arguments, ?default: Class) -> (File | HTTP | HTTPS | LDAP | LDAPS | Generic)
+  def self.for: (String scheme, *untyped arguments, ?default: Class) -> (File | FTP | HTTP | HTTPS | LDAP | LDAPS | MailTo | WS | WSS | Generic)
 
   # ## Synopsis
   #

--- a/stdlib/uri/0/ftp.rbs
+++ b/stdlib/uri/0/ftp.rbs
@@ -1,0 +1,10 @@
+module URI
+  # FTP URI syntax is defined by RFC1738 section 3.2.
+  #
+  # This class will be redesigned because of difference of implementations;
+  # the structure of its path. draft-hoffman-ftp-uri-04 is a draft but it
+  # is a good summary about the de facto spec.
+  # http://tools.ietf.org/html/draft-hoffman-ftp-uri-04
+  class FTP < Generic
+  end
+end

--- a/stdlib/uri/0/mailto.rbs
+++ b/stdlib/uri/0/mailto.rbs
@@ -1,0 +1,5 @@
+module URI
+  # RFC6068, the mailto URL scheme.
+  class MailTo < Generic
+  end
+end

--- a/stdlib/uri/0/ws.rbs
+++ b/stdlib/uri/0/ws.rbs
@@ -1,0 +1,10 @@
+module URI
+  # The syntax of WS URIs is defined in RFC6455 section 3.
+  #
+  # Note that the Ruby URI library allows WS URLs containing usernames and
+  # passwords. This is not legal as per the RFC, but used to be
+  # supported in Internet Explorer 5 and 6, before the MS04-004 security
+  # update. See <URL:http://support.microsoft.com/kb/834489>.
+  class WS < Generic
+  end
+end

--- a/stdlib/uri/0/wss.rbs
+++ b/stdlib/uri/0/wss.rbs
@@ -1,0 +1,7 @@
+module URI
+  # The default port for WSS URIs is 443, and the scheme is 'wss:' rather
+  # than 'ws:'. Other than that, WSS URIs are identical to WS URIs;
+  # see URI::WS.
+  class WSS < WS
+  end
+end


### PR DESCRIPTION
Fix https://github.com/ruby/rbs/issues/845

I fixed the definitions of `URI.parse` and `URI.for`.
And I also added the missing subclasses.

CRuby allows users to add classes later using `URI.register_scheme`, but users can override `URI.parse` and `URI.for`.