### PR TITLE
Polish URI.split signature

### DIFF
--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -340,7 +340,7 @@ module URI
   #     URI.split("http://www.ruby-lang.org/")
   #     # => ["http", nil, "www.ruby-lang.org", nil, nil, "/", nil, nil, nil]
   #
-  def self.split: (String uri) -> [ String?, String?, String?, String?, String?, String?, String?, String?, String? ]
+  def self.split: (String uri) -> [ String?, String?, String?, String?, nil, String?, String?, String?, String? ]
 end
 
 URI::ABS_PATH: Regexp

--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -340,7 +340,7 @@ module URI
   #     URI.split("http://www.ruby-lang.org/")
   #     # => ["http", nil, "www.ruby-lang.org", nil, nil, "/", nil, nil, nil]
   #
-  def self.split: (String uri) -> [ String?, String?, String?, String?, nil, String?, String?, String?, String? ]
+  def self.split: (_ToStr uri) -> [ String?, String?, String?, String?, nil, String?, String?, String?, String? ]
 end
 
 URI::ABS_PATH: Regexp


### PR DESCRIPTION
`URI.split` will never return a String to the registry, and giving a truthy object to the registry of `URI::Generic.new` will cause `URI::InvalidURIError`.