### PR TITLE
Add local source for rbs collection

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -79,6 +79,10 @@ sources:
     revision: main
     repo_dir: gems
 
+  # You can also add a local path as a collection source optionaly.
+  - type: local
+    path: path/to/local/dir
+
 # A directory to install the downloaded RBSs
 path: .gem_rbs_collection
 

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1076,10 +1076,15 @@ EOB
         config_path.write(<<~'YAML')
           # Download sources
           sources:
-            - name: ruby/gem_rbs_collection
+            - type: git
+              name: ruby/gem_rbs_collection
               remote: https://github.com/ruby/gem_rbs_collection.git
               revision: main
               repo_dir: gems
+
+          # You can specify local directories as sources also.
+          # - type: local
+          #   path: path/to/your/local/repository
 
           # A directory to install the downloaded RBSs
           path: .gem_rbs_collection

--- a/lib/rbs/collection/cleaner.rb
+++ b/lib/rbs/collection/cleaner.rb
@@ -16,7 +16,14 @@ module RBS
           version or raise
           next if needed? gem_name, version
 
-          FileUtils.remove_entry_secure(dir.to_s)
+          case
+          when dir.symlink?
+            dir.unlink
+          when dir.directory?
+            FileUtils.remove_entry_secure(dir.to_s)
+          else
+            raise
+          end
         end
       end
 

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -66,7 +66,7 @@ module RBS
       def sources
         @sources ||= (
           @data['sources']
-            .map { |c| Sources.from_config_entry(c) }
+            .map { |c| Sources.from_config_entry(c, base_directory: @config_path.dirname) }
             .push(Sources::Stdlib.instance)
             .push(Sources::Rubygems.instance)
         )

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -75,7 +75,7 @@ module RBS
           if gems = data["gems"]
             gems.each do |gem|
               src = gem["source"]
-              source = Sources.from_config_entry(src)
+              source = Sources.from_config_entry(src, base_directory: lockfile_path.dirname)
               lockfile.gems[gem["name"]] = {
                 name: gem["name"],
                 version: gem["version"],
@@ -106,6 +106,8 @@ module RBS
               meta_path = fullpath.join(gem[:name], gem[:version], Sources::Git::METADATA_FILENAME)
               raise CollectionNotAvailable unless meta_path.exist?
               raise CollectionNotAvailable unless library_data(gem) == YAML.load(meta_path.read)
+            when Sources::Local
+              raise CollectionNotAvailable unless fullpath.join(gem[:name], gem[:version]).symlink?
             end
           end
         end

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -105,7 +105,7 @@ module RBS
           unless locked
             source =
               if src_data
-                Sources.from_config_entry(src_data)
+                Sources.from_config_entry(src_data, base_directory: config.config_path.dirname)
               else
                 find_source(name: name)
               end

--- a/lib/rbs/collection/sources.rb
+++ b/lib/rbs/collection/sources.rb
@@ -4,11 +4,12 @@ require_relative './sources/base'
 require_relative './sources/git'
 require_relative './sources/stdlib'
 require_relative './sources/rubygems'
+require_relative './sources/local'
 
 module RBS
   module Collection
     module Sources
-      def self.from_config_entry(source_entry)
+      def self.from_config_entry(source_entry, base_directory:)
         case source_entry['type']
         when 'git', nil # git source by default
           # @type var source_entry: Git::source_entry
@@ -17,6 +18,12 @@ module RBS
             revision: source_entry["revision"],
             remote: source_entry["remote"],
             repo_dir: source_entry["repo_dir"]
+          )
+        when 'local'
+          # @type var source_entry: Local::source_entry
+          Local.new(
+            path: source_entry['path'],
+            base_directory: base_directory,
           )
         when 'stdlib'
           Stdlib.instance

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -45,7 +45,12 @@ module RBS
 
           gem_dir = dest.join(name, version)
 
-          if gem_dir.directory?
+          case
+          when gem_dir.symlink?
+            stdout.puts "Updating to #{format_config_entry(name, version)} from a local source"
+            gem_dir.unlink
+            _install(dest: dest, name: name, version: version)
+          when gem_dir.directory?
             prev = load_metadata(dir: gem_dir)
 
             if prev == metadata_content(name: name, version: version)
@@ -55,9 +60,11 @@ module RBS
               FileUtils.remove_entry_secure(gem_dir.to_s)
               _install(dest: dest, name: name, version: version)
             end
-          else
+          when !gem_dir.exist?
             stdout.puts "Installing #{format_config_entry(name, version)}"
             _install(dest: dest, name: name, version: version)
+          else
+            raise
           end
         end
 

--- a/lib/rbs/collection/sources/local.rb
+++ b/lib/rbs/collection/sources/local.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module RBS
+  module Collection
+    module Sources
+      class Local
+        include Base
+
+        attr_reader :path
+  
+        def initialize(path:, base_directory:)
+          # TODO: resolve relative path from dir of rbs_collection.yaml
+          @path = base_directory / path
+        end
+
+        def has?(name, version)
+          if version
+            @path.join(name, version).directory?
+          else
+            not versions(name).empty?
+          end
+        end
+
+        def versions(name)
+          @path.join(name).glob('*/').map { |path| path.basename.to_s }
+        end
+
+        # Create a symlink instead of copying file to refer files in @path.
+        # By avoiding copying RBS files, the users do not need re-run `rbs collection install`
+        # when the RBS files are updated.
+        def install(dest:, name:, version:, stdout:)
+          from = @path.join(name, version)
+          gem_dir = dest.join(name, version)
+
+          case
+          when gem_dir.symlink? && gem_dir.readlink == from
+            stdout.puts "Using #{name}:#{version} (#{from})"
+          when gem_dir.symlink?
+            prev = gem_dir.readlink
+            gem_dir.unlink
+            _install(from, dest.join(name, version))
+            stdout.puts "Updating #{name}:#{version} to #{from} from #{prev}"
+          when gem_dir.directory?
+            # TODO: Show version of git source
+            FileUtils.remove_entry_secure(gem_dir.to_s)
+            _install(from, dest.join(name, version))
+            stdout.puts "Updating #{name}:#{version} from git source"
+          when !gem_dir.exist?
+            _install(from, dest.join(name, version))
+            stdout.puts "Installing #{name}:#{version} (#{from})"
+          else
+            raise
+          end
+        end
+
+        private def _install(src, dst)
+          dst.dirname.mkpath
+          File.symlink(src, dst)
+        end
+
+        def manifest_of(name, version)
+          gem_dir = @path.join(name, version)
+          raise unless gem_dir.exist?
+
+          manifest_path = gem_dir.join('manifest.yaml')
+          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+        end
+
+        def to_lockfile
+          {
+            'type' => 'local',
+            'path' => @path.to_s,
+          }
+        end
+      end
+    end
+  end
+end

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -1,8 +1,8 @@
 module RBS
   module Collection
     module Sources
-      def self.from_config_entry: (Git::source_entry) -> Git
-                                | (source_entry) -> t
+      def self.from_config_entry: (Git::source_entry, base_directory: Pathname) -> Git
+                                | (source_entry, base_directory: Pathname) -> t
 
       interface _Source
         def has?: (String name, String? version) -> boolish
@@ -13,11 +13,12 @@ module RBS
         def dependencies_of: (String name, String version) -> Array[manifest_dependency]?
       end
 
-      type t = Git | Stdlib | Rubygems
+      type t = Git | Stdlib | Rubygems | Local
 
       type source_entry = Git::source_entry
                         | Stdlib::source_entry
                         | Rubygems::source_entry
+                        | Local::source_entry
 
       type manifest_entry = {
         "dependencies" => Array[manifest_dependency]?,
@@ -124,6 +125,33 @@ module RBS
         def load_metadata: (dir: Pathname) -> metadata
 
         def gems_versions: () -> Hash[String, Set[String]]
+      end
+
+      class Local
+        include Base
+
+        type source_entry = {
+          'type' => 'local',
+          'path' => String,
+        }
+
+        attr_reader path: Pathname
+
+        def initialize: (path: String, base_directory: Pathname) -> void
+
+        def has?: (String name, String? version) -> boolish
+
+        def versions: (String name) -> Array[String]
+
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
+
+        def to_lockfile: () -> source_entry
+
+        def manifest_of: (String name, String version) -> manifest_entry?
+
+        private
+
+        def _install: (Pathname src, Pathname dest) -> void
       end
 
       # signatures that are bundled in rbs gem under the stdlib/ directory

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -136,6 +136,7 @@ module RBS
         }
 
         attr_reader path: Pathname
+        attr_reader full_path: Pathname
 
         def initialize: (path: String, base_directory: Pathname) -> void
 

--- a/test/rbs/collection/installer_test.rb
+++ b/test/rbs/collection/installer_test.rb
@@ -110,6 +110,191 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
     end
   end
 
+  def test_install_from_local
+    mktmpdir do |tmpdir|
+      with_local_source do |local_source|
+        lockfile_path = tmpdir.join('rbs_collection.lock.yaml')
+        dest = tmpdir / 'gem_rbs_collection'
+        lockfile_path.write(<<~YAML)
+          sources:
+            - type: local
+              name: the local source
+              path: "#{local_source}"
+          path: "#{dest}"
+          gems:
+            - name: super-cool-gem
+              version: "0.1"
+              source:
+                type: local
+                name: the local source
+                path: "#{local_source}"
+        YAML
+
+        # Check installing
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+
+        assert dest.glob('*/').size == 1
+        assert dest.join('super-cool-gem/0.1').symlink?
+        assert dest.join('super-cool-gem/0.1/super-cool-gem.rbs').file?
+
+        assert_match("Installing super-cool-gem:0.1 (#{local_source.join("super-cool-gem/0.1")})", stdout.string)
+        assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
+
+        # Check idempotency
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+
+        assert_match("Using super-cool-gem:0.1 (#{local_source.join("super-cool-gem/0.1")})", stdout.string)
+
+        # Check updating
+        lockfile_path.write lockfile_path.read.sub('version: "0.1"', 'version: "0.42"')
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+
+        assert dest.glob('*/').size == 1
+        assert dest.join('super-cool-gem/0.42').symlink?
+        assert dest.join('super-cool-gem/0.42/super-cool-gem.rbs').file?
+
+        assert_match("Installing super-cool-gem:0.42 (#{local_source.join("super-cool-gem/0.42")})", stdout.string)
+        assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
+      end
+    end
+  end
+
+  def test_update_from_git_to_local
+    mktmpdir do |tmpdir|
+      lockfile_path = tmpdir.join('rbs_collection.lock.yaml')
+      dest = tmpdir / 'gem_rbs_collection'
+      lockfile_path.write(<<~YAML)
+        sources:
+          - name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+            repo_dir: gems
+        path: "#{dest}"
+        gems:
+          - name: ast
+            version: "2.4"
+            source:
+              type: git
+              name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+      YAML
+
+      # Preparation by installing RBSs from git source
+      stdout = StringIO.new
+      RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+      assert dest.join('ast/2.4/ast.rbs').file?
+
+      # Install from local source
+      with_local_source do |local_source|
+        lockfile_path.write(<<~YAML)
+          sources:
+            - type: local
+              name: the local source
+              path: "#{local_source}"
+          path: "#{dest}"
+          gems:
+            - name: ast
+              version: "2.4"
+              source:
+                type: local
+                name: the local source
+                path: "#{local_source}"
+        YAML
+
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+
+        assert dest.glob('*/').size == 1
+        assert dest.join('ast/2.4').symlink?
+        assert dest.join('ast/2.4/ast.rbs').file?
+
+        assert_match("Updating ast:2.4 from git source", stdout.string)
+        assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
+      end
+    end
+  end
+
+  def test_update_from_local_to_git
+    mktmpdir do |tmpdir|
+      with_local_source do |local_source|
+        lockfile_path = tmpdir.join('rbs_collection.lock.yaml')
+        dest = tmpdir / 'gem_rbs_collection'
+        lockfile_path.write(<<~YAML)
+          sources:
+            - type: local
+              name: the local source
+              path: "#{local_source}"
+          path: "#{dest}"
+          gems:
+            - name: ast
+              version: "2.4"
+              source:
+                type: local
+                name: the local source
+                path: "#{local_source}"
+        YAML
+
+        # Preparation by installing RBSs from local source
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+        assert dest.join('ast/2.4/ast.rbs').file?
+
+        # Install from git source
+        lockfile_path.write(<<~YAML)
+          sources:
+            - name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+          path: "#{dest}"
+          gems:
+            - name: ast
+              version: "2.4"
+              source:
+                type: git
+                name: ruby/gem_rbs_collection
+                remote: https://github.com/ruby/gem_rbs_collection.git
+                revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+                repo_dir: gems
+        YAML
+
+        stdout = StringIO.new
+        RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: stdout).install_from_lockfile
+
+        assert dest.glob('*/').size == 1
+        refute dest.join('ast/2.4').symlink?
+        assert dest.join('ast/2.4/ast.rbs').file?
+
+        assert_match("Updating to ast:2.4 (ast@b4d3b346d96) from a local source", stdout.string)
+        assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
+      end
+    end
+  end
+
+  private def with_local_source
+    mktmpdir do |path|
+      path.join('super-cool-gem/0.1').tap do |dir|
+        dir.mkpath
+        dir.join('super-cool-gem.rbs').write('class SuperCoolGem end')
+      end
+      path.join('super-cool-gem/0.42').tap do |dir|
+        dir.mkpath
+        dir.join('super-cool-gem.rbs').write('class SuperCoolGem end')
+      end
+      path.join('ast/2.4').tap do |dir|
+        dir.mkpath
+        dir.join('ast.rbs').write('class Ast end')
+      end
+
+      yield path
+    end
+  end
+
   private def mktmpdir
     Dir.mktmpdir do |path|
       yield Pathname(path)

--- a/test/rbs/collection/sources/git_test.rb
+++ b/test/rbs/collection/sources/git_test.rb
@@ -37,7 +37,7 @@ class RBS::Collection::Sources::GitTest < Test::Unit::TestCase
       'revision' => revision,
       'remote' => 'https://github.com/ruby/gem_rbs_collection.git',
       'repo_dir' => 'gems',
-    })
+    }, base_directory: nil)
   end
 
   def git(*cmd, **opts)

--- a/test/rbs/collection/sources/local_test.rb
+++ b/test/rbs/collection/sources/local_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class RBS::Collection::Sources::LocalTest < Test::Unit::TestCase
+  def test_has?
+    with_local_source do |s|
+      assert s.has?('ast', nil)
+      refute s.has?('ast', "1.2.3.4")
+
+      refute s.has?('rbs', nil)
+    end
+  end
+
+  def test_versions
+    with_local_source do |s|
+      assert_equal ['2.4'], s.versions('ast')
+    end
+  end
+
+  def test_manifest_of
+    with_local_source do |s|
+      assert_instance_of Hash, s.manifest_of('manifest', '4.5')
+      assert_nil s.manifest_of('ast', '2.4')
+
+      assert_raises do
+        s.manifest_of('ast', '0.0')
+      end
+    end
+  end
+
+  private def source(path:)
+    RBS::Collection::Sources.from_config_entry({
+      'type' => 'local',
+      'name' => 'the local source',
+      'path' => path,
+    }, base_directory: Pathname(path).dirname)
+  end
+
+  private def with_local_source
+    mktmpdir do |path|
+      path.join('ast/2.4').tap do |dir|
+        dir.mkpath
+        dir.join('ast.rbs').write('class Ast end')
+      end
+
+      path.join('manifest/4.5').tap do |dir|
+        dir.mkpath
+        dir.join('manifest.rbs').write('class Manifest end')
+        dir.join('manifest.yaml').write(<<~YAML)
+          dependencies:
+            - name: logger
+        YAML
+      end
+
+      yield source(path: path)
+    end
+  end
+
+  private def mktmpdir
+    Dir.mktmpdir do |path|
+      yield Pathname(path)
+    end
+  end
+end

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -28,6 +28,6 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
   def source
     RBS::Collection::Sources.from_config_entry({
       'type' => 'stdlib',
-    })
+    }, base_directory: nil)
   end
 end

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -240,7 +240,7 @@ end
     end
   end
 
-  def test_loading_from_rbs_collection_without_install
+  def test_loading_from_rbs_collection_git_source_without_install
     mktmpdir do |path|
       lockfile_path = path.join('rbs_collection.lock.yaml')
       lockfile_path.write(<<~YAML)
@@ -267,6 +267,35 @@ end
               revision: b4d3b346d9657543099a35a1fd20347e75b8c523
               repo_dir: gems
               type: git
+      YAML
+      lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))
+
+      repo = RBS::Repository.new()
+
+      loader = EnvironmentLoader.new(repository: repo)
+
+      assert_raises RBS::Collection::Config::CollectionNotAvailable do
+        loader.add_collection(lock)
+      end
+    end
+  end
+
+  def test_loading_from_rbs_collection_local_source_without_install
+    mktmpdir do |path|
+      lockfile_path = path.join('rbs_collection.lock.yaml')
+      lockfile_path.write(<<~YAML)
+        sources:
+          - type: local
+            name: the local source
+            path: path/to/local/source
+        path: '.gem_rbs_collection'
+        gems:
+          - name: ast
+            version: "2.4"
+            source:
+              type: local
+              name: the local source
+              path: path/to/local/source
       YAML
       lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))
 


### PR DESCRIPTION
Fix #842 

This PR adds local source feature to rbs collection.

This feature allows you to write a local path as an rbs collection's source. Previously you need to create a git repository to add a source, but now you can just specify a local directory as a source.

# Usage

```yaml
# rbs_collection.yaml

sources:
  - type: local
    path: path/to/local_source/
```

Then, `rbs collection install` installs RBSs from the specified path.



