### PR TITLE
Remove experimental warning of rbs collection

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -836,8 +836,6 @@ EOB
     end
 
     def run_collection(args, options)
-      warn "warning: rbs collection is experimental, and the behavior may change until RBS v2.0"
-
       opts = collection_options(args)
       params = {}
       opts.order args.drop(1), into: params

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -48,8 +48,6 @@ module RBS
     end
 
     def add_collection(collection_config)
-      warn "warning: rbs collection is experimental, and the behavior may change until RBS v2.0"
-
       collection_config.check_rbs_availability!
 
       repository.add(collection_config.repo_path)


### PR DESCRIPTION
`rbs collection` is GA on Ruby 3.1.