### PR TITLE
Resolve super type name in outer context

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -240,6 +240,8 @@ module RBS
         array.unshift(head + decl.name.to_namespace)
       end
 
+      outer_context = context.drop(1)
+
       case decl
       when AST::Declarations::Class
         outer_ = outer + [decl]
@@ -249,8 +251,8 @@ module RBS
           type_params: decl.type_params,
           super_class: decl.super_class&.yield_self do |super_class|
             AST::Declarations::Class::Super.new(
-              name: absolute_type_name(resolver, super_class.name, context: context),
-              args: super_class.args.map {|type| absolute_type(resolver, type, context: context) },
+              name: absolute_type_name(resolver, super_class.name, context: outer_context),
+              args: super_class.args.map {|type| absolute_type(resolver, type, context: outer_context) },
               location: super_class.location
             )
           end,

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -384,6 +384,31 @@ end
 RBS
   end
 
+  def test_absolute_type_super
+    env = Environment.new
+
+    decls = RBS::Parser.parse_signature(<<-RBS)
+module A
+  class C
+  end
+
+  class B < C
+    class C
+    end
+  end
+end
+    RBS
+
+    decls.each do |decl|
+      env << decl
+    end
+
+    env.resolve_type_names.tap do |env|
+      class_decl = env.class_decls[TypeName("::A::B")]
+      assert_equal TypeName("::A::C"), class_decl.primary.decl.super_class.name
+    end
+  end
+
   def test_reject
     env = Environment.new
 


### PR DESCRIPTION
Fixes https://github.com/ruby/rbs/issues/764 for better compatibility with Ruby.

Note that other type names --self types and generics upper bounds-- continue to be resolved in inner context. This is intentional that we often write types like the following:

```
module Foo : _Fooable
  interface _Fooable
    def foo: () -> void
  end
end
```

The `_Fooable` interface is only used by the `Foo` module, and we may want to keep it in the module.