### PR TITLE
Make `prototype rb` to be aware of prepend

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -197,6 +197,18 @@ module RBS
                 )
               end
             end
+          when :prepend
+            args.each do |arg|
+              if (name = const_to_name(arg))
+                decls << AST::Members::Prepend.new(
+                  name: name,
+                  args: [],
+                  annotations: [],
+                  location: nil,
+                  comment: comments[node.first_lineno - 1]
+                )
+              end
+            end
           when :extend
             args.each do |arg|
               if (name = const_to_name(arg, context: context))

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -250,6 +250,7 @@ end
 class Hello
   include Foo
   extend ::Bar, baz
+  prepend Baz
 
   attr_reader :x
   attr_accessor :y, :z
@@ -278,6 +279,8 @@ class Hello
   include Foo
 
   extend ::Bar
+
+  prepend Baz
 
   attr_reader x: untyped
 


### PR DESCRIPTION
RBS has `prepend` but `rbs prototype rb` ignored `prepend Mod`.
By this change, `rbs prototype rb` will be aware of `prepend Mod` correctly.