### PR TITLE
URI sig improvements

### DIFF
--- a/stdlib/uri/0/generic.rbs
+++ b/stdlib/uri/0/generic.rbs
@@ -880,7 +880,7 @@ module URI
     #     uri.merge!("/main.rbx?page=1")
     #     uri.to_s  # => "http://my.example.com/main.rbx?page=1"
     #
-    def merge!: (string oth) -> String
+    def merge!: (URI::Generic | string oth) -> String
 
     # <!--
     #   rdoc-file=lib/uri/generic.rb
@@ -904,7 +904,7 @@ module URI
     #     uri.merge("/main.rbx?page=1")
     #     # => "http://my.example.com/main.rbx?page=1"
     #
-    def merge: (string oth) -> URI::Generic
+    def merge: (URI::Generic | string oth) -> URI::Generic
 
     # :stopdoc:
     def route_from_path: (String src, String dst) -> String

--- a/stdlib/uri/0/http.rbs
+++ b/stdlib/uri/0/http.rbs
@@ -50,6 +50,41 @@ module URI
 
     # <!--
     #   rdoc-file=lib/uri/http.rb
+    #   - authority()
+    # -->
+    # ## Description
+    #
+    # Returns the authority for an HTTP uri, as defined in
+    # https://datatracker.ietf.org/doc/html/rfc3986/#section-3.2.
+    #
+    # Example:
+    #
+    #     URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').authority #=> "www.example.com"
+    #     URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').authority #=> "www.example.com:8000"
+    #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority #=> "www.example.com"
+    #
+    def authority: () -> String
+
+    # <!--
+    #   rdoc-file=lib/uri/http.rb
+    #   - origin()
+    # -->
+    # ## Description
+    #
+    # Returns the origin for an HTTP uri, as defined in
+    # https://datatracker.ietf.org/doc/html/rfc6454.
+    #
+    # Example:
+    #
+    #     URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').origin #=> "http://www.example.com"
+    #     URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').origin #=> "http://www.example.com:8000"
+    #     URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').origin #=> "http://www.example.com"
+    #     URI::HTTPS.build(host: 'www.example.com', path: '/foo/bar').origin #=> "https://www.example.com"
+    #
+    def origin: () -> String
+
+    # <!--
+    #   rdoc-file=lib/uri/http.rb
     #   - request_uri()
     # -->
     # ## Description


### PR DESCRIPTION
Improving method defs which can receive a generic uri as arg.

Added sigs for new `URI::HTTP` methods added in v0.11. 