### PR TITLE
several openssl fixes

### DIFF
--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -1274,7 +1274,7 @@ module OpenSSL
 
     def block_length: () -> Integer
 
-    def digest: () -> String
+    def digest: (?String data) -> String
 
     def digest_length: () -> Integer
 

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -2069,7 +2069,8 @@ module OpenSSL
 
       private
 
-      def initialize: (instance ec_key) -> void
+      def initialize: () -> void
+                    | (instance ec_key) -> void
                     | (Group group) -> void
                     | (String pem_or_der_or_curve, ?String pass) -> void
 
@@ -2269,7 +2270,8 @@ module OpenSSL
 
       private
 
-      def initialize: (Integer key_size) -> void
+      def initialize: () -> void
+                    | (Integer key_size) -> void
                     | (String encoded_key, ?String pass_phrase) -> void
 
       def initialize_copy: (instance) -> void

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -1441,9 +1441,9 @@ module OpenSSL
   end
 
   class HMAC
-    def self.digest: (String algo, String key, String data) -> String
+    def self.digest: (String | Digest algo, String key, String data) -> String
 
-    def self.hexdigest: (String algo, String key, String data) -> String
+    def self.hexdigest: (String | Digest algo, String key, String data) -> String
 
     public
 
@@ -1465,7 +1465,7 @@ module OpenSSL
 
     private
 
-    def initialize: (String key, Digest digest) -> void
+    def initialize: (String key, String | Digest digest) -> void
 
     def initialize_copy: (instance) -> void
   end

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -1011,8 +1011,8 @@ module OpenSSL
 
     def initialize: (instance) -> void
                   | (int) -> void
-                  | (String) -> void
-                  | (String, 0 | 2 | 10 | 16) -> void
+                  | (string) -> void
+                  | (string, 0 | 2 | 10 | 16) -> void
 
     def initialize_copy: (instance other) -> instance
   end


### PR DESCRIPTION
fixing pkey and bn initializers, as well as some digest-related APIs.