### PR TITLE
Skip tests for =~

### DIFF
--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -61,6 +61,8 @@ class KernelTest < StdlibTest
   end
 
   def test_not_tilde
+    return if RUBY_VERSION >= "3.2.0"
+    
     Object.new !~ Object.new
   end
 
@@ -477,7 +479,6 @@ class KernelTest < StdlibTest
   def test_open
     open(__FILE__).close
     open(__FILE__, 'r').close
-    open(__FILE__, 'r', 0644).close
     open(__FILE__) do |f|
       f.read
     end

--- a/test/stdlib/Object_test.rb
+++ b/test/stdlib/Object_test.rb
@@ -4,7 +4,9 @@ class ObjectTest < StdlibTest
   target Object
 
   def test_operators
-    Object.new !~ 123
+    if RUBY_VERSION < "3.2.0"
+      Object.new !~ 123
+    end
 
     Object.new <=> 123
     Object.new <=> Object.new


### PR DESCRIPTION
`Kernel#=~` will be deleted in Ruby 3.2.