### PR TITLE
Delete deprecated `exists?` methods

### DIFF
--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -295,10 +295,6 @@ class Dir
   #
   def self.exist?: (string file) -> bool
 
-  # Deprecated method. Don't use.
-  #
-  def self.exists?: (string file) -> bool
-
   # <!--
   #   rdoc-file=dir.c
   #   - Dir.foreach( dirname ) {| filename | block }                 -> nil

--- a/core/file_test.rbs
+++ b/core/file_test.rbs
@@ -88,8 +88,6 @@ module FileTest
   #
   def self?.exist?: (String | IO file_name) -> bool
 
-  def self?.exists?: (String | IO file_name) -> bool
-
   # <!--
   #   rdoc-file=file.c
   #   - File.file?(file) -> true or false


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2 🔪 