### PR TITLE
Skip RDoc testing on CI for `ruby/ruby/

### DIFF
--- a/test/rbs/annotate/rdoc_annotator_test.rb
+++ b/test/rbs/annotate/rdoc_annotator_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
 
+return if ENV["RUBY"]
+
 class RBS::Annotate::RDocAnnotatorTest < Test::Unit::TestCase
   def load_source(files)
     Dir.mktmpdir do |dir|

--- a/test/rbs/annotate/rdoc_source_test.rb
+++ b/test/rbs/annotate/rdoc_source_test.rb
@@ -1,5 +1,7 @@
 require "test_helper"
 
+return if ENV["RUBY"]
+
 class RDocSourceTest < Test::Unit::TestCase
   def load_source(files)
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
CI on `ruby/ruby` runs without installing the ruby, and trying `rdoc` invokes system (older) ruby. 💣 