### PR TITLE
[Schema] Fix incorrect URI reference in `typeParam.json`

### DIFF
--- a/schema/typeParam.json
+++ b/schema/typeParam.json
@@ -15,13 +15,13 @@
     "upper_bound": {
       "oneOf": [
         {
-          "$ref": "types.json#definitions/classInstance"
+          "$ref": "types.json#/definitions/classInstance"
         },
         {
-          "$ref": "types.json#definitions/classSingleton"
+          "$ref": "types.json#/definitions/classSingleton"
         },
         {
-          "$ref": "types.json#definitions/interface"
+          "$ref": "types.json#/definitions/interface"
         },
         {
           "type": "null"


### PR DESCRIPTION
# Description
The current schema definition of `typeParam.json` is an invalid definition. It results in a validation error.
![image](https://user-images.githubusercontent.com/57192414/152149901-09dec679-a9c8-4cfa-a5c8-cbd17a20b2f9.png)
The issue is a missing `/` at the beginning of the `fragment` of `URI` specified for `$ref`.
I have added the missing `/` to the respective `URI`s.