### PR TITLE
[Net::HTTP] Add timeout errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,6 +73,7 @@ task :validate => :compile do
 
     if lib == ["net-http"]
       lib << "uri"
+      lib << "timeout"
     end
 
     if lib == ["resolv"]

--- a/stdlib/net-http/0/manifest.yaml
+++ b/stdlib/net-http/0/manifest.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - name: uri
+  - name: timeout

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -33,18 +33,24 @@ module Net
   class HTTPHeaderSyntaxError < StandardError
   end
 
-  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot
-  # be created within the open_timeout.
+  # <!-- rdoc-file=lib/net/protocol.rb -->
+  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot be
+  # created within the open_timeout.
+  #
   class OpenTimeout < Timeout::Error
   end
 
+  # <!-- rdoc-file=lib/net/protocol.rb -->
   # ReadTimeout, a subclass of Timeout::Error, is raised if a chunk of the
   # response cannot be read within the read_timeout.
+  #
   class ReadTimeout < Timeout::Error
   end
 
+  # <!-- rdoc-file=lib/net/protocol.rb -->
   # WriteTimeout, a subclass of Timeout::Error, is raised if a chunk of the
   # response cannot be written within the write_timeout.  Not raised on Windows.
+  #
   class WriteTimeout < Timeout::Error
   end
 

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -33,6 +33,21 @@ module Net
   class HTTPHeaderSyntaxError < StandardError
   end
 
+  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot
+  # be created within the open_timeout.
+  class OpenTimeout < Timeout::Error
+  end
+
+  # ReadTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be read within the read_timeout.
+  class ReadTimeout < Timeout::Error
+  end
+
+  # WriteTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be written within the write_timeout.  Not raised on Windows.
+  class WriteTimeout < Timeout::Error
+  end
+
   # <!-- rdoc-file=lib/net/http.rb -->
   # ## An HTTP client API for Ruby.
   #


### PR DESCRIPTION
# Description
The current `rbs` file for `Net::HTTP` contained only `ProtocolError`s. Hence, this PR adds the missing `Timeout` errors.

# Changes
- Added `timeout` as a dependency, since `OpenTimeout`, `ReadTimeout`, `WriteTimeout` are subclasses of `Timeout::Error`. [Ref](https://github.com/ruby/net-protocol/blob/master/lib/net/protocol.rb#L70-L99)
- The corresponding `Timeout` errors have been added into `net-http.rbs`

Fixes: #843