### PR TITLE
Define `#sleep` in more detail

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1986,7 +1986,11 @@ module Kernel : BasicObject
   #     Time.new    #=> 2008-03-08 19:56:22 +0900
   #
   def self?.sleep: () -> bot
-                 | (Numeric duration) -> Integer
+                 | ((Integer | Float | _Divmod) duration) -> Integer
+
+  interface _Divmod
+    def divmod: (Numeric) -> [ Numeric, Numeric ]
+  end
 
   # <!--
   #   rdoc-file=io.c

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -576,10 +576,15 @@ class KernelTest < StdlibTest
   end
 
   def test_sleep
-    # TODO
-    #   sleep
+    sleep 0
 
     sleep 0.01
+
+    o = Object.new
+    def o.divmod(i)
+      [0.001, 0.001]
+    end
+    sleep o
   end
 
   def test_syscall


### PR DESCRIPTION
Defined `Kernel#sleep` in more detail.

## Fix some problems

### 1. `Complex` inherits from `Numeric`, but does not accept.

```
$ ruby -e 'sleep 1.to_c'
-e:1:in `sleep': can't convert Complex into time interval (TypeError)
	from -e:1:in `<main>'
```

### 2. Any object that does not inherit from Numeric can be passed as an argument, as long as `#divmod` is defined.

https://github.com/ruby/spec/blob/1a68f6e0ffede9f0c2c6eb8c6dff75924df79d91/core/kernel/sleep_spec.rb#L25-L29

## More detail

Since `#divmod` is defined for both `Integer` and `Float`, it could be just `(_Divmod duration) -> Integer`, but there are some surprises in the documentation, and I used `(Integer | Float | _Divmod)` in reference to CRuby implementation.

CRuby implementation is `time_timespec` function in time.c.

https://github.com/ruby/ruby/blob/af107710457b4bd148c6e5ee7a336ed4961f5423/time.c#L2560-L2609

There is a method `File.utime` that uses `time_timespec` function, but its behavior is not described in ruby/spec, and I've narrowed down the scope to sleep.