### PR TITLE
Add c99 flag for compiling on Ruby 2

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,3 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
+$CFLAGS += " -std=c99 "
 create_makefile 'rbs_extension'


### PR DESCRIPTION
The native extension fails to compile on Ruby 2.6/7 with errors like the following:

```
../../../../ext/rbs_extension/parserstate.c:77:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (size_t i = 0; i < table->count; i++) {
     ^
../../../../ext/rbs_extension/parserstate.c:77:5: note: use option -std=c99 or -std=gnu99 to compile your code
```

This PR adds `-std=c99` to $CFLAGS to enforce C99 mode.

Tested locally on Ruby 2.6.3, 2.7.2, and 3.0.1.