### PR TITLE
Let `Writer` preserve format

### DIFF
--- a/lib/rbs/annotate/rdoc_annotator.rb
+++ b/lib/rbs/annotate/rdoc_annotator.rb
@@ -11,7 +11,7 @@ module RBS
         @include_filename = true
       end
 
-      def annotate_file(path)
+      def annotate_file(path, preserve:)
         content = path.read()
 
         decls = Parser.parse_signature(content)
@@ -19,7 +19,7 @@ module RBS
         annotate_decls(decls)
 
         path.open("w") do |io|
-          Writer.new(out: io).write(decls)
+          Writer.new(out: io).preserve!(preserve: preserve).write(decls)
         end
       end
 

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -797,6 +797,8 @@ Examples:
       source = RBS::Annotate::RDocSource.new()
       annotator = RBS::Annotate::RDocAnnotator.new(source: source)
 
+      preserve = true
+
       OptionParser.new do |opts|
         opts.banner = <<-EOB
 Usage: rbs annotate [options...] [files...]
@@ -817,6 +819,7 @@ Options:
         opts.on("-d", "--dir DIRNAME", "Load RDoc from DIRNAME") {|d| source.extra_dirs << Pathname(d) }
         opts.on("--[no-]arglists", "Generate arglists section (defaults to true)") {|b| annotator.include_arg_lists = b }
         opts.on("--[no-]filename", "Include source file name in the documentation (defaults to true)") {|b| annotator.include_filename = b }
+        opts.on("--[no-]preserve", "Try preserve the format of the original file (defaults to true)") {|b| preserve = b }
       end.parse!(args)
 
       source.load()
@@ -826,11 +829,11 @@ Options:
         if path.directory?
           Pathname.glob((path + "**/*.rbs").to_s).each do |path|
             stdout.puts "Processing #{path}..."
-            annotator.annotate_file(path)
+            annotator.annotate_file(path, preserve: preserve)
           end
         else
           stdout.puts "Processing #{path}..."
-          annotator.annotate_file(path)
+          annotator.annotate_file(path, preserve: preserve)
         end
       end
     end

--- a/sig/annotate/rdoc_annotater.rbs
+++ b/sig/annotate/rdoc_annotater.rbs
@@ -8,7 +8,7 @@ module RBS
 
       def initialize: (source: RDocSource) -> void
 
-      def annotate_file: (Pathname) -> void
+      def annotate_file: (Pathname, preserve: bool) -> void
 
       def annotate_decls: (Array[AST::Declarations::t], ?outer: Array[Namespace]) -> void
 

--- a/sig/writer.rbs
+++ b/sig/writer.rbs
@@ -1,4 +1,6 @@
 module RBS
+  # Writer prints RBS AST to String.
+  #
   class Writer
     interface _IO
       def puts: (*untyped) -> void
@@ -6,22 +8,95 @@ module RBS
       def flush: () -> void
     end
 
+    # Channel to output the result.
+    #
     attr_reader out: _IO
+
+    # Array of indentations.
+    #
     attr_reader indentation: Array[String]
 
     def initialize: (out: _IO) -> void
 
+    # Output the array of declarations.
+    # It automatically inserts empty lines between the declarations.
+    #
+    def write: (Array[AST::Declarations::t]) -> void
+
+    def preserve?: () -> bool
+
+    def preserve!: (?preserve: bool) -> self
+
+    private
+
+    @preserve: bool
+
+    # Increases the indentation and yields the block.
+    #
     def indent: (?Integer size) { () -> void } -> void
 
+    # Returns the current indentation of lines.
+    #
     def prefix: () -> String
 
+    # Prints a string.
+    # Automatically appends the `#prefix` and newline at the end.
+    #
     def puts: (?String) -> void
+
+    # Prints a (possibly) multi-line string.
+    #
+    # Drops `leading_spaces` of spaces at the beginning of each line.
+    #
+    # ```ruby
+    # put_lines(<<TEXT, leading_spaces: 0)
+    # Hello
+    #   world!
+    # TEXT
+    #
+    # # Outputs
+    # # Hello
+    # #   world!
+    #
+    # put_lines(<<TEXT, leading_spaces: 2)
+    # Hello
+    #   world!
+    # TEXT
+    #
+    # # Outputs
+    # # Hello
+    # # world!
+    # ```
+    #
+    # This is for `Location#source`.
+    # The `#source` returns the text spans from the beginning to end of the element.
+    # It will look like the following.
+    #
+    # ```rbs
+    # module Foo
+    #   type t = Integer     # the definition of `t` starts from line=2, column=2
+    #          | String
+    #          | :false      # the definition of `t` ends from line=4, column=17
+    # end
+    # ```
+    #
+    # The expected output will be something like:
+    #
+    # ```rbs
+    # type t = Integer       # Extracted from `Foo` definition and keeps the line breaks
+    #        | String
+    #        | :false
+    # ```
+    #
+    # And it can be done with a `#put_lines(source, leading_spaces: 2)` call.
+    #
+    def put_lines: (String, leading_spaces: Integer) -> void
+
+    def write_loc_source: (_Located) { () -> void } -> void
 
     def write_annotation: (Array[AST::Annotation]) -> void
 
     def write_comment: (AST::Comment?) -> void
-
-    def write: (Array[AST::Declarations::t]) -> void
 
     def write_decl: (AST::Declarations::t) -> void
 
@@ -30,6 +105,8 @@ module RBS
     def name_and_params: (TypeName, Array[AST::TypeParam]) -> String?
 
     def name_and_args: (TypeName, Array[Types::t]) -> String?
+
+    def write_alias: (AST::Declarations::Alias) -> void
 
     def method_name: (Symbol) -> String
 


### PR DESCRIPTION
I found some RBS files has manually formatted definitions like:

```
type expr = IntExpr
          | StringExpr
          | FuncallExpr

def foo: (some, params,
          many: bool,
          keyword: String,
          ?parameters: bool) -> void
```

And I don't want to destroy the good format.

I add an option `#preserve?` to `Writer` to re-use the source text from which the ast is constructed.
The option works only for `type` decl and method definitions.