### PR TITLE
Reduce memory usage of RBS::Buffer

### DIFF
--- a/lib/rbs/buffer.rb
+++ b/lib/rbs/buffer.rb
@@ -2,23 +2,29 @@ module RBS
   class Buffer
     attr_reader :name
     attr_reader :content
-    attr_reader :lines
-    attr_reader :ranges
 
     def initialize(name:, content:)
       @name = name
       @content = content
+    end
 
-      @lines = content.lines
+    def lines
+      @lines ||= content.lines
+    end
 
-      @ranges = []
-      offset = 0
-      lines.each do |line|
-        size = line.size
-        range = offset...(offset+size)
-        ranges << range
-        offset += size
-      end
+    def ranges
+      @ranges ||=
+        begin
+          @ranges = []
+          offset = 0
+          lines.each do |line|
+            size = line.size
+            range = offset...(offset+size)
+            @ranges << range
+            offset += size
+          end
+          @ranges
+        end
     end
 
     def pos_to_loc(pos)

--- a/sig/buffer.rbs
+++ b/sig/buffer.rbs
@@ -11,11 +11,15 @@ module RBS
     # The content of the buffer.
     attr_reader content: String
 
-    attr_reader lines: Array[String]
+    @lines: Array[String]
 
-    attr_reader ranges: Array[Range[Integer]]
+    @ranges: Array[Range[Integer]]
 
     def initialize: (name: untyped name, content: String content) -> void
+
+    def lines: () -> Array[String]
+
+    def ranges: () -> Array[Range[Integer]]
 
     # Translate position to location.
     def pos_to_loc: (Integer pos) -> loc


### PR DESCRIPTION
This PR reduces memory usage of RBS::Buffer.


`RBS::Buffer` setups `@lines` and `@ranges` on `initialize`, but they aren't used in many cases and they consume large memory.
This patch makes the initialization lazy to avoid allocating memory.

It doesn't affect `rbs` command speed, but it reduces memory usage.


# Benchmarking

It reduces 8,275kb (17%) memory only with the core libraries, and reduces 33,718kb (24%) memory with rails gems.


## With core libraries

```ruby
$LOAD_PATH << File.join(__dir__, "./lib")
require 'rbs'
require 'rbs/cli'

def rss
  `ps u --no-headers --pid #{Process.pid}`.split(' ')[5].to_i
end

l = RBS::EnvironmentLoader.new
x = x = RBS::Environment.from_loader(l).resolve_type_names
GC.start
p rss
```

before: 48690 (kb)
after: 40415 (kb)

## With rails gems

```ruby
$LOAD_PATH << File.join(__dir__, "./lib")
require 'rbs'
require 'rbs/cli'

def rss
  `ps u --no-headers --pid #{Process.pid}`.split(' ')[5].to_i
end

l = RBS::EnvironmentLoader.new
path = Pathname('/path/to/rbs_collection.yaml')
lock = RBS::Collection::Config.lockfile_of(path)
l.add_collection lock
x = x = RBS::Environment.from_loader(l).resolve_type_names
GC.start
p rss
```

before: 139662 (kb)
after: 105944 (kb)