### PR TITLE
Clarify `self?.` method semantics

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -275,8 +275,6 @@
 #
 %a{annotate:rdoc:source:from=object.c}
 module Kernel : BasicObject
-  private
-
   # <!--
   #   rdoc-file=vm_backtrace.c
   #   - caller(start=1, length=nil)  -> array or nil

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -328,13 +328,15 @@ An instance variable definition consists of the name of an instance variable and
 
 Method definition has several syntax variations.
 
-You can write `self.` or `self?.` before the name of the method to specify the kind of method: instance, singleton, or both instance and singleton.
+You can write `self.` or `self?.` before the name of the method to specify the kind of method: instance, singleton, or module function.
 
 ```
 def to_s: () -> String                        # Defines a instance method
 def self.new: () -> AnObject                  # Defines singleton method
 def self?.sqrt: (Numeric) -> Numeric          # self? is for `module_function`s
 ```
+
+`self?` method definition adds two methods: a public singleton method and a private instance method, which is equivalent to `module_function` in Ruby.
 
 The method type can be connected with `|`s to define an overloaded method.
 
@@ -404,7 +406,7 @@ alias collect map                                   # `#collect` has the same ty
 
 ### `public`, `private`
 
-`public` and `private` allows specifying the visibility of methods.
+`public` and `private` allows specifying the visibility of instance methods.
 
 These work only as _statements_, not per-method specifier.
 

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -587,7 +587,7 @@ module RBS
             defs: original_method.defs.map do |defn|
               defn.update(defined_in: definition.type_name, implemented_in: definition.type_name)
             end,
-            accessibility: method_def.accessibility,
+            accessibility: original_method.accessibility,
             alias_of: original_method
           )
         else

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -10,7 +10,11 @@ module RBS
           end
 
           def accessibility
-            accessibilities[0]
+            if original.is_a?(AST::Members::Alias)
+              raise "alias member doesn't have accessibility"
+            else
+              accessibilities[0] or raise
+            end
           end
 
           def self.empty(name:, type:)
@@ -127,7 +131,7 @@ module RBS
                     end
                   when AST::Members::Alias
                     if member.kind == :instance
-                      build_alias(methods, type, member: member, accessibility: accessibility)
+                      build_alias(methods, type, member: member)
                     end
                   end
                 end
@@ -156,7 +160,7 @@ module RBS
                     end
                   when AST::Members::Alias
                     if member.kind == :singleton
-                      build_alias(methods, type, member: member, accessibility: :public)
+                      build_alias(methods, type, member: member)
                     end
                   end
                 end
@@ -178,18 +182,16 @@ module RBS
                 when AST::Members::MethodDefinition
                   build_method(methods, type, member: member, accessibility: :public)
                 when AST::Members::Alias
-                  build_alias(methods, type, member: member, accessibility: :public)
+                  build_alias(methods, type, member: member)
                 end
               end
             end.validate!
           end
       end
 
-      def build_alias(methods, type, member:, accessibility:)
+      def build_alias(methods, type, member:)
         defn = methods.methods[member.new_name] ||= Methods::Definition.empty(type: type, name: member.new_name)
-
         defn.originals << member
-        defn.accessibilities << accessibility
       end
 
       def build_attribute(methods, type, member:, accessibility:)

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -134,19 +134,19 @@ module RBS
 
             Methods.new(type: type).tap do |methods|
               entry.decls.each do |d|
-                each_member_with_accessibility(d.decl.members) do |member, accessibility|
+                d.decl.members.each do |member|
                   case member
                   when AST::Members::MethodDefinition
                     if member.singleton?
-                      build_method(methods, type, member: member, accessibility: accessibility)
+                      build_method(methods, type, member: member, accessibility: :public)
                     end
                   when AST::Members::AttrReader, AST::Members::AttrWriter, AST::Members::AttrAccessor
                     if member.kind == :singleton
-                      build_attribute(methods, type, member: member, accessibility: accessibility)
+                      build_attribute(methods, type, member: member, accessibility: :public)
                     end
                   when AST::Members::Alias
                     if member.kind == :singleton
-                      build_alias(methods, type, member: member, accessibility: accessibility)
+                      build_alias(methods, type, member: member, accessibility: :public)
                     end
                   end
                 end

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -102,11 +102,21 @@ module RBS
                 each_member_with_accessibility(d.decl.members) do |member, accessibility|
                   case member
                   when AST::Members::MethodDefinition
-                    if member.instance?
-                      build_method(methods,
-                                   type,
-                                   member: member.update(types: member.types.map {|type| type.sub(subst) }),
-                                   accessibility: accessibility)
+                    case member.kind
+                    when :instance
+                      build_method(
+                        methods,
+                        type,
+                        member: member.update(types: member.types.map {|type| type.sub(subst) }),
+                        accessibility: accessibility
+                      )
+                    when :singleton_instance
+                      build_method(
+                        methods,
+                        type,
+                        member: member.update(types: member.types.map {|type| type.sub(subst) }),
+                        accessibility: :private
+                      )
                     end
                   when AST::Members::AttrReader, AST::Members::AttrWriter, AST::Members::AttrAccessor
                     if member.kind == :instance

--- a/sig/method_builder.rbs
+++ b/sig/method_builder.rbs
@@ -6,7 +6,8 @@ module RBS
 
         class Definition
           type original = AST::Members::MethodDefinition | AST::Members::Alias | AST::Members::AttrAccessor | AST::Members::AttrWriter | AST::Members::AttrReader
-          type accessibility = :public | :private
+
+          type accessibility = RBS::Definition::accessibility
 
           attr_reader name: Symbol
           attr_reader type: instance_type
@@ -59,11 +60,11 @@ module RBS
 
       def build_interface: (TypeName) -> Methods
 
-      def build_alias: (Methods, Methods::instance_type, member: AST::Members::Alias, accessibility: Methods::Definition::accessibility) -> void
+      def build_alias: (Methods, Methods::instance_type, member: AST::Members::Alias) -> void
 
-      def build_attribute: (Methods, Methods::instance_type, member: AST::Members::AttrAccessor | AST::Members::AttrReader | AST::Members::AttrWriter, accessibility: Methods::Definition::accessibility) -> void
+      def build_attribute: (Methods, Methods::instance_type, member: AST::Members::AttrAccessor | AST::Members::AttrReader | AST::Members::AttrWriter, accessibility: Definition::accessibility) -> void
 
-      def build_method: (Methods, Methods::instance_type, member: AST::Members::MethodDefinition, accessibility: Methods::Definition::accessibility) -> void
+      def build_method: (Methods, Methods::instance_type, member: AST::Members::MethodDefinition, accessibility: Definition::accessibility) -> void
 
       def each_member_with_accessibility: (Array[AST::Members::t | AST::Declarations::t], ?accessibility: Definition::accessibility) { (AST::Members::t | AST::Declarations::t, Definition::accessibility) -> void } -> void
 

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2031,4 +2031,45 @@ end
       end
     end
   end
+
+  def test_module_function
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class C
+  def self?.a: () -> void
+end
+
+module M
+  def self?.b: () -> void
+end
+      EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_singleton(type_name("::C")).tap do |definition|
+          definition.methods[:a].tap do |a|
+            assert_predicate a, :public?
+          end
+        end
+
+        builder.build_instance(type_name("::C")).tap do |definition|
+          definition.methods[:a].tap do |a|
+            assert_predicate a, :private?
+          end
+        end
+
+        builder.build_singleton(type_name("::M")).tap do |definition|
+          definition.methods[:b].tap do |b|
+            assert_predicate b, :public?
+          end
+        end
+
+        builder.build_instance(type_name("::M")).tap do |definition|
+          definition.methods[:b].tap do |b|
+            assert_predicate b, :private?
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2072,4 +2072,31 @@ end
       end
     end
   end
+
+  def test_alias_visibility
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class C
+  def self?.a: () -> void
+
+  public
+
+  alias b a
+end
+      EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::C")).tap do |definition|
+          definition.methods[:a].tap do |a|
+            assert_predicate a, :private?
+          end
+
+          definition.methods[:b].tap do |b|
+            assert_predicate b, :private?
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2000,4 +2000,35 @@ type pair[S, T] = [S, T]
 end
     end
   end
+
+  def test_singleton_public_private
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class C
+  private
+  def self.a: () -> void
+end
+
+module M
+  private
+  def self.b: () -> void
+end
+      EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_singleton(type_name("::C")).tap do |definition|
+          definition.methods[:a].tap do |a|
+            assert_predicate a, :public?
+          end
+        end
+
+        builder.build_singleton(type_name("::M")).tap do |definition|
+          definition.methods[:b].tap do |b|
+            assert_predicate b, :public?
+          end
+        end
+      end
+    end
+  end
 end

--- a/test/rbs/method_builder_test.rb
+++ b/test/rbs/method_builder_test.rb
@@ -120,7 +120,7 @@ EOF
               assert_equal :bar, member.name
             end
 
-            assert_equal [:public], bar.accessibilities
+            assert_equal [], bar.accessibilities
           end
         end
       end
@@ -233,7 +233,7 @@ EOF
               assert_equal :bar, member.name
             end
 
-            assert_equal [:public], bar.accessibilities
+            assert_equal [], bar.accessibilities
           end
         end
       end
@@ -292,18 +292,21 @@ EOF
         builder.build_interface(type_name("::_Foo")).tap do |methods|
           assert_equal parse_type("::_Foo"), methods.type
 
-          methods.methods[:world].tap do |hello|
-            assert_instance_of MethodBuilder::Methods::Definition, hello
+          methods.methods[:world].tap do |world|
+            assert_instance_of MethodBuilder::Methods::Definition, world
 
-            assert_instance_of AST::Members::Alias, hello.original
-            assert_equal :hello, hello.original.old_name
+            assert_instance_of AST::Members::Alias, world.original
+            assert_equal :hello, world.original.old_name
 
-            assert_any!(hello.overloads, size: 1) do |member|
+            assert_any!(world.overloads, size: 1) do |member|
               assert_instance_of AST::Members::MethodDefinition, member
               assert_equal [parse_method_type("() -> ::Integer")], member.types
             end
 
-            assert_equal :public, hello.accessibility
+            assert_equal [], world.accessibilities
+            assert_raises do
+              world.accessibility
+            end
           end
         end
       end


### PR DESCRIPTION
It's a syntax for _module function_! 💡 

This PR introduces two changes:

1. Singleton methods ignore `public` and `private` members: Singleton methods always have `public` visibility. Will be changed in #911 
2. Instance methods defined with `self?` have `private` visibility, even with `public`

These changes will make `self?` methods closer to _module function_.

```rbs
module Kernel
  def self?.puts: (*untyped) -> void     # Defines `Kernel.puts` public method and `Kernel#puts` private method.
end
```