### PR TITLE
Add `public`/`private` per member modifier

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -279,13 +279,12 @@ _member_ ::= _ivar-member_                # Ivar definition
            | _extend-member_              # Mixin (extend)
            | _prepend-member_             # Mixin (prepend)
            | _alias-member_               # Alias
-           | `public`                     # Public
-           | `private`                    # Private
+           | _visibility-member_          # Visibility member
 
 _ivar-member_ ::= _ivar-name_ `:` _type_
 
-_method-member_ ::= `def` _method-name_ `:` _method-types_            # Instance method
-                  | `def self.` _method-name_ `:` _method-types_      # Singleton method
+_method-member_ ::= _visibility_ `def` _method-name_ `:` _method-types_            # Instance method
+                  | _visibility_ `def self.` _method-name_ `:` _method-types_      # Singleton method
                   | `def self?.` _method-name_ `:` _method-types_     # Singleton and instance method
 
 _method-types_ ::= _method-type-parameters_ _method-type_                       # Single method type
@@ -295,9 +294,11 @@ _method-types_ ::= _method-type-parameters_ _method-type_                       
 _method-type-parameters_ ::=                                                    # Empty
                            | `[` _type-variable_ `,` ... `]`
 
-_attribute-member_ ::= _attribute-type_ _method-name_ `:` _type_                     # Attribute
-                     | _attribute-type_ _method-name_ `(` _ivar-name_ `) :` _type_   # Attribute with variable name specification
-                     | _attribute-type_ _method-name_ `() :` _type_                  # Attribute without variable
+_attribute-member_ ::= _visibility_ _attribute-type_ _method-name_ `:` _type_                     # Attribute
+                     | _visibility_ _attribute-type_ _method-name_ `(` _ivar-name_ `) :` _type_   # Attribute with variable name specification
+                     | _visibility_ _attribute-type_ _method-name_ `() :` _type_                  # Attribute without variable
+
+_visibility_ ::= `public` | `private`
 
 _attribute-type_ ::= `attr_reader` | `attr_writer` | `attr_accessor`
 
@@ -309,6 +310,8 @@ _prepend-member_ ::= `prepend` _class-name_ _type-arguments_
 
 _alias-member_ ::= `alias` _method-name_ _method-name_
                  | `alias self.` _method-name_ `self.` _method-name_
+
+_visibility-member_ ::= _visibility_
 
 _ivar-name_ ::= /@\w+/
 _method-name_ ::= ...
@@ -353,6 +356,16 @@ def +: (Float | Integer) -> (Float | Integer)
      | (Numeric) -> Numeric
 ```
 
+Adding `public` and `private` modifier changes the visibility of the method.
+
+```
+private def puts: (*untyped) -> void       # Defines private instance method
+
+public def self.puts: (*untyped) -> void   # Defines public singleton method
+
+public def self?.puts: (*untyped) -> void  # 🚨🚨🚨 Error: `?.` has own visibility semantics (== `module_function`) 🚨🚨🚨
+```
+
 ### Attribute definition
 
 Attribute definitions help to define methods and instance variables based on the convention of `attr_reader`, `attr_writer` and `attr_accessor` methods in Ruby.
@@ -374,6 +387,14 @@ attr_writer name (@raw_name) : String
 attr_accessor people (): Array[Person]
 # def people: () -> Array[Person]
 # def people=: (Array[Person]) -> Array[Person]
+```
+
+Attribute definitions can have the `public` and `private` modifiers like method definitions:
+
+```
+private attr_accessor id: Integer
+
+private attr_reader self.name: String
 ```
 
 ### Mixin (include), Mixin (extend), Mixin (prepend)
@@ -404,11 +425,31 @@ def map: [X] () { (String) -> X } -> Array[X]
 alias collect map                                   # `#collect` has the same type with `map`
 ```
 
-### `public`, `private`
+### Visibility member
 
-`public` and `private` allows specifying the visibility of instance methods.
+Visibility member allows specifying the default visibility of instance methods and instance attributes.
 
-These work only as _statements_, not per-method specifier.
+```rbs
+public
+
+def foo: () -> void          # public instance method
+
+attr_reader name: String     # public instance attribute
+
+private
+
+def bar: () -> void          # private instance method
+
+attr_reader email: String    # private instance attribute
+```
+
+The visibility _modifiers_ overwrite the default visibility per member bases.
+
+The visibility member requires a new line `\n` after the token.
+
+```rbs
+private alias foo bar       # Syntax error
+```
 
 ## Declarations
 

--- a/ext/rbs_extension/lexer.h
+++ b/ext/rbs_extension/lexer.h
@@ -150,6 +150,11 @@ unsigned int peek(lexstate *state);
 void skip(lexstate *state);
 
 /**
+ * Skip n characters.
+ * */
+void skipn(lexstate *state, size_t size);
+
+/**
  * Return new token with given type.
  * */
 token next_token(lexstate *state, enum TokenType type);

--- a/ext/rbs_extension/lexstate.c
+++ b/ext/rbs_extension/lexstate.c
@@ -134,6 +134,12 @@ void skip(lexstate *state) {
   }
 }
 
+void skipn(lexstate *state, size_t size) {
+  for (size_t i = 0; i < size; i ++) {
+    skip(state);
+  }
+}
+
 char *peek_token(lexstate *state, token tok) {
   return RSTRING_PTR(state->string) + tok.range.start.byte_pos;
 }

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -400,7 +400,7 @@ VALUE rbs_ast_decl_module(VALUE name, VALUE type_params, VALUE self_types, VALUE
   );
 }
 
-VALUE rbs_ast_members_method_definition(VALUE name, VALUE kind, VALUE types, VALUE annotations, VALUE location, VALUE comment, VALUE overload) {
+VALUE rbs_ast_members_method_definition(VALUE name, VALUE kind, VALUE types, VALUE annotations, VALUE location, VALUE comment, VALUE overload, VALUE visibility) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("name")), name);
   rb_hash_aset(args, ID2SYM(rb_intern("kind")), kind);
@@ -409,6 +409,7 @@ VALUE rbs_ast_members_method_definition(VALUE name, VALUE kind, VALUE types, VAL
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
   rb_hash_aset(args, ID2SYM(rb_intern("comment")), comment);
   rb_hash_aset(args, ID2SYM(rb_intern("overload")), overload);
+  rb_hash_aset(args, ID2SYM(rb_intern("visibility")), visibility);
 
   return CLASS_NEW_INSTANCE(
     RBS_AST_Members_MethodDefinition,
@@ -446,7 +447,7 @@ VALUE rbs_ast_members_mixin(VALUE klass, VALUE name, VALUE module_args, VALUE an
   );
 }
 
-VALUE rbs_ast_members_attribute(VALUE klass, VALUE name, VALUE type, VALUE ivar_name, VALUE kind, VALUE annotations, VALUE location, VALUE comment) {
+VALUE rbs_ast_members_attribute(VALUE klass, VALUE name, VALUE type, VALUE ivar_name, VALUE kind, VALUE annotations, VALUE location, VALUE comment, VALUE visibility) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("name")), name);
   rb_hash_aset(args, ID2SYM(rb_intern("type")), type);
@@ -455,6 +456,7 @@ VALUE rbs_ast_members_attribute(VALUE klass, VALUE name, VALUE type, VALUE ivar_
   rb_hash_aset(args, ID2SYM(rb_intern("annotations")), annotations);
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
   rb_hash_aset(args, ID2SYM(rb_intern("comment")), comment);
+  rb_hash_aset(args, ID2SYM(rb_intern("visibility")), visibility);
 
   return CLASS_NEW_INSTANCE(
     klass,

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -16,8 +16,8 @@ VALUE rbs_ast_decl_interface(VALUE name, VALUE type_params, VALUE members, VALUE
 VALUE rbs_ast_decl_module_self(VALUE name, VALUE args, VALUE location);
 VALUE rbs_ast_decl_module(VALUE name, VALUE type_params, VALUE self_types, VALUE members, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_members_alias(VALUE new_name, VALUE old_name, VALUE kind, VALUE annotations, VALUE location, VALUE comment);
-VALUE rbs_ast_members_attribute(VALUE klass, VALUE name, VALUE type, VALUE ivar_name, VALUE kind, VALUE annotations, VALUE location, VALUE comment);
-VALUE rbs_ast_members_method_definition(VALUE name, VALUE kind, VALUE types, VALUE annotations, VALUE location, VALUE comment, VALUE overload);
+VALUE rbs_ast_members_attribute(VALUE klass, VALUE name, VALUE type, VALUE ivar_name, VALUE kind, VALUE annotations, VALUE location, VALUE comment, VALUE visibility);
+VALUE rbs_ast_members_method_definition(VALUE name, VALUE kind, VALUE types, VALUE annotations, VALUE location, VALUE comment, VALUE overload, VALUE visibility);
 VALUE rbs_ast_members_mixin(VALUE klass, VALUE name, VALUE args, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_members_variable(VALUE klass, VALUE name, VALUE type, VALUE location, VALUE comment);
 VALUE rbs_ast_members_visibility(VALUE klass, VALUE location);

--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -12,8 +12,9 @@ module RBS
         attr_reader :location
         attr_reader :comment
         attr_reader :overload
+        attr_reader :visibility
 
-        def initialize(name:, kind:, types:, annotations:, location:, comment:, overload:)
+        def initialize(name:, kind:, types:, annotations:, location:, comment:, overload:, visibility: nil)
           @name = name
           @kind = kind
           @types = types
@@ -21,6 +22,7 @@ module RBS
           @location = location
           @comment = comment
           @overload = overload ? true : false
+          @visibility = visibility
         end
 
         def ==(other)
@@ -28,7 +30,8 @@ module RBS
             other.name == name &&
             other.kind == kind &&
             other.types == types &&
-            other.overload == overload
+            other.overload == overload &&
+            other.visibility == visibility
         end
 
         alias eql? ==
@@ -49,7 +52,7 @@ module RBS
           overload
         end
 
-        def update(name: self.name, kind: self.kind, types: self.types, annotations: self.annotations, location: self.location, comment: self.comment, overload: self.overload)
+        def update(name: self.name, kind: self.kind, types: self.types, annotations: self.annotations, location: self.location, comment: self.comment, overload: self.overload, visibility: self.visibility)
           self.class.new(
             name: name,
             kind: kind,
@@ -57,7 +60,8 @@ module RBS
             annotations: annotations,
             location: location,
             comment: comment,
-            overload: overload
+            overload: overload,
+            visibility: visibility
           )
         end
 
@@ -221,8 +225,9 @@ module RBS
         attr_reader :annotations
         attr_reader :location
         attr_reader :comment
+        attr_reader :visibility
 
-        def initialize(name:, type:, ivar_name:, kind:, annotations:, location:, comment:)
+        def initialize(name:, type:, ivar_name:, kind:, annotations:, location:, comment:, visibility: nil)
           @name = name
           @type = type
           @ivar_name = ivar_name
@@ -230,6 +235,7 @@ module RBS
           @location = location
           @comment = comment
           @kind = kind
+          @visibility = visibility
         end
 
         def ==(other)
@@ -237,16 +243,17 @@ module RBS
             other.name == name &&
             other.type == type &&
             other.ivar_name == ivar_name &&
-            other.kind == kind
+            other.kind == kind &&
+            other.visibility == visibility
         end
 
         alias eql? ==
 
         def hash
-          name.hash ^ type.hash ^ ivar_name.hash ^ kind.hash
+          name.hash ^ type.hash ^ ivar_name.hash ^ kind.hash ^ visibility.hash
         end
 
-        def update(name: self.name, type: self.type, ivar_name: self.ivar_name, kind: self.kind, annotations: self.annotations, location: self.location, comment: self.comment)
+        def update(name: self.name, type: self.type, ivar_name: self.ivar_name, kind: self.kind, annotations: self.annotations, location: self.location, comment: self.comment, visibility: self.visibility)
           klass = _ = self.class
           klass.new(
             name: name,
@@ -255,7 +262,8 @@ module RBS
             kind: kind,
             annotations: annotations,
             location: location,
-            comment: comment
+            comment: comment,
+            visibility: visibility
           )
         end
       end

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -112,7 +112,7 @@ module RBS
                         methods,
                         type,
                         member: member.update(types: member.types.map {|type| type.sub(subst) }),
-                        accessibility: accessibility
+                        accessibility: member.visibility || accessibility
                       )
                     when :singleton_instance
                       build_method(
@@ -127,7 +127,7 @@ module RBS
                       build_attribute(methods,
                                       type,
                                       member: member.update(type: member.type.sub(subst)),
-                                      accessibility: accessibility)
+                                      accessibility: member.visibility || accessibility)
                     end
                   when AST::Members::Alias
                     if member.kind == :instance
@@ -152,11 +152,11 @@ module RBS
                   case member
                   when AST::Members::MethodDefinition
                     if member.singleton?
-                      build_method(methods, type, member: member, accessibility: :public)
+                      build_method(methods, type, member: member, accessibility: member.visibility || :public)
                     end
                   when AST::Members::AttrReader, AST::Members::AttrWriter, AST::Members::AttrAccessor
                     if member.kind == :singleton
-                      build_attribute(methods, type, member: member, accessibility: :public)
+                      build_attribute(methods, type, member: member, accessibility: member.visibility || :public)
                     end
                   when AST::Members::Alias
                     if member.kind == :singleton

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -357,7 +357,8 @@ module RBS
           comment: member.comment,
           overload: member.overload?,
           annotations: member.annotations,
-          location: member.location
+          location: member.location,
+          visibility: member.visibility
         )
       when AST::Members::AttrAccessor
         AST::Members::AttrAccessor.new(
@@ -367,7 +368,8 @@ module RBS
           annotations: member.annotations,
           comment: member.comment,
           location: member.location,
-          ivar_name: member.ivar_name
+          ivar_name: member.ivar_name,
+          visibility: member.visibility
         )
       when AST::Members::AttrReader
         AST::Members::AttrReader.new(
@@ -377,7 +379,8 @@ module RBS
           annotations: member.annotations,
           comment: member.comment,
           location: member.location,
-          ivar_name: member.ivar_name
+          ivar_name: member.ivar_name,
+          visibility: member.visibility
         )
       when AST::Members::AttrWriter
         AST::Members::AttrWriter.new(
@@ -387,7 +390,8 @@ module RBS
           annotations: member.annotations,
           comment: member.comment,
           location: member.location,
-          ivar_name: member.ivar_name
+          ivar_name: member.ivar_name,
+          visibility: member.visibility
         )
       when AST::Members::InstanceVariable
         AST::Members::InstanceVariable.new(

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -261,6 +261,16 @@ module RBS
     end
 
     def write_def(member)
+      visibility =
+        case member.visibility
+        when :public
+          "public "
+        when :private
+          "private "
+        else
+          ""
+        end
+
       name = case member.kind
              when :instance
                "#{method_name(member.name)}"
@@ -272,7 +282,7 @@ module RBS
 
       string = ""
 
-      prefix = "def #{name}:"
+      prefix = "#{visibility}def #{name}:"
       padding = " " * (prefix.size-1)
 
       string << prefix
@@ -300,6 +310,16 @@ module RBS
     end
 
     def attribute(kind, attr)
+      visibility =
+        case attr.visibility
+        when :public
+          "public "
+        when :private
+          "private "
+        else
+          ""
+        end
+
       var = case attr.ivar_name
             when nil
               ""
@@ -316,7 +336,7 @@ module RBS
                    ""
                  end
 
-      "attr_#{kind} #{receiver}#{attr.name}#{var}: #{attr.type}"
+      "#{visibility}attr_#{kind} #{receiver}#{attr.name}#{var}: #{attr.type}"
     end
 
     def preserve_empty_line(prev, decl)

--- a/sig/members.rbs
+++ b/sig/members.rbs
@@ -12,6 +12,8 @@ module RBS
       class Base
       end
 
+      type visibility = :public | :private
+
       class MethodDefinition < Base
         type kind = :instance | :singleton | :singleton_instance
 
@@ -19,13 +21,14 @@ module RBS
         # ^^^                    keyword
         #     ^^^                name
         #
-        # def self.bar: () -> void | ...
-        # ^^^                              keyword
-        #     ^^^^^                        kind
-        #          ^^^                     name
-        #                            ^^^   overload
+        # private def self.bar: () -> void | ...
+        # ^^^^^^^                                  visibility
+        #         ^^^                              keyword
+        #             ^^^^^                        kind
+        #                  ^^^                     name
+        #                                    ^^^   overload
         #
-        type loc = Location[:keyword | :name, :kind | :overload]
+        type loc = Location[:keyword | :name, :kind | :overload | :visibility]
 
         attr_reader name: Symbol
         attr_reader kind: kind
@@ -34,8 +37,9 @@ module RBS
         attr_reader location: loc?
         attr_reader comment: Comment?
         attr_reader overload: bool
+        attr_reader visibility: visibility?
 
-        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: loc?, comment: Comment?, overload: boolish) -> void
+        def initialize: (name: Symbol, kind: kind, types: Array[MethodType], annotations: Array[Annotation], location: loc?, comment: Comment?, overload: boolish, ?visibility: visibility?) -> void
 
         include _HashEqual
         include _ToJson
@@ -46,7 +50,7 @@ module RBS
 
         def overload?: () -> bool
 
-        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?, ?overload: boolish) -> MethodDefinition
+        def update: (?name: Symbol, ?kind: kind, ?types: Array[MethodType], ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?, ?overload: boolish, ?visibility: visibility?) -> MethodDefinition
       end
 
       module Var
@@ -133,15 +137,16 @@ module RBS
         #             ^^^^             name
         #                 ^            colon
         #
-        # attr_accessor self.name (@foo) : String
-        # ^^^^^^^^^^^^^                             keyword
-        #               ^^^^^                       kind
-        #                    ^^^^                   name
-        #                         ^^^^^^            ivar
-        #                          ^^^^             ivar_name
-        #                                ^          colon
+        # public attr_accessor self.name (@foo) : String
+        # ^^^^^^                                           visibility
+        #        ^^^^^^^^^^^^^                             keyword
+        #                      ^^^^^                       kind
+        #                           ^^^^                   name
+        #                                ^^^^^^            ivar
+        #                                 ^^^^             ivar_name
+        #                                       ^          colon
         #
-        type loc = Location[:keyword | :name | :colon, :kind | :ivar | :ivar_name]
+        type loc = Location[:keyword | :name | :colon, :kind | :ivar | :ivar_name | :visibility]
 
         attr_reader name: Symbol
         attr_reader type: Types::t
@@ -150,12 +155,13 @@ module RBS
         attr_reader annotations: Array[Annotation]
         attr_reader location: loc?
         attr_reader comment: Comment?
+        attr_reader visibility: visibility?
 
-        def initialize: (name: Symbol, type: Types::t, ivar_name: Symbol | false | nil, kind: kind, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
+        def initialize: (name: Symbol, type: Types::t, ivar_name: Symbol | false | nil, kind: kind, annotations: Array[Annotation], location: loc?, comment: Comment?, ?visibility: visibility?) -> void
 
         include _HashEqual
 
-        def update: (?name: Symbol, ?type: Types::t, ?ivar_name: Symbol | false | nil, ?kind: kind, ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?) -> instance
+        def update: (?name: Symbol, ?type: Types::t, ?ivar_name: Symbol | false | nil, ?kind: kind, ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?, ?visibility: visibility) -> instance
       end
 
       class AttrReader < Base

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -272,4 +272,18 @@ class Foo
 end
     SIG
   end
+
+  def test_write_visibility_modifier
+    assert_writer <<-SIG, preserve: true
+class Foo
+  private def foo: () -> String
+
+  public def bar: () -> String
+
+  def baz: () -> String
+
+  private attr_reader name: String
+end
+    SIG
+  end
 end


### PR DESCRIPTION
This PR introduces `public` and `private` visibility modifier syntax, which changes the visibility of a method definition or attribute declaration.

```rbs
class A
  public                           # The default visibility of members below is `public`

  def foo: () -> void              # A#foo is a public method

  private def self.foo: () -> void # A.foo is a private method

  private                          # The default visibility of members below is `public`

  attr_reader bar: String          # A#bar is a private method

  public attr_accessor baz: String # A#baz and A#baz= are public methods

  public def self?.raise: () -> bot     # Syntax error 🚨
end
```