### PR TITLE
Let `validate_type_alias` run without an error on unknown type

### DIFF
--- a/lib/rbs/type_alias_regularity.rb
+++ b/lib/rbs/type_alias_regularity.rb
@@ -55,7 +55,7 @@ module RBS
     end
 
     def build_alias_type(name)
-      entry = env.alias_decls[name] or raise "Unknown alias name: #{name}"
+      entry = env.alias_decls[name] or return
       unless entry.decl.type_params.empty?
         as = entry.decl.type_params.each.map {|param| Types::Variable.new(name: param.name, location: nil) }
         Types::Alias.new(name: name, args: as, location: nil)
@@ -85,9 +85,11 @@ module RBS
       end
       # @type var each_child: TSort::_EachChild[TypeName]
       each_child = __skip__ = -> (name, &block) do
-        type = builder.expand_alias1(name)
-        each_alias_type(type) do |ty|
-          block[ty.name]
+        if env.alias_decls.key?(name)
+          type = builder.expand_alias1(name)
+          each_alias_type(type) do |ty|
+            block[ty.name]
+          end
         end
       end
 

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -89,6 +89,10 @@ module RBS
           location: entry.decl.location&.aref(:type_params)
         )
       end
+
+      if block_given?
+        yield entry.decl.type
+      end
     end
 
     def validate_method_definition(method_def, type_name:)

--- a/sig/validator.rbs
+++ b/sig/validator.rbs
@@ -23,7 +23,9 @@ module RBS
     # - The generics type parameter variance annotation is consistent with respect to their usage
     # - There is no circular dependencies between the generics type parameter bounds
     #
-    def validate_type_alias: (entry: Environment::SingleEntry[TypeName, AST::Declarations::Alias]) -> void
+    # It yields the rhs type if block is given, so that you can validate the rhs type.
+    #
+    def validate_type_alias: (entry: Environment::SingleEntry[TypeName, AST::Declarations::Alias]) ?{ (Types::t rhs_type) -> void } -> void
 
     # Validates the type parameters in generic methods.
     #


### PR DESCRIPTION
It raised an RuntimeError because of `DefinitionBuilder#expand_alias1`. Skipping a part of validation stops raising the error, and yielding the rhs type helps validating it.