### PR TITLE
Accept Numeric by Integer#{upto,downto}

### DIFF
--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -857,8 +857,8 @@ class Integer < Numeric
   #
   # With no block given, returns an Enumerator.
   #
-  def downto: (Integer limit) { (Integer) -> void } -> Integer
-            | (Integer limit) -> ::Enumerator[Integer, self]
+  def downto: (Numeric limit) { (Integer) -> void } -> Integer
+            | (Numeric limit) -> ::Enumerator[Integer, self]
 
   def dup: () -> self
 
@@ -1432,8 +1432,8 @@ class Integer < Numeric
   #
   # With no block given, returns an Enumerator.
   #
-  def upto: (Integer limit) { (Integer) -> void } -> Integer
-          | (Integer limit) -> ::Enumerator[Integer, self]
+  def upto: (Numeric limit) { (Integer) -> void } -> Integer
+          | (Numeric limit) -> ::Enumerator[Integer, self]
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -205,6 +205,7 @@ class IntegerTest < StdlibTest
   def test_down_to
     30.downto(1) {}
     30.downto(31)
+    30.downto(4.2)
   end
 
   def test_eql?
@@ -338,6 +339,7 @@ class IntegerTest < StdlibTest
 
   def test_upto
     5.upto(10) {}
+    5.upto(10.1) {}
   end
 end
 


### PR DESCRIPTION
`Integer#{upto,downto}` accept Float, Rational, and so on.
This PR allows them.


By the way, the type definitions will also accept Complex as the argument but actually it raises an error on Ruby level.
I think it is acceptable for now. They accept the same argument as `Integer#<` ([ref](https://github.com/ruby/ruby/blob/fb928f0ea0e35e06ecc96f592702ff21d28fbdd4/numeric.c#L5603)) and currently `Integer#<` accepts Numeric on RBS level.

