### PR TITLE
Fix `bin/sort` for constants

### DIFF
--- a/bin/sort
+++ b/bin/sort
@@ -9,6 +9,8 @@ def group(member)
   case member
   when Members::Include, Members::Extend, Members::Prepend
     0
+  when RBS::AST::Declarations::Constant
+    -5
   when Members::ClassVariable
     -3
   when Members::ClassInstanceVariable
@@ -54,6 +56,8 @@ def key(member)
     member.name.to_s
   when Members::Alias
     member.new_name.to_s
+  when RBS::AST::Declarations::Constant
+    member.name.to_s
   else
     1
   end


### PR DESCRIPTION
This PR partially fixes issue #918.

Previously `bin/sort` raises an error on a constant declaration in a class decl.

For example:

```rbs
# test.rbs
class C
  def foo: () -> void
  C: String
  B: String
  A: String
end
```

```bash
$ bin/sort test.rbs
bin/sort:71:in `sort!': comparison of RBS::AST::Members::MethodDefinition with RBS::AST::Declarations::Constant failed (ArgumentError)
	from bin/sort:71:in `block (2 levels) in <main>'
	from bin/sort:68:in `each'
	from bin/sort:68:in `block in <main>'
	from bin/sort:62:in `each'
	from bin/sort:62:in `<main>'
Opening test.rbs...
```

This change fixes this problem. The `test.rbs` will be sorted as the following.

```rbs
# test.rbs
class C
  A: String
  B: String
  C: String
  def foo: () -> void
end
```