### PR TITLE
Add manifest.yaml for rbs gem

### DIFF
--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,0 +1,8 @@
+dependencies:
+  - name: logger
+  - name: set
+  - name: pathname
+  - name: json
+  - name: optparse
+  - name: rubygems
+  - name: tsort


### PR DESCRIPTION
Fix ruby/typeprof#111

Previously loading rbs gem's RBSs raises an error, which displays "no
Logger found", without specifying the all dependencies in the
rbs_collection.yaml.
Because I forgot adding manifest.yaml for this gem.

This patch adds manifest.yaml for RBS gem to fix this problem.


----


By the way, the dependencies list is duplicated with Steepfile. I should remove the duplication by introducing `rbs collection` for this repository, but I remained the duplication to keep this PR simple. I'll do it soon.