### PR TITLE
Add visibility modifier to method definition json

### DIFF
--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -73,7 +73,8 @@ module RBS
             annotations: annotations,
             location: location,
             comment: comment,
-            overload: overload
+            overload: overload,
+            visibility: visibility
           }.to_json(state)
         end
       end


### PR DESCRIPTION
It's currently omitted when the ast is serialized to json