### PR TITLE
[rbs collection] Fix error message to tell gem name when source is not found

### DIFF
--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -20,7 +20,10 @@ module RBS
 
       private def source_for(config_entry)
         @source_for ||= {}
-        key = config_entry['source'] or raise
+        key = config_entry['source']
+        unless key
+          raise "Cannot find source of '#{config_entry['name']}' gem"
+        end
         @source_for[key] ||= Sources.from_config_entry(key)
       end
     end


### PR DESCRIPTION
In the current `rbs collection` command, if the rbs of gem listed in `rbs_collection.yaml` was not found, the error message did not tell which gem was missing.

This PR modifies the error message to put the name of the missing gem in the error message.