### PR TITLE
Core signature updates

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -515,7 +515,7 @@ end
 #
 # This type of objects can be created by Enumerable#chain and Enumerator#+.
 #
-class Enumerator::Chain[out Elem] < Object
+class Enumerator::Chain[out Elem] < Enumerator[Elem, void]
   include Enumerable[Elem]
 
   # <!--

--- a/core/false_class.rbs
+++ b/core/false_class.rbs
@@ -27,7 +27,7 @@ class FalseClass
   # statements.
   #
   def ===: (false) -> true
-         | (untyped obj) -> bool
+         | (untyped obj) -> false
 
   # <!--
   #   rdoc-file=object.c

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -363,7 +363,7 @@ class Module < Object
   #
   #     Hello there!
   #
-  def class_exec: (*untyped args) { () -> untyped } -> untyped
+  def class_exec: [U] (*untyped args) { () -> U } -> U
 
   # <!--
   #   rdoc-file=object.c
@@ -675,6 +675,8 @@ class Module < Object
   #
   def define_method: (Symbol | String arg0, ?Proc | Method | UnboundMethod arg1) -> Symbol
                    | (Symbol | String arg0) { () -> untyped } -> Symbol
+
+  def deprecate_constant: (*Symbol) -> self
 
   def eql?: (untyped other) -> bool
 
@@ -1025,7 +1027,7 @@ class Module < Object
   #
   #     Hello there!
   #
-  def module_exec: (*untyped args) { () -> untyped } -> untyped
+  def module_exec: [U] (*untyped args) { (*untyped args) -> U } -> U
 
   # <!--
   #   rdoc-file=vm_method.c

--- a/core/nil_class.rbs
+++ b/core/nil_class.rbs
@@ -4,6 +4,8 @@
 class NilClass
   public
 
+  def !: () -> true
+
   # <!--
   #   rdoc-file=object.c
   #   - false & obj   -> false
@@ -12,7 +14,7 @@ class NilClass
   # And---Returns `false`. *obj* is always evaluated as it is the argument to a
   # method call---there is no short-circuit evaluation in this case.
   #
-  def &: (untyped obj) -> bool
+  def &: (untyped obj) -> false
 
   # <!--
   #   rdoc-file=object.c
@@ -23,7 +25,7 @@ class NilClass
   # statements.
   #
   def ===: (nil) -> true
-         | (untyped obj) -> bool
+         | (untyped obj) -> false
 
   # <!--
   #   rdoc-file=object.c
@@ -43,7 +45,7 @@ class NilClass
   #
   def ^: (nil) -> false
        | (false) -> false
-       | (untyped obj) -> bool
+       | (untyped obj) -> true
 
   # <!--
   #   rdoc-file=object.c
@@ -59,7 +61,7 @@ class NilClass
   # -->
   # Only the object *nil* responds `true` to `nil?`.
   #
-  def nil?: () -> bool
+  def nil?: () -> true
 
   # <!--
   #   rdoc-file=rational.c
@@ -142,7 +144,7 @@ class NilClass
   #
   def |: (nil) -> false
        | (false) -> false
-       | (untyped obj) -> bool
+       | (untyped obj) -> true
 
   def clone: (?freeze: true?) -> self
 end

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -912,6 +912,8 @@ class Object < BasicObject
   #
   def public_method: (name name) -> Method
 
+  def public_methods: (?boolish all) -> Array[Symbol]
+
   # <!--
   #   rdoc-file=vm_eval.c
   #   - obj.public_send(symbol [, args...])  -> obj

--- a/core/true_class.rbs
+++ b/core/true_class.rbs
@@ -27,7 +27,7 @@ class TrueClass
   # statements.
   #
   def ===: (true) -> true
-         | (untyped obj) -> bool
+         | (untyped obj) -> false
 
   # <!--
   #   rdoc-file=object.c


### PR DESCRIPTION
Hi!

These are just some small signature updates that I came across the past couple of months.

* `Array#[]` marked as nilable. I'm not sure if it was intentionally non-nil before, but given `#fetch` is documented as the "non nil" version that throws an error, I think it makes sense to have `#[]` nilable and if a user doesn't want warnings then they can use `#fetch`.
* Missing superclass in `Enumerator::Chain`, couple of tiny missing signatures in `Object` and `Module`.
* Made some signatures more accurate (`true`/`false` instead of `bool`) for some core methods such as `nil?`. Making these more accurate helps with IDE support - we use the return type in some cases to offer fixes that simplify expressions, so this just helps a lot here (e.g., in the IDE we can offer to replace `!nil` with `true` now).

Hope they look okay - let me know if I should change anything in them, or drop any commits if you don't like the changes.