### PR TITLE
Resolve method calls that return `self`

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -597,6 +597,14 @@ module RBS
           BuiltinNames::Array.instance_type(default)
         when :HASH
           BuiltinNames::Hash.instance_type(default, default)
+        when :CALL
+          receiver, method_name, * = node.children
+          case method_name
+          when :freeze, :tap, :itself, :dup, :clone, :taint, :untaint, :extend
+            node_type(receiver)
+          else
+            default
+          end
         else
           default
         end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -49,6 +49,8 @@ class Hello
   end
 
   def kw_req(a:) end
+
+  def opt_with_method_call(a = 'a'.freeze, b: 'b'.dup) end
 end
     EOR
 
@@ -61,6 +63,8 @@ class Hello
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 
   def kw_req: (a: untyped a) -> nil
+
+  def opt_with_method_call: (?::String a, ?b: ::String b) -> nil
 end
     EOF
   end
@@ -561,6 +565,7 @@ end
     rb = <<-EOR
 module Foo
   VERSION = '0.1.1'
+  FROZEN = 'str'.freeze
   ::Hello::World = :foo
 end
     EOR
@@ -570,6 +575,8 @@ end
     assert_write parser.decls, <<-EOF
 module Foo
   VERSION: ::String
+
+  FROZEN: ::String
 
   ::Hello::World: ::Symbol
 end


### PR DESCRIPTION
## Background

I call `rbs prototype` on a number of files defined in my Rails application to keep the type definitions as fresh as possible without having to write them by hand.

## Issues to be resolved

It is a common pattern to call `kernel#freeze` when defining constants.

However, all calls to the `Kernel#freeze` method are currently untyped.

```
cat t.rb
class Foo
  CONST_1 = 'bar'
  CONST_2 = 'baz'.freeze
end

$ rbs prototype rb t.rb
class Foo
  CONST_1: ::String

  CONST_2: untyped
end
```

## Expect

If I can output the type before calling the `#freeze` method, I don't have to modify many constants directly.

```rbs
class Foo
  CONST_1: ::String

  CONST_2: ::String
end
```

## How to resolve

In the case of a method name that returns self in an object instance, the receiver is determined to be an instance that inherits from the object class, and the type of the receiver is returned.

## Side effect

The same conversion applies to method calls with optional method arguments.

## Out of scope

Array or Hash object.