### PR TITLE
Const types as literal types

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -408,7 +408,7 @@ module RBS
           name = lvasgn.children[0]
           fun.optional_positionals << Types::Function::Param.new(
             name: name,
-            type: node_type(lvasgn.children[1])
+            type: param_type(lvasgn.children[1])
           )
         end
 
@@ -429,7 +429,7 @@ module RBS
           when nil, :NODE_SPECIAL_REQUIRED_KEYWORD
             fun.required_keywords[name] = Types::Function::Param.new(name: name, type: untyped)
           when RubyVM::AbstractSyntaxTree::Node
-            fun.optional_keywords[name] = Types::Function::Param.new(name: name, type: node_type(value))
+            fun.optional_keywords[name] = Types::Function::Param.new(name: name, type: param_type(value))
           else
             raise "Unexpected keyword arg value: #{value}"
           end
@@ -578,7 +578,7 @@ module RBS
         end
       end
 
-      def node_type(node, default: Types::Bases::Any.new(location: nil))
+      def param_type(node, default: Types::Bases::Any.new(location: nil))
         case node.type
         when :LIT
           case node.children[0]
@@ -609,6 +609,9 @@ module RBS
           default
         end
       end
+
+      # backward compatible
+      alias node_type param_type
 
       def private
         @private ||= AST::Members::Private.new(location: nil)

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -536,6 +536,14 @@ module RBS
             value_type = types_to_union_type(value_types)
             BuiltinNames::Hash.instance_type([key_type, value_type])
           end
+        when :CALL
+          receiver, method_name, * = node.children
+          case method_name
+          when :freeze, :tap, :itself, :dup, :clone, :taint, :untaint, :extend
+            literal_to_type(receiver)
+          else
+            default
+          end
         else
           untyped
         end
@@ -597,14 +605,6 @@ module RBS
           BuiltinNames::Array.instance_type(default)
         when :HASH
           BuiltinNames::Hash.instance_type(default, default)
-        when :CALL
-          receiver, method_name, * = node.children
-          case method_name
-          when :freeze, :tap, :itself, :dup, :clone, :taint, :untaint, :extend
-            node_type(receiver)
-          else
-            default
-          end
         else
           default
         end

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -477,9 +477,9 @@ module RBS
         when :DREGX
           BuiltinNames::Regexp.instance_type
         when :TRUE
-          BuiltinNames::TrueClass.instance_type
+          Types::Literal.new(literal: true, location: nil)
         when :FALSE
-          BuiltinNames::FalseClass.instance_type
+          Types::Literal.new(literal: false, location: nil)
         when :NIL
           Types::Bases::Nil.new(location: nil)
         when :LIT

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -338,7 +338,7 @@ module RBS
                   # Give up type prediction when node is MASGN.
                   Types::Bases::Any.new(location: nil)
                 else
-                  node_type(value_node)
+                  literal_to_type(value_node)
                 end
           decls << AST::Declarations::Constant.new(
             name: const_name,

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -130,9 +130,9 @@ class Hello
 
   def dregx: () -> ::Regexp
 
-  def t: () -> ::TrueClass
+  def t: () -> true
 
-  def f: () -> ::FalseClass
+  def f: () -> false
 
   def n: () -> nil
 
@@ -628,7 +628,7 @@ D: :hello
 
 E: nil
 
-F: ::FalseClass
+F: false
 
 G: ::Array[1 | 2 | 3]
 

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -49,8 +49,6 @@ class Hello
   end
 
   def kw_req(a:) end
-
-  def opt_with_method_call(a = 'a'.freeze, b: 'b'.dup) end
 end
     EOR
 
@@ -63,8 +61,6 @@ class Hello
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 
   def kw_req: (a: untyped a) -> nil
-
-  def opt_with_method_call: (?::String a, ?b: ::String b) -> nil
 end
     EOF
   end
@@ -576,7 +572,7 @@ end
 module Foo
   VERSION: "0.1.1"
 
-  FROZEN: untyped
+  FROZEN: "str"
 
   ::Hello::World: :foo
 end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -574,11 +574,11 @@ end
 
     assert_write parser.decls, <<-EOF
 module Foo
-  VERSION: ::String
+  VERSION: "0.1.1"
 
-  FROZEN: ::String
+  FROZEN: untyped
 
-  ::Hello::World: ::Symbol
+  ::Hello::World: :foo
 end
     EOF
   end
@@ -622,21 +622,21 @@ H = { id: 123 }
     parser.parse(rb)
 
     assert_write parser.decls, <<-EOF
-A: ::Integer
+A: 1
 
 B: ::Float
 
 C: ::String
 
-D: ::Symbol
+D: :hello
 
-E: untyped?
+E: nil
 
-F: bool
+F: ::FalseClass
 
-G: ::Array[untyped]
+G: ::Array[1 | 2 | 3]
 
-H: ::Hash[untyped, untyped]
+H: { id: 123 }
     EOF
   end
 


### PR DESCRIPTION
Sorry for multi fix.
All commit includes testing code.

Currently, const(CDECL node) use the same type resolution as the optional arguments of the method(`node_type`).
However, most constants are immutable, and it is unnatural to treat them the same as method optional arguments.

For example

````
E = nil
#=> prototype out `E: untyped?`, But is it useful?
````

I've modified the case of const and optional arguments to be separated, and const are now attempted to be resolved as literals like method return type.