### PR TITLE
Fix return value type for `IO#wait_writable`

### DIFF
--- a/core/io/wait.rbs
+++ b/core/io/wait.rbs
@@ -54,5 +54,5 @@ class IO
   # -->
   # Waits until IO is writable and returns `true` or `false` when times out.
   #
-  def wait_writable: (?Numeric? timeout) -> (self | bool | nil)?
+  def wait_writable: (?Numeric? timeout) -> boolish
 end


### PR DESCRIPTION
`IO#wait_writable` does not return bool unlike `IO#wait_readable`.
https://docs.ruby-lang.org/en/3.1/IO.html#method-i-wait_writable