### PR TITLE
Move rb_global_variable

### DIFF
--- a/ext/rbs_extension/unescape.c
+++ b/ext/rbs_extension/unescape.c
@@ -19,6 +19,7 @@ void rbs_unescape_string(VALUE string) {
 
   if (!HASH) {
     HASH = rb_hash_new();
+    rb_global_variable(&HASH);
     rb_hash_aset(HASH, rb_str_new_literal("\\a"), rb_str_new_literal("\a"));
     rb_hash_aset(HASH, rb_str_new_literal("\\b"), rb_str_new_literal("\b"));
     rb_hash_aset(HASH, rb_str_new_literal("\\e"), rb_str_new_literal("\e"));
@@ -29,7 +30,6 @@ void rbs_unescape_string(VALUE string) {
     rb_hash_aset(HASH, rb_str_new_literal("\\t"), rb_str_new_literal("\t"));
     rb_hash_aset(HASH, rb_str_new_literal("\\v"), rb_str_new_literal("\v"));
     rb_hash_aset(HASH, rb_str_new_literal("\\\""), rb_str_new_literal("\""));
-    rb_global_variable(&HASH);
   }
 
   rb_funcall(string, gsub, 2, REGEXP, HASH);


### PR DESCRIPTION
Trying to fix random test failure:

```
/__w/rbs/rbs/lib/rbs/parser_aux.rb:12:in `gsub!': no implicit conversion of Array into String (TypeError)
	from /__w/rbs/rbs/lib/rbs/parser_aux.rb:12:in `_parse_signature'
	from /__w/rbs/rbs/lib/rbs/parser_aux.rb:12:in `parse_signature'
```