### PR TITLE
Warning in C extension

### DIFF
--- a/ext/rbs_extension/constants.c
+++ b/ext/rbs_extension/constants.c
@@ -67,7 +67,7 @@ VALUE RBS_MethodType;
 
 VALUE RBS_ParsingError;
 
-void rbs__init_constants() {
+void rbs__init_constants(void) {
   ID id_RBS = rb_intern_const("RBS");
 
   RBS = rb_const_get(rb_cObject, id_RBS);

--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
-$CFLAGS += " -std=c99 "
+$CFLAGS += " -std=c99 -Wold-style-definition"
 create_makefile 'rbs_extension'

--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -276,7 +276,7 @@ VALUE rbs_location_pp(VALUE buffer, const position *start_pos, const position *e
   return rbs_new_location(buffer, rg);
 }
 
-void rbs__init_location() {
+void rbs__init_location(void) {
   RBS_Location = rb_define_class_under(RBS, "Location", rb_cObject);
   rb_define_alloc_func(RBS_Location, location_s_allocate);
   rb_define_private_method(RBS_Location, "initialize", location_initialize, 3);

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -77,7 +77,7 @@ static VALUE string_of_loc(parserstate *state, position start, position end) {
 /**
  * Raises RuntimeError with "Unexpected error " messsage.
  * */
-static NORETURN(void) rbs_abort() {
+static NORETURN(void) rbs_abort(void) {
   rb_raise(
     rb_eRuntimeError,
     "Unexpected error"
@@ -1065,7 +1065,7 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
       }
 
       param_range.end = state->current_token.range.end;
-      
+
       VALUE location = rbs_new_location(state->buffer, param_range);
       rbs_loc *loc = rbs_check_location(location);
       rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
@@ -2496,7 +2496,7 @@ rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE line, VALUE column)
   return signature;
 }
 
-void rbs__init_parser() {
+void rbs__init_parser(void) {
   RBS_Parser = rb_define_class_under(RBS, "Parser", rb_cObject);
   rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 4);
   rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 4);

--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -2,7 +2,7 @@
 
 #define RESET_TABLE_P(table) (table->size == 0)
 
-id_table *alloc_empty_table() {
+id_table *alloc_empty_table(void) {
   id_table *table = malloc(sizeof(id_table));
   table->size = 10;
   table->count = 0;
@@ -11,7 +11,7 @@ id_table *alloc_empty_table() {
   return table;
 }
 
-id_table *alloc_reset_table() {
+id_table *alloc_reset_table(void) {
   id_table *table = malloc(sizeof(id_table));
   table->size = 0;
 


### PR DESCRIPTION
Fix warnings:

```
location.c: In function ‘rbs__init_location’:
location.c:279:6: warning: old-style function definition [-Wold-style-definition]
  279 | void rbs__init_location() {
      |      ^~~~~~~~~~~~~~~~~~
location.c: At top level:
```