### PR TITLE
[Fixes 961] Use default value also for literal_to_type

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -542,7 +542,7 @@ module RBS
           when :freeze, :tap, :itself, :dup, :clone, :taint, :untaint, :extend
             literal_to_type(receiver)
           else
-            default
+            untyped
           end
         else
           untyped

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -754,6 +754,32 @@ end
     RBS
   end
 
+  def test_calling_class_method_from_instance
+    parser = RB.new
+
+    rb = <<~'RUBY'
+class HelloWorld
+  def self.world(str)
+    str + 'world'
+  end
+
+  def hello
+    self.class.world('hello')
+  end
+end
+    RUBY
+
+    parser.parse(rb)
+
+    assert_write parser.decls, <<~RBS
+class HelloWorld
+  def self.world: (untyped str) -> untyped
+
+  def hello: () -> untyped
+end
+    RBS
+  end
+
   if RUBY_VERSION >= '2.7'
     def test_argument_forwarding
       parser = RB.new


### PR DESCRIPTION
Fixes #961 

It seems that when this piece of code  https://github.com/ruby/rbs/pull/937/files#diff-207b29733058e35f6d05687cd78c9e8e4aec1d51e86f794ea1f5d5620d66027fR545 was moved to a new place, the `default` value variable got left behind.

This is a naive implementation to fix it.