### PR TITLE
Fix rbs_extension build on Windows

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
-$CFLAGS += " -std=c99 -Wold-style-definition"
+$CFLAGS += " -std=c99 -Wold-style-definition" unless have_macro('_MSC_VER')
 create_makefile 'rbs_extension'


### PR DESCRIPTION
Version 2.3.0 is [failing] on Windows CI for ruby/ruby because
Visual Studio 2015 does not support the -Wold-style-definition flag.

Check for MSVC with mkmf using its predefined [macro].

[macro]: https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-140
[failing]: https://ci.appveyor.com/project/ruby/ruby/builds/43108024/job/lqdka0uxpqbudah9#L2861


---

Testing upstream at https://github.com/ruby/ruby/pull/5752