### PR TITLE
Fix mswin build, use append_cflags, add Windows 'compile only' CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,3 +66,21 @@ jobs:
     - name: Run test
       run: |
         bundle exec rake ${{ matrix.job }}
+
+  windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-2019, windows-2022 ]
+        ruby: [ ucrt, mswin ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: rake-compiler
+        run: gem install rake-compiler
+      - name: compile
+        run: rake compile

--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
-$CFLAGS += " -std=c99 -Wold-style-definition"
+append_cflags ['-std=c99', '-Wold-style-definition']
 create_makefile 'rbs_extension'


### PR DESCRIPTION
With ruby-loco's mswin `make install`, the following error is thrown:
```
cl : Command line error D8021 : invalid numeric argument '/Wold-style-definition'
```