### PR TITLE
Raise syntax error from `parse_record_attributes`

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -684,7 +684,11 @@ VALUE parse_record_attributes(parserstate *state) {
         key = rb_funcall(parse_type(state), rb_intern("literal"), 0);
         break;
       default:
-        rbs_abort();
+        raise_syntax_error(
+          state,
+          state->next_token,
+          "unexpected record key token"
+        );
       }
       parser_advance_assert(state, pFATARROW);
     }

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -594,6 +594,13 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
                    }, type.fields)
       assert_equal "{ foo: untyped, }", type.location.source
     end
+
+    error = assert_raises(RBS::ParsingError) do
+      Parser.parse_type("{ foo")
+    end
+    assert_equal "tLIDENT", error.token_type
+    assert_equal "foo", error.location.source
+    assert_equal "a.rbs:1:2...1:5: Syntax error: unexpected record key token, token=`foo` (tLIDENT)", error.message
   end
 
   def test_type_var


### PR DESCRIPTION
It raises `RuntimeError` and crashes Steep LSP. 💣 