### PR TITLE
Use -std=gnu99 instead of -std=c99

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
-append_cflags ['-std=c99']
+append_cflags ['-std=gnu99']
 create_makefile 'rbs_extension'


### PR DESCRIPTION
If you use -std=c99, GCC doesn't use optimizations which use compiler
builtin functions instead of C library.

https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
https://bugs.ruby-lang.org/issues/12336