### PR TITLE
Fix ARGF 

### DIFF
--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -1,0 +1,112 @@
+class ARGFClass
+  include Enumerable[untyped]
+
+  public
+
+  def argv: () -> untyped
+
+  def binmode: () -> untyped
+
+  def binmode?: () -> untyped
+
+  def close: () -> untyped
+
+  def closed?: () -> untyped
+
+  def each: (*untyped) -> untyped
+
+  def each_byte: () -> untyped
+
+  def each_char: () -> untyped
+
+  def each_codepoint: () -> untyped
+
+  def each_line: (*untyped) -> untyped
+
+  def eof: () -> untyped
+
+  def eof?: () -> untyped
+
+  def external_encoding: () -> untyped
+
+  def file: () -> untyped
+
+  def filename: () -> untyped
+
+  def fileno: () -> untyped
+
+  def getbyte: () -> untyped
+
+  def getc: () -> untyped
+
+  def gets: (*untyped) -> untyped
+
+  def inplace_mode: () -> untyped
+
+  def inplace_mode=: (untyped) -> untyped
+
+  alias inspect to_s
+
+  def internal_encoding: () -> untyped
+
+  def lineno: () -> untyped
+
+  def lineno=: (untyped) -> untyped
+
+  def path: () -> untyped
+
+  def pos: () -> untyped
+
+  def pos=: (untyped) -> untyped
+
+  def print: (*untyped) -> untyped
+
+  def printf: (*untyped) -> untyped
+
+  def putc: (untyped) -> untyped
+
+  def puts: (*untyped) -> untyped
+
+  def read: (*untyped) -> untyped
+
+  def read_nonblock: (*untyped) -> untyped
+
+  def readbyte: () -> untyped
+
+  def readchar: () -> untyped
+
+  def readline: (*untyped) -> untyped
+
+  def readlines: (*untyped) -> untyped
+
+  def readpartial: (*untyped) -> untyped
+
+  def rewind: () -> untyped
+
+  def seek: (*untyped) -> untyped
+
+  def set_encoding: (*untyped) -> untyped
+
+  def skip: () -> untyped
+
+  def tell: () -> untyped
+
+  def to_a: (*untyped) -> untyped
+
+  def to_i: () -> untyped
+
+  def to_io: () -> untyped
+
+  def to_s: () -> untyped
+
+  def to_write_io: () -> untyped
+
+  def write: (untyped) -> untyped
+
+  private
+
+  def initialize: (*untyped) -> void
+
+  def initialize_copy: (untyped) -> untyped
+end
+

--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -1,155 +1,948 @@
+# <!-- rdoc-file=io.c -->
+# `ARGF` is a stream designed for use in scripts that process files given as
+# command-line arguments or passed in via STDIN.
+#
+# The arguments passed to your script are stored in the `ARGV` Array, one
+# argument per element. `ARGF` assumes that any arguments that aren't filenames
+# have been removed from `ARGV`. For example:
+#
+#     $ ruby argf.rb --verbose file1 file2
+#
+#     ARGV  #=> ["--verbose", "file1", "file2"]
+#     option = ARGV.shift #=> "--verbose"
+#     ARGV  #=> ["file1", "file2"]
+#
+# You can now use `ARGF` to work with a concatenation of each of these named
+# files. For instance, `ARGF.read` will return the contents of *file1* followed
+# by the contents of *file2*.
+#
+# After a file in `ARGV` has been read `ARGF` removes it from the Array. Thus,
+# after all files have been read `ARGV` will be empty.
+#
+# You can manipulate `ARGV` yourself to control what `ARGF` operates on. If you
+# remove a file from `ARGV`, it is ignored by `ARGF`; if you add files to
+# `ARGV`, they are treated as if they were named on the command line. For
+# example:
+#
+#     ARGV.replace ["file1"]
+#     ARGF.readlines # Returns the contents of file1 as an Array
+#     ARGV           #=> []
+#     ARGV.replace ["file2", "file3"]
+#     ARGF.read      # Returns the contents of file2 and file3
+#
+# If `ARGV` is empty, `ARGF` acts as if it contained STDIN, i.e. the data piped
+# to your script. For example:
+#
+#     $ echo "glark" | ruby -e 'p ARGF.read'
+#     "glark\n"
+#
 %a{annotate:rdoc:copy:ARGF}
 class ARGFClass
   include Enumerable[untyped]
 
   public
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.argv  -> ARGV
+  # -->
+  # Returns the `ARGV` array, which contains the arguments passed to your script,
+  # one per element.
+  #
+  # For example:
+  #
+  #     $ ruby argf.rb -v glark.txt
+  #
+  #     ARGF.argv   #=> ["-v", "glark.txt"]
+  #
   %a{annotate:rdoc:copy:ARGF#argv}
   def argv: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.binmode  -> ARGF
+  # -->
+  # Puts `ARGF` into binary mode. Once a stream is in binary mode, it cannot be
+  # reset to non-binary mode. This option has the following effects:
+  #
+  # *   Newline conversion is disabled.
+  # *   Encoding conversion is disabled.
+  # *   Content is treated as ASCII-8BIT.
+  #
   %a{annotate:rdoc:copy:ARGF#binmode}
   def binmode: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.binmode?  -> true or false
+  # -->
+  # Returns true if `ARGF` is being read in binary mode; false otherwise. To
+  # enable binary mode use `ARGF.binmode`.
+  #
+  # For example:
+  #
+  #     ARGF.binmode?  #=> false
+  #     ARGF.binmode
+  #     ARGF.binmode?  #=> true
+  #
   %a{annotate:rdoc:copy:ARGF#binmode?}
   def binmode?: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.close  -> ARGF
+  # -->
+  # Closes the current file and skips to the next file in ARGV. If there are no
+  # more files to open, just closes the current file. `STDIN` will not be closed.
+  #
+  # For example:
+  #
+  #     $ ruby argf.rb foo bar
+  #
+  #     ARGF.filename  #=> "foo"
+  #     ARGF.close
+  #     ARGF.filename  #=> "bar"
+  #     ARGF.close
+  #
   %a{annotate:rdoc:copy:ARGF#close}
   def close: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.closed?  -> true or false
+  # -->
+  # Returns *true* if the current file has been closed; *false* otherwise. Use
+  # `ARGF.close` to actually close the current file.
+  #
   %a{annotate:rdoc:copy:ARGF#closed?}
   def closed?: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.each(sep=$/)             {|line| block }  -> ARGF
+  #   - ARGF.each(sep=$/, limit)      {|line| block }  -> ARGF
+  #   - ARGF.each(...)                                 -> an_enumerator
+  #   - ARGF.each_line(sep=$/)        {|line| block }  -> ARGF
+  #   - ARGF.each_line(sep=$/, limit) {|line| block }  -> ARGF
+  #   - ARGF.each_line(...)                            -> an_enumerator
+  # -->
+  # Returns an enumerator which iterates over each line (separated by *sep*, which
+  # defaults to your platform's newline character) of each file in `ARGV`. If a
+  # block is supplied, each line in turn will be yielded to the block, otherwise
+  # an enumerator is returned. The optional *limit* argument is an `Integer`
+  # specifying the maximum length of each line; longer lines will be split
+  # according to this limit.
+  #
+  # This method allows you to treat the files supplied on the command line as a
+  # single file consisting of the concatenation of each named file. After the last
+  # line of the first file has been returned, the first line of the second file is
+  # returned. The `ARGF.filename` and `ARGF.lineno` methods can be used to
+  # determine the filename of the current line and line number of the whole input,
+  # respectively.
+  #
+  # For example, the following code prints out each line of each named file
+  # prefixed with its line number, displaying the filename once per file:
+  #
+  #     ARGF.each_line do |line|
+  #       puts ARGF.filename if ARGF.file.lineno == 1
+  #       puts "#{ARGF.file.lineno}: #{line}"
+  #     end
+  #
+  # While the following code prints only the first file's name at first, and the
+  # contents with line number counted through all named files.
+  #
+  #     ARGF.each_line do |line|
+  #       puts ARGF.filename if ARGF.lineno == 1
+  #       puts "#{ARGF.lineno}: #{line}"
+  #     end
+  #
   %a{annotate:rdoc:copy:ARGF#each}
   def each: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.each_byte {|byte| block }  -> ARGF
+  #   - ARGF.each_byte                  -> an_enumerator
+  # -->
+  # Iterates over each byte of each file in `ARGV`. A byte is returned as an
+  # `Integer` in the range 0..255.
+  #
+  # This method allows you to treat the files supplied on the command line as a
+  # single file consisting of the concatenation of each named file. After the last
+  # byte of the first file has been returned, the first byte of the second file is
+  # returned. The `ARGF.filename` method can be used to determine the filename of
+  # the current byte.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
+  # For example:
+  #
+  #     ARGF.bytes.to_a  #=> [35, 32, ... 95, 10]
+  #
   %a{annotate:rdoc:copy:ARGF#each_byte}
   def each_byte: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.each_char {|char| block }  -> ARGF
+  #   - ARGF.each_char                  -> an_enumerator
+  # -->
+  # Iterates over each character of each file in `ARGF`.
+  #
+  # This method allows you to treat the files supplied on the command line as a
+  # single file consisting of the concatenation of each named file. After the last
+  # character of the first file has been returned, the first character of the
+  # second file is returned. The `ARGF.filename` method can be used to determine
+  # the name of the file in which the current character appears.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
   %a{annotate:rdoc:copy:ARGF#each_char}
   def each_char: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.each_codepoint {|codepoint| block }  -> ARGF
+  #   - ARGF.each_codepoint                       -> an_enumerator
+  # -->
+  # Iterates over each codepoint of each file in `ARGF`.
+  #
+  # This method allows you to treat the files supplied on the command line as a
+  # single file consisting of the concatenation of each named file. After the last
+  # codepoint of the first file has been returned, the first codepoint of the
+  # second file is returned. The `ARGF.filename` method can be used to determine
+  # the name of the file in which the current codepoint appears.
+  #
+  # If no block is given, an enumerator is returned instead.
+  #
   %a{annotate:rdoc:copy:ARGF#each_codepoint}
   def each_codepoint: () -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Returns an enumerator which iterates over each line (separated by *sep*, which
+  # defaults to your platform's newline character) of each file in `ARGV`. If a
+  # block is supplied, each line in turn will be yielded to the block, otherwise
+  # an enumerator is returned. The optional *limit* argument is an `Integer`
+  # specifying the maximum length of each line; longer lines will be split
+  # according to this limit.
+  #
+  # This method allows you to treat the files supplied on the command line as a
+  # single file consisting of the concatenation of each named file. After the last
+  # line of the first file has been returned, the first line of the second file is
+  # returned. The `ARGF.filename` and `ARGF.lineno` methods can be used to
+  # determine the filename of the current line and line number of the whole input,
+  # respectively.
+  #
+  # For example, the following code prints out each line of each named file
+  # prefixed with its line number, displaying the filename once per file:
+  #
+  #     ARGF.each_line do |line|
+  #       puts ARGF.filename if ARGF.file.lineno == 1
+  #       puts "#{ARGF.file.lineno}: #{line}"
+  #     end
+  #
+  # While the following code prints only the first file's name at first, and the
+  # contents with line number counted through all named files.
+  #
+  #     ARGF.each_line do |line|
+  #       puts ARGF.filename if ARGF.lineno == 1
+  #       puts "#{ARGF.lineno}: #{line}"
+  #     end
+  #
   %a{annotate:rdoc:copy:ARGF#each_line}
   def each_line: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.eof?  -> true or false
+  #   - ARGF.eof   -> true or false
+  # -->
+  # Returns true if the current file in `ARGF` is at end of file, i.e. it has no
+  # data to read. The stream must be opened for reading or an `IOError` will be
+  # raised.
+  #
+  #     $ echo "eof" | ruby argf.rb
+  #
+  #     ARGF.eof?                 #=> false
+  #     3.times { ARGF.readchar }
+  #     ARGF.eof?                 #=> false
+  #     ARGF.readchar             #=> "\n"
+  #     ARGF.eof?                 #=> true
+  #
   %a{annotate:rdoc:copy:ARGF#eof}
   def eof: () -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Returns true if the current file in `ARGF` is at end of file, i.e. it has no
+  # data to read. The stream must be opened for reading or an `IOError` will be
+  # raised.
+  #
+  #     $ echo "eof" | ruby argf.rb
+  #
+  #     ARGF.eof?                 #=> false
+  #     3.times { ARGF.readchar }
+  #     ARGF.eof?                 #=> false
+  #     ARGF.readchar             #=> "\n"
+  #     ARGF.eof?                 #=> true
+  #
   %a{annotate:rdoc:copy:ARGF#eof?}
   def eof?: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.external_encoding   -> encoding
+  # -->
+  # Returns the external encoding for files read from `ARGF` as an `Encoding`
+  # object. The external encoding is the encoding of the text as stored in a file.
+  # Contrast with `ARGF.internal_encoding`, which is the encoding used to
+  # represent this text within Ruby.
+  #
+  # To set the external encoding use `ARGF.set_encoding`.
+  #
+  # For example:
+  #
+  #     ARGF.external_encoding  #=>  #<Encoding:UTF-8>
+  #
   %a{annotate:rdoc:copy:ARGF#external_encoding}
   def external_encoding: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.file  -> IO or File object
+  # -->
+  # Returns the current file as an `IO` or `File` object. `$stdin` is returned
+  # when the current file is STDIN.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > foo
+  #     $ echo "bar" > bar
+  #
+  #     $ ruby argf.rb foo bar
+  #
+  #     ARGF.file      #=> #<File:foo>
+  #     ARGF.read(5)   #=> "foo\nb"
+  #     ARGF.file      #=> #<File:bar>
+  #
   %a{annotate:rdoc:copy:ARGF#file}
   def file: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.filename  -> String
+  #   - ARGF.path      -> String
+  # -->
+  # Returns the current filename. "-" is returned when the current file is STDIN.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > foo
+  #     $ echo "bar" > bar
+  #     $ echo "glark" > glark
+  #
+  #     $ ruby argf.rb foo bar glark
+  #
+  #     ARGF.filename  #=> "foo"
+  #     ARGF.read(5)   #=> "foo\nb"
+  #     ARGF.filename  #=> "bar"
+  #     ARGF.skip
+  #     ARGF.filename  #=> "glark"
+  #
   %a{annotate:rdoc:copy:ARGF#filename}
   def filename: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.fileno    -> integer
+  #   - ARGF.to_i      -> integer
+  # -->
+  # Returns an integer representing the numeric file descriptor for the current
+  # file. Raises an `ArgumentError` if there isn't a current file.
+  #
+  #     ARGF.fileno    #=> 3
+  #
   %a{annotate:rdoc:copy:ARGF#fileno}
   def fileno: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.getbyte  -> Integer or nil
+  # -->
+  # Gets the next 8-bit byte (0..255) from `ARGF`. Returns `nil` if called at the
+  # end of the stream.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > file
+  #     $ ruby argf.rb file
+  #
+  #     ARGF.getbyte #=> 102
+  #     ARGF.getbyte #=> 111
+  #     ARGF.getbyte #=> 111
+  #     ARGF.getbyte #=> 10
+  #     ARGF.getbyte #=> nil
+  #
   %a{annotate:rdoc:copy:ARGF#getbyte}
   def getbyte: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.getc  -> String or nil
+  # -->
+  # Reads the next character from `ARGF` and returns it as a `String`. Returns
+  # `nil` at the end of the stream.
+  #
+  # `ARGF` treats the files named on the command line as a single file created by
+  # concatenating their contents. After returning the last character of the first
+  # file, it returns the first character of the second file, and so on.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > file
+  #     $ ruby argf.rb file
+  #
+  #     ARGF.getc  #=> "f"
+  #     ARGF.getc  #=> "o"
+  #     ARGF.getc  #=> "o"
+  #     ARGF.getc  #=> "\n"
+  #     ARGF.getc  #=> nil
+  #     ARGF.getc  #=> nil
+  #
   %a{annotate:rdoc:copy:ARGF#getc}
   def getc: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.gets(sep=$/ [, getline_args])     -> string or nil
+  #   - ARGF.gets(limit [, getline_args])      -> string or nil
+  #   - ARGF.gets(sep, limit [, getline_args]) -> string or nil
+  # -->
+  # Returns the next line from the current file in `ARGF`.
+  #
+  # By default lines are assumed to be separated by `$/`; to use a different
+  # character as a separator, supply it as a `String` for the *sep* argument.
+  #
+  # The optional *limit* argument specifies how many characters of each line to
+  # return. By default all characters are returned.
+  #
+  # See IO.readlines for details about getline_args.
+  #
   %a{annotate:rdoc:copy:ARGF#gets}
   def gets: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.inplace_mode  -> String
+  # -->
+  # Returns the file extension appended to the names of modified files under
+  # in-place edit mode. This value can be set using `ARGF.inplace_mode=` or
+  # passing the `-i` switch to the Ruby binary.
+  #
   %a{annotate:rdoc:copy:ARGF#inplace_mode}
   def inplace_mode: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.inplace_mode = ext  -> ARGF
+  # -->
+  # Sets the filename extension for in-place editing mode to the given String.
+  # Each file being edited has this value appended to its filename. The modified
+  # file is saved under this new name.
+  #
+  # For example:
+  #
+  #     $ ruby argf.rb file.txt
+  #
+  #     ARGF.inplace_mode = '.bak'
+  #     ARGF.each_line do |line|
+  #       print line.sub("foo","bar")
+  #     end
+  #
+  # Each line of *file.txt* has the first occurrence of "foo" replaced with "bar",
+  # then the new line is written out to *file.txt.bak*.
+  #
   %a{annotate:rdoc:copy:ARGF#inplace_mode=}
   def inplace_mode=: (untyped) -> untyped
 
   alias inspect to_s
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.internal_encoding   -> encoding
+  # -->
+  # Returns the internal encoding for strings read from `ARGF` as an `Encoding`
+  # object.
+  #
+  # If `ARGF.set_encoding` has been called with two encoding names, the second is
+  # returned. Otherwise, if `Encoding.default_external` has been set, that value
+  # is returned. Failing that, if a default external encoding was specified on the
+  # command-line, that value is used. If the encoding is unknown, `nil` is
+  # returned.
+  #
   %a{annotate:rdoc:copy:ARGF#internal_encoding}
   def internal_encoding: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.lineno  -> integer
+  # -->
+  # Returns the current line number of ARGF as a whole. This value can be set
+  # manually with `ARGF.lineno=`.
+  #
+  # For example:
+  #
+  #     ARGF.lineno   #=> 0
+  #     ARGF.readline #=> "This is line 1\n"
+  #     ARGF.lineno   #=> 1
+  #
   %a{annotate:rdoc:copy:ARGF#lineno}
   def lineno: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.lineno = integer  -> integer
+  # -->
+  # Sets the line number of `ARGF` as a whole to the given `Integer`.
+  #
+  # `ARGF` sets the line number automatically as you read data, so normally you
+  # will not need to set it explicitly. To access the current line number use
+  # `ARGF.lineno`.
+  #
+  # For example:
+  #
+  #     ARGF.lineno      #=> 0
+  #     ARGF.readline    #=> "This is line 1\n"
+  #     ARGF.lineno      #=> 1
+  #     ARGF.lineno = 0  #=> 0
+  #     ARGF.lineno      #=> 0
+  #
   %a{annotate:rdoc:copy:ARGF#lineno=}
   def lineno=: (untyped) -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Returns the current filename. "-" is returned when the current file is STDIN.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > foo
+  #     $ echo "bar" > bar
+  #     $ echo "glark" > glark
+  #
+  #     $ ruby argf.rb foo bar glark
+  #
+  #     ARGF.filename  #=> "foo"
+  #     ARGF.read(5)   #=> "foo\nb"
+  #     ARGF.filename  #=> "bar"
+  #     ARGF.skip
+  #     ARGF.filename  #=> "glark"
+  #
   %a{annotate:rdoc:copy:ARGF#path}
   def path: () -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Returns the current offset (in bytes) of the current file in `ARGF`.
+  #
+  #     ARGF.pos    #=> 0
+  #     ARGF.gets   #=> "This is line one\n"
+  #     ARGF.pos    #=> 17
+  #
   %a{annotate:rdoc:copy:ARGF#pos}
   def pos: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.pos = position  -> Integer
+  # -->
+  # Seeks to the position given by *position* (in bytes) in `ARGF`.
+  #
+  # For example:
+  #
+  #     ARGF.pos = 17
+  #     ARGF.gets   #=> "This is line two\n"
+  #
   %a{annotate:rdoc:copy:ARGF#pos=}
   def pos=: (untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ios.print               -> nil
+  #   - ios.print(obj, ...)     -> nil
+  # -->
+  # Writes the given object(s) to *ios*. Returns `nil`.
+  #
+  # The stream must be opened for writing. Each given object that isn't a string
+  # will be converted by calling its `to_s` method. When called without arguments,
+  # prints the contents of `$_`.
+  #
+  # If the output field separator (`$,`) is not `nil`, it is inserted between
+  # objects. If the output record separator (`$\`) is not `nil`, it is appended to
+  # the output.
+  #
+  #     $stdout.print("This is ", 100, " percent.\n")
+  #
+  # *produces:*
+  #
+  #     This is 100 percent.
+  #
   %a{annotate:rdoc:copy:ARGF#print}
   def print: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ios.printf(format_string [, obj, ...])   -> nil
+  # -->
+  # Formats and writes to *ios*, converting parameters under control of the format
+  # string. See Kernel#sprintf for details.
+  #
   %a{annotate:rdoc:copy:ARGF#printf}
   def printf: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ios.putc(obj)    -> obj
+  # -->
+  # If *obj* is Numeric, write the character whose code is the least-significant
+  # byte of *obj*.  If *obj* is String, write the first character of *obj* to
+  # *ios*.  Otherwise, raise TypeError.
+  #
+  #     $stdout.putc "A"
+  #     $stdout.putc 65
+  #
+  # *produces:*
+  #
+  #     AA
+  #
   %a{annotate:rdoc:copy:ARGF#putc}
   def putc: (untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ios.puts(obj, ...)    -> nil
+  # -->
+  # Writes the given object(s) to *ios*. Writes a newline after any that do not
+  # already end with a newline sequence. Returns `nil`.
+  #
+  # The stream must be opened for writing. If called with an array argument,
+  # writes each element on a new line. Each given object that isn't a string or
+  # array will be converted by calling its `to_s` method. If called without
+  # arguments, outputs a single newline.
+  #
+  #     $stdout.puts("this", "is", ["a", "test"])
+  #
+  # *produces:*
+  #
+  #     this
+  #     is
+  #     a
+  #     test
+  #
+  # Note that `puts` always uses newlines and is not affected by the output record
+  # separator (`$\`).
+  #
   %a{annotate:rdoc:copy:ARGF#puts}
   def puts: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.read([length [, outbuf]])    -> string, outbuf, or nil
+  # -->
+  # Reads *length* bytes from ARGF. The files named on the command line are
+  # concatenated and treated as a single file by this method, so when called
+  # without arguments the contents of this pseudo file are returned in their
+  # entirety.
+  #
+  # *length* must be a non-negative integer or `nil`.
+  #
+  # If *length* is a positive integer, `read` tries to read *length* bytes without
+  # any conversion (binary mode). It returns `nil` if an EOF is encountered before
+  # anything can be read. Fewer than *length* bytes are returned if an EOF is
+  # encountered during the read. In the case of an integer *length*, the resulting
+  # string is always in ASCII-8BIT encoding.
+  #
+  # If *length* is omitted or is `nil`, it reads until EOF and the encoding
+  # conversion is applied, if applicable. A string is returned even if EOF is
+  # encountered before any data is read.
+  #
+  # If *length* is zero, it returns an empty string (`""`).
+  #
+  # If the optional *outbuf* argument is present, it must reference a String,
+  # which will receive the data. The *outbuf* will contain only the received data
+  # after the method call even if it is not empty at the beginning.
+  #
+  # For example:
+  #
+  #     $ echo "small" > small.txt
+  #     $ echo "large" > large.txt
+  #     $ ./glark.rb small.txt large.txt
+  #
+  #     ARGF.read      #=> "small\nlarge"
+  #     ARGF.read(200) #=> "small\nlarge"
+  #     ARGF.read(2)   #=> "sm"
+  #     ARGF.read(0)   #=> ""
+  #
+  # Note that this method behaves like the fread() function in C. This means it
+  # retries to invoke read(2) system calls to read data with the specified length.
+  # If you need the behavior like a single read(2) system call, consider
+  # ARGF#readpartial or ARGF#read_nonblock.
+  #
   %a{annotate:rdoc:copy:ARGF#read}
   def read: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.read_nonblock(maxlen[, options])              -> string
+  #   - ARGF.read_nonblock(maxlen, outbuf[, options])      -> outbuf
+  # -->
+  # Reads at most *maxlen* bytes from the ARGF stream in non-blocking mode.
+  #
   %a{annotate:rdoc:copy:ARGF#read_nonblock}
   def read_nonblock: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.readbyte  -> Integer
+  # -->
+  # Reads the next 8-bit byte from ARGF and returns it as an `Integer`. Raises an
+  # `EOFError` after the last byte of the last file has been read.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > file
+  #     $ ruby argf.rb file
+  #
+  #     ARGF.readbyte  #=> 102
+  #     ARGF.readbyte  #=> 111
+  #     ARGF.readbyte  #=> 111
+  #     ARGF.readbyte  #=> 10
+  #     ARGF.readbyte  #=> end of file reached (EOFError)
+  #
   %a{annotate:rdoc:copy:ARGF#readbyte}
   def readbyte: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.readchar  -> String or nil
+  # -->
+  # Reads the next character from `ARGF` and returns it as a `String`. Raises an
+  # `EOFError` after the last character of the last file has been read.
+  #
+  # For example:
+  #
+  #     $ echo "foo" > file
+  #     $ ruby argf.rb file
+  #
+  #     ARGF.readchar  #=> "f"
+  #     ARGF.readchar  #=> "o"
+  #     ARGF.readchar  #=> "o"
+  #     ARGF.readchar  #=> "\n"
+  #     ARGF.readchar  #=> end of file reached (EOFError)
+  #
   %a{annotate:rdoc:copy:ARGF#readchar}
   def readchar: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.readline(sep=$/)     -> string
+  #   - ARGF.readline(limit)      -> string
+  #   - ARGF.readline(sep, limit) -> string
+  # -->
+  # Returns the next line from the current file in `ARGF`.
+  #
+  # By default lines are assumed to be separated by `$/`; to use a different
+  # character as a separator, supply it as a `String` for the *sep* argument.
+  #
+  # The optional *limit* argument specifies how many characters of each line to
+  # return. By default all characters are returned.
+  #
+  # An `EOFError` is raised at the end of the file.
+  #
   %a{annotate:rdoc:copy:ARGF#readline}
   def readline: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.readlines(sep=$/)     -> array
+  #   - ARGF.readlines(limit)      -> array
+  #   - ARGF.readlines(sep, limit) -> array
+  #   - ARGF.to_a(sep=$/)     -> array
+  #   - ARGF.to_a(limit)      -> array
+  #   - ARGF.to_a(sep, limit) -> array
+  # -->
+  # Reads `ARGF`'s current file in its entirety, returning an `Array` of its
+  # lines, one line per element. Lines are assumed to be separated by *sep*.
+  #
+  #     lines = ARGF.readlines
+  #     lines[0]                #=> "This is line one\n"
+  #
   %a{annotate:rdoc:copy:ARGF#readlines}
   def readlines: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.readpartial(maxlen)              -> string
+  #   - ARGF.readpartial(maxlen, outbuf)      -> outbuf
+  # -->
+  # Reads at most *maxlen* bytes from the ARGF stream.
+  #
+  # If the optional *outbuf* argument is present, it must reference a String,
+  # which will receive the data. The *outbuf* will contain only the received data
+  # after the method call even if it is not empty at the beginning.
+  #
+  # It raises EOFError on end of ARGF stream. Since ARGF stream is a concatenation
+  # of multiple files, internally EOF is occur for each file. ARGF.readpartial
+  # returns empty strings for EOFs except the last one and raises EOFError for the
+  # last one.
+  #
   %a{annotate:rdoc:copy:ARGF#readpartial}
   def readpartial: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.rewind   -> 0
+  # -->
+  # Positions the current file to the beginning of input, resetting `ARGF.lineno`
+  # to zero.
+  #
+  #     ARGF.readline   #=> "This is line one\n"
+  #     ARGF.rewind     #=> 0
+  #     ARGF.lineno     #=> 0
+  #     ARGF.readline   #=> "This is line one\n"
+  #
   %a{annotate:rdoc:copy:ARGF#rewind}
   def rewind: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.seek(amount, whence=IO::SEEK_SET)  -> 0
+  # -->
+  # Seeks to offset *amount* (an `Integer`) in the `ARGF` stream according to the
+  # value of *whence*. See IO#seek for further details.
+  #
   %a{annotate:rdoc:copy:ARGF#seek}
   def seek: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.set_encoding(ext_enc)                -> ARGF
+  #   - ARGF.set_encoding("ext_enc:int_enc")      -> ARGF
+  #   - ARGF.set_encoding(ext_enc, int_enc)       -> ARGF
+  #   - ARGF.set_encoding("ext_enc:int_enc", opt) -> ARGF
+  #   - ARGF.set_encoding(ext_enc, int_enc, opt)  -> ARGF
+  # -->
+  # If single argument is specified, strings read from ARGF are tagged with the
+  # encoding specified.
+  #
+  # If two encoding names separated by a colon are given, e.g. "ascii:utf-8", the
+  # read string is converted from the first encoding (external encoding) to the
+  # second encoding (internal encoding), then tagged with the second encoding.
+  #
+  # If two arguments are specified, they must be encoding objects or encoding
+  # names. Again, the first specifies the external encoding; the second specifies
+  # the internal encoding.
+  #
+  # If the external encoding and the internal encoding are specified, the optional
+  # `Hash` argument can be used to adjust the conversion process. The structure of
+  # this hash is explained in the String#encode documentation.
+  #
+  # For example:
+  #
+  #     ARGF.set_encoding('ascii')         # Tag the input as US-ASCII text
+  #     ARGF.set_encoding(Encoding::UTF_8) # Tag the input as UTF-8 text
+  #     ARGF.set_encoding('utf-8','ascii') # Transcode the input from US-ASCII
+  #                                        # to UTF-8.
+  #
   %a{annotate:rdoc:copy:ARGF#set_encoding}
   def set_encoding: (*untyped) -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.skip  -> ARGF
+  # -->
+  # Sets the current file to the next file in ARGV. If there aren't any more files
+  # it has no effect.
+  #
+  # For example:
+  #
+  #     $ ruby argf.rb foo bar
+  #     ARGF.filename  #=> "foo"
+  #     ARGF.skip
+  #     ARGF.filename  #=> "bar"
+  #
   %a{annotate:rdoc:copy:ARGF#skip}
   def skip: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.tell  -> Integer
+  #   - ARGF.pos   -> Integer
+  # -->
+  # Returns the current offset (in bytes) of the current file in `ARGF`.
+  #
+  #     ARGF.pos    #=> 0
+  #     ARGF.gets   #=> "This is line one\n"
+  #     ARGF.pos    #=> 17
+  #
   %a{annotate:rdoc:copy:ARGF#tell}
   def tell: () -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Reads `ARGF`'s current file in its entirety, returning an `Array` of its
+  # lines, one line per element. Lines are assumed to be separated by *sep*.
+  #
+  #     lines = ARGF.readlines
+  #     lines[0]                #=> "This is line one\n"
+  #
   %a{annotate:rdoc:copy:ARGF#to_a}
   def to_a: (*untyped) -> untyped
 
+  # <!-- rdoc-file=io.c -->
+  # Returns an integer representing the numeric file descriptor for the current
+  # file. Raises an `ArgumentError` if there isn't a current file.
+  #
+  #     ARGF.fileno    #=> 3
+  #
   %a{annotate:rdoc:copy:ARGF#to_i}
   def to_i: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.to_io     -> IO
+  # -->
+  # Returns an `IO` object representing the current file. This will be a `File`
+  # object unless the current file is a stream such as STDIN.
+  #
+  # For example:
+  #
+  #     ARGF.to_io    #=> #<File:glark.txt>
+  #     ARGF.to_io    #=> #<IO:<STDIN>>
+  #
   %a{annotate:rdoc:copy:ARGF#to_io}
   def to_io: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.to_s  -> String
+  # -->
+  # Returns "ARGF".
+  #
   %a{annotate:rdoc:copy:ARGF#to_s}
   def to_s: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.to_write_io  -> io
+  # -->
+  # Returns IO instance tied to *ARGF* for writing if inplace mode is enabled.
+  #
   %a{annotate:rdoc:copy:ARGF#to_write_io}
   def to_write_io: () -> untyped
 
+  # <!--
+  #   rdoc-file=io.c
+  #   - ARGF.write(string)   -> integer
+  # -->
+  # Writes *string* if inplace mode.
+  #
   %a{annotate:rdoc:copy:ARGF#write}
   def write: (untyped) -> untyped
 
@@ -161,4 +954,3 @@ class ARGFClass
   %a{annotate:rdoc:copy:ARGF#initialize_copy}
   def initialize_copy: (untyped) -> untyped
 end
-

--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -522,7 +522,7 @@ class ARGFClass
   #     ARGF.lineno      #=> 0
   #
   %a{annotate:rdoc:copy:ARGF#lineno=}
-  def lineno=: (Integer) -> untyped    # TODO: call-seq says it returns an integer, but the implementation does not
+  def lineno=: (Integer) -> untyped
 
   # <!-- rdoc-file=io.c -->
   # Returns the current filename. "-" is returned when the current file is STDIN.

--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -1,112 +1,164 @@
+%a{annotate:rdoc:copy:ARGF}
 class ARGFClass
   include Enumerable[untyped]
 
   public
 
+  %a{annotate:rdoc:copy:ARGF#argv}
   def argv: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#binmode}
   def binmode: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#binmode?}
   def binmode?: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#close}
   def close: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#closed?}
   def closed?: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#each}
   def each: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#each_byte}
   def each_byte: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#each_char}
   def each_char: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#each_codepoint}
   def each_codepoint: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#each_line}
   def each_line: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#eof}
   def eof: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#eof?}
   def eof?: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#external_encoding}
   def external_encoding: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#file}
   def file: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#filename}
   def filename: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#fileno}
   def fileno: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#getbyte}
   def getbyte: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#getc}
   def getc: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#gets}
   def gets: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#inplace_mode}
   def inplace_mode: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#inplace_mode=}
   def inplace_mode=: (untyped) -> untyped
 
   alias inspect to_s
 
+  %a{annotate:rdoc:copy:ARGF#internal_encoding}
   def internal_encoding: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#lineno}
   def lineno: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#lineno=}
   def lineno=: (untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#path}
   def path: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#pos}
   def pos: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#pos=}
   def pos=: (untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#print}
   def print: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#printf}
   def printf: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#putc}
   def putc: (untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#puts}
   def puts: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#read}
   def read: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#read_nonblock}
   def read_nonblock: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#readbyte}
   def readbyte: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#readchar}
   def readchar: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#readline}
   def readline: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#readlines}
   def readlines: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#readpartial}
   def readpartial: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#rewind}
   def rewind: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#seek}
   def seek: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#set_encoding}
   def set_encoding: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#skip}
   def skip: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#tell}
   def tell: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#to_a}
   def to_a: (*untyped) -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#to_i}
   def to_i: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#to_io}
   def to_io: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#to_s}
   def to_s: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#to_write_io}
   def to_write_io: () -> untyped
 
+  %a{annotate:rdoc:copy:ARGF#write}
   def write: (untyped) -> untyped
 
   private
 
+  %a{annotate:rdoc:copy:ARGF#initialize}
   def initialize: (*untyped) -> void
 
+  %a{annotate:rdoc:copy:ARGF#initialize_copy}
   def initialize_copy: (untyped) -> untyped
 end
 

--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -522,8 +522,7 @@ class ARGFClass
   #     ARGF.lineno      #=> 0
   #
   %a{annotate:rdoc:copy:ARGF#lineno=}
-  # TODO: call-seq says it returns an integer, but the implementation does not
-  def lineno=: (Integer) -> untyped
+  def lineno=: (Integer) -> untyped    # TODO: call-seq says it returns an integer, but the implementation does not
 
   # <!-- rdoc-file=io.c -->
   # Returns the current filename. "-" is returned when the current file is STDIN.

--- a/core/argf.rbs
+++ b/core/argf.rbs
@@ -38,7 +38,7 @@
 #
 %a{annotate:rdoc:copy:ARGF}
 class ARGFClass
-  include Enumerable[untyped]
+  include Enumerable[String]
 
   public
 
@@ -56,7 +56,7 @@ class ARGFClass
   #     ARGF.argv   #=> ["-v", "glark.txt"]
   #
   %a{annotate:rdoc:copy:ARGF#argv}
-  def argv: () -> untyped
+  def argv: () -> ::Array[String]
 
   # <!--
   #   rdoc-file=io.c
@@ -70,7 +70,7 @@ class ARGFClass
   # *   Content is treated as ASCII-8BIT.
   #
   %a{annotate:rdoc:copy:ARGF#binmode}
-  def binmode: () -> untyped
+  def binmode: () -> self
 
   # <!--
   #   rdoc-file=io.c
@@ -86,7 +86,7 @@ class ARGFClass
   #     ARGF.binmode?  #=> true
   #
   %a{annotate:rdoc:copy:ARGF#binmode?}
-  def binmode?: () -> untyped
+  def binmode?: () -> bool
 
   # <!--
   #   rdoc-file=io.c
@@ -105,7 +105,7 @@ class ARGFClass
   #     ARGF.close
   #
   %a{annotate:rdoc:copy:ARGF#close}
-  def close: () -> untyped
+  def close: () -> self
 
   # <!--
   #   rdoc-file=io.c
@@ -115,7 +115,7 @@ class ARGFClass
   # `ARGF.close` to actually close the current file.
   #
   %a{annotate:rdoc:copy:ARGF#closed?}
-  def closed?: () -> untyped
+  def closed?: () -> bool
 
   # <!--
   #   rdoc-file=io.c
@@ -157,7 +157,8 @@ class ARGFClass
   #     end
   #
   %a{annotate:rdoc:copy:ARGF#each}
-  def each: (*untyped) -> untyped
+  def each: (?String sep, ?Integer limit) { (String line) -> untyped } -> self
+          | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!--
   #   rdoc-file=io.c
@@ -180,7 +181,8 @@ class ARGFClass
   #     ARGF.bytes.to_a  #=> [35, 32, ... 95, 10]
   #
   %a{annotate:rdoc:copy:ARGF#each_byte}
-  def each_byte: () -> untyped
+  def each_byte: () { (Integer byte) -> untyped } -> self
+               | () -> ::Enumerator[Integer, self]
 
   # <!--
   #   rdoc-file=io.c
@@ -198,7 +200,8 @@ class ARGFClass
   # If no block is given, an enumerator is returned instead.
   #
   %a{annotate:rdoc:copy:ARGF#each_char}
-  def each_char: () -> untyped
+  def each_char: () { (String char) -> untyped } -> self
+               | () -> ::Enumerator[String, self]
 
   # <!--
   #   rdoc-file=io.c
@@ -216,7 +219,8 @@ class ARGFClass
   # If no block is given, an enumerator is returned instead.
   #
   %a{annotate:rdoc:copy:ARGF#each_codepoint}
-  def each_codepoint: () -> untyped
+  def each_codepoint: () { (Integer codepoint) -> untyped } -> self
+                    | () -> ::Enumerator[Integer, self]
 
   # <!-- rdoc-file=io.c -->
   # Returns an enumerator which iterates over each line (separated by *sep*, which
@@ -250,7 +254,8 @@ class ARGFClass
   #     end
   #
   %a{annotate:rdoc:copy:ARGF#each_line}
-  def each_line: (*untyped) -> untyped
+  def each_line: (?String sep, ?Integer limit) { (String line) -> untyped } -> self
+               | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!--
   #   rdoc-file=io.c
@@ -270,7 +275,7 @@ class ARGFClass
   #     ARGF.eof?                 #=> true
   #
   %a{annotate:rdoc:copy:ARGF#eof}
-  def eof: () -> untyped
+  def eof: () -> bool
 
   # <!-- rdoc-file=io.c -->
   # Returns true if the current file in `ARGF` is at end of file, i.e. it has no
@@ -286,7 +291,7 @@ class ARGFClass
   #     ARGF.eof?                 #=> true
   #
   %a{annotate:rdoc:copy:ARGF#eof?}
-  def eof?: () -> untyped
+  def eof?: () -> bool
 
   # <!--
   #   rdoc-file=io.c
@@ -304,7 +309,7 @@ class ARGFClass
   #     ARGF.external_encoding  #=>  #<Encoding:UTF-8>
   #
   %a{annotate:rdoc:copy:ARGF#external_encoding}
-  def external_encoding: () -> untyped
+  def external_encoding: () -> Encoding
 
   # <!--
   #   rdoc-file=io.c
@@ -325,7 +330,7 @@ class ARGFClass
   #     ARGF.file      #=> #<File:bar>
   #
   %a{annotate:rdoc:copy:ARGF#file}
-  def file: () -> untyped
+  def file: () -> (IO | File)
 
   # <!--
   #   rdoc-file=io.c
@@ -349,7 +354,7 @@ class ARGFClass
   #     ARGF.filename  #=> "glark"
   #
   %a{annotate:rdoc:copy:ARGF#filename}
-  def filename: () -> untyped
+  def filename: () -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -362,7 +367,7 @@ class ARGFClass
   #     ARGF.fileno    #=> 3
   #
   %a{annotate:rdoc:copy:ARGF#fileno}
-  def fileno: () -> untyped
+  def fileno: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -383,7 +388,7 @@ class ARGFClass
   #     ARGF.getbyte #=> nil
   #
   %a{annotate:rdoc:copy:ARGF#getbyte}
-  def getbyte: () -> untyped
+  def getbyte: () -> Integer?
 
   # <!--
   #   rdoc-file=io.c
@@ -409,7 +414,7 @@ class ARGFClass
   #     ARGF.getc  #=> nil
   #
   %a{annotate:rdoc:copy:ARGF#getc}
-  def getc: () -> untyped
+  def getc: () -> String?
 
   # <!--
   #   rdoc-file=io.c
@@ -428,7 +433,7 @@ class ARGFClass
   # See IO.readlines for details about getline_args.
   #
   %a{annotate:rdoc:copy:ARGF#gets}
-  def gets: (*untyped) -> untyped
+  def gets: (?String sep, ?Integer limit) -> String?
 
   # <!--
   #   rdoc-file=io.c
@@ -439,7 +444,7 @@ class ARGFClass
   # passing the `-i` switch to the Ruby binary.
   #
   %a{annotate:rdoc:copy:ARGF#inplace_mode}
-  def inplace_mode: () -> untyped
+  def inplace_mode: () -> String?
 
   # <!--
   #   rdoc-file=io.c
@@ -462,7 +467,7 @@ class ARGFClass
   # then the new line is written out to *file.txt.bak*.
   #
   %a{annotate:rdoc:copy:ARGF#inplace_mode=}
-  def inplace_mode=: (untyped) -> untyped
+  def inplace_mode=: (String) -> self
 
   alias inspect to_s
 
@@ -480,7 +485,7 @@ class ARGFClass
   # returned.
   #
   %a{annotate:rdoc:copy:ARGF#internal_encoding}
-  def internal_encoding: () -> untyped
+  def internal_encoding: () -> Encoding
 
   # <!--
   #   rdoc-file=io.c
@@ -496,7 +501,7 @@ class ARGFClass
   #     ARGF.lineno   #=> 1
   #
   %a{annotate:rdoc:copy:ARGF#lineno}
-  def lineno: () -> untyped
+  def lineno: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -517,7 +522,8 @@ class ARGFClass
   #     ARGF.lineno      #=> 0
   #
   %a{annotate:rdoc:copy:ARGF#lineno=}
-  def lineno=: (untyped) -> untyped
+  # TODO: call-seq says it returns an integer, but the implementation does not
+  def lineno=: (Integer) -> untyped
 
   # <!-- rdoc-file=io.c -->
   # Returns the current filename. "-" is returned when the current file is STDIN.
@@ -537,7 +543,7 @@ class ARGFClass
   #     ARGF.filename  #=> "glark"
   #
   %a{annotate:rdoc:copy:ARGF#path}
-  def path: () -> untyped
+  def path: () -> String
 
   # <!-- rdoc-file=io.c -->
   # Returns the current offset (in bytes) of the current file in `ARGF`.
@@ -547,7 +553,7 @@ class ARGFClass
   #     ARGF.pos    #=> 17
   #
   %a{annotate:rdoc:copy:ARGF#pos}
-  def pos: () -> untyped
+  def pos: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -561,7 +567,7 @@ class ARGFClass
   #     ARGF.gets   #=> "This is line two\n"
   #
   %a{annotate:rdoc:copy:ARGF#pos=}
-  def pos=: (untyped) -> untyped
+  def pos=: (Integer) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -585,7 +591,7 @@ class ARGFClass
   #     This is 100 percent.
   #
   %a{annotate:rdoc:copy:ARGF#print}
-  def print: (*untyped) -> untyped
+  def print: (*untyped args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -595,7 +601,7 @@ class ARGFClass
   # string. See Kernel#sprintf for details.
   #
   %a{annotate:rdoc:copy:ARGF#printf}
-  def printf: (*untyped) -> untyped
+  def printf: (String format_string, *untyped args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -613,7 +619,7 @@ class ARGFClass
   #     AA
   #
   %a{annotate:rdoc:copy:ARGF#putc}
-  def putc: (untyped) -> untyped
+  def putc: (Numeric | String obj) -> untyped
 
   # <!--
   #   rdoc-file=io.c
@@ -640,7 +646,7 @@ class ARGFClass
   # separator (`$\`).
   #
   %a{annotate:rdoc:copy:ARGF#puts}
-  def puts: (*untyped) -> untyped
+  def puts: (*untyped obj) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -686,7 +692,7 @@ class ARGFClass
   # ARGF#readpartial or ARGF#read_nonblock.
   #
   %a{annotate:rdoc:copy:ARGF#read}
-  def read: (*untyped) -> untyped
+  def read: (?int? length, ?string outbuf) -> String?
 
   # <!--
   #   rdoc-file=io.c
@@ -696,7 +702,7 @@ class ARGFClass
   # Reads at most *maxlen* bytes from the ARGF stream in non-blocking mode.
   #
   %a{annotate:rdoc:copy:ARGF#read_nonblock}
-  def read_nonblock: (*untyped) -> untyped
+  def read_nonblock: (int maxlen, ?string buf, **untyped options) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -717,7 +723,7 @@ class ARGFClass
   #     ARGF.readbyte  #=> end of file reached (EOFError)
   #
   %a{annotate:rdoc:copy:ARGF#readbyte}
-  def readbyte: () -> untyped
+  def readbyte: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -738,7 +744,7 @@ class ARGFClass
   #     ARGF.readchar  #=> end of file reached (EOFError)
   #
   %a{annotate:rdoc:copy:ARGF#readchar}
-  def readchar: () -> untyped
+  def readchar: () -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -757,7 +763,7 @@ class ARGFClass
   # An `EOFError` is raised at the end of the file.
   #
   %a{annotate:rdoc:copy:ARGF#readline}
-  def readline: (*untyped) -> untyped
+  def readline: (?String sep, ?Integer limit) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -775,7 +781,7 @@ class ARGFClass
   #     lines[0]                #=> "This is line one\n"
   #
   %a{annotate:rdoc:copy:ARGF#readlines}
-  def readlines: (*untyped) -> untyped
+  def readlines: (?String sep, ?Integer limit) -> ::Array[String]
 
   # <!--
   #   rdoc-file=io.c
@@ -794,7 +800,7 @@ class ARGFClass
   # last one.
   #
   %a{annotate:rdoc:copy:ARGF#readpartial}
-  def readpartial: (*untyped) -> untyped
+  def readpartial: (int maxlen, ?string outbuf) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -809,7 +815,7 @@ class ARGFClass
   #     ARGF.readline   #=> "This is line one\n"
   #
   %a{annotate:rdoc:copy:ARGF#rewind}
-  def rewind: () -> untyped
+  def rewind: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -819,7 +825,7 @@ class ARGFClass
   # value of *whence*. See IO#seek for further details.
   #
   %a{annotate:rdoc:copy:ARGF#seek}
-  def seek: (*untyped) -> untyped
+  def seek: (Integer amount, ?Integer whence) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -852,7 +858,7 @@ class ARGFClass
   #                                        # to UTF-8.
   #
   %a{annotate:rdoc:copy:ARGF#set_encoding}
-  def set_encoding: (*untyped) -> untyped
+  def set_encoding: (String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc) -> self
 
   # <!--
   #   rdoc-file=io.c
@@ -869,7 +875,7 @@ class ARGFClass
   #     ARGF.filename  #=> "bar"
   #
   %a{annotate:rdoc:copy:ARGF#skip}
-  def skip: () -> untyped
+  def skip: () -> self
 
   # <!--
   #   rdoc-file=io.c
@@ -883,7 +889,7 @@ class ARGFClass
   #     ARGF.pos    #=> 17
   #
   %a{annotate:rdoc:copy:ARGF#tell}
-  def tell: () -> untyped
+  def tell: () -> Integer
 
   # <!-- rdoc-file=io.c -->
   # Reads `ARGF`'s current file in its entirety, returning an `Array` of its
@@ -893,7 +899,7 @@ class ARGFClass
   #     lines[0]                #=> "This is line one\n"
   #
   %a{annotate:rdoc:copy:ARGF#to_a}
-  def to_a: (*untyped) -> untyped
+  def to_a: (?String sep, ?Integer limit) -> ::Array[String]
 
   # <!-- rdoc-file=io.c -->
   # Returns an integer representing the numeric file descriptor for the current
@@ -902,7 +908,7 @@ class ARGFClass
   #     ARGF.fileno    #=> 3
   #
   %a{annotate:rdoc:copy:ARGF#to_i}
-  def to_i: () -> untyped
+  def to_i: () -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -917,7 +923,7 @@ class ARGFClass
   #     ARGF.to_io    #=> #<IO:<STDIN>>
   #
   %a{annotate:rdoc:copy:ARGF#to_io}
-  def to_io: () -> untyped
+  def to_io: () -> IO
 
   # <!--
   #   rdoc-file=io.c
@@ -926,7 +932,7 @@ class ARGFClass
   # Returns "ARGF".
   #
   %a{annotate:rdoc:copy:ARGF#to_s}
-  def to_s: () -> untyped
+  def to_s: () -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -935,7 +941,7 @@ class ARGFClass
   # Returns IO instance tied to *ARGF* for writing if inplace mode is enabled.
   #
   %a{annotate:rdoc:copy:ARGF#to_write_io}
-  def to_write_io: () -> untyped
+  def to_write_io: () -> IO
 
   # <!--
   #   rdoc-file=io.c
@@ -944,13 +950,13 @@ class ARGFClass
   # Writes *string* if inplace mode.
   #
   %a{annotate:rdoc:copy:ARGF#write}
-  def write: (untyped) -> untyped
+  def write: (_ToS string) -> Integer
 
   private
 
   %a{annotate:rdoc:copy:ARGF#initialize}
-  def initialize: (*untyped) -> void
+  def initialize: (*String argv) -> void
 
   %a{annotate:rdoc:copy:ARGF#initialize_copy}
-  def initialize_copy: (untyped) -> untyped
+  def initialize_copy: (self orig) -> self
 end

--- a/core/constants.rbs
+++ b/core/constants.rbs
@@ -4,7 +4,7 @@
 #
 # See ARGF (the class) for more details.
 #
-::ARGF: Object
+::ARGF: ARGFClass
 
 # <!-- rdoc-file=ruby.c -->
 # ARGV contains the command line arguments used to run ruby.

--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -115,7 +115,7 @@ $:: Array[String]
 $;: Regexp | String | nil
 
 # The same as ARGF.
-$<: IO
+$<: ARGFClass
 
 # This variable is no longer effective. Deprecated.
 $=: bool

--- a/test/stdlib/ARGF_test.rb
+++ b/test/stdlib/ARGF_test.rb
@@ -1,0 +1,292 @@
+require_relative "test_helper"
+
+class ARGFSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "singleton(::ARGF)"
+
+
+  def test_new
+    assert_send_type  "(*::String argv) -> ::ARGF",
+                      ARGF.class, :new
+  end
+end
+
+class ARGFTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  # library "pathname", "set", "securerandom"     # Declare library signatures to load
+  testing "::ARGF"
+
+
+  def test_initialize
+    assert_send_type  "(*::String argv) -> void",
+                      ARGF.class.new, :initialize
+  end
+
+  def test_initialize_copy
+    assert_send_type  "(self orig) -> self",
+                      ARGF.class.new, :initialize_copy
+  end
+
+  def test_gets
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::String?",
+                      ARGF.class.new, :gets
+  end
+
+  def test_print
+    assert_send_type  "(*untyped args) -> nil",
+                      ARGF.class.new, :print
+  end
+
+  def test_printf
+    assert_send_type  "(::String format_string, *untyped args) -> nil",
+                      ARGF.class.new, :printf
+  end
+
+  def test_putc
+    assert_send_type  "(::Numeric | ::String obj) -> untyped",
+                      ARGF.class.new, :putc
+  end
+
+  def test_puts
+    assert_send_type  "(*untyped obj) -> nil",
+                      ARGF.class.new, :puts
+  end
+
+  def test_readline
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::String",
+                      ARGF.class.new, :readline
+  end
+
+  def test_readlines
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Array[::String]",
+                      ARGF.class.new, :readlines
+  end
+
+  def test_inspect
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new, :inspect
+  end
+
+  def test_to_s
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new, :to_s
+  end
+
+  def test_to_a
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Array[::String]",
+                      ARGF.class.new, :to_a
+  end
+
+  def test_argv
+    assert_send_type  "() -> ::Array[::String]",
+                      ARGF.class.new, :argv
+  end
+
+  def test_binmode
+    assert_send_type  "() -> self",
+                      ARGF.class.new, :binmode
+  end
+
+  def test_binmode?
+    assert_send_type  "() -> bool",
+                      ARGF.class.new, :binmode?
+  end
+
+  def test_close
+    assert_send_type  "() -> self",
+                      ARGF.class.new, :close
+  end
+
+  def test_closed?
+    assert_send_type  "() -> bool",
+                      ARGF.class.new, :closed?
+  end
+
+  def test_each
+    assert_send_type  "(?::String sep, ?::Integer limit) { (::String line) -> untyped } -> self",
+                      ARGF.class.new, :each
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Enumerator[::String, self]",
+                      ARGF.class.new, :each
+  end
+
+  def test_each_byte
+    assert_send_type  "() { (::Integer byte) -> untyped } -> self",
+                      ARGF.class.new, :each_byte
+    assert_send_type  "() -> ::Enumerator[::Integer, self]",
+                      ARGF.class.new, :each_byte
+  end
+
+  def test_each_char
+    assert_send_type  "() { (::String char) -> untyped } -> self",
+                      ARGF.class.new, :each_char
+    assert_send_type  "() -> ::Enumerator[::String, self]",
+                      ARGF.class.new, :each_char
+  end
+
+  def test_each_codepoint
+    assert_send_type  "() { (::Integer codepoint) -> untyped } -> self",
+                      ARGF.class.new, :each_codepoint
+    assert_send_type  "() -> ::Enumerator[::Integer, self]",
+                      ARGF.class.new, :each_codepoint
+  end
+
+  def test_each_line
+    assert_send_type  "(?::String sep, ?::Integer limit) { (::String line) -> untyped } -> self",
+                      ARGF.class.new, :each_line
+    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Enumerator[::String, self]",
+                      ARGF.class.new, :each_line
+  end
+
+  def test_eof
+    assert_send_type  "() -> bool",
+                      ARGF.class.new, :eof
+  end
+
+  def test_eof?
+    assert_send_type  "() -> bool",
+                      ARGF.class.new, :eof?
+  end
+
+  def test_external_encoding
+    assert_send_type  "() -> ::Encoding",
+                      ARGF.class.new, :external_encoding
+  end
+
+  def test_file
+    assert_send_type  "() -> (::IO | ::File)",
+                      ARGF.class.new, :file
+  end
+
+  def test_filename
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new, :filename
+  end
+
+  def test_fileno
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :fileno
+  end
+
+  def test_getbyte
+    assert_send_type  "() -> ::Integer?",
+                      ARGF.class.new, :getbyte
+  end
+
+  def test_getc
+    assert_send_type  "() -> ::String?",
+                      ARGF.class.new, :getc
+  end
+
+  def test_inplace_mode
+    assert_send_type  "() -> ::String?",
+                      ARGF.class.new, :inplace_mode
+  end
+
+  def test_inplace_mode=
+    assert_send_type  "(::String) -> self",
+                      ARGF.class.new, :inplace_mode=
+  end
+
+  def test_internal_encoding
+    assert_send_type  "() -> ::Encoding",
+                      ARGF.class.new, :internal_encoding
+  end
+
+  def test_lineno
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :lineno
+  end
+
+  def test_lineno=
+    assert_send_type  "(::Integer) -> untyped",
+                      ARGF.class.new, :lineno=
+  end
+
+  def test_path
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new, :path
+  end
+
+  def test_pos
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :pos
+  end
+
+  def test_pos=
+    assert_send_type  "(::Integer) -> ::Integer",
+                      ARGF.class.new, :pos=
+  end
+
+  def test_read
+    assert_send_type  "(?::int? length, ?::string outbuf) -> ::String?",
+                      ARGF.class.new, :read
+  end
+
+  def test_read_nonblock
+    assert_send_type  "(::int maxlen, ?::string buf, **untyped options) -> ::String",
+                      ARGF.class.new, :read_nonblock
+  end
+
+  def test_readbyte
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :readbyte
+  end
+
+  def test_readchar
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new, :readchar
+  end
+
+  def test_readpartial
+    assert_send_type  "(::int maxlen, ?::string outbuf) -> ::String",
+                      ARGF.class.new, :readpartial
+  end
+
+  def test_rewind
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :rewind
+  end
+
+  def test_seek
+    assert_send_type  "(::Integer amount, ?::Integer whence) -> ::Integer",
+                      ARGF.class.new, :seek
+  end
+
+  def test_set_encoding
+    assert_send_type  "(::String | ::Encoding ext_or_ext_int_enc, ?::String | ::Encoding int_enc) -> self",
+                      ARGF.class.new, :set_encoding
+  end
+
+  def test_skip
+    assert_send_type  "() -> self",
+                      ARGF.class.new, :skip
+  end
+
+  def test_tell
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :tell
+  end
+
+  def test_to_i
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new, :to_i
+  end
+
+  def test_to_io
+    assert_send_type  "() -> ::IO",
+                      ARGF.class.new, :to_io
+  end
+
+  def test_to_write_io
+    assert_send_type  "() -> ::IO",
+                      ARGF.class.new, :to_write_io
+  end
+
+  def test_write
+    assert_send_type  "(::_ToS string) -> ::Integer",
+                      ARGF.class.new, :write
+  end
+end

--- a/test/stdlib/ARGF_test.rb
+++ b/test/stdlib/ARGF_test.rb
@@ -1,292 +1,346 @@
 require_relative "test_helper"
+require 'tempfile'
 
-class ARGFSingletonTest < Test::Unit::TestCase
-  include TypeAssertions
-
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
-  testing "singleton(::ARGF)"
-
-
-  def test_new
-    assert_send_type  "(*::String argv) -> ::ARGF",
-                      ARGF.class, :new
-  end
+# initialize temporary class
+class ARGFClass
 end
 
 class ARGFTest < Test::Unit::TestCase
   include TypeAssertions
+  testing "::ARGFClass"
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
-  testing "::ARGF"
-
-
-  def test_initialize
-    assert_send_type  "(*::String argv) -> void",
-                      ARGF.class.new, :initialize
-  end
-
-  def test_initialize_copy
-    assert_send_type  "(self orig) -> self",
-                      ARGF.class.new, :initialize_copy
+  def argf_for_write
+    argf = ARGF.class.new(Tempfile.new.path)
+    argf.inplace_mode = ".bak"
+    # NOTE: Call rewind to call ARGF.next_argv internally (see: argf_write_io in io.c)
+    argf.rewind
+    argf
   end
 
   def test_gets
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::String?",
-                      ARGF.class.new, :gets
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new(__FILE__), :gets
+    assert_send_type  "(::String sep) -> ::String",
+                      ARGF.class.new(__FILE__), :gets, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::String",
+                      ARGF.class.new(__FILE__), :gets, "\n", 1
+    assert_send_type  "() -> nil",
+                      ARGF.class.new(Tempfile.new), :gets
   end
 
   def test_print
     assert_send_type  "(*untyped args) -> nil",
-                      ARGF.class.new, :print
+                      argf_for_write, :print, "ok"
   end
 
   def test_printf
     assert_send_type  "(::String format_string, *untyped args) -> nil",
-                      ARGF.class.new, :printf
+                      argf_for_write, :printf, "%s", "ok"
   end
 
   def test_putc
-    assert_send_type  "(::Numeric | ::String obj) -> untyped",
-                      ARGF.class.new, :putc
+    assert_send_type  "(::String obj) -> untyped",
+                      argf_for_write, :putc, "c"
+    assert_send_type  "(::Numeric) -> untyped",
+                      argf_for_write, :putc, "c".ord
   end
 
   def test_puts
     assert_send_type  "(*untyped obj) -> nil",
-                      ARGF.class.new, :puts
+                      argf_for_write, :puts, "ok"
   end
 
   def test_readline
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::String",
-                      ARGF.class.new, :readline
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new(__FILE__), :readline
+    assert_send_type  "(::String sep) -> ::String",
+                      ARGF.class.new(__FILE__), :readline, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::String",
+                      ARGF.class.new(__FILE__), :readline, "\n", 1
   end
 
   def test_readlines
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Array[::String]",
-                      ARGF.class.new, :readlines
+    assert_send_type  "() -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :readlines
+    assert_send_type  "(::String sep) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :readlines, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :readlines, "\n", 1
   end
 
   def test_inspect
     assert_send_type  "() -> ::String",
-                      ARGF.class.new, :inspect
+                      ARGF.class.new(__FILE__), :inspect
   end
 
   def test_to_s
     assert_send_type  "() -> ::String",
-                      ARGF.class.new, :to_s
+                      ARGF.class.new(__FILE__), :to_s
   end
 
   def test_to_a
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Array[::String]",
-                      ARGF.class.new, :to_a
+    assert_send_type  "() -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :to_a
+    assert_send_type  "(::String sep) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :to_a, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :to_a, "\n", 1
   end
 
   def test_argv
     assert_send_type  "() -> ::Array[::String]",
-                      ARGF.class.new, :argv
+                      ARGF.class.new(__FILE__), :argv
   end
 
   def test_binmode
     assert_send_type  "() -> self",
-                      ARGF.class.new, :binmode
+                      ARGF.class.new(__FILE__), :binmode
   end
 
   def test_binmode?
     assert_send_type  "() -> bool",
-                      ARGF.class.new, :binmode?
+                      ARGF.class.new(__FILE__), :binmode?
   end
 
   def test_close
     assert_send_type  "() -> self",
-                      ARGF.class.new, :close
+                      ARGF.class.new(__FILE__), :close
   end
 
   def test_closed?
     assert_send_type  "() -> bool",
-                      ARGF.class.new, :closed?
+                      ARGF.class.new(__FILE__), :closed?
   end
 
   def test_each
-    assert_send_type  "(?::String sep, ?::Integer limit) { (::String line) -> untyped } -> self",
-                      ARGF.class.new, :each
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Enumerator[::String, self]",
-                      ARGF.class.new, :each
+    assert_send_type  "() { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each do |line| line end
+    assert_send_type  "(::String sep) { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each, "\n" do |line| line end
+    assert_send_type  "(::String sep, ::Integer limit) { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each, "\n", 1 do |line| line end
+
+    assert_send_type  "() -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each
+    assert_send_type  "(::String sep) -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each, "\n", 1
   end
 
   def test_each_byte
     assert_send_type  "() { (::Integer byte) -> untyped } -> self",
-                      ARGF.class.new, :each_byte
+                      ARGF.class.new(__FILE__), :each_byte do |byte| byte end
     assert_send_type  "() -> ::Enumerator[::Integer, self]",
-                      ARGF.class.new, :each_byte
+                      ARGF.class.new(__FILE__), :each_byte
   end
 
   def test_each_char
     assert_send_type  "() { (::String char) -> untyped } -> self",
-                      ARGF.class.new, :each_char
+                      ARGF.class.new(__FILE__), :each_char do |char| char end
     assert_send_type  "() -> ::Enumerator[::String, self]",
-                      ARGF.class.new, :each_char
+                      ARGF.class.new(__FILE__), :each_char
   end
 
   def test_each_codepoint
     assert_send_type  "() { (::Integer codepoint) -> untyped } -> self",
-                      ARGF.class.new, :each_codepoint
+                      ARGF.class.new(__FILE__), :each_codepoint do |codepoint| end
     assert_send_type  "() -> ::Enumerator[::Integer, self]",
-                      ARGF.class.new, :each_codepoint
+                      ARGF.class.new(__FILE__), :each_codepoint
   end
 
   def test_each_line
-    assert_send_type  "(?::String sep, ?::Integer limit) { (::String line) -> untyped } -> self",
-                      ARGF.class.new, :each_line
-    assert_send_type  "(?::String sep, ?::Integer limit) -> ::Enumerator[::String, self]",
-                      ARGF.class.new, :each_line
+    assert_send_type  "() { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each_line do |line| line end
+    assert_send_type  "(::String sep) { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each_line, "\n" do |line| line end
+    assert_send_type  "(::String sep, ::Integer limit) { (::String line) -> untyped } -> self",
+                      ARGF.class.new(__FILE__), :each_line, "\n", 1 do |line| line end
+
+    assert_send_type  "() -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each_line
+    assert_send_type  "(::String sep) -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each_line, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::Enumerator[::String, self]",
+                      ARGF.class.new(__FILE__), :each_line, "\n", 1
   end
 
   def test_eof
     assert_send_type  "() -> bool",
-                      ARGF.class.new, :eof
+                      ARGF.class.new(__FILE__), :eof
   end
 
   def test_eof?
     assert_send_type  "() -> bool",
-                      ARGF.class.new, :eof?
+                      ARGF.class.new(__FILE__), :eof?
   end
 
   def test_external_encoding
     assert_send_type  "() -> ::Encoding",
-                      ARGF.class.new, :external_encoding
+                      ARGF.class.new(__FILE__), :external_encoding
   end
 
   def test_file
     assert_send_type  "() -> (::IO | ::File)",
-                      ARGF.class.new, :file
+                      ARGF.class.new(__FILE__), :file
   end
 
   def test_filename
     assert_send_type  "() -> ::String",
-                      ARGF.class.new, :filename
+                      ARGF.class.new(__FILE__), :filename
   end
 
   def test_fileno
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :fileno
+                      ARGF.class.new(__FILE__), :fileno
   end
 
   def test_getbyte
-    assert_send_type  "() -> ::Integer?",
-                      ARGF.class.new, :getbyte
+    assert_send_type  "() -> ::Integer",
+                      ARGF.class.new(__FILE__), :getbyte
+    assert_send_type  "() -> nil",
+                      ARGF.class.new(Tempfile.new), :getbyte
   end
 
   def test_getc
-    assert_send_type  "() -> ::String?",
-                      ARGF.class.new, :getc
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new(__FILE__), :getc
+    assert_send_type  "() -> nil",
+                      ARGF.class.new(Tempfile.new), :getc
   end
 
   def test_inplace_mode
-    assert_send_type  "() -> ::String?",
-                      ARGF.class.new, :inplace_mode
+    assert_send_type  "() -> nil",
+                      ARGF.class.new(__FILE__), :inplace_mode
+
+    argf = ARGF.class.new(__FILE__)
+    argf.inplace_mode = ".bak"
+    assert_send_type  "() -> String",
+                      argf, :inplace_mode
   end
 
-  def test_inplace_mode=
+  def test_inplace_mode=()
     assert_send_type  "(::String) -> self",
-                      ARGF.class.new, :inplace_mode=
+                      ARGF.class.new(__FILE__), :inplace_mode=, ".bak"
   end
 
   def test_internal_encoding
     assert_send_type  "() -> ::Encoding",
-                      ARGF.class.new, :internal_encoding
+                      ARGF.class.new(__FILE__), :internal_encoding
   end
 
   def test_lineno
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :lineno
+                      ARGF.class.new(__FILE__), :lineno
   end
 
-  def test_lineno=
+  def test_lineno=()
     assert_send_type  "(::Integer) -> untyped",
-                      ARGF.class.new, :lineno=
+                      ARGF.class.new(__FILE__), :lineno=, 1
   end
 
   def test_path
     assert_send_type  "() -> ::String",
-                      ARGF.class.new, :path
+                      ARGF.class.new(__FILE__), :path
   end
 
   def test_pos
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :pos
+                      ARGF.class.new(__FILE__), :pos
   end
 
   def test_pos=
     assert_send_type  "(::Integer) -> ::Integer",
-                      ARGF.class.new, :pos=
+                      ARGF.class.new(__FILE__), :pos=, 1
   end
 
   def test_read
-    assert_send_type  "(?::int? length, ?::string outbuf) -> ::String?",
-                      ARGF.class.new, :read
+    assert_send_type  "() -> ::String",
+                      ARGF.class.new(__FILE__), :read
+    assert_send_type  "(::int length) -> ::String",
+                      ARGF.class.new(__FILE__), :read, 1
+    assert_send_type  "(::int length, ::string outbuf) -> ::String",
+                      ARGF.class.new(__FILE__), :read, 1, ""
+    assert_send_type  "(::int length) -> nil",
+                      ARGF.class.new(Tempfile.new), :read, 1
   end
 
   def test_read_nonblock
-    assert_send_type  "(::int maxlen, ?::string buf, **untyped options) -> ::String",
-                      ARGF.class.new, :read_nonblock
+    assert_send_type  "(::int maxlen) -> ::String",
+                      ARGF.class.new(__FILE__), :read_nonblock, 1
+    assert_send_type  "(::int maxlen, ::string buf) -> ::String",
+                      ARGF.class.new(__FILE__), :read_nonblock, 1, ""
   end
 
   def test_readbyte
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :readbyte
+                      ARGF.class.new(__FILE__), :readbyte
   end
 
   def test_readchar
     assert_send_type  "() -> ::String",
-                      ARGF.class.new, :readchar
+                      ARGF.class.new(__FILE__), :readchar
   end
 
   def test_readpartial
-    assert_send_type  "(::int maxlen, ?::string outbuf) -> ::String",
-                      ARGF.class.new, :readpartial
+    assert_send_type  "(::int maxlen) -> ::String",
+                      ARGF.class.new(__FILE__), :readpartial, 1
+    assert_send_type  "(::int maxlen, ::string buf) -> ::String",
+                      ARGF.class.new(__FILE__), :readpartial, 1, ""
   end
 
   def test_rewind
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :rewind
+                      ARGF.class.new(__FILE__), :rewind
   end
 
   def test_seek
-    assert_send_type  "(::Integer amount, ?::Integer whence) -> ::Integer",
-                      ARGF.class.new, :seek
-  end
+    assert_send_type  "(::Integer amount) -> ::Integer",
+                      ARGF.class.new(__FILE__), :seek, 1
+    assert_send_type  "(::Integer amount, ::Integer whence) -> ::Integer",
+                      ARGF.class.new(__FILE__), :seek, 1, IO::SEEK_SET
 
+  end
   def test_set_encoding
-    assert_send_type  "(::String | ::Encoding ext_or_ext_int_enc, ?::String | ::Encoding int_enc) -> self",
-                      ARGF.class.new, :set_encoding
+    assert_send_type  "(::String) -> self",
+                      ARGF.class.new(__FILE__), :set_encoding, "utf-8"
+    assert_send_type  "(::Encoding) -> self",
+                      ARGF.class.new(__FILE__), :set_encoding, Encoding::UTF_8
+    assert_send_type  "(::String, ::String) -> self",
+                      ARGF.class.new(__FILE__), :set_encoding, "utf-8", "utf-8"
+    assert_send_type  "(::Encoding, ::Encoding) -> self",
+                      ARGF.class.new(__FILE__), :set_encoding, Encoding::UTF_8, Encoding::UTF_8
   end
 
   def test_skip
     assert_send_type  "() -> self",
-                      ARGF.class.new, :skip
+                      ARGF.class.new(__FILE__), :skip
   end
 
   def test_tell
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :tell
+                      ARGF.class.new(__FILE__), :tell
   end
 
   def test_to_i
     assert_send_type  "() -> ::Integer",
-                      ARGF.class.new, :to_i
+                      ARGF.class.new(__FILE__), :to_i
   end
 
   def test_to_io
     assert_send_type  "() -> ::IO",
-                      ARGF.class.new, :to_io
+                      ARGF.class.new(__FILE__), :to_io
   end
 
   def test_to_write_io
     assert_send_type  "() -> ::IO",
-                      ARGF.class.new, :to_write_io
+                      argf_for_write, :to_write_io
   end
 
   def test_write
-    assert_send_type  "(::_ToS string) -> ::Integer",
-                      ARGF.class.new, :write
+    assert_send_type  "(::String) -> ::Integer",
+                      argf_for_write, :write, "ok"
+    assert_send_type  "(::Integer) -> ::Integer",
+                      argf_for_write, :write, 1
   end
 end


### PR DESCRIPTION
Fixed `ARGF` class being `Object`.

Since `ARGF` does not have a named class, I implemented it using `ARGFClass` in reference to the `ENV` implementation.

Most of type definitions is borrowed from `io.rbs`.


References:
- https://docs.ruby-lang.org/ja/latest/class/ARGF=2eclass.html
- https://docs.ruby-lang.org/en/3.1/ARGF.html
- https://github.com/ruby/ruby/blob/7b1ece9b9490a892861f2336ae41d611a06bdf2b/io.c#L14889-L14894
- https://github.com/ruby/rbs/blob/ff384ffe425f8d38b0111ba00ead3a53d1519285/core/env.rbs#L258
