### PR TITLE
Use Random::Base for super_class of Random

### DIFF
--- a/core/random.rbs
+++ b/core/random.rbs
@@ -20,9 +20,7 @@
 # of 2**19937-1.  As this algorithm is *not* for cryptographical use, you must
 # use SecureRandom for security purpose, instead of this PRNG.
 #
-class Random < Object
-  include Random::Formatter
-
+class Random < Random::Base
   # <!--
   #   rdoc-file=random.c
   #   - prng1 == prng2 -> true or false
@@ -48,78 +46,6 @@ class Random < Object
   #     prng1 == prng2 # => true
   #
   def ==: (untyped arg0) -> bool
-
-  # <!--
-  #   rdoc-file=random.c
-  #   - prng.bytes(size) -> string
-  # -->
-  # Returns a random binary string containing `size` bytes.
-  #
-  #     random_string = Random.new.bytes(10) # => "\xD7:R\xAB?\x83\xCE\xFAkO"
-  #     random_string.size                   # => 10
-  #
-  def bytes: (Integer size) -> String
-
-  # <!--
-  #   rdoc-file=random.c
-  #   - Random.new(seed = Random.new_seed) -> prng
-  # -->
-  # Creates a new PRNG using `seed` to set the initial state. If `seed` is
-  # omitted, the generator is initialized with Random.new_seed.
-  #
-  # See Random.srand for more information on the use of seed values.
-  #
-  def initialize: (?Integer seed) -> void
-
-  # <!--
-  #   rdoc-file=random.c
-  #   - prng.rand -> float
-  #   - prng.rand(max) -> number
-  #   - prng.rand(range) -> number
-  # -->
-  # When `max` is an Integer, `rand` returns a random integer greater than or
-  # equal to zero and less than `max`. Unlike Kernel.rand, when `max` is a
-  # negative integer or zero, `rand` raises an ArgumentError.
-  #
-  #     prng = Random.new
-  #     prng.rand(100)       # => 42
-  #
-  # When `max` is a Float, `rand` returns a random floating point number between
-  # 0.0 and `max`, including 0.0 and excluding `max`.
-  #
-  #     prng.rand(1.5)       # => 1.4600282860034115
-  #
-  # When `range` is a Range, `rand` returns a random number where
-  # `range.member?(number) == true`.
-  #
-  #     prng.rand(5..9)      # => one of [5, 6, 7, 8, 9]
-  #     prng.rand(5...9)     # => one of [5, 6, 7, 8]
-  #     prng.rand(5.0..9.0)  # => between 5.0 and 9.0, including 9.0
-  #     prng.rand(5.0...9.0) # => between 5.0 and 9.0, excluding 9.0
-  #
-  # Both the beginning and ending values of the range must respond to subtract
-  # (`-`) and add (`+`)methods, or rand will raise an ArgumentError.
-  #
-  def rand: () -> Float
-          | (Integer | ::Range[Integer] max) -> Integer
-          | (Float | ::Range[Float] max) -> Float
-
-  # <!--
-  #   rdoc-file=random.c
-  #   - prng.seed -> integer
-  # -->
-  # Returns the seed value used to initialize the generator. This may be used to
-  # initialize another generator with the same state at a later time, causing it
-  # to produce the same sequence of numbers.
-  #
-  #     prng1 = Random.new(1234)
-  #     prng1.seed       #=> 1234
-  #     prng1.rand(100)  #=> 47
-  #
-  #     prng2 = Random.new(prng1.seed)
-  #     prng2.rand(100)  #=> 47
-  #
-  def seed: () -> Integer
 
   # <!--
   #   rdoc-file=random.c
@@ -365,4 +291,85 @@ module Random::Formatter
   # See RFC 4122 for details of UUID.
   #
   def uuid: () -> String
+end
+
+class Random::Base
+  include Random::Formatter
+  extend Random::Formatter
+
+  # <!--
+  #   rdoc-file=random.c
+  #   - Random.new(seed = Random.new_seed) -> prng
+  # -->
+  # Creates a new PRNG using `seed` to set the initial state. If `seed` is
+  # omitted, the generator is initialized with Random.new_seed.
+  #
+  # See Random.srand for more information on the use of seed values.
+  #
+  %a{annotate:rdoc:copy:Random.new}
+  def initialize: (?Integer seed) -> void
+
+  # <!--
+  #   rdoc-file=random.c
+  #   - prng.rand -> float
+  #   - prng.rand(max) -> number
+  #   - prng.rand(range) -> number
+  # -->
+  # When `max` is an Integer, `rand` returns a random integer greater than or
+  # equal to zero and less than `max`. Unlike Kernel.rand, when `max` is a
+  # negative integer or zero, `rand` raises an ArgumentError.
+  #
+  #     prng = Random.new
+  #     prng.rand(100)       # => 42
+  #
+  # When `max` is a Float, `rand` returns a random floating point number between
+  # 0.0 and `max`, including 0.0 and excluding `max`.
+  #
+  #     prng.rand(1.5)       # => 1.4600282860034115
+  #
+  # When `range` is a Range, `rand` returns a random number where
+  # `range.member?(number) == true`.
+  #
+  #     prng.rand(5..9)      # => one of [5, 6, 7, 8, 9]
+  #     prng.rand(5...9)     # => one of [5, 6, 7, 8]
+  #     prng.rand(5.0..9.0)  # => between 5.0 and 9.0, including 9.0
+  #     prng.rand(5.0...9.0) # => between 5.0 and 9.0, excluding 9.0
+  #
+  # Both the beginning and ending values of the range must respond to subtract
+  # (`-`) and add (`+`)methods, or rand will raise an ArgumentError.
+  #
+  %a{annotate:rdoc:copy:Random#rand}
+  def rand: () -> Float
+          | (Integer | ::Range[Integer] max) -> Integer
+          | (Float | ::Range[Float] max) -> Float
+
+  # <!--
+  #   rdoc-file=random.c
+  #   - prng.bytes(size) -> string
+  # -->
+  # Returns a random binary string containing `size` bytes.
+  #
+  #     random_string = Random.new.bytes(10) # => "\xD7:R\xAB?\x83\xCE\xFAkO"
+  #     random_string.size                   # => 10
+  #
+  %a{annotate:rdoc:copy:Random#bytes}
+  def bytes: (Integer size) -> String
+
+  # <!--
+  #   rdoc-file=random.c
+  #   - prng.seed -> integer
+  # -->
+  # Returns the seed value used to initialize the generator. This may be used to
+  # initialize another generator with the same state at a later time, causing it
+  # to produce the same sequence of numbers.
+  #
+  #     prng1 = Random.new(1234)
+  #     prng1.seed       #=> 1234
+  #     prng1.rand(100)  #=> 47
+  #
+  #     prng2 = Random.new(prng1.seed)
+  #     prng2.rand(100)  #=> 47
+  #
+  %a{annotate:rdoc:copy:Random#seed}
+  def seed: () -> Integer
 end

--- a/test/stdlib/Random_test.rb
+++ b/test/stdlib/Random_test.rb
@@ -1,0 +1,66 @@
+require_relative "test_helper"
+
+class RandomSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::Random)"
+
+  def test_srand
+    assert_send_type  "(?::Integer number) -> ::Integer",
+                      Random, :srand
+  end
+
+  def test_rand
+    assert_send_type  "() -> ::Float",
+                      Random, :rand
+    assert_send_type  "(::Integer | ::Range[::Integer] max) -> ::Integer",
+                      Random, :rand, 100
+    assert_send_type  "(::Float | ::Range[::Float] max) -> ::Float",
+                      Random, :rand, 100.0
+  end
+
+  def test_new
+    assert_send_type  "(?::Integer seed) -> ::Random",
+                      Random, :new
+  end
+
+  def test_new_seed
+    assert_send_type  "() -> ::Integer",
+                      Random, :new_seed
+  end
+end
+
+class RandomTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Random"
+
+  def test_double_equal
+    assert_send_type  "(untyped arg0) -> bool",
+                      Random.new, :==, Random.new
+  end
+
+  def test_initialize
+    assert_send_type  "(?::Integer seed) -> void",
+                      Random.new, :initialize
+  end
+
+  def test_rand
+    assert_send_type  "() -> ::Float",
+                      Random.new, :rand
+    assert_send_type  "(::Integer | ::Range[::Integer] max) -> ::Integer",
+                      Random.new, :rand, 100
+    assert_send_type  "(::Float | ::Range[::Float] max) -> ::Float",
+                      Random.new, :rand, 100.0
+  end
+
+  def test_bytes
+    assert_send_type  "(::Integer size) -> ::String",
+                      Random.new, :bytes, 8
+  end
+
+  def test_seed
+    assert_send_type  "() -> ::Integer",
+                      Random.new, :seed
+  end
+end


### PR DESCRIPTION
Starting with ruby v3.0, Random::Base was created to facilitate algorithm changes,
and the inheritance relationship was changed.
ref: https://github.com/ruby/ruby/pull/3024

Also, since there was no test, I created a new one.