### PR TITLE
Define only name Singleton::SingletonClassMethods

### DIFF
--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -126,6 +126,9 @@ module Singleton
   # Raises a TypeError to prevent duping.
   #
   def dup: () -> bot
+
+  module SingletonClassMethods
+  end
 end
 
 Singleton::VERSION: String


### PR DESCRIPTION
`Singleton::SingletonClassMethods` is internal module.
But it does exist.
Therefore, I propose to register only the module name.
This module name will prevent the problem of a non-existent module name when the RBS is mechanically generated.
If this module name does not exist, the developer will have to write code to work around the error.