### PR TITLE
Add Exception for pattern-matching

### DIFF
--- a/core/errors.rbs
+++ b/core/errors.rbs
@@ -299,6 +299,36 @@ class NameError[T] < StandardError
   def receiver: () -> T?
 end
 
+class NoMatchingPatternError < StandardError
+end
+
+class NoMatchingPatternKeyError[M, K] < NoMatchingPatternError
+  # <!--
+  #   rdoc-file=error.c
+  #   - NoMatchingPatternKeyError.new(message=nil, matchee: nil, key: nil) -> no_matching_pattern_key_error
+  # -->
+  # Construct a new `NoMatchingPatternKeyError` exception with the given message,
+  # matchee and key.
+  #
+  def initialize: (?string message, matchee: M, key: K) -> void
+
+  # <!--
+  #   rdoc-file=error.c
+  #   - no_matching_pattern_key_error.matchee  -> object
+  # -->
+  # Return the matchee associated with this NoMatchingPatternKeyError exception.
+  #
+  def matchee: () -> M
+
+  # <!--
+  #   rdoc-file=error.c
+  #   - no_matching_pattern_key_error.key  -> object
+  # -->
+  # Return the key caused this NoMatchingPatternKeyError exception.
+  #
+  def key: () -> K
+end
+
 # <!-- rdoc-file=error.c -->
 # Raised when memory allocation fails.
 #

--- a/test/stdlib/NoMatchingPatternKeyError_test.rb
+++ b/test/stdlib/NoMatchingPatternKeyError_test.rb
@@ -1,0 +1,35 @@
+require_relative "test_helper"
+
+class NoMatchingPatternKeyErrorSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::NoMatchingPatternKeyError)"
+
+
+  def test_new
+    assert_send_type  "[Matchee, Key] (?::string message, matchee: Integer, key: Integer) -> ::NoMatchingPatternKeyError[Integer, Integer]",
+                      NoMatchingPatternKeyError, :new, matchee: 123, key: 234
+  end
+end
+
+class NoMatchingPatternKeyErrorTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::NoMatchingPatternKeyError[Hash[Symbol, untyped], Symbol]"
+
+
+  def test_initialize
+    assert_send_type  "(?::string message, matchee: Hash[Symbol, untyped], key: Symbol) -> void",
+                      NoMatchingPatternKeyError.new(matchee: {a: 1}, key: :aa), :initialize, matchee: {a: 1}, key: :aa
+  end
+
+  def test_matchee
+    assert_send_type  "() -> Hash[Symbol, untyped]",
+                      NoMatchingPatternKeyError.new(matchee: {a: 1}, key: :aa), :matchee
+  end
+
+  def test_key
+    assert_send_type  "() -> Symbol",
+                      NoMatchingPatternKeyError.new(matchee: {a: 1}, key: :aa), :key
+  end
+end


### PR DESCRIPTION
I'm considering `DidYouMean` as a use case.

https://github.com/ruby/did_you_mean/blob/80c74fe3e80da672e6d94a3eaf6ade803c4a22fd/lib/did_you_mean/spell_checkers/pattern_key_name_checker.rb#L5-L8