### PR TITLE
Fix git unsafe repository error on ci test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -36,6 +36,8 @@ jobs:
       image: rubylang/ruby:${{ matrix.container_tag }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set working directory as safe
+      run: /usr/bin/git config --global --add safe.directory $(pwd)
     - name: Install dependencies
       run: |
         apt-get update


### PR DESCRIPTION
fixes #983

I set `safe.directory` to avoid the following error in CI

```
fatal: unsafe repository ('/__w/rbs/rbs' is owned by someone else)
```

## Cause

Starting with git v2.35.2, it seems to cause an error if the current user and the ownership of the directory are different.

ref https://github.blog/2022-04-12-git-security-vulnerability-announced/

> The most effective way to protect against this vulnerability is to upgrade to Git v2.35.2. This version changes Git's behavior when looking for a top-level .git directory to stop when its directory traversal changes ownership from the current user. directory configuration).

According to https://github.com/actions/checkout/issues/760, this problem affects if running GH Action in Docker.

rbs project was using git commands in the test, so it was an error.
