### PR TITLE
Suppress code output that cannot be parsed as RBS

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -85,9 +85,14 @@ module RBS
         case node.type
         when :CLASS
           class_name, super_class, *class_body = node.children
+          super_class_name = const_to_name(super_class)
+          if super_class_name.nil?
+            # Give up detect super class e.g. `class Foo < Struct.new(:bar)`
+            super_class = nil
+          end
           kls = AST::Declarations::Class.new(
             name: const_to_name(class_name),
-            super_class: super_class && AST::Declarations::Class::Super.new(name: const_to_name(super_class), args: [], location: nil),
+            super_class: super_class && AST::Declarations::Class::Super.new(name: super_class_name, args: [], location: nil),
             type_params: [],
             members: [],
             annotations: [],

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -17,6 +17,9 @@ end
 
 module Foo
 end
+
+class Bar < Struct.new(:bar)
+end
     EOR
 
     parser.parse(rb)
@@ -29,6 +32,9 @@ class World < Hello
 end
 
 module Foo
+end
+
+class Bar
 end
     EOF
   end


### PR DESCRIPTION
Fixes a problem in which an unparsable RBS is output if the superclass name could not be obtained.
For example, `class Foo < Struct.new(:bar)` and `class Foo < DelegateClass(Bar)` are currently output as `class Foo <`.

In this case, I propose to give up getting the superclass name statically and output it as `class Foo`.