### PR TITLE
Fix (ArgumentError) invalid byte sequence in UTF-8

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -485,7 +485,7 @@ module RBS
         case node.type
         when :STR
           lit = node.children[0]
-          if lit.match?(/\A[ -~]+\z/)
+          if lit.ascii_only?
             Types::Literal.new(literal: lit, location: nil)
           else
             BuiltinNames::String.instance_type
@@ -506,7 +506,7 @@ module RBS
           lit = node.children[0]
           case lit
           when Symbol
-            if lit.match?(/\A[ -~]+\z/)
+            if lit.to_s.ascii_only?
               Types::Literal.new(literal: lit, location: nil)
             else
               BuiltinNames::Symbol.instance_type

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -72,7 +72,7 @@ end
 class Hello
   def initialize() 'foo' end
 
-  def str() "foo\nbar" end
+  def str() "こんにちは" end
   def str_lit() "foo" end
   def dstr() "f#{x}oo" end
   def xstr() `ls` end
@@ -713,6 +713,12 @@ G: ::Array[1 | 2 | 3]
 
 H: { id: 123 }
     EOF
+  end
+
+  def test_invalid_byte_sequence_in_utf8
+    parser = RB.new
+    parser.parse('A = "\xff"')
+    assert_write parser.decls, "A: ::String\n"
   end
 
   def test_argumentless_fcall


### PR DESCRIPTION
I exec `$ rb prototype rb` on the following file and found the problem.

https://github.com/rails/rails/blob/b5630e232b95859c4171a285cd8f130e37d3c501/activesupport/lib/active_support/core_ext/digest/uuid.rb

```
$ rbs prototype rb activesupport/lib/active_support/core_ext/digest/uuid.rb
/Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:488:in `match?': invalid byte sequence in UTF-8 (ArgumentError)
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:488:in `literal_to_type'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:341:in `process'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:357:in `block in process_children'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/helpers.rb:74:in `block in each_node'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/helpers.rb:72:in `each'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/helpers.rb:72:in `each_node'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/helpers.rb:68:in `each_child'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:356:in `process_children'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/prototype/rb.rb:351:in `process'
```

I suggest using `String#ascii_only?` since the original Regexp(`/\A[ -~]+\z/`) seemed to be determining if it was an ascii string only.

As a side effect, strings like `""` and `"foo\nbar"`, which were not previously converted as literals, are now recognized as literals.

