### PR TITLE
Fix broken args after parsed decls from `RBS::Prototype::RB`

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -518,15 +518,15 @@ module RBS
             Types::ClassInstance.new(name: type_name, args: [], location: nil)
           end
         when :ZLIST, :ZARRAY
-          BuiltinNames::Array.instance_type([untyped])
+          BuiltinNames::Array.instance_type(untyped)
         when :LIST, :ARRAY
           elem_types = node.children.compact.map { |e| literal_to_type(e) }
           t = types_to_union_type(elem_types)
-          BuiltinNames::Array.instance_type([t])
+          BuiltinNames::Array.instance_type(t)
         when :DOT2, :DOT3
           types = node.children.map { |c| literal_to_type(c) }
           type = range_element_type(types)
-          BuiltinNames::Range.instance_type([type])
+          BuiltinNames::Range.instance_type(type)
         when :HASH
           list = node.children[0]
           if list
@@ -554,7 +554,7 @@ module RBS
           else
             key_type = types_to_union_type(key_types)
             value_type = types_to_union_type(value_types)
-            BuiltinNames::Hash.instance_type([key_type, value_type])
+            BuiltinNames::Hash.instance_type(key_type, value_type)
           end
         when :CALL
           receiver, method_name, * = node.children

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -859,6 +859,23 @@ end
     RBS
   end
 
+  def test_literal_to_type
+    parser = RBS::Prototype::RB.new
+    [
+      [%{"abc"}, %{"abc"}],
+      [%{:abc}, %{:abc}],
+      [%{[]}, %{::Array[untyped]}],
+      [%{[true]}, %{::Array[true]}],
+      [%{1..2}, %{::Range[::Integer]}],
+      [%{{}}, %{::Hash[untyped, untyped]}],
+      [%{{a: nil}}, %{ { a: nil } }],
+      [%{{"a" => /b/}}, %{ ::Hash[::String, ::Regexp] }],
+    ].each do |rb, rbs|
+      node = RubyVM::AbstractSyntaxTree.parse(rb).children[2]
+      assert_equal RBS::Parser.parse_type(rbs), parser.literal_to_type(node)
+    end
+  end
+
   if RUBY_VERSION >= '2.7'
     def test_argument_forwarding
       parser = RB.new


### PR DESCRIPTION
Decls created with `RBS::Prototype::RB` are in an unintended format and will cause errors when combined with `RBS::Environment`.

```rb
env = RBS::Environment.new
parser = RBS::Prototype::RB.new
parser.parse("H = []")
parser.decls.each do |decl|
  env << decl
end
env.resolve_type_names
```

```
/Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/types.rb:310:in `block in map_type_name': undefined method `map_type_name' for [#<RBS::Types::Bases::Any:0x0000000108d9a1a8 @location=nil>]:Array (NoMethodError)

          args: args.map {|type| type.map_type_name(&block) },
                                     ^^^^^^^^^^^^^^
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/types.rb:310:in `map'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/types.rb:310:in `map_type_name'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/environment.rb:477:in `absolute_type'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/environment.rb:353:in `resolve_declaration'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/environment.rb:239:in `block in resolve_type_names'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/environment.rb:235:in `each'
	from /Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/rbs-2.4.0/lib/rbs/environment.rb:235:in `resolve_type_names'
	from t.rb:9:in `<main>'
```

```rb
> parser.decls
=> [#<RBS::AST::Declarations::Constant:0x0000000108f46560
  @comment=nil,
  @location=nil,
  @name=#<RBS::TypeName:0x0000000108f46a38 @kind=:class, @name=:H, @namespace=#<RBS::Namespace:0x0000000108f46ab0 @absolute=false, @path=[]>>,
  @type=
   #<RBS::Types::ClassInstance:0x0000000108f46650
    @args=[[#<RBS::Types::Bases::Any:0x0000000108f467b8 @location=nil>]],
    @location=nil,
    @name=#<RBS::TypeName:0x000000010535bcf8 @kind=:class, @name=:Array, @namespace=#<RBS::Namespace:0x000000010535bd70 @absolute=true, @path=[]>>>>]

> RBS::Parser.parse_type("::Array[untyped]")
=>
#<RBS::Types::ClassInstance:0x0000000104d84578
 @args=[#<RBS::Types::Bases::Any:0x0000000104d84640 @location=#<RBS::Location:40400 buffer=a.rbs, start=1:8, pos=8...15, children= source='untyped'>>],
 @location=#<RBS::Location:40500 buffer=a.rbs, start=1:0, pos=0...16, children=name,?args source='::Array[untyped]'>,
 @name=#<RBS::TypeName:0x0000000104d847a8 @kind=:class, @name=:Array, @namespace=#<RBS::Namespace:0x0000000104d847f8 @absolute=true, @path=[]>>>
```

I think,

```
@args=[[#<RBS::Types::Bases::Any:0x0000000108f467b8 @location=nil>]]
```

should be

```
@args=[#<RBS::Types::Bases::Any:0x0000000108f467b8 @location=nil>]
```