### PR TITLE
Fix `OpenSSL::PKey::PKeyError: EVP_PKEY_keygen: bad ffc parameters` with OpenSSL 3

### DIFF
--- a/test/stdlib/OpenSSL_test.rb
+++ b/test/stdlib/OpenSSL_test.rb
@@ -773,7 +773,7 @@ class OpenSSLDSATest < Test::Unit::TestCase
   private
 
   def pkey
-    OpenSSL::PKey::DSA.new(512)
+    OpenSSL::PKey::DSA.new(1024)
   end
 end
 


### PR DESCRIPTION
For example:
```
  Error: test_export(OpenSSLDSATest): OpenSSL::PKey::PKeyError: EVP_PKEY_keygen: bad ffc parameters
  /home/runner/work/actions/actions/snapshot-master/.ext/common/openssl/pkey.rb:173:in `generate_key'
  /home/runner/work/actions/actions/snapshot-master/.ext/common/openssl/pkey.rb:173:in `generate'
  /home/runner/work/actions/actions/snapshot-master/.ext/common/openssl/pkey.rb:180:in `new'
  test/stdlib/OpenSSL_test.rb:776:in `pkey'
  test/stdlib/OpenSSL_test.rb:717:in `test_export'
```

Before:
113 tests, 362 assertions, 0 failures, 19 errors, 0 pendings, 0 omissions, 0 notifications
After:
113 tests, 386 assertions, 0 failures, 10 errors, 0 pendings, 0 omissions, 0 notifications