### PR TITLE
Hash#dig requires at least one key

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -978,7 +978,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h.dig(:hello, :world) # => h
   #     h.dig(:hello, :world, :foo, :bar, 2) # => :c
   #
-  def dig: (K arg0, *untyped) -> untyped
+  def dig: (K, *untyped) -> untyped
 
   # <!-- rdoc-file=hash.c -->
   # Hash#each is an alias for Hash#each_pair.

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -978,7 +978,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h.dig(:hello, :world) # => h
   #     h.dig(:hello, :world, :foo, :bar, 2) # => :c
   #
-  def dig: (*untyped) -> untyped
+  def dig: (K arg0, *untyped) -> untyped
 
   # <!-- rdoc-file=hash.c -->
   # Hash#each is an alias for Hash#each_pair.


### PR DESCRIPTION
The signature for Hash#dig is `hash.dig(key, *identifiers)`. It requires at least one key to be passed and then optionally accepts more identifiers.