### PR TITLE
Fix `Rational#*` signature

### DIFF
--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -68,7 +68,8 @@ class Rational < Numeric
   #     Rational(9, 8)  * 4                #=> (9/2)
   #     Rational(20, 9) * 9.8              #=> 21.77777777777778
   #
-  def *: (Integer | Rational) -> Rational
+  def *: (Integer) -> Rational
+       | (Rational) -> Rational
        | [T < Numeric](T) -> T
 
   # <!--

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -69,9 +69,7 @@ class Rational < Numeric
   #     Rational(20, 9) * 9.8              #=> 21.77777777777778
   #
   def *: (Integer | Rational) -> Rational
-       | (Float) -> Float
-       | (Complex) -> Complex
-       | (Numeric) -> Numeric
+       | [T < Numeric](T) -> T
 
   # <!--
   #   rdoc-file=rational.c

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -68,7 +68,8 @@ class Rational < Numeric
   #     Rational(9, 8)  * 4                #=> (9/2)
   #     Rational(20, 9) * 9.8              #=> 21.77777777777778
   #
-  def *: (Float) -> Float
+  def *: (Integer | Rational) -> Rational
+       | (Float) -> Float
        | (Complex) -> Complex
        | (Numeric) -> Numeric
 

--- a/test/stdlib/Rational_test.rb
+++ b/test/stdlib/Rational_test.rb
@@ -179,3 +179,20 @@ class RationalTest < StdlibTest
     a.truncate(1)
   end
 end
+
+class RationalInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Rational"
+
+  def test_multiply
+    assert_send_type "(Integer) -> Rational",
+                      1r, :*, 1
+    assert_send_type "(Rational) -> Rational",
+                      1r, :*, 1r
+    assert_send_type "(Float) -> Float",
+                      1r, :*, 3.1
+    assert_send_type "(Complex) -> Complex",
+                      1, :*, Complex.rect(1,2)
+  end
+end


### PR DESCRIPTION
Currently trancated to Numeric

```ruby
(Rational(4, 3) * 2).to_i
#=> Type `::Numeric` does not have method `to_i`(Ruby::NoMethod)
```

Smilar issues looks exists in around calculation methods. However this PR scopes only to multiply for now.

