### PR TITLE
Load dependencies on -r option also

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,11 +60,6 @@ task :validate => :compile do
 
   FileList["stdlib/*"].each do |path|
     lib = [File.basename(path).to_s]
-    if File.exist?("#{path}/0/manifest.yaml")
-      YAML.load_file("#{path}/0/manifest.yaml")["dependencies"].each do |dep|
-        lib << dep["name"]
-      end
-    end
 
     sh "#{ruby} #{rbs} #{lib.map {|l| "-r #{l}"}.join(" ")} validate --silent"
   end

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -60,8 +60,7 @@ module RBS
 
           upsert_gem specified, locked
           source = Sources.from_config_entry(locked['source'])
-          manifest = source.manifest_of(locked) or return
-          manifest['dependencies']&.each do |dep|
+          source.dependencies_of(locked)&.each do |dep|
             @gem_queue.push({ name: dep['name'], version: nil} )
           end
         end

--- a/lib/rbs/collection/sources.rb
+++ b/lib/rbs/collection/sources.rb
@@ -1,3 +1,4 @@
+require_relative './sources/base'
 require_relative './sources/git'
 require_relative './sources/stdlib'
 require_relative './sources/rubygems'

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -1,0 +1,12 @@
+module RBS
+  module Collection
+    module Sources
+      module Base
+        def dependencies_of(config_entry)
+          manifest = manifest_of(config_entry) or return
+          manifest['dependencies']
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -6,6 +6,7 @@ module RBS
   module Collection
     module Sources
       class Git
+        include Base
         METADATA_FILENAME = '.rbs_meta.yaml'
 
         class CommandError < StandardError; end

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -5,6 +5,7 @@ module RBS
     module Sources
       # Signatures that are inclduded in gem package as sig/ directory.
       class Rubygems
+        include Base
         include Singleton
 
         def has?(config_entry)

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -5,6 +5,7 @@ module RBS
     module Sources
       # signatures that are bundled in rbs gem under the stdlib/ directory
       class Stdlib
+        include Base
         include Singleton
 
         REPO = Repository.default

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -9,6 +9,7 @@ module RBS
         def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
         def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def dependencies_of: (Config::gem_entry) -> Array[{"name" => String}]?
       end
 
       type source_entry = Git::source_entry
@@ -18,7 +19,13 @@ module RBS
         "dependencies" => Array[{"name" => String}]?,
       }
 
+      module Base : _Source
+        def dependencies_of: (Config::gem_entry config_entry) -> Array[{"name" => String}]?
+      end
+
       class Git
+        include Base
+
         METADATA_FILENAME: String
 
         type source_entry = {
@@ -77,7 +84,10 @@ module RBS
 
       # signatures that are bundled in rbs gem under the stdlib/ directory
       class Stdlib
+
         REPO: Repository
+
+        include Base
 
         type source_entry =  {
           'type' => 'stdlib',
@@ -103,6 +113,8 @@ module RBS
 
       # sig/ directory
       class Rubygems
+        include Base
+
         type source_entry = {
           'type' => 'rubygems',
         }

--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -40,7 +40,7 @@ module RBS
     attr_reader core_root: Pathname?
     attr_reader repository: Repository
 
-    attr_reader libs: Array[Library]
+    attr_reader libs: Set[Library]
     attr_reader dirs: Array[Pathname]
 
     # The source where the RBS comes from.
@@ -76,7 +76,9 @@ module RBS
     # If RBS files cannot be found in the gem, it tries to load RBSs from repository.
     #
     def add: (path: Pathname) -> void
-           | (library: String, version: String?) -> void
+           | (library: String, version: String?, ?resolve_dependencies: boolish) -> void
+
+    def resolve_dependencies: (library: String, version: String?) -> void
 
     # Add repository path and libraries via rbs_collection.lock.yaml.
     def add_collection: (Collection::Config collection_config) -> void

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -165,6 +165,20 @@ end
     end
   end
 
+  def test_loading_dependencies
+    mktmpdir do |path|
+      loader = EnvironmentLoader.new
+      loader.add(library: "yaml")
+
+      env = Environment.new
+      loader.load(env: env)
+
+      assert_operator env.class_decls, :key?, TypeName("::YAML")
+      assert_operator env.class_decls, :key?, TypeName("::DBM")
+      assert_operator env.class_decls, :key?, TypeName("::PStore")
+    end
+  end
+
   def test_loading_from_rbs_collection
     mktmpdir do |path|
       lockfile_path = path.join('rbs_collection.lock.yaml')


### PR DESCRIPTION
This PR allows you to load dependency for standard libraries loaded with `-r` out of the box.

# Problem

`rbs collection` is the manager of third-party gems' RBSs. It resolves dependencies of gems/stdlibs.
But it requires defining the application dependency with `rbs_collection.yaml`. It means it doesn't resolve the dependencies on `-r`.

So, we needed to resolve the dependencies manually on `-r`.


# Solution


With this change, the dependencies are loaded automatically even if we use `-r`. It uses the same way as `rbs collection` but for `-r`.

RBS-related tools do not need to care about this PR. The dependency will be resolved without any changes for the related tools such as typeprof.