### PR TITLE
Add support for RSpec's verifying doubles in test setup helper

### DIFF
--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -30,7 +30,12 @@ module RBS
 
         case double_suite.downcase.strip
         when 'rspec'
-          ['::RSpec::Mocks::Double']
+          [
+            '::RSpec::Mocks::Double',
+            '::RSpec::Mocks::InstanceVerifyingDouble',
+            '::RSpec::Mocks::ObjectVerifyingDouble',
+            '::RSpec::Mocks::ClassVerifyingDouble',
+          ]
         when 'minitest'
           ['::Minitest::Mock']
         else

--- a/test/rbs/test/setup_helper_test.rb
+++ b/test/rbs/test/setup_helper_test.rb
@@ -28,7 +28,12 @@ class SetupHelperTest < Test::Unit::TestCase
   end
 
   def test_to_double_class
-    assert_equal ['::RSpec::Mocks::Double'], to_double_class('rspec')
+    assert_equal [
+      '::RSpec::Mocks::Double',
+      '::RSpec::Mocks::InstanceVerifyingDouble',
+      '::RSpec::Mocks::ObjectVerifyingDouble',
+      '::RSpec::Mocks::ClassVerifyingDouble',
+    ], to_double_class('rspec')
     assert_equal ['::Minitest::Mock'], to_double_class('minitest')
 
     silence_warnings do
@@ -40,4 +45,3 @@ class SetupHelperTest < Test::Unit::TestCase
     end
   end
 end
-


### PR DESCRIPTION
Besides regular doubles, RSpec also provides verifying doubles (created with `instance_double`), which are stricter and check that the stubbed methods actually do exist in the original class or object.

In my experience, they tend to be preferred over regular doubles and thus adding support for them is essential for RBS test hooks to be useful out of the box, without specifying both the test suite and additional classes to be ignored.

All classes listed in https://github.com/rspec/rspec-mocks/blob/v3.11.1/lib/rspec/mocks/verifying_double.rb have been added in this PR.

Please let me know if there's anything I should do before this PR is ready to be merged. Thanks!

References:
- https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles