### PR TITLE
Improve `Prototype::RBI`

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -3,7 +3,13 @@ D = Steep::Diagnostic
 target :lib do
   signature "sig"
   check "lib"
-  ignore "lib/rbs/prototype", "lib/rbs/test", "lib/rbs/test.rb"
+  ignore(
+    "lib/rbs/prototype/rb.rb",
+    "lib/rbs/prototype/runtime.rb",
+    "lib/rbs/prototype/helpers.rb",
+    "lib/rbs/test",
+    "lib/rbs/test.rb"
+  )
 
   library "set", "pathname", "json", "logger", "monitor", "tsort", "uri"
   signature "stdlib/strscan/0/"

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -14,17 +14,20 @@ module RBS
       def parse(string)
         comments = Ripper.lex(string).yield_self do |tokens|
           tokens.each.with_object({}) do |token, hash|
+            # @type var hash: Hash[Integer, AST::Comment]
+
             if token[1] == :on_comment
               line = token[0][0]
-              body = token[2][2..-1]
+              body = token[2][2..-1] or raise
 
               body = "\n" if body.empty?
 
               comment = AST::Comment.new(string: body, location: nil)
-              if (prev_comment = hash[line - 1])
-                hash[line - 1] = nil
-                hash[line] = AST::Comment.new(string: prev_comment.string + comment.string,
-                                              location: nil)
+              if (prev_comment = hash.delete(line - 1))
+                hash[line] = AST::Comment.new(
+                  string: prev_comment.string + comment.string,
+                  location: nil
+                )
               else
                 hash[line] = comment
               end
@@ -45,7 +48,7 @@ module RBS
       end
 
       def push_class(name, super_class, comment:)
-        modules.push AST::Declarations::Class.new(
+        class_decl = AST::Declarations::Class.new(
           name: nested_name(name),
           super_class: super_class && AST::Declarations::Class::Super.new(name: const_to_name(super_class), args: [], location: nil),
           type_params: [],
@@ -55,7 +58,8 @@ module RBS
           comment: comment
         )
 
-        decls << modules.last
+        modules << class_decl
+        decls << class_decl
 
         yield
       ensure
@@ -63,7 +67,7 @@ module RBS
       end
 
       def push_module(name, comment:)
-        modules.push AST::Declarations::Module.new(
+        module_decl = AST::Declarations::Module.new(
           name: nested_name(name),
           type_params: [],
           members: [],
@@ -73,7 +77,8 @@ module RBS
           comment: comment
         )
 
-        decls << modules.last
+        modules << module_decl
+        decls << module_decl
 
         yield
       ensure
@@ -84,9 +89,16 @@ module RBS
         modules.last
       end
 
+      def current_module!
+        current_module or raise
+      end
+
       def push_sig(node)
-        @last_sig ||= []
-        @last_sig << node
+        if last_sig = @last_sig
+          last_sig << node
+        else
+          @last_sig = [node]
+        end
       end
 
       def pop_sig
@@ -125,7 +137,7 @@ module RBS
                   location: nil,
                   comment: nil
                 )
-                current_module.members << include_member
+                current_module!.members << include_member
               end
             end
           when :extend
@@ -140,15 +152,16 @@ module RBS
                     location: nil,
                     comment: nil
                   )
-                  current_module.members << member
+                  current_module!.members << member
                 end
               end
             end
           when :sig
-            push_sig outer.last.children.last.children.last
+            out = outer.last or raise
+            push_sig out.children.last.children.last
           when :alias_method
             new, old = each_arg(node.children[1]).map {|x| x.children[0] }
-            current_module.members << AST::Members::Alias.new(
+            current_module!.members << AST::Members::Alias.new(
               new_name: new,
               old_name: old,
               location: nil,
@@ -164,9 +177,9 @@ module RBS
             comment = join_comments(sigs, comments)
 
             args = node.children[2]
-            types = sigs.map {|sig| method_type(args, sig, variables: current_module.type_params) }
+            types = sigs.map {|sig| method_type(args, sig, variables: current_module!.type_params) }.compact
 
-            current_module.members << AST::Members::MethodDefinition.new(
+            current_module!.members << AST::Members::MethodDefinition.new(
               name: node.children[1],
               location: nil,
               annotations: [],
@@ -184,9 +197,9 @@ module RBS
             comment = join_comments(sigs, comments)
 
             args = node.children[1]
-            types = sigs.map {|sig| method_type(args, sig, variables: current_module.type_params) }
+            types = sigs.map {|sig| method_type(args, sig, variables: current_module!.type_params) }.compact
 
-            current_module.members << AST::Members::MethodDefinition.new(
+            current_module!.members << AST::Members::MethodDefinition.new(
               name: node.children[0],
               location: nil,
               annotations: [],
@@ -203,7 +216,8 @@ module RBS
               node.type == :HASH &&
                 each_arg(node.children[0]).each_slice(2).any? {|a, _| a.type == :LIT && a.children[0] == :fixed }
             }
-              if (a0 = each_arg(send.children[1]).to_a[0])&.type == :LIT
+              # @type var variance: AST::TypeParam::variance?
+              if (a0 = each_arg(send.children[1]).to_a[0]) && a0.type == :LIT
                 variance = case a0.children[0]
                            when :out
                              :covariant
@@ -212,7 +226,7 @@ module RBS
                            end
               end
 
-              current_module.type_params << AST::TypeParam.new(
+              current_module!.type_params << AST::TypeParam.new(
                 name: node.children[0],
                 variance: variance || :invariant,
                 location: nil,
@@ -242,7 +256,7 @@ module RBS
             )
           end
         when :ALIAS
-          current_module.members << AST::Members::Alias.new(
+          current_module!.members << AST::Members::Alias.new(
             new_name: node.children[0].children[0],
             old_name: node.children[1].children[0],
             location: nil,
@@ -260,7 +274,7 @@ module RBS
       def method_type(args_node, type_node, variables:)
         if type_node
           if type_node.type == :CALL
-            method_type = method_type(args_node, type_node.children[0], variables: variables)
+            method_type = method_type(args_node, type_node.children[0], variables: variables) or raise
           else
             method_type = MethodType.new(
               type: Types::Function.empty(Types::Bases::Any.new(location: nil)),
@@ -322,12 +336,19 @@ module RBS
       def parse_params(args_node, args, method_type, variables:)
         vars = (node_to_hash(each_arg(args).to_a[0]) || {}).transform_values {|value| type_of(value, variables: variables) }
 
+        # @type var required_positionals: Array[Types::Function::Param]
         required_positionals = []
+        # @type var optional_positionals: Array[Types::Function::Param]
         optional_positionals = []
+        # @type var rest_positionals: Types::Function::Param?
         rest_positionals = nil
+        # @type var trailing_positionals: Array[Types::Function::Param]
         trailing_positionals = []
+        # @type var required_keywords: Hash[Symbol, Types::Function::Param]
         required_keywords = {}
+        # @type var optional_keywords: Hash[Symbol, Types::Function::Param]
         optional_keywords = {}
+        # @type var rest_keywords: Types::Function::Param?
         rest_keywords = nil
 
         var_names = args_node.children[0]
@@ -396,8 +417,8 @@ module RBS
                 type: Types::Function.empty(Types::Bases::Any.new(location: nil))
               )
             # Handle an optional block like `T.nilable(T.proc.void)`.
-            elsif type.is_a?(Types::Optional) && type.type.is_a?(Types::Proc)
-              method_block = Types::Block.new(required: false, type: type.type.type)
+            elsif type.is_a?(Types::Optional) && (proc_type = type.type).is_a?(Types::Proc)
+              method_block = Types::Block.new(required: false, type: proc_type.type)
             else
               STDERR.puts "Unexpected block type: #{type}"
               PP.pp args_node, STDERR
@@ -439,7 +460,7 @@ module RBS
       def type_of0(type_node, variables:)
         case
         when type_node.type == :CONST
-          if variables.each.include?(type_node.children[0])
+          if variables.include?(type_node.children[0])
             Types::Variable.new(name: type_node.children[0], location: nil)
           else
             Types::ClassInstance.new(name: const_to_name(type_node), args: [], location: nil)
@@ -447,7 +468,10 @@ module RBS
         when type_node.type == :COLON2
           Types::ClassInstance.new(name: const_to_name(type_node), args: [], location: nil)
         when call_node?(type_node, name: :[], receiver: -> (_) { true })
+          # The type_node represents a type application
           type = type_of(type_node.children[0], variables: variables)
+          type.is_a?(Types::ClassInstance) or raise
+
           each_arg(type_node.children[2]) do |arg|
             type.args << type_of(arg, variables: variables)
           end
@@ -487,7 +511,8 @@ module RBS
           Types::Tuple.new(types: types, location: nil)
         else
           if proc_type?(type_node)
-            Types::Proc.new(type: method_type(nil, type_node, variables: variables).type, block: nil, location: nil)
+            method_type = method_type(nil, type_node, variables: variables) or raise
+            Types::Proc.new(type: method_type.type, block: nil, location: nil)
           else
             STDERR.puts "Unexpected type_node:"
             PP.pp type_node, STDERR
@@ -572,9 +597,12 @@ module RBS
 
       def node_to_hash(node)
         if node&.type == :HASH
+          # @type var hash: Hash[Symbol, untyped]
           hash = {}
 
           each_arg(node.children[0]).each_slice(2) do |var, type|
+            var or raise
+
             if var.type == :LIT && type
               hash[var.children[0]] = type
             end

--- a/sig/prototype/rbi.rbs
+++ b/sig/prototype/rbi.rbs
@@ -1,0 +1,53 @@
+module RBS
+  module Prototype
+    class RBI
+      attr_reader decls: untyped
+
+      attr_reader modules: untyped
+
+      attr_reader last_sig: untyped
+
+      def initialize: () -> void
+
+      def parse: (untyped string) -> untyped
+
+      def nested_name: (untyped name) -> untyped
+
+      def current_namespace: () -> untyped
+
+      def push_class: (untyped name, untyped super_class, comment: untyped) { () -> untyped } -> untyped
+
+      def push_module: (untyped name, comment: untyped) { () -> untyped } -> untyped
+
+      def current_module: () -> untyped
+
+      def push_sig: (untyped node) -> untyped
+
+      def pop_sig: () -> untyped
+
+      def join_comments: (untyped nodes, untyped comments) -> untyped
+
+      def process: (untyped node, comments: untyped, ?outer: untyped) -> untyped
+
+      def method_type: (untyped args_node, untyped type_node, variables: untyped) -> (untyped | nil)
+
+      def parse_params: (untyped args_node, untyped args, untyped method_type, variables: untyped) -> untyped
+
+      def type_of: (untyped type_node, variables: untyped) -> untyped
+
+      def type_of0: (untyped type_node, variables: untyped) -> untyped
+
+      def proc_type?: (untyped type_node) -> (true | untyped)
+
+      def call_node?: (untyped node, name: untyped, ?receiver: untyped, ?args: untyped) -> untyped
+
+      def const_to_name: (untyped node) -> untyped
+
+      def each_arg: (untyped array) { (untyped) -> untyped } -> (untyped | nil | untyped)
+
+      def each_child: (untyped node) { (untyped) -> untyped } -> untyped
+
+      def node_to_hash: (untyped node) -> (untyped | nil)
+    end
+  end
+end

--- a/sig/prototype/rbi.rbs
+++ b/sig/prototype/rbi.rbs
@@ -1,53 +1,73 @@
 module RBS
   module Prototype
     class RBI
-      attr_reader decls: untyped
+      attr_reader decls: Array[AST::Declarations::t]
 
-      attr_reader modules: untyped
+      type module_decl = AST::Declarations::Class | AST::Declarations::Module
 
-      attr_reader last_sig: untyped
+      # A stack representing the module nesting structure in the Ruby code
+      attr_reader modules: Array[module_decl]
+
+      # Last subsequent `sig` calls
+      attr_reader last_sig: Array[RubyVM::AbstractSyntaxTree::Node]?
 
       def initialize: () -> void
 
-      def parse: (untyped string) -> untyped
+      def parse: (String) -> void
 
-      def nested_name: (untyped name) -> untyped
+      def nested_name: (RubyVM::AbstractSyntaxTree::Node name) -> TypeName
 
-      def current_namespace: () -> untyped
+      def current_namespace: () -> Namespace
 
-      def push_class: (untyped name, untyped super_class, comment: untyped) { () -> untyped } -> untyped
+      def push_class: (
+        RubyVM::AbstractSyntaxTree::Node name,
+        RubyVM::AbstractSyntaxTree::Node super_class,
+        comment: AST::Comment?
+      ) { () -> void } -> void
 
-      def push_module: (untyped name, comment: untyped) { () -> untyped } -> untyped
+      def push_module: (RubyVM::AbstractSyntaxTree::Node name, comment: AST::Comment?) { () -> void } -> void
 
-      def current_module: () -> untyped
+      # The inner most module/class definition, returns `nil` on toplevel
+      def current_module: () -> module_decl?
 
-      def push_sig: (untyped node) -> untyped
+      # The inner most module/class definition, raises on toplevel
+      def current_module!: () -> module_decl
 
-      def pop_sig: () -> untyped
+      # Put a `sig` call to current list.
+      def push_sig: (RubyVM::AbstractSyntaxTree::Node node) -> void
 
-      def join_comments: (untyped nodes, untyped comments) -> untyped
+      # Clear the `sig` call list
+      def pop_sig: () -> Array[RubyVM::AbstractSyntaxTree::Node]?
 
-      def process: (untyped node, comments: untyped, ?outer: untyped) -> untyped
+      def join_comments: (Array[RubyVM::AbstractSyntaxTree::Node] nodes, Hash[Integer, AST::Comment] comments) -> AST::Comment
 
-      def method_type: (untyped args_node, untyped type_node, variables: untyped) -> (untyped | nil)
+      def process: (RubyVM::AbstractSyntaxTree::Node node, comments: Hash[Integer, AST::Comment], ?outer: Array[RubyVM::AbstractSyntaxTree::Node]) -> void
 
-      def parse_params: (untyped args_node, untyped args, untyped method_type, variables: untyped) -> untyped
+      def method_type: (RubyVM::AbstractSyntaxTree::Node? args_node, RubyVM::AbstractSyntaxTree::Node? type_node, variables: Array[AST::TypeParam]) -> MethodType?
 
-      def type_of: (untyped type_node, variables: untyped) -> untyped
+      def parse_params: (RubyVM::AbstractSyntaxTree::Node args_node, RubyVM::AbstractSyntaxTree::Node args, MethodType method_type, variables: Array[AST::TypeParam]) -> MethodType
 
-      def type_of0: (untyped type_node, variables: untyped) -> untyped
+      def type_of: (RubyVM::AbstractSyntaxTree::Node type_node, variables: Array[AST::TypeParam]) -> Types::t
 
-      def proc_type?: (untyped type_node) -> (true | untyped)
+      def type_of0: (RubyVM::AbstractSyntaxTree::Node type_node, variables: Array[AST::TypeParam]) -> Types::t
 
-      def call_node?: (untyped node, name: untyped, ?receiver: untyped, ?args: untyped) -> untyped
+      def proc_type?: (RubyVM::AbstractSyntaxTree::Node type_node) -> bool
 
-      def const_to_name: (untyped node) -> untyped
+      def call_node?: (RubyVM::AbstractSyntaxTree::Node node, name: Symbol, ?receiver: ^(RubyVM::AbstractSyntaxTree::Node) -> bool, ?args: ^(RubyVM::AbstractSyntaxTree::Node) -> bool) -> bool
 
-      def each_arg: (untyped array) { (untyped) -> untyped } -> (untyped | nil | untyped)
+      # Receives a constant node and returns `TypeName` instance
+      def const_to_name: (RubyVM::AbstractSyntaxTree::Node node) -> TypeName
 
-      def each_child: (untyped node) { (untyped) -> untyped } -> untyped
+      # Receives `:ARRAY` or `:LIST` node and yields the child nodes.
+      def each_arg: (RubyVM::AbstractSyntaxTree::Node array) { (RubyVM::AbstractSyntaxTree::Node) -> void } -> void
+                  | (RubyVM::AbstractSyntaxTree::Node array) -> Enumerator[RubyVM::AbstractSyntaxTree::Node, void]
 
-      def node_to_hash: (untyped node) -> (untyped | nil)
+      # Receives node and yields the child nodes.
+      def each_child: (RubyVM::AbstractSyntaxTree::Node node) { (RubyVM::AbstractSyntaxTree::Node) -> void } -> void
+                    | (RubyVM::AbstractSyntaxTree::Node node) -> Enumerator[RubyVM::AbstractSyntaxTree::Node, void]
+
+      # Receives a keyword `:HASH` node and returns hash instance.
+      def node_to_hash: (RubyVM::AbstractSyntaxTree::Node node) -> Hash[Symbol, RubyVM::AbstractSyntaxTree::Node]?
     end
   end
 end

--- a/sig/prototype/rbi.rbs
+++ b/sig/prototype/rbi.rbs
@@ -43,9 +43,9 @@ module RBS
 
       def process: (RubyVM::AbstractSyntaxTree::Node node, comments: Hash[Integer, AST::Comment], ?outer: Array[RubyVM::AbstractSyntaxTree::Node]) -> void
 
-      def method_type: (RubyVM::AbstractSyntaxTree::Node? args_node, RubyVM::AbstractSyntaxTree::Node? type_node, variables: Array[AST::TypeParam]) -> MethodType?
+      def method_type: (RubyVM::AbstractSyntaxTree::Node? args_node, RubyVM::AbstractSyntaxTree::Node? type_node, variables: Array[AST::TypeParam], overloads: Integer) -> MethodType?
 
-      def parse_params: (RubyVM::AbstractSyntaxTree::Node args_node, RubyVM::AbstractSyntaxTree::Node args, MethodType method_type, variables: Array[AST::TypeParam]) -> MethodType
+      def parse_params: (RubyVM::AbstractSyntaxTree::Node args_node, RubyVM::AbstractSyntaxTree::Node args, MethodType method_type, variables: Array[AST::TypeParam], overloads: Integer) -> MethodType
 
       def type_of: (RubyVM::AbstractSyntaxTree::Node type_node, variables: Array[AST::TypeParam]) -> Types::t
 

--- a/sig/shims/abstract_syntax_tree.rbs
+++ b/sig/shims/abstract_syntax_tree.rbs
@@ -1,0 +1,25 @@
+class RubyVM
+  module AbstractSyntaxTree
+    def self.parse: (String src) -> Node
+
+    def self.parse_file: (String pathname) -> Node
+
+    def self.of: (untyped proc) -> Node
+
+    class Node
+      attr_reader children (): Array[untyped]
+
+      attr_reader first_column (): Integer
+
+      attr_reader first_lineno (): Integer
+
+      attr_reader last_column (): Integer
+
+      attr_reader last_lineno (): Integer
+
+      attr_reader type (): Symbol
+
+      def inspect: () -> String
+    end
+  end
+end

--- a/sig/shims/enumerable.rbs
+++ b/sig/shims/enumerable.rbs
@@ -1,0 +1,5 @@
+module Enumerable[unchecked out Elem] : _Each[Elem]
+  def each_slice: (2) { ([Elem, Elem]) -> void } -> void
+                | (2) -> Enumerator[[Elem, Elem], void]
+                | ...
+end

--- a/sig/shims/ripper.rbs
+++ b/sig/shims/ripper.rbs
@@ -1,0 +1,8 @@
+class Ripper
+  def self.lex: (String src, ?String filename, ?Integer lineno, ?raise_errors: bool) -> Array[[[Integer, Integer], Symbol, String, Lexer::State]]
+
+  class Lexer
+    class State
+    end
+  end
+end

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -180,6 +180,27 @@ end
     EOF
   end
 
+  def test_implicit_block
+    parser = RBI.new
+
+    rbi = <<-EOR
+class Hello
+  sig do
+    params(arg0: String).void
+  end
+  def hello(arg0, &blk); end
+end
+    EOR
+
+    parser.parse(rbi)
+
+    assert_write parser.decls, <<-EOF
+class Hello
+  def hello: (String arg0) ?{ () -> untyped } -> void
+end
+    EOF
+  end
+
   def test_optional_block
     parser = RBI.new
 


### PR DESCRIPTION
1. Add RBS type declarations
2. Support implicit `&block` parameter typing

Let's see how the _implicit `&block`_ parameter typing works:

```rb
sig { void }
def foo(&block)      # Sorbet assumes the method takes an optional block with the `&block` param
end
```

The result RBS will be:

```rbs
def foo: () ?{ () -> untyped } -> void
```
