### PR TITLE
Lean to the optional side

### DIFF
--- a/lib/rbs/prototype/helpers.rb
+++ b/lib/rbs/prototype/helpers.rb
@@ -12,10 +12,7 @@ module RBS
 
         if block
           method_block = Types::Block.new(
-            # HACK: The `block` is :& on `def m(...)` syntax.
-            #       In this case the block looks optional in most cases, so it marks optional.
-            #       In other cases, we can't determine which is required or optional, so it marks required.
-            required: block != :&,
+            required: false,
             type: Types::Function.empty(untyped)
           )
         end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -62,7 +62,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class Hello
-  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped, ?f: ::Integer, **untyped g) { () -> untyped } -> nil
+  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped, ?f: ::Integer, **untyped g) ?{ () -> untyped } -> nil
 
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 


### PR DESCRIPTION
In `gem_rbs_collection`, I think there are a few fixes coming so far that will make the blocks optional.

https://github.com/ruby/gem_rbs_collection/pull/88
https://github.com/ruby/gem_rbs_collection/pull/132
https://github.com/ruby/gem_rbs_collection/pull/135
https://github.com/ruby/gem_rbs_collection/pull/136
https://github.com/ruby/gem_rbs_collection/pull/138
https://github.com/ruby/gem_rbs_collection/pull/165

The cause is due to prototype output.

I feel it is not practical to make the block required.
I suggest leaning towards the optional side and relaxing the requirement.