### PR TITLE
Clarify GHA step name for `rake annotate`

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -29,6 +29,6 @@ jobs:
     - name: bin/setup
       run: |
         bin/setup
-    - name: Run test
+    - name: Check if `rake annotate` has been executed
       run: |
         bundle exec rake annotate confirm_annotation


### PR DESCRIPTION
Previously, when the step is failed, a developer needs to find how to fix the error from the action definition.
By this change, the developer can find the rake task more easily.