### PR TITLE
Support to call collection command in child dir

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -17,7 +17,7 @@ module RBS
 
         @libs = []
         @dirs = []
-        @config_path = Collection::Config::PATH
+        @config_path = Collection::Config.find_config_path || Collection::Config::PATH
       end
 
       def loader
@@ -1001,12 +1001,12 @@ EOB
       case args[0]
       when 'install'
         unless params[:frozen]
-          Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: Pathname('./Gemfile.lock'))
+          Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: Bundler.default_lockfile)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'update'
         # TODO: Be aware of argv to update only specified gem
-        Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: Pathname('./Gemfile.lock'), with_lockfile: false)
+        Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: Bundler.default_lockfile, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'init'
         if config_path.exist?

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -14,6 +14,15 @@ module RBS
 
       PATH = Pathname('rbs_collection.yaml')
 
+      def self.find_config_path
+        current = Dir.pwd
+        until File.exist?(File.join(current, PATH))
+          return nil if current == File.expand_path("..", current)
+          current = File.expand_path("..", current)
+        end
+        Pathname(current) / PATH
+      end
+
       # Generate a rbs lockfile from Gemfile.lock to `config_path`.
       # If `with_lockfile` is true, it respects existing rbs lockfile.
       def self.generate_lockfile(config_path:, gemfile_lock_path:, with_lockfile: true)

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -43,6 +43,8 @@ module RBS
 
       @config_path: Pathname
 
+      def self.find_config_path: () -> Pathname?
+
       def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
 
       def self.from_path: (Pathname path) -> Config

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -531,8 +531,21 @@ Processing `test/a_test.rb`...
 
         with_cli do |cli|
           cli.run(%w[collection install])
-          assert dir.join('rbs_collection.lock.yaml').exist?
-          assert dir.join('gem_rbs_collection/ast').exist?
+
+          rbs_collection_lock = dir.join('rbs_collection.lock.yaml')
+          assert rbs_collection_lock.exist?
+          rbs_collection_lock.delete
+
+          collection_file = dir.join('gem_rbs_collection/ast')
+          assert collection_file.exist?
+          collection_file.rmtree
+
+          Dir.mkdir("child")
+          Dir.chdir("child") do
+            cli.run(%w[collection install])
+            assert rbs_collection_lock.exist?
+            assert collection_file.exist?
+          end
         end
       end
     end


### PR DESCRIPTION
I am inconvenienced by the specification that I have to go to the root directory every time when I run the rbs collection commands.

I propose that the rbs collection command be able to be executed in the child directory, like bundler or rake.