### PR TITLE
Fix method commenting

### DIFF
--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -566,7 +566,7 @@ end
     rb = <<-EOR
 # Comments for class.
 # This is a comment.
-class Hello
+class Hello # :nodoc:
   # Comment for include.
   include Foo
 


### PR DESCRIPTION
The result of the comment is broken because there is no distinction between a code ending comment and a comment without a code.

------

t.rb

```rb
# Foo doc
module Foo # :nodoc:
  # foo doc
  def foo
  end
end
```

### Before

```rb
module Foo
  # Foo doc
  # :nodoc:
  # foo doc
  def foo: () -> nil
end
```

### After

```rb
# Foo doc
module Foo
  # foo doc
  def foo: () -> nil
end
```