### PR TITLE
Fix decls of output from Prototype::Runtime

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -341,7 +341,7 @@ module RBS
                  end
 
           decls << AST::Declarations::Constant.new(
-            name: name,
+            name: to_type_name(name.to_s),
             type: type,
             location: nil,
             comment: nil

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -415,4 +415,31 @@ end
       end
     end
   end
+
+  module TestForEnv
+    # A = 1
+    def a
+      2
+    end
+    alias b a
+    module B
+    end
+    include B
+    extend B
+    prepend B
+  end
+
+  def test_decls_structure
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForEnv"], env: env, merge: true)
+        assert_equal(p.decls.length, 1)
+        p.decls.each do |decl|
+          env << decl
+        end
+        env.resolve_type_names
+        assert(true) # nothing raised above
+      end
+    end
+  end
 end


### PR DESCRIPTION
I have a problem when I give the decls output by `RBS::Prototype:Runtime` to `RBS::Environment`.

The `RBS::Environment` expects `RBS::TypeName` for the const `name`, but it is set to Symbol.