### PR TITLE
Fix class name resolution of prototype runtime

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -470,8 +470,9 @@ module RBS
         *outer_module_names, _ = const_name(mod).split(/::/) #=> parent = [A, B], mod = C
         destination = @decls # Copy the entries in ivar @decls, not .dup
 
-        outer_module_names&.each do |outer_module_name|
-          outer_module = @modules.detect { |x| const_name(x) == outer_module_name }
+        outer_module_names&.each_with_index do |outer_module_name, i|
+          current_name = outer_module_names[0, i + 1].join('::')
+          outer_module = @modules.detect { |x| const_name(x) == current_name }
           outer_decl = destination.detect { |decl| decl.is_a?(outer_module.is_a?(Class) ? AST::Declarations::Class : AST::Declarations::Module) && decl.name.name == outer_module_name.to_sym }
 
           # Insert AST::Declarations if declarations are not added previously

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -47,7 +47,7 @@ class RBS::RuntimePrototypeTest < Test::Unit::TestCase
 
         assert_write p.decls, <<-EOF
 module RBS
-  module RuntimePrototypeTest
+  class RuntimePrototypeTest < Test::Unit::TestCase
     module TestTargets
       module Bar
       end
@@ -91,7 +91,7 @@ end
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
 class RBS
-  class RuntimePrototypeTest
+  class RuntimePrototypeTest < Test::Unit::TestCase
     class TestTargets
       class Test
         def self.baz: () -> void
@@ -111,7 +111,7 @@ EOF
 
         assert_write p.decls, <<-EOF
 module RBS
-  module RuntimePrototypeTest
+  class RuntimePrototypeTest < Test::Unit::TestCase
     module TestTargets
       module Bar
       end
@@ -172,7 +172,7 @@ end
 
         assert_write p.decls, <<-EOF
 module RBS
-  module RuntimePrototypeTest
+  class RuntimePrototypeTest < Test::Unit::TestCase
     module IncludeTests
       class ChildClass < RBS::RuntimePrototypeTest::IncludeTests::SuperClass
         def self.foo: () -> untyped
@@ -223,12 +223,16 @@ end
   end
 
   def test_decls_for_anonymous_class_or_module
-    p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForAnonymous::*"],
-                    env: nil, merge: false)
-    silence_warnings do
-      p.decls
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestForAnonymous::*"],
+                        env: env, merge: false)
+        silence_warnings do
+          p.decls
+        end
+        assert(true) # nothing raised above
+      end
     end
-    assert(true) # nothing raised above
   end
 
   if RUBY_VERSION >= '2.7' && RUBY_VERSION <= '3.0'
@@ -246,7 +250,7 @@ end
 
           assert_write p.decls, <<-EOF
 module RBS
-  module RuntimePrototypeTest
+  class RuntimePrototypeTest < Test::Unit::TestCase
     class TestForArgumentForwarding
       public
 
@@ -287,7 +291,7 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            module RuntimePrototypeTest
+            class RuntimePrototypeTest < Test::Unit::TestCase
               module TestForOverrideModuleName
                 class C
                   include RBS::RuntimePrototypeTest::TestForOverrideModuleName::M
@@ -337,7 +341,7 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            module RuntimePrototypeTest
+            class RuntimePrototypeTest < Test::Unit::TestCase
               module TestForTypeParameters
                 class C < Hash[untyped, untyped]
                 end
@@ -368,7 +372,7 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            module RuntimePrototypeTest
+            class RuntimePrototypeTest < Test::Unit::TestCase
               class TestForInitialize
                 private
 
@@ -396,7 +400,7 @@ end
 
           assert_write p.decls, <<~RBS
             module RBS
-              module RuntimePrototypeTest
+              class RuntimePrototypeTest < Test::Unit::TestCase
                 class TestForYield
                   public
 


### PR DESCRIPTION
In `$ rbs prototype runtime`, there was an unintended output in the case of class.

---

t.rb

```rb
module Foo
  class Bar
    class Baz
    end
  end
end
```

### before

```rb
$ bundle exec rbs prototype runtime --require-relative t.rb 'Foo::*'
module Foo
  class Bar
  end

  module Bar
    class Baz
    end
  end
end
```

```
$ bundle exec rbs -r pathname -r singleton -r tsort prototype runtime -R lib/rbs 'RBS::*' > before.rbs

$ bundle exec rbs -r pathname -r singleton -r tsort -I before.rbs validate --silent
bundler: failed to load command: rbs (/Users/ksss/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/bin/rbs)
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/environment.rb:190:in `insert_decl': before:582:2...610:5: Duplicated declaration: ::RBS::AncestorGraph (RBS::DuplicatedDeclarationError)
```

### after

```
$ bundle exec rbs prototype runtime --require-relative t.rb 'Foo::*'
module Foo
  class Bar
    class Baz
    end
  end
end
```

```
$ bundle exec rbs -r pathname -r singleton -r tsort prototype runtime -R lib/rbs 'RBS::*' > after.rbs

$ bundle exec rbs -r pathname -r singleton -r tsort -I after.rbs validate --silent
# no error
```