### PR TITLE
Add Time#to_{time,date,datetime} to stdlib/date

### DIFF
--- a/stdlib/date/0/time.rbs
+++ b/stdlib/date/0/time.rbs
@@ -1,0 +1,26 @@
+%a{annotate:rdoc:skip}
+class Time
+  # <!--
+  #   rdoc-file=ext/date/date_core.c
+  #   - t.to_time  ->  time
+  # -->
+  # Returns self.
+  #
+  def to_time: () -> Time
+
+  # <!--
+  #   rdoc-file=ext/date/date_core.c
+  #   - t.to_date  ->  date
+  # -->
+  # Returns a Date object which denotes self.
+  #
+  def to_date: () -> Date
+
+  # <!--
+  #   rdoc-file=ext/date/date_core.c
+  #   - t.to_datetime  ->  datetime
+  # -->
+  # Returns a DateTime object which denotes self.
+  #
+  def to_datetime: () -> DateTime
+end

--- a/test/stdlib/Time_test.rb
+++ b/test/stdlib/Time_test.rb
@@ -334,3 +334,24 @@ class TimeSingletonTest < Test::Unit::TestCase
     )
   end
 end
+
+class TimeInDateTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  require "date"
+
+  library "date"
+  testing "::Time"
+
+  def test_to_time
+    assert_send_type "() -> Time", Time.now, :to_time
+  end
+
+  def test_to_date
+    assert_send_type "() -> Date", Time.now, :to_date
+  end
+
+  def test_to_datetime
+    assert_send_type "() -> DateTime", Time.now, :to_datetime
+  end
+end


### PR DESCRIPTION
stdlib `date` define `Time#to_time` `Time#to_date` and `Time#to_datetime`.

https://github.com/ruby/ruby/blob/2c190863239bee3f54cfb74b16bb6ea4cae6ed20/ext/date/date_core.c#L9957-L9959

These methods should be defined in the `date` library.