### PR TITLE
Fix Regexp.new argument

### DIFF
--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -6,7 +6,7 @@ class RegexpTest < StdlibTest
   def test_new
     Regexp.new('dog')
     Regexp.new('dog', option = Regexp::IGNORECASE)
-    Regexp.new('dog', code = 'n')
+    Regexp.new('dog', option = nil, code = 'n')
     Regexp.new('dog', option = Regexp::IGNORECASE, code = 'n')
     Regexp.new(/^a-z+:\\s+\w+/)
   end
@@ -14,7 +14,7 @@ class RegexpTest < StdlibTest
   def test_compile
     Regexp.compile('dog')
     Regexp.compile('dog', option = Regexp::IGNORECASE)
-    Regexp.compile('dog', code = 'n')
+    Regexp.compile('dog', option = nil, code = 'n')
     Regexp.compile('dog', option = Regexp::IGNORECASE, code = 'n')
     Regexp.compile(/^a-z+:\\s+\w+/)
   end


### PR DESCRIPTION
`code` must be third argument and `option` cannot be ommitted.
If the second argument is not an Integer, it has been assumed as just true.
Ruby 3.2 will extend the second argument `option`, and unknown flags will cause errors.