### PR TITLE
Skip failing tests on ruby/ruby CI

### DIFF
--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -273,36 +273,40 @@ class IOWaitTest < Test::Unit::TestCase
   end
 
   def test_wait_readable
-    IO.pipe.tap do |r, w|
-      w.write("hello")
+    if_ruby "3.0.0"..."3.2.0" do
+      IO.pipe.tap do |r, w|
+        w.write("hello")
 
-      assert_send_type(
-        "() -> IO",
-        r, :wait_readable
-      )
-    end
+        assert_send_type(
+          "() -> IO",
+          r, :wait_readable
+        )
+      end
 
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "(Integer) -> nil",
-        r, :wait_readable, 1
-      )
+      IO.pipe.tap do |r, w|
+        assert_send_type(
+          "(Integer) -> nil",
+          r, :wait_readable, 1
+        )
+      end
     end
   end
 
   def test_wait_writable
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "() -> IO",
-        w, :wait_writable
-      )
-    end
+    if_ruby "3.0.0"..."3.2.0" do
+      IO.pipe.tap do |r, w|
+        assert_send_type(
+          "() -> IO",
+          w, :wait_writable
+        )
+      end
 
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "(Integer) -> IO",
-        w, :wait_writable, 1
-      )
+      IO.pipe.tap do |r, w|
+        assert_send_type(
+          "(Integer) -> IO",
+          w, :wait_writable, 1
+        )
+      end
     end
   end
 
@@ -316,7 +320,7 @@ class IOWaitTest < Test::Unit::TestCase
   end
 
   def test_wait
-    if_ruby3 do
+    if_ruby "3.0.0"..."3.2.0" do
       IO.pipe.tap do |r, w|
         w.write("hello")
 

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -251,7 +251,7 @@ class IOWaitTest < Test::Unit::TestCase
   testing "::IO"
 
   def test_readyp
-    if_ruby3 do
+    if_ruby31 do
       # This method returns true|false in Ruby 2.7, nil|IO in 3.0, and true|false in 3.1.
 
       IO.pipe.tap do |r, w|

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -368,8 +368,12 @@ module TypeAssertions
     if_ruby("3.0.0"..."4.0.0", &block)
   end
 
-  def if_ruby30
+  def if_ruby30(&block)
     if_ruby("3.0.0"..."3.1.0", &block)
+  end
+
+  def if_ruby31(&block)
+    if_ruby("3.1.0"..."3.2.0", &block)
   end
 end
 


### PR DESCRIPTION
Ruby 3.2 changes the return types of `IO#wait_*`.