### PR TITLE
Fix lexer to analyze escape characters

### DIFF
--- a/ext/rbs_extension/lexer.c
+++ b/ext/rbs_extension/lexer.c
@@ -171,42 +171,42 @@ yy11:
 		if (yych <= 0x0000001F) {
 			if (yych <= '\n') {
 				if (yych <= 0x00000000) goto yy3;
-				if (yych <= 0x00000008) goto yy71;
+				if (yych <= 0x00000008) goto yy70;
 				goto yy3;
 			} else {
 				if (yych == '\r') goto yy3;
-				goto yy71;
+				goto yy70;
 			}
 		} else {
 			if (yych <= '#') {
 				if (yych <= ' ') goto yy3;
-				if (yych <= '"') goto yy73;
-				goto yy71;
+				if (yych <= '"') goto yy72;
+				goto yy70;
 			} else {
 				if (yych == '%') goto yy3;
-				if (yych <= '\'') goto yy73;
+				if (yych <= '\'') goto yy72;
 				goto yy3;
 			}
 		}
 	} else {
 		if (yych <= 'Z') {
 			if (yych <= '/') {
-				if (yych == '-') goto yy71;
-				goto yy73;
+				if (yych == '-') goto yy70;
+				goto yy72;
 			} else {
-				if (yych <= '9') goto yy71;
-				if (yych <= '>') goto yy73;
-				goto yy71;
+				if (yych <= '9') goto yy70;
+				if (yych <= '>') goto yy72;
+				goto yy70;
 			}
 		} else {
 			if (yych <= '^') {
-				if (yych == '\\') goto yy73;
+				if (yych == '\\') goto yy72;
 				goto yy3;
 			} else {
-				if (yych <= 'z') goto yy71;
+				if (yych <= 'z') goto yy70;
 				if (yych <= '}') goto yy3;
-				if (yych <= '~') goto yy73;
-				goto yy71;
+				if (yych <= '~') goto yy72;
+				goto yy70;
 			}
 		}
 	}
@@ -215,7 +215,7 @@ yy12:
 	skip(state);
 	backup = *state;
 	yych = peek(state);
-	if (yych == 'a') goto yy74;
+	if (yych == 'a') goto yy73;
 	goto yy7;
 yy13:
 	skip(state);
@@ -228,7 +228,7 @@ yy14:
 	backup = *state;
 	yych = peek(state);
 	if (yych <= 0x00000000) goto yy3;
-	goto yy76;
+	goto yy75;
 yy15:
 	skip(state);
 #line 25 "ext/rbs_extension/lexer.re"
@@ -242,7 +242,7 @@ yy16:
 yy17:
 	skip(state);
 	yych = peek(state);
-	if (yych == '*') goto yy80;
+	if (yych == '*') goto yy79;
 #line 36 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pSTAR); }
 #line 249 "ext/rbs_extension/lexer.c"
@@ -266,7 +266,7 @@ yy20:
 		if (yych <= '9') goto yy24;
 		goto yy7;
 	} else {
-		if (yych <= '>') goto yy81;
+		if (yych <= '>') goto yy80;
 		if (yych == '@') goto yy23;
 		goto yy7;
 	}
@@ -275,7 +275,7 @@ yy21:
 	skip(state);
 	backup = *state;
 	yych = peek(state);
-	if (yych == '.') goto yy82;
+	if (yych == '.') goto yy81;
 yy22:
 #line 38 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pDOT); }
@@ -299,25 +299,25 @@ yy26:
 	backup = *state;
 	yych = peek(state);
 	switch (yych) {
-		case '!': goto yy83;
-		case '"': goto yy85;
-		case '$': goto yy86;
+		case '!': goto yy82;
+		case '"': goto yy84;
+		case '$': goto yy85;
 		case '%':
 		case '&':
 		case '/':
 		case '^':
 		case '`':
 		case '|':
-		case '~': goto yy87;
-		case '\'': goto yy88;
-		case '*': goto yy89;
+		case '~': goto yy86;
+		case '\'': goto yy87;
+		case '*': goto yy88;
 		case '+':
-		case '-': goto yy90;
-		case ':': goto yy91;
-		case '<': goto yy92;
-		case '=': goto yy93;
-		case '>': goto yy94;
-		case '@': goto yy95;
+		case '-': goto yy89;
+		case ':': goto yy90;
+		case '<': goto yy91;
+		case '=': goto yy92;
+		case '>': goto yy93;
+		case '@': goto yy94;
 		case 'A':
 		case 'B':
 		case 'C':
@@ -370,8 +370,8 @@ yy26:
 		case 'w':
 		case 'x':
 		case 'y':
-		case 'z': goto yy96;
-		case '[': goto yy98;
+		case 'z': goto yy95;
+		case '[': goto yy97;
 		default: goto yy27;
 	}
 yy27:
@@ -383,7 +383,7 @@ yy28:
 	yych = peek(state);
 	if (yych <= ';') goto yy29;
 	if (yych <= '<') goto yy23;
-	if (yych <= '=') goto yy99;
+	if (yych <= '=') goto yy98;
 yy29:
 #line 47 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pLT); }
@@ -393,8 +393,8 @@ yy30:
 	yych = peek(state);
 	if (yych <= '>') {
 		if (yych <= '<') goto yy31;
-		if (yych <= '=') goto yy100;
-		goto yy101;
+		if (yych <= '=') goto yy99;
+		goto yy100;
 	} else {
 		if (yych == '~') goto yy23;
 	}
@@ -420,12 +420,12 @@ yy34:
 	yych = peek(state);
 	if (yych <= '^') {
 		if (yych <= '?') goto yy3;
-		if (yych <= '@') goto yy102;
-		if (yych <= 'Z') goto yy103;
+		if (yych <= '@') goto yy101;
+		if (yych <= 'Z') goto yy102;
 		goto yy3;
 	} else {
 		if (yych == '`') goto yy3;
-		if (yych <= 'z') goto yy103;
+		if (yych <= 'z') goto yy102;
 		goto yy3;
 	}
 yy35:
@@ -433,10 +433,10 @@ yy35:
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy35;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -454,7 +454,7 @@ yy36:
 yy37:
 	skip(state);
 	yych = peek(state);
-	if (yych == ']') goto yy107;
+	if (yych == ']') goto yy106;
 #line 27 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pLBRACKET); }
 #line 461 "ext/rbs_extension/lexer.c"
@@ -473,18 +473,18 @@ yy40:
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
-			if (yych <= '9') goto yy108;
-			if (yych >= '=') goto yy106;
+			if (yych <= '9') goto yy107;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
 			if (yych <= '@') goto yy41;
-			if (yych <= 'Z') goto yy110;
+			if (yych <= 'Z') goto yy109;
 		} else {
 			if (yych == '`') goto yy41;
-			if (yych <= 'z') goto yy108;
+			if (yych <= 'z') goto yy107;
 		}
 	}
 yy41:
@@ -498,9 +498,9 @@ yy42:
 	yych = peek(state);
 	if (yych <= ' ') {
 		if (yych <= 0x00000000) goto yy43;
-		if (yych <= 0x0000001F) goto yy112;
+		if (yych <= 0x0000001F) goto yy111;
 	} else {
-		if (yych != ':') goto yy112;
+		if (yych != ':') goto yy111;
 	}
 yy43:
 #line 40 "ext/rbs_extension/lexer.re"
@@ -509,8 +509,8 @@ yy43:
 yy44:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy113;
-	if (yych == 't') goto yy114;
+	if (yych == 'l') goto yy112;
+	if (yych == 't') goto yy113;
 	goto yy52;
 yy45:
 #line 122 "ext/rbs_extension/lexer.re"
@@ -519,28 +519,28 @@ yy45:
 yy46:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'o') goto yy115;
+	if (yych == 'o') goto yy114;
 	goto yy52;
 yy47:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy116;
+	if (yych == 'l') goto yy115;
 	goto yy52;
 yy48:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy117;
+	if (yych == 'e') goto yy116;
 	goto yy52;
 yy49:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy118;
-	if (yych == 'x') goto yy119;
+	if (yych == 'n') goto yy117;
+	if (yych == 'x') goto yy118;
 	goto yy52;
 yy50:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy120;
+	if (yych == 'a') goto yy119;
 	goto yy52;
 yy51:
 	skip(state);
@@ -548,12 +548,12 @@ yy51:
 yy52:
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 			goto yy45;
 		} else {
 			if (yych <= '9') goto yy51;
 			if (yych <= '<') goto yy45;
-			goto yy106;
+			goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -569,55 +569,55 @@ yy52:
 yy53:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy121;
+	if (yych == 'n') goto yy120;
 	goto yy52;
 yy54:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'o') goto yy123;
+	if (yych == 'o') goto yy122;
 	goto yy52;
 yy55:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'i') goto yy124;
+	if (yych == 'i') goto yy123;
 	goto yy52;
 yy56:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'u') goto yy125;
+	if (yych == 'u') goto yy124;
 	goto yy52;
 yy57:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'r') goto yy126;
-	if (yych == 'u') goto yy127;
+	if (yych == 'r') goto yy125;
+	if (yych == 'u') goto yy126;
 	goto yy52;
 yy58:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy128;
-	if (yych == 'i') goto yy129;
+	if (yych == 'e') goto yy127;
+	if (yych == 'i') goto yy128;
 	goto yy52;
 yy59:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 'q') {
-		if (yych == 'o') goto yy130;
+		if (yych == 'o') goto yy129;
 		goto yy52;
 	} else {
-		if (yych <= 'r') goto yy131;
-		if (yych == 'y') goto yy132;
+		if (yych <= 'r') goto yy130;
+		if (yych == 'y') goto yy131;
 		goto yy52;
 	}
 yy60:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy133;
+	if (yych == 'n') goto yy132;
 	goto yy52;
 yy61:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'o') goto yy134;
+	if (yych == 'o') goto yy133;
 	goto yy52;
 yy62:
 	skip(state);
@@ -643,281 +643,341 @@ yy66:
 		if (yych <= '!') goto yy65;
 		goto yy68;
 	} else {
-		if (yych == '\\') goto yy70;
+		if (yych == '\\') goto yy69;
 		goto yy65;
 	}
 yy67:
 	*state = backup;
-	if (yyaccept <= 4) {
-		if (yyaccept <= 2) {
-			if (yyaccept <= 1) {
-				if (yyaccept == 0) {
-					goto yy3;
-				} else {
-					goto yy7;
-				}
+	if (yyaccept <= 3) {
+		if (yyaccept <= 1) {
+			if (yyaccept == 0) {
+				goto yy3;
 			} else {
-				goto yy22;
+				goto yy7;
 			}
 		} else {
-			if (yyaccept == 3) {
-				goto yy27;
+			if (yyaccept == 2) {
+				goto yy22;
 			} else {
-				goto yy43;
+				goto yy27;
 			}
 		}
 	} else {
-		if (yyaccept <= 6) {
-			if (yyaccept == 5) {
-				goto yy69;
+		if (yyaccept <= 5) {
+			if (yyaccept == 4) {
+				goto yy43;
 			} else {
-				goto yy78;
+				goto yy77;
 			}
 		} else {
-			if (yyaccept == 7) {
-				goto yy144;
-			} else {
-				goto yy150;
-			}
+			goto yy147;
 		}
 	}
 yy68:
 	skip(state);
-yy69:
 #line 100 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tDQSTRING); }
-#line 690 "ext/rbs_extension/lexer.c"
-yy70:
+#line 681 "ext/rbs_extension/lexer.c"
+yy69:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '"') {
-		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '!') goto yy65;
-		goto yy135;
+	if (yych <= 'd') {
+		if (yych <= '[') {
+			if (yych == '"') goto yy65;
+			goto yy67;
+		} else {
+			if (yych <= '\\') goto yy65;
+			if (yych <= '`') goto yy67;
+			if (yych <= 'b') goto yy65;
+			goto yy67;
+		}
 	} else {
-		if (yych == '\\') goto yy70;
-		goto yy65;
+		if (yych <= 'q') {
+			if (yych <= 'f') goto yy65;
+			if (yych == 'n') goto yy65;
+			goto yy67;
+		} else {
+			if (yych == 'u') goto yy67;
+			if (yych <= 'v') goto yy65;
+			goto yy67;
+		}
 	}
-yy71:
+yy70:
 	skip(state);
 	yych = peek(state);
 	if (yych <= ',') {
 		if (yych <= '\f') {
-			if (yych <= 0x00000000) goto yy72;
-			if (yych <= 0x00000008) goto yy71;
-			if (yych >= '\v') goto yy71;
+			if (yych <= 0x00000000) goto yy71;
+			if (yych <= 0x00000008) goto yy70;
+			if (yych >= '\v') goto yy70;
 		} else {
 			if (yych <= 0x0000001F) {
-				if (yych >= 0x0000000E) goto yy71;
+				if (yych >= 0x0000000E) goto yy70;
 			} else {
-				if (yych == '#') goto yy71;
+				if (yych == '#') goto yy70;
 			}
 		}
 	} else {
 		if (yych <= '>') {
-			if (yych <= '-') goto yy71;
-			if (yych <= '/') goto yy72;
-			if (yych <= '9') goto yy71;
+			if (yych <= '-') goto yy70;
+			if (yych <= '/') goto yy71;
+			if (yych <= '9') goto yy70;
 		} else {
 			if (yych <= '^') {
-				if (yych <= 'Z') goto yy71;
+				if (yych <= 'Z') goto yy70;
 			} else {
-				if (yych <= 'z') goto yy71;
-				if (yych >= 0x0000007F) goto yy71;
+				if (yych <= 'z') goto yy70;
+				if (yych >= 0x0000007F) goto yy70;
 			}
 		}
 	}
-yy72:
+yy71:
 #line 133 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tGIDENT); }
-#line 734 "ext/rbs_extension/lexer.c"
-yy73:
+#line 738 "ext/rbs_extension/lexer.c"
+yy72:
 	skip(state);
-	goto yy72;
-yy74:
+	goto yy71;
+yy73:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 'Z') {
 		if (yych <= '(') {
 			if (yych <= '\'') goto yy67;
-			goto yy136;
+			goto yy134;
 		} else {
-			if (yych == '<') goto yy137;
+			if (yych == '<') goto yy135;
 			goto yy67;
 		}
 	} else {
 		if (yych <= 'z') {
-			if (yych <= '[') goto yy138;
+			if (yych <= '[') goto yy136;
 			goto yy67;
 		} else {
-			if (yych <= '{') goto yy139;
-			if (yych <= '|') goto yy140;
+			if (yych <= '{') goto yy137;
+			if (yych <= '|') goto yy138;
 			goto yy67;
 		}
 	}
-yy75:
+yy74:
 	skip(state);
 	yych = peek(state);
-yy76:
+yy75:
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '&') goto yy75;
+		if (yych <= '&') goto yy74;
 	} else {
-		if (yych == '\\') goto yy79;
-		goto yy75;
+		if (yych == '\\') goto yy78;
+		goto yy74;
 	}
-yy77:
+yy76:
 	skip(state);
-yy78:
+yy77:
 #line 101 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tSQSTRING); }
-#line 775 "ext/rbs_extension/lexer.c"
-yy79:
+#line 779 "ext/rbs_extension/lexer.c"
+yy78:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '&') goto yy75;
-		goto yy141;
+		if (yych <= '&') goto yy74;
+		goto yy139;
 	} else {
-		if (yych == '\\') goto yy79;
-		goto yy75;
+		if (yych == '\\') goto yy78;
+		goto yy74;
 	}
-yy80:
+yy79:
 	skip(state);
 #line 37 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pSTAR2); }
-#line 791 "ext/rbs_extension/lexer.c"
-yy81:
+#line 795 "ext/rbs_extension/lexer.c"
+yy80:
 	skip(state);
 #line 42 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pARROW); }
-#line 796 "ext/rbs_extension/lexer.c"
+#line 800 "ext/rbs_extension/lexer.c"
+yy81:
+	skip(state);
+	yych = peek(state);
+	if (yych == '.') goto yy140;
+	goto yy67;
 yy82:
 	skip(state);
 	yych = peek(state);
-	if (yych == '.') goto yy142;
-	goto yy67;
+	if (yych == '=') goto yy86;
+	if (yych == '~') goto yy86;
 yy83:
-	skip(state);
-	yych = peek(state);
-	if (yych == '=') goto yy87;
-	if (yych == '~') goto yy87;
-yy84:
 #line 120 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tSYMBOL); }
-#line 810 "ext/rbs_extension/lexer.c"
-yy85:
+#line 814 "ext/rbs_extension/lexer.c"
+yy84:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '"') {
 		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '!') goto yy85;
-		goto yy143;
+		if (yych <= '!') goto yy84;
+		goto yy141;
 	} else {
-		if (yych == '\\') goto yy145;
-		goto yy85;
+		if (yych == '\\') goto yy142;
+		goto yy84;
 	}
-yy86:
+yy85:
 	skip(state);
 	yych = peek(state);
 	if (yych <= ')') {
 		if (yych <= 0x0000001F) {
 			if (yych <= '\n') {
 				if (yych <= 0x00000000) goto yy67;
-				if (yych <= 0x00000008) goto yy146;
+				if (yych <= 0x00000008) goto yy143;
 				goto yy67;
 			} else {
 				if (yych == '\r') goto yy67;
-				goto yy146;
+				goto yy143;
 			}
 		} else {
 			if (yych <= '#') {
 				if (yych <= ' ') goto yy67;
-				if (yych <= '"') goto yy148;
-				goto yy146;
+				if (yych <= '"') goto yy145;
+				goto yy143;
 			} else {
 				if (yych == '%') goto yy67;
-				if (yych <= '\'') goto yy148;
+				if (yych <= '\'') goto yy145;
 				goto yy67;
 			}
 		}
 	} else {
 		if (yych <= 'Z') {
 			if (yych <= '/') {
-				if (yych == '-') goto yy146;
-				goto yy148;
+				if (yych == '-') goto yy143;
+				goto yy145;
 			} else {
-				if (yych <= '9') goto yy146;
-				if (yych <= '>') goto yy148;
-				goto yy146;
+				if (yych <= '9') goto yy143;
+				if (yych <= '>') goto yy145;
+				goto yy143;
 			}
 		} else {
 			if (yych <= '^') {
-				if (yych == '\\') goto yy148;
+				if (yych == '\\') goto yy145;
 				goto yy67;
 			} else {
-				if (yych <= 'z') goto yy146;
+				if (yych <= 'z') goto yy143;
 				if (yych <= '}') goto yy67;
-				if (yych <= '~') goto yy148;
-				goto yy146;
+				if (yych <= '~') goto yy145;
+				goto yy143;
 			}
 		}
 	}
-yy87:
+yy86:
 	skip(state);
-	goto yy84;
-yy88:
+	goto yy83;
+yy87:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '&') goto yy88;
-		goto yy149;
+		if (yych <= '&') goto yy87;
+		goto yy146;
 	} else {
-		if (yych == '\\') goto yy151;
-		goto yy88;
+		if (yych == '\\') goto yy148;
+		goto yy87;
 	}
+yy88:
+	skip(state);
+	yych = peek(state);
+	if (yych == '*') goto yy86;
+	goto yy83;
 yy89:
 	skip(state);
 	yych = peek(state);
-	if (yych == '*') goto yy87;
-	goto yy84;
+	if (yych == '@') goto yy86;
+	goto yy83;
 yy90:
-	skip(state);
-	yych = peek(state);
-	if (yych == '@') goto yy87;
-	goto yy84;
-yy91:
 	skip(state);
 #line 46 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pCOLON2); }
-#line 896 "ext/rbs_extension/lexer.c"
+#line 900 "ext/rbs_extension/lexer.c"
+yy91:
+	skip(state);
+	yych = peek(state);
+	if (yych <= ';') goto yy83;
+	if (yych <= '<') goto yy86;
+	if (yych <= '=') goto yy149;
+	goto yy83;
 yy92:
 	skip(state);
 	yych = peek(state);
-	if (yych <= ';') goto yy84;
-	if (yych <= '<') goto yy87;
-	if (yych <= '=') goto yy152;
-	goto yy84;
+	if (yych == '=') goto yy150;
+	if (yych == '~') goto yy86;
+	goto yy67;
 yy93:
 	skip(state);
 	yych = peek(state);
-	if (yych == '=') goto yy153;
-	if (yych == '~') goto yy87;
-	goto yy67;
+	if (yych <= '<') goto yy83;
+	if (yych <= '>') goto yy86;
+	goto yy83;
 yy94:
-	skip(state);
-	yych = peek(state);
-	if (yych <= '<') goto yy84;
-	if (yych <= '>') goto yy87;
-	goto yy84;
-yy95:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '^') {
 		if (yych <= '?') goto yy67;
-		if (yych <= '@') goto yy154;
+		if (yych <= '@') goto yy151;
+		if (yych <= 'Z') goto yy152;
+		goto yy67;
+	} else {
+		if (yych == '`') goto yy67;
+		if (yych <= 'z') goto yy152;
+		goto yy67;
+	}
+yy95:
+	skip(state);
+	yych = peek(state);
+	if (yych <= '>') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy154;
+		} else {
+			if (yych <= '9') goto yy95;
+			if (yych == '=') goto yy154;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '?') goto yy154;
+			if (yych <= '@') goto yy96;
+			if (yych <= 'Z') goto yy95;
+		} else {
+			if (yych == '`') goto yy96;
+			if (yych <= 'z') goto yy95;
+		}
+	}
+yy96:
+#line 116 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, tSYMBOL); }
+#line 956 "ext/rbs_extension/lexer.c"
+yy97:
+	skip(state);
+	yych = peek(state);
+	if (yych == ']') goto yy150;
+	goto yy67;
+yy98:
+	skip(state);
+	yych = peek(state);
+	if (yych == '>') goto yy23;
+	goto yy7;
+yy99:
+	skip(state);
+	yych = peek(state);
+	if (yych == '=') goto yy23;
+	goto yy7;
+yy100:
+	skip(state);
+#line 43 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, pFATARROW); }
+#line 976 "ext/rbs_extension/lexer.c"
+yy101:
+	skip(state);
+	yych = peek(state);
+	if (yych <= '^') {
+		if (yych <= '@') goto yy67;
 		if (yych <= 'Z') goto yy155;
 		goto yy67;
 	} else {
@@ -925,515 +985,486 @@ yy95:
 		if (yych <= 'z') goto yy155;
 		goto yy67;
 	}
-yy96:
-	skip(state);
-	yych = peek(state);
-	if (yych <= '>') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy157;
-		} else {
-			if (yych <= '9') goto yy96;
-			if (yych == '=') goto yy157;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '?') goto yy157;
-			if (yych <= '@') goto yy97;
-			if (yych <= 'Z') goto yy96;
-		} else {
-			if (yych == '`') goto yy97;
-			if (yych <= 'z') goto yy96;
-		}
-	}
-yy97:
-#line 116 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, tSYMBOL); }
-#line 952 "ext/rbs_extension/lexer.c"
-yy98:
-	skip(state);
-	yych = peek(state);
-	if (yych == ']') goto yy153;
-	goto yy67;
-yy99:
-	skip(state);
-	yych = peek(state);
-	if (yych == '>') goto yy23;
-	goto yy7;
-yy100:
-	skip(state);
-	yych = peek(state);
-	if (yych == '=') goto yy23;
-	goto yy7;
-yy101:
-	skip(state);
-#line 43 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, pFATARROW); }
-#line 972 "ext/rbs_extension/lexer.c"
 yy102:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '^') {
-		if (yych <= '@') goto yy67;
-		if (yych <= 'Z') goto yy158;
-		goto yy67;
-	} else {
-		if (yych == '`') goto yy67;
-		if (yych <= 'z') goto yy158;
-		goto yy67;
-	}
-yy103:
-	skip(state);
-	yych = peek(state);
 	if (yych <= 'Z') {
-		if (yych <= '/') goto yy104;
-		if (yych <= '9') goto yy103;
-		if (yych >= 'A') goto yy103;
+		if (yych <= '/') goto yy103;
+		if (yych <= '9') goto yy102;
+		if (yych >= 'A') goto yy102;
 	} else {
 		if (yych <= '_') {
-			if (yych >= '_') goto yy103;
+			if (yych >= '_') goto yy102;
 		} else {
-			if (yych <= '`') goto yy104;
-			if (yych <= 'z') goto yy103;
+			if (yych <= '`') goto yy103;
+			if (yych <= 'z') goto yy102;
 		}
 	}
-yy104:
+yy103:
 #line 130 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tAIDENT); }
-#line 1003 "ext/rbs_extension/lexer.c"
-yy105:
+#line 1007 "ext/rbs_extension/lexer.c"
+yy104:
 	skip(state);
 #line 127 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tBANGIDENT); }
-#line 1008 "ext/rbs_extension/lexer.c"
-yy106:
+#line 1012 "ext/rbs_extension/lexer.c"
+yy105:
 	skip(state);
 #line 128 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tEQIDENT); }
-#line 1013 "ext/rbs_extension/lexer.c"
-yy107:
+#line 1017 "ext/rbs_extension/lexer.c"
+yy106:
 	skip(state);
 	yych = peek(state);
 	if (yych == '=') goto yy23;
 #line 48 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pAREF_OPR); }
-#line 1020 "ext/rbs_extension/lexer.c"
-yy108:
+#line 1024 "ext/rbs_extension/lexer.c"
+yy107:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
-			if (yych <= '9') goto yy108;
-			if (yych >= '=') goto yy106;
+			if (yych <= '9') goto yy107;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy109;
-			if (yych <= 'Z') goto yy108;
+			if (yych <= '@') goto yy108;
+			if (yych <= 'Z') goto yy107;
 		} else {
-			if (yych == '`') goto yy109;
-			if (yych <= 'z') goto yy108;
+			if (yych == '`') goto yy108;
+			if (yych <= 'z') goto yy107;
 		}
 	}
-yy109:
+yy108:
 #line 124 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tULLIDENT); }
-#line 1043 "ext/rbs_extension/lexer.c"
-yy110:
+#line 1047 "ext/rbs_extension/lexer.c"
+yy109:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
-			if (yych <= '9') goto yy110;
-			if (yych >= '=') goto yy106;
+			if (yych <= '9') goto yy109;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy111;
-			if (yych <= 'Z') goto yy110;
+			if (yych <= '@') goto yy110;
+			if (yych <= 'Z') goto yy109;
 		} else {
-			if (yych == '`') goto yy111;
-			if (yych <= 'z') goto yy110;
+			if (yych == '`') goto yy110;
+			if (yych <= 'z') goto yy109;
 		}
 	}
-yy111:
+yy110:
 #line 125 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tULIDENT); }
-#line 1066 "ext/rbs_extension/lexer.c"
-yy112:
+#line 1070 "ext/rbs_extension/lexer.c"
+yy111:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 0x00000000) goto yy67;
-	if (yych == '`') goto yy160;
-	goto yy112;
+	if (yych == '`') goto yy157;
+	goto yy111;
+yy112:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'i') goto yy158;
+	goto yy52;
 yy113:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'i') goto yy161;
+	if (yych == 't') goto yy159;
 	goto yy52;
 yy114:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy162;
+	if (yych == 'o') goto yy160;
+	if (yych == 't') goto yy161;
 	goto yy52;
 yy115:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'o') goto yy163;
-	if (yych == 't') goto yy164;
+	if (yych == 'a') goto yy163;
 	goto yy52;
 yy116:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy166;
+	if (yych == 'f') goto yy164;
 	goto yy52;
 yy117:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'f') goto yy167;
+	if (yych == 'd') goto yy166;
 	goto yy52;
 yy118:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy169;
+	if (yych == 't') goto yy168;
 	goto yy52;
 yy119:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy171;
+	if (yych == 'l') goto yy169;
 	goto yy52;
 yy120:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy172;
-	goto yy52;
-yy121:
-	skip(state);
-	yych = peek(state);
 	if (yych <= '^') {
 		if (yych <= '9') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 			if (yych >= '0') goto yy51;
 		} else {
 			if (yych <= '=') {
-				if (yych >= '=') goto yy106;
+				if (yych >= '=') goto yy105;
 			} else {
-				if (yych <= '@') goto yy122;
+				if (yych <= '@') goto yy121;
 				if (yych <= 'Z') goto yy51;
 			}
 		}
 	} else {
 		if (yych <= 'c') {
-			if (yych == '`') goto yy122;
+			if (yych == '`') goto yy121;
 			if (yych <= 'b') goto yy51;
-			goto yy173;
+			goto yy170;
 		} else {
 			if (yych <= 's') {
 				if (yych <= 'r') goto yy51;
-				goto yy174;
+				goto yy171;
 			} else {
-				if (yych <= 't') goto yy175;
+				if (yych <= 't') goto yy172;
 				if (yych <= 'z') goto yy51;
 			}
 		}
 	}
-yy122:
+yy121:
 #line 78 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, kIN); }
-#line 1147 "ext/rbs_extension/lexer.c"
+#line 1151 "ext/rbs_extension/lexer.c"
+yy122:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'd') goto yy173;
+	goto yy52;
 yy123:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy176;
+	if (yych == 'l') goto yy174;
 	goto yy52;
 yy124:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy177;
+	if (yych == 't') goto yy176;
 	goto yy52;
 yy125:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy179;
+	if (yych == 'e') goto yy178;
+	if (yych == 'i') goto yy179;
 	goto yy52;
 yy126:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy181;
-	if (yych == 'i') goto yy182;
+	if (yych == 'b') goto yy180;
 	goto yy52;
 yy127:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'b') goto yy183;
+	if (yych == 'l') goto yy181;
 	goto yy52;
 yy128:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy184;
+	if (yych == 'n') goto yy182;
 	goto yy52;
 yy129:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy185;
+	if (yych == 'p') goto yy183;
 	goto yy52;
 yy130:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'p') goto yy186;
+	if (yych == 'u') goto yy185;
 	goto yy52;
 yy131:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'u') goto yy188;
+	if (yych == 'p') goto yy186;
 	goto yy52;
 yy132:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'p') goto yy189;
+	if (yych == 'c') goto yy187;
+	if (yych == 't') goto yy188;
 	goto yy52;
 yy133:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'c') goto yy190;
-	if (yych == 't') goto yy191;
+	if (yych == 'i') goto yy189;
 	goto yy52;
 yy134:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'i') goto yy192;
-	goto yy52;
+	if (yych <= 0x00000000) goto yy67;
+	if (yych == ')') goto yy190;
+	goto yy134;
 yy135:
-	yyaccept = 5;
 	skip(state);
-	backup = *state;
 	yych = peek(state);
-	if (yych <= '"') {
-		if (yych <= 0x00000000) goto yy69;
-		if (yych <= '!') goto yy65;
-		goto yy68;
-	} else {
-		if (yych == '\\') goto yy70;
-		goto yy65;
-	}
+	if (yych <= 0x00000000) goto yy67;
+	if (yych == '>') goto yy191;
+	goto yy135;
 yy136:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 0x00000000) goto yy67;
-	if (yych == ')') goto yy193;
+	if (yych == ']') goto yy192;
 	goto yy136;
 yy137:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 0x00000000) goto yy67;
-	if (yych == '>') goto yy194;
+	if (yych == '}') goto yy193;
 	goto yy137;
 yy138:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 0x00000000) goto yy67;
-	if (yych == ']') goto yy195;
+	if (yych == '|') goto yy194;
 	goto yy138;
 yy139:
-	skip(state);
-	yych = peek(state);
-	if (yych <= 0x00000000) goto yy67;
-	if (yych == '}') goto yy196;
-	goto yy139;
-yy140:
-	skip(state);
-	yych = peek(state);
-	if (yych <= 0x00000000) goto yy67;
-	if (yych == '|') goto yy197;
-	goto yy140;
-yy141:
-	yyaccept = 6;
+	yyaccept = 5;
 	skip(state);
 	backup = *state;
 	yych = peek(state);
 	if (yych <= '\'') {
-		if (yych <= 0x00000000) goto yy78;
-		if (yych <= '&') goto yy75;
-		goto yy77;
+		if (yych <= 0x00000000) goto yy77;
+		if (yych <= '&') goto yy74;
+		goto yy76;
 	} else {
-		if (yych == '\\') goto yy79;
-		goto yy75;
+		if (yych == '\\') goto yy78;
+		goto yy74;
 	}
-yy142:
+yy140:
 	skip(state);
 #line 39 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, pDOT3); }
-#line 1270 "ext/rbs_extension/lexer.c"
-yy143:
+#line 1261 "ext/rbs_extension/lexer.c"
+yy141:
 	skip(state);
-yy144:
 #line 102 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tDQSYMBOL); }
-#line 1276 "ext/rbs_extension/lexer.c"
-yy145:
+#line 1266 "ext/rbs_extension/lexer.c"
+yy142:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '"') {
-		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '!') goto yy85;
-		goto yy198;
+	if (yych <= 'd') {
+		if (yych <= '[') {
+			if (yych == '"') goto yy84;
+			goto yy67;
+		} else {
+			if (yych <= '\\') goto yy84;
+			if (yych <= '`') goto yy67;
+			if (yych <= 'b') goto yy84;
+			goto yy67;
+		}
 	} else {
-		if (yych == '\\') goto yy145;
-		goto yy85;
+		if (yych <= 'q') {
+			if (yych <= 'f') goto yy84;
+			if (yych == 'n') goto yy84;
+			goto yy67;
+		} else {
+			if (yych == 'u') goto yy67;
+			if (yych <= 'v') goto yy84;
+			goto yy67;
+		}
 	}
-yy146:
+yy143:
 	skip(state);
 	yych = peek(state);
 	if (yych <= ',') {
 		if (yych <= '\f') {
-			if (yych <= 0x00000000) goto yy147;
-			if (yych <= 0x00000008) goto yy146;
-			if (yych >= '\v') goto yy146;
+			if (yych <= 0x00000000) goto yy144;
+			if (yych <= 0x00000008) goto yy143;
+			if (yych >= '\v') goto yy143;
 		} else {
 			if (yych <= 0x0000001F) {
-				if (yych >= 0x0000000E) goto yy146;
+				if (yych >= 0x0000000E) goto yy143;
 			} else {
-				if (yych == '#') goto yy146;
+				if (yych == '#') goto yy143;
 			}
 		}
 	} else {
 		if (yych <= '>') {
-			if (yych <= '-') goto yy146;
-			if (yych <= '/') goto yy147;
-			if (yych <= '9') goto yy146;
+			if (yych <= '-') goto yy143;
+			if (yych <= '/') goto yy144;
+			if (yych <= '9') goto yy143;
 		} else {
 			if (yych <= '^') {
-				if (yych <= 'Z') goto yy146;
+				if (yych <= 'Z') goto yy143;
 			} else {
-				if (yych <= 'z') goto yy146;
-				if (yych >= 0x0000007F) goto yy146;
+				if (yych <= 'z') goto yy143;
+				if (yych >= 0x0000007F) goto yy143;
 			}
 		}
 	}
-yy147:
+yy144:
 #line 119 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tSYMBOL); }
-#line 1320 "ext/rbs_extension/lexer.c"
-yy148:
+#line 1323 "ext/rbs_extension/lexer.c"
+yy145:
 	skip(state);
-	goto yy147;
-yy149:
+	goto yy144;
+yy146:
 	skip(state);
-yy150:
+yy147:
 #line 103 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tSQSYMBOL); }
-#line 1329 "ext/rbs_extension/lexer.c"
-yy151:
+#line 1332 "ext/rbs_extension/lexer.c"
+yy148:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '\'') {
 		if (yych <= 0x00000000) goto yy67;
-		if (yych <= '&') goto yy88;
-		goto yy199;
+		if (yych <= '&') goto yy87;
+		goto yy195;
 	} else {
-		if (yych == '\\') goto yy151;
-		goto yy88;
+		if (yych == '\\') goto yy148;
+		goto yy87;
 	}
-yy152:
+yy149:
 	skip(state);
 	yych = peek(state);
-	if (yych == '>') goto yy87;
-	goto yy84;
-yy153:
+	if (yych == '>') goto yy86;
+	goto yy83;
+yy150:
 	skip(state);
 	yych = peek(state);
-	if (yych == '=') goto yy87;
-	goto yy84;
-yy154:
+	if (yych == '=') goto yy86;
+	goto yy83;
+yy151:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '^') {
 		if (yych <= '@') goto yy67;
-		if (yych <= 'Z') goto yy200;
+		if (yych <= 'Z') goto yy196;
 		goto yy67;
 	} else {
 		if (yych == '`') goto yy67;
-		if (yych <= 'z') goto yy200;
+		if (yych <= 'z') goto yy196;
 		goto yy67;
 	}
-yy155:
+yy152:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '>') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy202;
+			if (yych == '!') goto yy198;
 		} else {
-			if (yych <= '9') goto yy155;
-			if (yych == '=') goto yy202;
+			if (yych <= '9') goto yy152;
+			if (yych == '=') goto yy198;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '?') goto yy202;
-			if (yych <= '@') goto yy156;
-			if (yych <= 'Z') goto yy155;
+			if (yych <= '?') goto yy198;
+			if (yych <= '@') goto yy153;
+			if (yych <= 'Z') goto yy152;
 		} else {
-			if (yych == '`') goto yy156;
+			if (yych == '`') goto yy153;
+			if (yych <= 'z') goto yy152;
+		}
+	}
+yy153:
+#line 117 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, tSYMBOL); }
+#line 1389 "ext/rbs_extension/lexer.c"
+yy154:
+	skip(state);
+	goto yy96;
+yy155:
+	skip(state);
+	yych = peek(state);
+	if (yych <= 'Z') {
+		if (yych <= '/') goto yy156;
+		if (yych <= '9') goto yy155;
+		if (yych >= 'A') goto yy155;
+	} else {
+		if (yych <= '_') {
+			if (yych >= '_') goto yy155;
+		} else {
+			if (yych <= '`') goto yy156;
 			if (yych <= 'z') goto yy155;
 		}
 	}
 yy156:
-#line 117 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, tSYMBOL); }
-#line 1386 "ext/rbs_extension/lexer.c"
-yy157:
-	skip(state);
-	goto yy97;
-yy158:
-	skip(state);
-	yych = peek(state);
-	if (yych <= 'Z') {
-		if (yych <= '/') goto yy159;
-		if (yych <= '9') goto yy158;
-		if (yych >= 'A') goto yy158;
-	} else {
-		if (yych <= '_') {
-			if (yych >= '_') goto yy158;
-		} else {
-			if (yych <= '`') goto yy159;
-			if (yych <= 'z') goto yy158;
-		}
-	}
-yy159:
 #line 131 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tA2IDENT); }
-#line 1408 "ext/rbs_extension/lexer.c"
-yy160:
+#line 1411 "ext/rbs_extension/lexer.c"
+yy157:
 	skip(state);
 #line 41 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tQIDENT); }
-#line 1413 "ext/rbs_extension/lexer.c"
+#line 1416 "ext/rbs_extension/lexer.c"
+yy158:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'a') goto yy199;
+	goto yy52;
+yy159:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'r') goto yy200;
+	goto yy52;
+yy160:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'l') goto yy201;
+	goto yy52;
 yy161:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy203;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy162;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy162;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy162:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'r') goto yy204;
-	goto yy52;
+#line 72 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kBOT); }
+#line 1454 "ext/rbs_extension/lexer.c"
 yy163:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy205;
+	if (yych == 's') goto yy203;
 	goto yy52;
 yy164:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -1445,339 +1476,318 @@ yy164:
 		}
 	}
 yy165:
-#line 72 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kBOT); }
-#line 1451 "ext/rbs_extension/lexer.c"
+#line 74 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kDEF); }
+#line 1482 "ext/rbs_extension/lexer.c"
 yy166:
 	skip(state);
 	yych = peek(state);
-	if (yych == 's') goto yy207;
-	goto yy52;
-yy167:
-	skip(state);
-	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy168;
+			if (yych <= '@') goto yy167;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy168;
+			if (yych == '`') goto yy167;
 			if (yych <= 'z') goto yy51;
 		}
 	}
+yy167:
+#line 75 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kEND); }
+#line 1505 "ext/rbs_extension/lexer.c"
 yy168:
-#line 74 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kDEF); }
-#line 1479 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'e') goto yy204;
+	goto yy52;
 yy169:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy170;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy170;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 's') goto yy205;
+	goto yy52;
 yy170:
-#line 75 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kEND); }
-#line 1502 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'l') goto yy206;
+	goto yy52;
 yy171:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy208;
+	if (yych == 't') goto yy207;
 	goto yy52;
 yy172:
 	skip(state);
 	yych = peek(state);
-	if (yych == 's') goto yy209;
+	if (yych == 'e') goto yy208;
 	goto yy52;
 yy173:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy210;
+	if (yych == 'u') goto yy209;
 	goto yy52;
 yy174:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy211;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy175;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy175;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy175:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy212;
-	goto yy52;
+#line 83 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kNIL); }
+#line 1558 "ext/rbs_extension/lexer.c"
 yy176:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'u') goto yy213;
-	goto yy52;
-yy177:
-	skip(state);
-	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy178;
+			if (yych <= '@') goto yy177;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy178;
+			if (yych == '`') goto yy177;
 			if (yych <= 'z') goto yy51;
 		}
 	}
+yy177:
+#line 84 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kOUT); }
+#line 1581 "ext/rbs_extension/lexer.c"
 yy178:
-#line 83 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kNIL); }
-#line 1555 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'p') goto yy210;
+	goto yy52;
 yy179:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy180;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy180;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'v') goto yy211;
+	goto yy52;
 yy180:
-#line 84 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kOUT); }
-#line 1578 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'l') goto yy212;
+	goto yy52;
 yy181:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'p') goto yy214;
+	if (yych == 'f') goto yy213;
 	goto yy52;
 yy182:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'v') goto yy215;
+	if (yych == 'g') goto yy215;
 	goto yy52;
 yy183:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy216;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy184;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy184;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy184:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'f') goto yy217;
-	goto yy52;
+#line 90 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kTOP); }
+#line 1629 "ext/rbs_extension/lexer.c"
 yy185:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'g') goto yy219;
+	if (yych == 'e') goto yy216;
 	goto yy52;
 yy186:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy187;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy187;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'e') goto yy218;
+	goto yy52;
 yy187:
-#line 90 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kTOP); }
-#line 1626 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'h') goto yy220;
+	goto yy52;
 yy188:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy220;
+	if (yych == 'y') goto yy221;
 	goto yy52;
 yy189:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy222;
+	if (yych == 'd') goto yy222;
 	goto yy52;
 yy190:
 	skip(state);
-	yych = peek(state);
-	if (yych == 'h') goto yy224;
-	goto yy52;
-yy191:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'y') goto yy225;
-	goto yy52;
-yy192:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'd') goto yy226;
-	goto yy52;
-yy193:
-	skip(state);
 #line 55 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tANNOTATION); }
-#line 1656 "ext/rbs_extension/lexer.c"
-yy194:
+#line 1659 "ext/rbs_extension/lexer.c"
+yy191:
 	skip(state);
 #line 58 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tANNOTATION); }
-#line 1661 "ext/rbs_extension/lexer.c"
-yy195:
+#line 1664 "ext/rbs_extension/lexer.c"
+yy192:
 	skip(state);
 #line 56 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tANNOTATION); }
-#line 1666 "ext/rbs_extension/lexer.c"
-yy196:
+#line 1669 "ext/rbs_extension/lexer.c"
+yy193:
 	skip(state);
 #line 54 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tANNOTATION); }
-#line 1671 "ext/rbs_extension/lexer.c"
-yy197:
+#line 1674 "ext/rbs_extension/lexer.c"
+yy194:
 	skip(state);
 #line 57 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tANNOTATION); }
-#line 1676 "ext/rbs_extension/lexer.c"
-yy198:
-	yyaccept = 7;
-	skip(state);
-	backup = *state;
-	yych = peek(state);
-	if (yych <= '"') {
-		if (yych <= 0x00000000) goto yy144;
-		if (yych <= '!') goto yy85;
-		goto yy143;
-	} else {
-		if (yych == '\\') goto yy145;
-		goto yy85;
-	}
-yy199:
-	yyaccept = 8;
+#line 1679 "ext/rbs_extension/lexer.c"
+yy195:
+	yyaccept = 6;
 	skip(state);
 	backup = *state;
 	yych = peek(state);
 	if (yych <= '\'') {
-		if (yych <= 0x00000000) goto yy150;
-		if (yych <= '&') goto yy88;
-		goto yy149;
+		if (yych <= 0x00000000) goto yy147;
+		if (yych <= '&') goto yy87;
+		goto yy146;
 	} else {
-		if (yych == '\\') goto yy151;
-		goto yy88;
+		if (yych == '\\') goto yy148;
+		goto yy87;
 	}
-yy200:
+yy196:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '>') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy228;
+			if (yych == '!') goto yy224;
 		} else {
-			if (yych <= '9') goto yy200;
-			if (yych == '=') goto yy228;
+			if (yych <= '9') goto yy196;
+			if (yych == '=') goto yy224;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '?') goto yy228;
-			if (yych <= '@') goto yy201;
-			if (yych <= 'Z') goto yy200;
+			if (yych <= '?') goto yy224;
+			if (yych <= '@') goto yy197;
+			if (yych <= 'Z') goto yy196;
 		} else {
-			if (yych == '`') goto yy201;
-			if (yych <= 'z') goto yy200;
+			if (yych == '`') goto yy197;
+			if (yych <= 'z') goto yy196;
 		}
 	}
-yy201:
+yy197:
 #line 118 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, tSYMBOL); }
-#line 1726 "ext/rbs_extension/lexer.c"
-yy202:
+#line 1716 "ext/rbs_extension/lexer.c"
+yy198:
 	skip(state);
-	goto yy156;
-yy203:
-	skip(state);
-	yych = peek(state);
-	if (yych == 's') goto yy229;
-	goto yy52;
-yy204:
+	goto yy153;
+yy199:
 	skip(state);
 	yych = peek(state);
-	if (yych == '_') goto yy231;
+	if (yych == 's') goto yy225;
 	goto yy52;
-yy205:
+yy200:
+	skip(state);
+	yych = peek(state);
+	if (yych == '_') goto yy227;
+	goto yy52;
+yy201:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy206;
+			if (yych <= '@') goto yy202;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy206;
+			if (yych == '`') goto yy202;
 			if (yych <= 'z') goto yy51;
 		}
 	}
-yy206:
+yy202:
 #line 71 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, kBOOL); }
-#line 1762 "ext/rbs_extension/lexer.c"
+#line 1752 "ext/rbs_extension/lexer.c"
+yy203:
+	skip(state);
+	yych = peek(state);
+	if (yych == 's') goto yy228;
+	goto yy52;
+yy204:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'n') goto yy230;
+	goto yy52;
+yy205:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'e') goto yy231;
+	goto yy52;
+yy206:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'u') goto yy233;
+	goto yy52;
 yy207:
 	skip(state);
 	yych = peek(state);
-	if (yych == 's') goto yy232;
+	if (yych == 'a') goto yy234;
 	goto yy52;
 yy208:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy234;
+	if (yych == 'r') goto yy235;
 	goto yy52;
 yy209:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy235;
+	if (yych == 'l') goto yy236;
 	goto yy52;
 yy210:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'u') goto yy237;
+	if (yych == 'e') goto yy237;
 	goto yy52;
 yy211:
 	skip(state);
@@ -1787,88 +1797,101 @@ yy211:
 yy212:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'r') goto yy239;
+	if (yych == 'i') goto yy239;
 	goto yy52;
 yy213:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'l') goto yy240;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy214;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy214;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy214:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy241;
-	goto yy52;
+#line 88 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kSELF); }
+#line 1825 "ext/rbs_extension/lexer.c"
 yy215:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy242;
+	if (yych == 'l') goto yy240;
 	goto yy52;
 yy216:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'i') goto yy243;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy217;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy217;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy217:
+#line 91 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kTRUE); }
+#line 1853 "ext/rbs_extension/lexer.c"
+yy218:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy218;
+			if (yych <= '@') goto yy219;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy218;
+			if (yych == '`') goto yy219;
 			if (yych <= 'z') goto yy51;
 		}
 	}
-yy218:
-#line 88 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kSELF); }
-#line 1835 "ext/rbs_extension/lexer.c"
 yy219:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'l') goto yy244;
-	goto yy52;
+#line 92 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kTYPE); }
+#line 1876 "ext/rbs_extension/lexer.c"
 yy220:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy221;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy221;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'e') goto yy241;
+	goto yy52;
 yy221:
-#line 91 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kTRUE); }
-#line 1863 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'p') goto yy242;
+	goto yy52;
 yy222:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -1880,164 +1903,151 @@ yy222:
 		}
 	}
 yy223:
-#line 92 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kTYPE); }
-#line 1886 "ext/rbs_extension/lexer.c"
+#line 95 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kVOID); }
+#line 1909 "ext/rbs_extension/lexer.c"
 yy224:
 	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy245;
-	goto yy52;
+	goto yy197;
 yy225:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'p') goto yy246;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy226;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy226;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy226:
-	skip(state);
-	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy227;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy227;
-			if (yych <= 'z') goto yy51;
-		}
-	}
-yy227:
-#line 95 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kVOID); }
-#line 1919 "ext/rbs_extension/lexer.c"
-yy228:
-	skip(state);
-	goto yy201;
-yy229:
-	skip(state);
-	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy230;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy230;
-			if (yych <= 'z') goto yy51;
-		}
-	}
-yy230:
 #line 67 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, kALIAS); }
-#line 1945 "ext/rbs_extension/lexer.c"
-yy231:
+#line 1935 "ext/rbs_extension/lexer.c"
+yy227:
 	skip(state);
 	yych = peek(state);
 	if (yych <= 'q') {
-		if (yych == 'a') goto yy247;
+		if (yych == 'a') goto yy243;
 		goto yy52;
 	} else {
-		if (yych <= 'r') goto yy248;
-		if (yych == 'w') goto yy249;
+		if (yych <= 'r') goto yy244;
+		if (yych == 'w') goto yy245;
 		goto yy52;
 	}
-yy232:
+yy228:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy233;
+			if (yych <= '@') goto yy229;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy233;
+			if (yych == '`') goto yy229;
 			if (yych <= 'z') goto yy51;
 		}
 	}
-yy233:
+yy229:
 #line 73 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, kCLASS); }
-#line 1979 "ext/rbs_extension/lexer.c"
+#line 1969 "ext/rbs_extension/lexer.c"
+yy230:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'd') goto yy246;
+	goto yy52;
+yy231:
+	skip(state);
+	yych = peek(state);
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy232;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy232;
+			if (yych <= 'z') goto yy51;
+		}
+	}
+yy232:
+#line 77 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kFALSE); }
+#line 1997 "ext/rbs_extension/lexer.c"
+yy233:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'd') goto yy248;
+	goto yy52;
 yy234:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy250;
+	if (yych == 'n') goto yy249;
 	goto yy52;
 yy235:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy236;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy236;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'f') goto yy250;
+	goto yy52;
 yy236:
-#line 77 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kFALSE); }
-#line 2007 "ext/rbs_extension/lexer.c"
-yy237:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy252;
+	if (yych == 'e') goto yy251;
 	goto yy52;
-yy238:
+yy237:
 	skip(state);
 	yych = peek(state);
 	if (yych == 'n') goto yy253;
 	goto yy52;
+yy238:
+	skip(state);
+	yych = peek(state);
+	if (yych == 't') goto yy254;
+	goto yy52;
 yy239:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'f') goto yy254;
+	if (yych == 'c') goto yy255;
 	goto yy52;
 yy240:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy255;
+	if (yych == 'e') goto yy257;
 	goto yy52;
 yy241:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy257;
+	if (yych == 'c') goto yy258;
 	goto yy52;
 yy242:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy258;
+	if (yych == 'e') goto yy259;
 	goto yy52;
 yy243:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'c') goto yy259;
+	if (yych == 'c') goto yy260;
 	goto yy52;
 yy244:
 	skip(state);
@@ -2047,75 +2057,88 @@ yy244:
 yy245:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'c') goto yy262;
+	if (yych == 'r') goto yy262;
 	goto yy52;
 yy246:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy263;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy247;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy247;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy247:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'c') goto yy264;
-	goto yy52;
+#line 76 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kEXTEND); }
+#line 2085 "ext/rbs_extension/lexer.c"
 yy248:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy265;
+	if (yych == 'e') goto yy263;
 	goto yy52;
 yy249:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'r') goto yy266;
+	if (yych == 'c') goto yy265;
 	goto yy52;
 yy250:
 	skip(state);
 	yych = peek(state);
+	if (yych == 'a') goto yy266;
+	goto yy52;
+yy251:
+	skip(state);
+	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy251;
+			if (yych <= '@') goto yy252;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy251;
+			if (yych == '`') goto yy252;
 			if (yych <= 'z') goto yy51;
 		}
 	}
-yy251:
-#line 76 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kEXTEND); }
-#line 2095 "ext/rbs_extension/lexer.c"
 yy252:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy267;
-	goto yy52;
+#line 82 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kMODULE); }
+#line 2123 "ext/rbs_extension/lexer.c"
 yy253:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'c') goto yy269;
+	if (yych == 'd') goto yy267;
 	goto yy52;
 yy254:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy270;
+	if (yych == 'e') goto yy269;
 	goto yy52;
 yy255:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -2127,81 +2150,81 @@ yy255:
 		}
 	}
 yy256:
-#line 82 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kMODULE); }
-#line 2133 "ext/rbs_extension/lexer.c"
+#line 87 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kPUBLIC); }
+#line 2156 "ext/rbs_extension/lexer.c"
 yy257:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy271;
+	if (yych == 't') goto yy271;
 	goto yy52;
 yy258:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy273;
+	if (yych == 'k') goto yy272;
 	goto yy52;
 yy259:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy260;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy260;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'd') goto yy273;
+	goto yy52;
 yy260:
-#line 87 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kPUBLIC); }
-#line 2166 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'c') goto yy275;
+	goto yy52;
 yy261:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy275;
+	if (yych == 'a') goto yy276;
 	goto yy52;
 yy262:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'k') goto yy276;
+	if (yych == 'i') goto yy277;
 	goto yy52;
 yy263:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy277;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy264;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy264;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy264:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'c') goto yy279;
-	goto yy52;
+#line 79 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kINCLUDE); }
+#line 2209 "ext/rbs_extension/lexer.c"
 yy265:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'a') goto yy280;
+	if (yych == 'e') goto yy278;
 	goto yy52;
 yy266:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'i') goto yy281;
+	if (yych == 'c') goto yy280;
 	goto yy52;
 yy267:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -2213,51 +2236,51 @@ yy267:
 		}
 	}
 yy268:
-#line 79 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kINCLUDE); }
-#line 2219 "ext/rbs_extension/lexer.c"
+#line 85 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kPREPEND); }
+#line 2242 "ext/rbs_extension/lexer.c"
 yy269:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy282;
-	goto yy52;
-yy270:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'c') goto yy284;
-	goto yy52;
-yy271:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy272;
+			if (yych <= '@') goto yy270;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy272;
+			if (yych == '`') goto yy270;
 			if (yych <= 'z') goto yy51;
 		}
 	}
+yy270:
+#line 86 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kPRIVATE); }
+#line 2265 "ext/rbs_extension/lexer.c"
+yy271:
+	skip(state);
+	yych = peek(state);
+	if (yych == 'o') goto yy281;
+	goto yy52;
 yy272:
-#line 85 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kPREPEND); }
-#line 2252 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'e') goto yy282;
+	goto yy52;
 yy273:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -2269,119 +2292,132 @@ yy273:
 		}
 	}
 yy274:
-#line 86 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kPRIVATE); }
-#line 2275 "ext/rbs_extension/lexer.c"
+#line 94 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kUNTYPED); }
+#line 2298 "ext/rbs_extension/lexer.c"
 yy275:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'o') goto yy285;
+	if (yych == 'e') goto yy283;
 	goto yy52;
 yy276:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy286;
+	if (yych == 'd') goto yy284;
 	goto yy52;
 yy277:
 	skip(state);
 	yych = peek(state);
+	if (yych == 't') goto yy285;
+	goto yy52;
+yy278:
+	skip(state);
+	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
-			if (yych <= '@') goto yy278;
+			if (yych <= '@') goto yy279;
 			if (yych <= 'Z') goto yy51;
 		} else {
-			if (yych == '`') goto yy278;
+			if (yych == '`') goto yy279;
 			if (yych <= 'z') goto yy51;
 		}
 	}
-yy278:
-#line 94 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kUNTYPED); }
-#line 2308 "ext/rbs_extension/lexer.c"
 yy279:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy287;
-	goto yy52;
+#line 80 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kINSTANCE); }
+#line 2336 "ext/rbs_extension/lexer.c"
 yy280:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy288;
+	if (yych == 'e') goto yy286;
 	goto yy52;
 yy281:
 	skip(state);
 	yych = peek(state);
-	if (yych == 't') goto yy289;
+	if (yych == 'n') goto yy288;
 	goto yy52;
 yy282:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy283;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy283;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'd') goto yy290;
+	goto yy52;
 yy283:
-#line 80 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kINSTANCE); }
-#line 2346 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 's') goto yy292;
+	goto yy52;
 yy284:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy290;
+	if (yych == 'e') goto yy293;
 	goto yy52;
 yy285:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'n') goto yy292;
+	if (yych == 'e') goto yy294;
 	goto yy52;
 yy286:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'd') goto yy294;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy287;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy287;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy287:
-	skip(state);
-	yych = peek(state);
-	if (yych == 's') goto yy296;
-	goto yy52;
+#line 81 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kINTERFACE); }
+#line 2389 "ext/rbs_extension/lexer.c"
 yy288:
 	skip(state);
 	yych = peek(state);
-	if (yych == 'e') goto yy297;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy289;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy289;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy289:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'e') goto yy298;
-	goto yy52;
+#line 89 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kSINGLETON); }
+#line 2412 "ext/rbs_extension/lexer.c"
 yy290:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -2393,84 +2429,87 @@ yy290:
 		}
 	}
 yy291:
-#line 81 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kINTERFACE); }
-#line 2399 "ext/rbs_extension/lexer.c"
+#line 93 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kUNCHECKED); }
+#line 2435 "ext/rbs_extension/lexer.c"
 yy292:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy293;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy293;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 's') goto yy295;
+	goto yy52;
 yy293:
-#line 89 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kSINGLETON); }
-#line 2422 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'r') goto yy296;
+	goto yy52;
 yy294:
 	skip(state);
 	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy295;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy295;
-			if (yych <= 'z') goto yy51;
-		}
-	}
+	if (yych == 'r') goto yy298;
+	goto yy52;
 yy295:
-#line 93 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kUNCHECKED); }
-#line 2445 "ext/rbs_extension/lexer.c"
+	skip(state);
+	yych = peek(state);
+	if (yych == 'o') goto yy300;
+	goto yy52;
 yy296:
 	skip(state);
 	yych = peek(state);
-	if (yych == 's') goto yy299;
-	goto yy52;
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy297;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy297;
+			if (yych <= 'z') goto yy51;
+		}
+	}
 yy297:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'r') goto yy300;
-	goto yy52;
+#line 69 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kATTRREADER); }
+#line 2478 "ext/rbs_extension/lexer.c"
 yy298:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'r') goto yy302;
-	goto yy52;
-yy299:
-	skip(state);
-	yych = peek(state);
-	if (yych == 'o') goto yy304;
-	goto yy52;
-yy300:
 	skip(state);
 	yych = peek(state);
 	if (yych <= '=') {
 		if (yych <= '/') {
-			if (yych == '!') goto yy105;
+			if (yych == '!') goto yy104;
 		} else {
 			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
+			if (yych >= '=') goto yy105;
+		}
+	} else {
+		if (yych <= '^') {
+			if (yych <= '@') goto yy299;
+			if (yych <= 'Z') goto yy51;
+		} else {
+			if (yych == '`') goto yy299;
+			if (yych <= 'z') goto yy51;
+		}
+	}
+yy299:
+#line 70 "ext/rbs_extension/lexer.re"
+	{ return next_token(state, kATTRWRITER); }
+#line 2501 "ext/rbs_extension/lexer.c"
+yy300:
+	skip(state);
+	yych = peek(state);
+	if (yych != 'r') goto yy52;
+	skip(state);
+	yych = peek(state);
+	if (yych <= '=') {
+		if (yych <= '/') {
+			if (yych == '!') goto yy104;
+		} else {
+			if (yych <= '9') goto yy51;
+			if (yych >= '=') goto yy105;
 		}
 	} else {
 		if (yych <= '^') {
@@ -2482,58 +2521,9 @@ yy300:
 		}
 	}
 yy301:
-#line 69 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kATTRREADER); }
-#line 2488 "ext/rbs_extension/lexer.c"
-yy302:
-	skip(state);
-	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy303;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy303;
-			if (yych <= 'z') goto yy51;
-		}
-	}
-yy303:
-#line 70 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, kATTRWRITER); }
-#line 2511 "ext/rbs_extension/lexer.c"
-yy304:
-	skip(state);
-	yych = peek(state);
-	if (yych != 'r') goto yy52;
-	skip(state);
-	yych = peek(state);
-	if (yych <= '=') {
-		if (yych <= '/') {
-			if (yych == '!') goto yy105;
-		} else {
-			if (yych <= '9') goto yy51;
-			if (yych >= '=') goto yy106;
-		}
-	} else {
-		if (yych <= '^') {
-			if (yych <= '@') goto yy305;
-			if (yych <= 'Z') goto yy51;
-		} else {
-			if (yych == '`') goto yy305;
-			if (yych <= 'z') goto yy51;
-		}
-	}
-yy305:
 #line 68 "ext/rbs_extension/lexer.re"
 	{ return next_token(state, kATTRACCESSOR); }
-#line 2537 "ext/rbs_extension/lexer.c"
+#line 2527 "ext/rbs_extension/lexer.c"
 }
 #line 140 "ext/rbs_extension/lexer.re"
 

--- a/ext/rbs_extension/lexer.re
+++ b/ext/rbs_extension/lexer.re
@@ -94,8 +94,8 @@ start:
       "untyped"       { return next_token(state, kUNTYPED); }
       "void"          { return next_token(state, kVOID); }
 
-      dqstring = ["] ("\\"["] | [^"\x00])* ["];
-      sqstring = ['] ("\\"['] | [^'\x00])* ['];
+      dqstring = ["] ("\\"[abefnrstv"\\] | [^"\\\x00])* ["];
+      sqstring = ['] ("\\"['\\] | [^'\x00])* ['];
 
       dqstring     { return next_token(state, tDQSTRING); }
       sqstring     { return next_token(state, tSQSTRING); }

--- a/ext/rbs_extension/rbs_extension.h
+++ b/ext/rbs_extension/rbs_extension.h
@@ -15,7 +15,7 @@
  *   '\\n' => "\n"
  *
  * */
-void rbs_unescape_string(VALUE string);
+void rbs_unescape_string(VALUE string, bool dq_string);
 
 /**
  * Receives `parserstate` and `range`, which represents a string token or symbol token, and returns a string VALUE.

--- a/ext/rbs_extension/unescape.c
+++ b/ext/rbs_extension/unescape.c
@@ -3,7 +3,7 @@
 static VALUE REGEXP = 0;
 static VALUE HASH = 0;
 
-static const char *regexp_str = "\\\\[abefnrstv\"]";
+static const char *regexp_str = "\\\\[abefnrstv\"\\\\]";
 
 static ID gsub = 0;
 
@@ -30,6 +30,7 @@ void rbs_unescape_string(VALUE string) {
     rb_hash_aset(HASH, rb_str_new_literal("\\t"), rb_str_new_literal("\t"));
     rb_hash_aset(HASH, rb_str_new_literal("\\v"), rb_str_new_literal("\v"));
     rb_hash_aset(HASH, rb_str_new_literal("\\\""), rb_str_new_literal("\""));
+    rb_hash_aset(HASH, rb_str_new_literal("\\\\"), rb_str_new_literal("\\"));
   }
 
   rb_funcall(string, gsub, 2, REGEXP, HASH);

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -581,6 +581,18 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_instance_of Types::Literal, type
       assert_equal 'not escape sequences \a\b\e\f\n\r\s\t\v\"', type.literal
     end
+
+    # "\\" in RBS
+    Parser.parse_type(%q{"\\\\"}).yield_self do |type|
+      assert_instance_of Types::Literal, type
+      assert_equal "\\", type.literal
+    end
+
+    # '\\' in RBS
+    Parser.parse_type(%q{'\\\\'}).yield_self do |type|
+      assert_instance_of Types::Literal, type
+      assert_equal "\\", type.literal
+    end
   end
 
   def test_literal_to_s

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -583,6 +583,25 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
     end
   end
 
+  def test_literal_to_s
+    Parser.parse_type(%q{"\\a\\\\"}).yield_self do |type|
+      assert_equal type, Parser.parse_type(type.to_s)
+    end
+  end
+
+  def test_string_literal_union
+    Parser.parse_type(%q{"\\\\" | "a"}).yield_self do |type|
+      assert_instance_of Types::Union, type
+
+      assert_instance_of Types::Literal, type.types[0]
+      assert_equal 1, type.types[0].literal.size
+      assert_equal '\\', type.types[0].literal
+
+      assert_instance_of Types::Literal, type.types[1]
+      assert_equal "a", type.types[1].literal
+    end
+  end
+
   def test_record
     Parser.parse_type("{ foo: untyped, 3 => 'hoge' }").yield_self do |type|
       assert_instance_of Types::Record, type


### PR DESCRIPTION
* Make it more explicit in `lexer.re`
* Unescape `\\` too in unescape.c

Closes https://github.com/ruby/rbs/issues/996