### PR TITLE
Improve Logger type signatures related to `level`.

### DIFF
--- a/stdlib/logger/0/logger.rbs
+++ b/stdlib/logger/0/logger.rbs
@@ -500,7 +500,7 @@ class Logger
   # `severity`
   # :   The Severity of the log message.
   #
-  def level=: (Integer | String severity) -> Integer
+  def level=: (Integer | String | Symbol severity) -> Integer
 
   # <!--
   #   rdoc-file=lib/logger.rb
@@ -646,7 +646,7 @@ class Logger
   #
   # Create an instance.
   #
-  def initialize: (logdev logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: boolish, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer) -> void
+  def initialize: (logdev logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: boolish, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer | String | Symbol) -> void
 end
 
 Logger::ProgName: String

--- a/test/stdlib/Logger_test.rb
+++ b/test/stdlib/Logger_test.rb
@@ -24,6 +24,10 @@ class LoggerSingletonTest < Test::Unit::TestCase
                       Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: Logger::INFO
     assert_send_type  "(String logdev, Integer shift_age, Integer shift_size, shift_period_suffix: String, binmode: Symbol, datetime_format: String, formatter: Proc, progname: String, level: Integer) -> void",
                       Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: :true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: Logger::INFO
+    assert_send_type  "(String logdev, Integer shift_age, Integer shift_size, shift_period_suffix: String, binmode: Symbol, datetime_format: String, formatter: Proc, progname: String, level: String) -> void",
+                      Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: :true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: "INFO"
+    assert_send_type  "(String logdev, Integer shift_age, Integer shift_size, shift_period_suffix: String, binmode: Symbol, datetime_format: String, formatter: Proc, progname: String, level: Symbol) -> void",
+                      Logger, :new, '/dev/null', 1, 1, shift_period_suffix: '%Y', binmode: :true, datetime_format: '%Y', formatter: proc { '' }, progname: 'foo', level: :INFO
   end
 end
 
@@ -209,6 +213,8 @@ class LoggerTest < Test::Unit::TestCase
                       logger, :level=, Logger::DEBUG
     assert_send_type  "(String severity) -> Integer",
                       logger, :level=, 'debug'
+    assert_send_type  "(Symbol severity) -> Integer",
+                      logger, :level=, :debug
   end
 
   def test_progname


### PR DESCRIPTION
As shown in the current docs, `level` can be a String, Symbol, or Integer:

https://github.com/ruby/ruby/blob/b180ffa62270dc32bb69167822b4c698def5c8f7/lib/logger.rb#L388-L393