### PR TITLE
Fix constant name resolving

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -256,7 +256,11 @@ module RBS
 
       context = (outer + [decl]).each.with_object([Namespace.root]) do |decl, array|
         head = array.first or raise
-        array.unshift(head + decl.name.to_namespace)
+        namespace = decl.name.to_namespace
+        namespace.path.each_with_index do |path, i|
+          part = Namespace.new(path: namespace.path[0, i + 1], absolute: false)
+          array.unshift(head + part)
+        end
       end
 
       outer_context = context.drop(1)

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -284,7 +284,11 @@ EOF
 # (Will be an error afterward.)
 #
 class Hello < String
-  def hello: (String) -> Integer
+  def hello: (String) -> Hello
+end
+
+class Hello::World
+  def world: () -> World
 end
 
 module Foo : _Each[String]
@@ -337,7 +341,11 @@ EOF
 # (Will be an error afterward.)
 #
 class ::Hello < ::String
-  def hello: (::String) -> Integer
+  def hello: (::String) -> ::Hello
+end
+
+class ::Hello::World
+  def world: () -> ::Hello::World
 end
 
 module ::Foo : ::Foo::_Each[::Foo::String]


### PR DESCRIPTION
There is a pattern in which class names fail to resolve if they are connected by `::`.
Shouldn't it be possible to resolve names in cases like the following?

### Current

```rb
class Hello < String
  def hello: (String) -> Hello
end

class Hello::World
  def world: () -> World
end

# after run `env.resolve_type_names`

class ::Hello < String
  def hello: (String) -> ::Hello
end

class ::Hello::World
  def world: () -> World #<= cannot resolve
end
```

### Expect

```rb
class Hello < String
  def hello: (String) -> Hello
end

class Hello::World
  def world: () -> World
end

# after run `env.resolve_type_names`

class ::Hello < ::String
  def hello: (::String) -> ::Hello
end

class ::Hello::World
  def world: () -> ::Hello::World #<= resolved
end
```
