### PR TITLE
Fix some error on prototype runtime

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -21,6 +21,7 @@ module RBS
 
       def target?(const)
         name = const_name(const)
+        return false unless name
 
         patterns.any? do |pattern|
           if pattern.end_with?("*")

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -318,7 +318,12 @@ module RBS
 
       def generate_constants(mod, decls)
         mod.constants(false).sort.each do |name|
-          value = mod.const_get(name)
+          begin
+            value = mod.const_get(name)
+          rescue StandardError, LoadError => e
+            RBS.logger.warn("Skipping constant #{name} of #{mod} since #{e}")
+            next
+          end
 
           next if value.is_a?(Class) || value.is_a?(Module)
           unless value.class.name

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -77,7 +77,7 @@ module RBS
           supers.merge(mix.included_modules)
         end
 
-        if mod.is_a?(Class)
+        if mod.is_a?(Class) && mod.superclass
           mod.superclass.included_modules.each do |mix|
             supers << mix
             supers.merge(mix.included_modules)
@@ -350,7 +350,7 @@ module RBS
       end
 
       def generate_super_class(mod)
-        if mod.superclass == ::Object
+        if mod.superclass.nil? || mod.superclass == ::Object
           nil
         elsif const_name(mod.superclass).nil?
           RBS.logger.warn("Skipping anonymous superclass #{mod.superclass} of #{mod}")

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -446,4 +446,18 @@ end
       end
     end
   end
+
+  def test_basic_object
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["BasicObject"], env: env, merge: true)
+        assert_equal(p.decls.length, 1)
+        p.decls.each do |decl|
+          env << decl
+        end
+        env.resolve_type_names
+        assert(true) # nothing raised above
+      end
+    end
+  end
 end


### PR DESCRIPTION
As a milestone, the following commands have been corrected so that errors do not occur.

```
$ bundle exec rbs prototype runtime '*'
```