### PR TITLE
Fix Warning.#warn and Kernel.#warn signatures

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2135,7 +2135,7 @@ module Kernel : BasicObject
   # :experimental
   # :   Used for experimental features that may change in future releases.
   #
-  def self?.warn: (*untyped msg, ?uplevel: Integer | nil) -> NilClass
+  def self?.warn: (*untyped msg, ?uplevel: Integer | nil, ?category: :deprecated | :experimental) -> NilClass
 
   # <!--
   #   rdoc-file=process.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2135,7 +2135,7 @@ module Kernel : BasicObject
   # :experimental
   # :   Used for experimental features that may change in future releases.
   #
-  def self?.warn: (*untyped msg, ?uplevel: Integer | nil, ?category: :deprecated | :experimental) -> NilClass
+  def self?.warn: (*untyped msg, ?uplevel: Integer | nil, ?category: :deprecated | :experimental | nil) -> NilClass
 
   # <!--
   #   rdoc-file=process.c

--- a/core/warning.rbs
+++ b/core/warning.rbs
@@ -38,5 +38,5 @@ module Warning
   #
   # See the documentation of the Warning module for how to customize this.
   #
-  def warn: (String) -> nil
+  def self?.warn: (String message, ?category: :deprecated | :experimental) -> nil
 end

--- a/core/warning.rbs
+++ b/core/warning.rbs
@@ -38,5 +38,5 @@ module Warning
   #
   # See the documentation of the Warning module for how to customize this.
   #
-  def self?.warn: (String message, ?category: :deprecated | :experimental) -> nil
+  def self?.warn: (String message, ?category: :deprecated | :experimental | nil) -> nil
 end

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -608,6 +608,10 @@ class KernelTest < StdlibTest
     warn 'foo'
     warn 'foo', 'bar'
     warn 'foo', uplevel: 1
+
+    omit_if(RUBY_VERSION < "3.0")
+
+    warn 'foo', uplevel: 1, category: :deprecated
   ensure
     $stderr = STDERR
   end

--- a/test/stdlib/Warning_test.rb
+++ b/test/stdlib/Warning_test.rb
@@ -23,11 +23,14 @@ class WarningTest < Test::Unit::TestCase
 
     omit_if(RUBY_VERSION < "3.0")
 
-    assert_send_type "(::String, category: :deprecated | :experimental) -> nil",
+    assert_send_type "(::String, category: :deprecated) -> nil",
         Warning, :warn, 'message', category: :deprecated
 
-    assert_send_type "(::String, category: :deprecated | :experimental) -> nil",
+    assert_send_type "(::String, category: :experimental) -> nil",
         Warning, :warn, 'message', category: :experimental
+
+    assert_send_type "(::String, category: nil) -> nil",
+        Warning, :warn, 'message', category: nil
 
     refute_send_type "(::String, category: ::Symbol) -> nil",
         Warning, :warn, 'message', category: :unknown_category

--- a/test/stdlib/Warning_test.rb
+++ b/test/stdlib/Warning_test.rb
@@ -1,0 +1,37 @@
+require_relative "test_helper"
+
+class WarningTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Warning"
+
+  class TestClass
+    include Warning
+  end
+
+  def test_warn
+    $stderr = StringIO.new
+
+    assert_send_type "(::String) -> nil",
+        Warning, :warn, 'message'
+
+    refute_send_type "(::_ToStr) -> nil",
+        Warning, :warn, ToStr.new
+
+    assert_send_type "(::String) -> nil",
+        TestClass.new, :warn, 'message'
+
+    omit_if(RUBY_VERSION < "3.0")
+
+    assert_send_type "(::String, category: :deprecated | :experimental) -> nil",
+        Warning, :warn, 'message', category: :deprecated
+
+    assert_send_type "(::String, category: :deprecated | :experimental) -> nil",
+        Warning, :warn, 'message', category: :experimental
+
+    refute_send_type "(::String, category: ::Symbol) -> nil",
+        Warning, :warn, 'message', category: :unknown_category
+  ensure
+    $stderr = STDERR
+  end
+end


### PR DESCRIPTION
Since Ruby 3.0, Warning and Kernel.#warn can take optional category.
And current RBS Warning.#warn is defined only on instance. This PR aims to fix both.

### Referenced followings

[Warning.#warn accept only 1 String for message](https://github.com/ruby/ruby/blob/cd34f56d450f2310cceaf4c5f34d23eddfda58e8/error.c#L267)
[Category names](https://github.com/ruby/ruby/blob/cd34f56d450f2310cceaf4c5f34d23eddfda58e8/error.c#L3061-L3062)
[deprecated  | experimental | nil](https://github.com/ruby/ruby/blob/cd34f56d450f2310cceaf4c5f34d23eddfda58e8/error.c#L3071-L3078)
[Can't define different signatures in different RUBY_VERSIONS](https://github.com/ruby/rbs/issues/613)