### PR TITLE
Let `Regexp.new` accept any `options` value

### DIFF
--- a/core/regexp.rbs
+++ b/core/regexp.rbs
@@ -760,7 +760,7 @@ class Regexp
   #     r3 = Regexp.new(r2)              #=> /cat/i
   #     r4 = Regexp.new('dog', Regexp::EXTENDED | Regexp::IGNORECASE) #=> /dog/ix
   #
-  def initialize: (String string, ?Integer | nil | false options, ?String kcode) -> Object
+  def initialize: (String string, ?Integer | nil | false | top options, ?String kcode) -> Object
                 | (Regexp regexp) -> void
 
   # <!--


### PR DESCRIPTION
`Regexp.new` accepts any value as `options` while the doc says it accepts `Integer | nil | false`. I found a code passing `true` and it cannot be rejected by a type checker, because the RDoc of `Regexp.new` shows it as an example.

This change will be reverted once Ruby 3.2 is out. The unexpected `options` value will be rejected by a runtime error on 3.2.

(See also #1040)