### PR TITLE
Remove redundant `add` for Repository.default

### DIFF
--- a/lib/rbs/repository.rb
+++ b/lib/rbs/repository.rb
@@ -79,9 +79,7 @@ module RBS
     end
 
     def self.default
-      new().tap do |repo|
-        repo.add(DEFAULT_STDLIB_ROOT)
-      end
+      new()
     end
 
     def self.find_best_version(version, candidates)


### PR DESCRIPTION
DEFAULT_STDLIB_ROOT is added in `initialize` already, so it is
duplicated.


## before

```
irb(main):001:0> RBS::Repository.default.dirs
=>
[#<Pathname:/Users/kuwabara.masataka/ghq/github.com/ruby/rbs/stdlib>,
 #<Pathname:/Users/kuwabara.masataka/ghq/github.com/ruby/rbs/stdlib>]
```



## after

```
irb(main):001:0> RBS::Repository.default.dirs
=> [#<Pathname:/Users/kuwabara.masataka/ghq/github.com/ruby/rbs/stdlib>]
```