### PR TITLE
Make the signature of StringIO#write compatible with _Writer interface

### DIFF
--- a/core/string_io.rbs
+++ b/core/string_io.rbs
@@ -450,7 +450,7 @@ class StringIO
   # opened for writing.  If the argument is not a string, it will be converted to
   # a string using `to_s`. Returns the number of bytes written.  See IO#write.
   #
-  def write: (String arg0) -> Integer
+  def write: (*_ToS) -> Integer
 
   # This is a deprecated alias for #each_byte.
   #

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -1,8 +1,6 @@
 require_relative "test_helper"
 
 class StringIOTest < StdlibTest
-  include TypeAssertions
-
   target StringIO
 
   def test_close_read
@@ -39,11 +37,17 @@ class StringIOTest < StdlibTest
     io = StringIO.new("")
     io.gets(chomp: :true)
   end
+end
+
+class StringIOTypeTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing '::StringIO'
 
   def test_write
     io = StringIO.new
 
-    assert_send_type "(*_ToS data) -> Integer",
+    assert_send_type "(*String data) -> Integer",
                      io, :write, "a", "b"
   end
 end

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -1,6 +1,8 @@
 require_relative "test_helper"
 
 class StringIOTest < StdlibTest
+  include TypeAssertions
+
   target StringIO
 
   def test_close_read
@@ -36,5 +38,12 @@ class StringIOTest < StdlibTest
   def test_gets
     io = StringIO.new("")
     io.gets(chomp: :true)
+  end
+
+  def test_write
+    io = StringIO.new
+
+    assert_send_type "(*_ToS data) -> Integer",
+                     io, :write, "a", "b"
   end
 end


### PR DESCRIPTION
I don't know how to write the test for the signature change. The way I added it make it pass locally for me (Archlinux/rbenv/ruby3.1.2).

What would be the correct solution?