### PR TITLE
adding IO.pipe sig

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2348,50 +2348,12 @@ class IO < Object
   #
   #     Sending message to parent
   #     Parent got: <Hi Dad>
-  def self.pipe: () -> [IO, IO]
-               | (Encoding ext_enc) -> [IO, IO]
-               | (String ext_int_enc,
-                    ?invalid: :replace | nil,
-                    ?undef: :replace | nil,
-                    ?replace: String,
-                    ?newline: :universal | :crlf | :cr,
-                    ?universal_newline: bool,
-                    ?crlf_newline: bool,
-                    ?cr_newline: bool,
-                    ?xml: :text | :attr
-                  ) -> [IO, IO]
-                | (Encoding ext_enc, Encoding int_enc,
-                  ?invalid: :replace | nil,
-                  ?undef: :replace | nil,
-                  ?replace: String,
-                  ?newline: :universal | :crlf | :cr,
-                  ?universal_newline: bool,
-                  ?crlf_newline: bool,
-                  ?cr_newline: bool,
-                  ?xml: :text | :attr
-                ) -> [IO, IO]
-               | [T] () { (IO read_io, IO write_io) -> T } -> T
-               | [T] (Encoding ext_enc) { (IO read_io, IO write_io) -> T } -> T
-               | [T] (String ext_int_enc,
-                       ?invalid: :replace | nil,
-                       ?undef: :replace | nil,
-                       ?replace: String,
-                       ?newline: :universal | :crlf | :cr,
-                       ?universal_newline: bool,
-                       ?crlf_newline: bool,
-                       ?cr_newline: bool,
-                       ?xml: :text | :attr
-                     ) { (IO read_io, IO write_io) -> T } -> T
-                | [T] (Encoding ext_enc, Encoding int_enc,
-                        ?invalid: :replace | nil,
-                        ?undef: :replace | nil,
-                        ?replace: String,
-                        ?newline: :universal | :crlf | :cr,
-                        ?universal_newline: bool,
-                        ?crlf_newline: bool,
-                        ?cr_newline: bool,
-                        ?xml: :text | :attr
-                      ) { (IO read_io, IO write_io) -> T } -> T
+  def self.pipe: (?Encoding ext_enc) -> [IO, IO]
+               | [A] (?Encoding ext_enc) { (IO, IO) -> A } -> A
+               | (Encoding ext_enc, Encoding int_enc, **untyped) -> [IO, IO]
+               | [A] (Encoding ext_enc, Encoding int_enc, **untyped) { (IO, IO) -> A } -> A
+               | (String ext_int_enc, **untyped) -> [IO, IO]
+               | [A] (String ext_int_enc, **untyped) { (IO, IO) -> A } -> A
 
   # <!--
   #   rdoc-file=io.c

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2302,6 +2302,99 @@ class IO < Object
 
   # <!--
   #   rdoc-file=io.c
+  #   - pipe → [read_io, write_io] click to toggle source
+  #   - pipe(ext_enc) → [read_io, write_io]
+  #   - pipe("ext_enc:int_enc" [, opt]) → [read_io, write_io]
+  #   - pipe(ext_enc, int_enc [, opt]) → [read_io, write_io]
+  #   - pipe(...) {|read_io, write_io| ... }
+  # -->
+  # Creates a pair of pipe endpoints (connected to each other) and returns them as a
+  # two-element array of IO objects: [ *read_io*, *write_io* ].
+  #
+  # If a block is given, the block is called and returns the value of the
+  # block. *read_io* and *write_io* are sent to the block as arguments.
+  # If *read_io* and *write_io* are not closed when the block exits,
+  # they are closed. i.e. closing *read_io* and/or *write_io* doesn't cause an error.
+  #
+  # Not available on all platforms.
+  #
+  # If an encoding (encoding name or encoding object) is specified as
+  # an optional argument, read string from pipe is tagged with the
+  # encoding specified. If the argument is a colon separated two encoding
+  # names “A:B”, the read string is converted from encoding A (external encoding) to encoding B (internal encoding), then tagged with B. If two optional arguments are specified, those must be encoding objects or encoding names, and the first one is the external encoding, and the second one is the internal encoding. If the external encoding and the internal encoding is specified, optional hash argument specify the conversion option.
+  #
+  # In the example below, the two processes close the ends of the pipe
+  # that they are not using. This is not just a cosmetic nicety. The
+  # read end of a pipe will not generate an end of file condition if
+  # there are any writers with the pipe still open. In the case of the
+  # parent process, the ```rd.`ead``` will never return if it does not first
+  # issue a ```wr`close```.
+  #
+  #     rd, wr = IO.pipe
+  #
+  #     if fork
+  #       wr.close
+  #       puts "Parent got: <#{rd.read}>"
+  #       rd.close
+  #       Process.wait
+  #     else
+  #       rd.close
+  #       puts "Sending message to parent"
+  #       wr.write "Hi Dad"
+  #       wr.close
+  #     end
+  #
+  # *produces:*
+  #
+  #     Sending message to parent
+  #     Parent got: <Hi Dad>
+  def self.pipe: () -> [IO, IO]
+               | (Encoding ext_enc) -> [IO, IO]
+               | (String ext_int_enc,
+                    ?invalid: :replace | nil,
+                    ?undef: :replace | nil,
+                    ?replace: String,
+                    ?newline: :universal | :crlf | :cr,
+                    ?universal_newline: bool,
+                    ?crlf_newline: bool,
+                    ?cr_newline: bool,
+                    ?xml: :text | :attr
+                  ) -> [IO, IO]
+                | (Encoding ext_enc, Encoding int_enc,
+                  ?invalid: :replace | nil,
+                  ?undef: :replace | nil,
+                  ?replace: String,
+                  ?newline: :universal | :crlf | :cr,
+                  ?universal_newline: bool,
+                  ?crlf_newline: bool,
+                  ?cr_newline: bool,
+                  ?xml: :text | :attr
+                ) -> [IO, IO]
+               | [T] () { (IO read_io, IO write_io) -> T } -> T
+               | [T] (Encoding ext_enc) { (IO read_io, IO write_io) -> T } -> T
+               | [T] (String ext_int_enc,
+                       ?invalid: :replace | nil,
+                       ?undef: :replace | nil,
+                       ?replace: String,
+                       ?newline: :universal | :crlf | :cr,
+                       ?universal_newline: bool,
+                       ?crlf_newline: bool,
+                       ?cr_newline: bool,
+                       ?xml: :text | :attr
+                     ) { (IO read_io, IO write_io) -> T } -> T
+                | [T] (Encoding ext_enc, Encoding int_enc,
+                        ?invalid: :replace | nil,
+                        ?undef: :replace | nil,
+                        ?replace: String,
+                        ?newline: :universal | :crlf | :cr,
+                        ?universal_newline: bool,
+                        ?crlf_newline: bool,
+                        ?cr_newline: bool,
+                        ?xml: :text | :attr
+                      ) { (IO read_io, IO write_io) -> T } -> T
+
+  # <!--
+  #   rdoc-file=io.c
   #   - IO.popen([env,] cmd, mode="r" [, opt])               -> io
   #   - IO.popen([env,] cmd, mode="r" [, opt]) {|io| block } -> obj
   # -->

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2302,33 +2302,37 @@ class IO < Object
 
   # <!--
   #   rdoc-file=io.c
-  #   - pipe → [read_io, write_io] click to toggle source
-  #   - pipe(ext_enc) → [read_io, write_io]
-  #   - pipe("ext_enc:int_enc" [, opt]) → [read_io, write_io]
-  #   - pipe(ext_enc, int_enc [, opt]) → [read_io, write_io]
-  #   - pipe(...) {|read_io, write_io| ... }
+  #   - IO.pipe                             ->  [read_io, write_io]
+  #   - IO.pipe(ext_enc)                    ->  [read_io, write_io]
+  #   - IO.pipe("ext_enc:int_enc" [, opt])  ->  [read_io, write_io]
+  #   - IO.pipe(ext_enc, int_enc [, opt])   ->  [read_io, write_io]
+  #   - IO.pipe(...) {|read_io, write_io| ... }
   # -->
-  # Creates a pair of pipe endpoints (connected to each other) and returns them as a
-  # two-element array of IO objects: [ *read_io*, *write_io* ].
+  # Creates a pair of pipe endpoints (connected to each other) and returns them as
+  # a two-element array of IO objects: `[` *read_io*, *write_io* `]`.
   #
-  # If a block is given, the block is called and returns the value of the
-  # block. *read_io* and *write_io* are sent to the block as arguments.
-  # If *read_io* and *write_io* are not closed when the block exits,
-  # they are closed. i.e. closing *read_io* and/or *write_io* doesn't cause an error.
+  # If a block is given, the block is called and returns the value of the block.
+  # *read_io* and *write_io* are sent to the block as arguments. If read_io and
+  # write_io are not closed when the block exits, they are closed. i.e. closing
+  # read_io and/or write_io doesn't cause an error.
   #
   # Not available on all platforms.
   #
-  # If an encoding (encoding name or encoding object) is specified as
-  # an optional argument, read string from pipe is tagged with the
-  # encoding specified. If the argument is a colon separated two encoding
-  # names “A:B”, the read string is converted from encoding A (external encoding) to encoding B (internal encoding), then tagged with B. If two optional arguments are specified, those must be encoding objects or encoding names, and the first one is the external encoding, and the second one is the internal encoding. If the external encoding and the internal encoding is specified, optional hash argument specify the conversion option.
+  # If an encoding (encoding name or encoding object) is specified as an optional
+  # argument, read string from pipe is tagged with the encoding specified. If the
+  # argument is a colon separated two encoding names "A:B", the read string is
+  # converted from encoding A (external encoding) to encoding B (internal
+  # encoding), then tagged with B. If two optional arguments are specified, those
+  # must be encoding objects or encoding names, and the first one is the external
+  # encoding, and the second one is the internal encoding. If the external
+  # encoding and the internal encoding is specified, optional hash argument
+  # specify the conversion option.
   #
-  # In the example below, the two processes close the ends of the pipe
-  # that they are not using. This is not just a cosmetic nicety. The
-  # read end of a pipe will not generate an end of file condition if
-  # there are any writers with the pipe still open. In the case of the
-  # parent process, the ```rd.`ead``` will never return if it does not first
-  # issue a ```wr`close```.
+  # In the example below, the two processes close the ends of the pipe that they
+  # are not using. This is not just a cosmetic nicety. The read end of a pipe will
+  # not generate an end of file condition if there are any writers with the pipe
+  # still open. In the case of the parent process, the `rd.read` will never return
+  # if it does not first issue a `wr.close`.
   #
   #     rd, wr = IO.pipe
   #
@@ -2348,6 +2352,7 @@ class IO < Object
   #
   #     Sending message to parent
   #     Parent got: <Hi Dad>
+  #
   def self.pipe: (?Encoding ext_enc) -> [IO, IO]
                | [A] (?Encoding ext_enc) { (IO, IO) -> A } -> A
                | (Encoding ext_enc, Encoding int_enc, **untyped) -> [IO, IO]

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -978,6 +978,8 @@ class Object < BasicObject
   #
   def respond_to?: (name name, ?boolish include_all) -> bool
 
+  def respond_to_missing?: (name name, ?boolish include_all) -> bool
+
   # <!--
   #   rdoc-file=vm_eval.c
   #   - foo.send(symbol [, args...])       -> obj

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -978,6 +978,20 @@ class Object < BasicObject
   #
   def respond_to?: (name name, ?boolish include_all) -> bool
 
+  # <!--
+  #   rdoc-file=vm_method.c
+  #   - obj.respond_to_missing?(symbol, include_all) -> true or false
+  #   - obj.respond_to_missing?(string, include_all) -> true or false
+  # -->
+  # DO NOT USE THIS DIRECTLY.
+  #
+  # Hook method to return whether the *obj* can respond to *id* method or not.
+  #
+  # When the method name parameter is given as a string, the string is converted
+  # to a symbol.
+  #
+  # See #respond_to?, and the example of BasicObject.
+  #
   def respond_to_missing?: (name name, ?boolish include_all) -> bool
 
   # <!--


### PR DESCRIPTION
This was missing from the IO module.

Couldn't find a less verbose way to set the conversion options. Suggestions welcome.