### PR TITLE
Add frozen_string_literal: true

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,8 @@ Lint/DuplicateMethods:
   Enabled: true
   Include:
     - 'test/**/*_test.rb'
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Include:
+    - 'lib/**/*.rb'

--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rbs/version"
 
 require "set"

--- a/lib/rbs/ancestor_graph.rb
+++ b/lib/rbs/ancestor_graph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class AncestorGraph
     InstanceNode = _ = Struct.new(:type_name, keyword_init: true)

--- a/lib/rbs/annotate.rb
+++ b/lib/rbs/annotate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rdoc"
 
 require "rbs/annotate/rdoc_annotator"

--- a/lib/rbs/annotate/annotations.rb
+++ b/lib/rbs/annotate/annotations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Annotate
     class Annotations

--- a/lib/rbs/annotate/formatter.rb
+++ b/lib/rbs/annotate/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Annotate
     class Formatter

--- a/lib/rbs/annotate/formatter.rb
+++ b/lib/rbs/annotate/formatter.rb
@@ -6,7 +6,7 @@ module RBS
       attr_reader :buffer
 
       def initialize()
-        @buffer = ""
+        @buffer = +""
         @pending_separator = nil
       end
 
@@ -16,7 +16,7 @@ module RBS
             s = self.class.translate(s) or raise
           end
 
-          s.rstrip!
+          s = s.rstrip
 
           unless s.empty?
             if ss = @pending_separator

--- a/lib/rbs/annotate/rdoc_annotator.rb
+++ b/lib/rbs/annotate/rdoc_annotator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Annotate
     class RDocAnnotator

--- a/lib/rbs/annotate/rdoc_source.rb
+++ b/lib/rbs/annotate/rdoc_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Annotate
     class RDocSource

--- a/lib/rbs/ast/annotation.rb
+++ b/lib/rbs/ast/annotation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module AST
     class Annotation

--- a/lib/rbs/ast/comment.rb
+++ b/lib/rbs/ast/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module AST
     class Comment

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module AST
     module Declarations

--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module AST
     module Members

--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -108,7 +108,7 @@ module RBS
       end
 
       def to_s
-        s = ""
+        s = +""
 
         if unchecked?
           s << "unchecked "

--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module AST
     class TypeParam

--- a/lib/rbs/buffer.rb
+++ b/lib/rbs/buffer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Buffer
     attr_reader :name

--- a/lib/rbs/builtin_names.rb
+++ b/lib/rbs/builtin_names.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module BuiltinNames
     class Name

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "open3"
 require "optparse"
 require "shellwords"

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'bundler'
 

--- a/lib/rbs/collection/cleaner.rb
+++ b/lib/rbs/collection/cleaner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
     class Cleaner

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
 

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
 

--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
     class Installer

--- a/lib/rbs/collection/sources.rb
+++ b/lib/rbs/collection/sources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './sources/base'
 require_relative './sources/git'
 require_relative './sources/stdlib'

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
     module Sources

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/sha2'
 require 'open3'
 require 'find'

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 module RBS

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 module RBS

--- a/lib/rbs/constant.rb
+++ b/lib/rbs/constant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Constant
     attr_reader :name

--- a/lib/rbs/constant_table.rb
+++ b/lib/rbs/constant_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class ConstantTable
     attr_reader :definition_builder

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Definition
     class Variable

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class DefinitionBuilder
     attr_reader :env

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class DefinitionBuilder
     class AncestorBuilder

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class DefinitionBuilder
     class MethodBuilder

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Environment
     attr_reader :declarations

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class EnvironmentLoader
     class UnknownLibraryError < StandardError

--- a/lib/rbs/environment_walker.rb
+++ b/lib/rbs/environment_walker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class EnvironmentWalker
     InstanceNode = _ = Struct.new(:type_name, keyword_init: true)

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module MethodNameHelper
     def method_name_string()

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -218,7 +218,7 @@ module RBS
       @method_name = method_name
       @members = members
 
-      message = "#{Location.to_string location}: #{qualified_method_name} has duplicated definitions"
+      message = +"#{Location.to_string location}: #{qualified_method_name} has duplicated definitions"
       if members.size > 1
         message << " in #{other_locations.map { |loc| Location.to_string loc }.join(', ')}"
       end

--- a/lib/rbs/factory.rb
+++ b/lib/rbs/factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Factory
     def type_name(string)

--- a/lib/rbs/location_aux.rb
+++ b/lib/rbs/location_aux.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Location
     def inspect

--- a/lib/rbs/locator.rb
+++ b/lib/rbs/locator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Locator
     attr_reader :decls

--- a/lib/rbs/method_type.rb
+++ b/lib/rbs/method_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class MethodType
     attr_reader :type_params

--- a/lib/rbs/namespace.rb
+++ b/lib/rbs/namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Namespace
     attr_reader :path

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Parser
     def self.parse_type(source, line: 1, column: 0, variables: [])

--- a/lib/rbs/parser_compat/lexer_error.rb
+++ b/lib/rbs/parser_compat/lexer_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RBS.print_warning {
   "RBS::Parser::LexerError is deprecated and will be deleted in RBS 2.0."
 }

--- a/lib/rbs/parser_compat/located_value.rb
+++ b/lib/rbs/parser_compat/located_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RBS.print_warning {
   "RBS::Parser::LocatedValue is deprecated and will be deleted in RBS 2.0."
 }

--- a/lib/rbs/parser_compat/semantics_error.rb
+++ b/lib/rbs/parser_compat/semantics_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RBS.print_warning {
   "RBS::Parser::SemanticsError is deprecated and will be deleted in RBS 2.0."
 }

--- a/lib/rbs/parser_compat/syntax_error.rb
+++ b/lib/rbs/parser_compat/syntax_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RBS.print_warning {
   "RBS::Parser::SyntaxError is deprecated and will be deleted in RBS 2.0."
 }

--- a/lib/rbs/prototype/helpers.rb
+++ b/lib/rbs/prototype/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Prototype
     module Helpers

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Prototype
     class RB

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Prototype
     class RBI

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Prototype
     class Runtime

--- a/lib/rbs/repository.rb
+++ b/lib/rbs/repository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Repository
     DEFAULT_STDLIB_ROOT = Pathname(_ = __dir__) + "../../stdlib"

--- a/lib/rbs/resolver/constant_resolver.rb
+++ b/lib/rbs/resolver/constant_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Resolver
     class ConstantResolver

--- a/lib/rbs/resolver/type_name_resolver.rb
+++ b/lib/rbs/resolver/type_name_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Resolver
     class TypeNameResolver

--- a/lib/rbs/sorter.rb
+++ b/lib/rbs/sorter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Sorter
     include RBS::AST

--- a/lib/rbs/substitution.rb
+++ b/lib/rbs/substitution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Substitution
     attr_reader :mapping

--- a/lib/rbs/test.rb
+++ b/lib/rbs/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "securerandom"
 require "rbs/test/observer"
 require "rbs/test/spy"

--- a/lib/rbs/test/errors.rb
+++ b/lib/rbs/test/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
     module Errors

--- a/lib/rbs/test/hook.rb
+++ b/lib/rbs/test/hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rbs"
 require "pp"
 

--- a/lib/rbs/test/observer.rb
+++ b/lib/rbs/test/observer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
     module Observer

--- a/lib/rbs/test/setup.rb
+++ b/lib/rbs/test/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rbs"
 require "rbs/test"
 require "optparse"

--- a/lib/rbs/test/setup_helper.rb
+++ b/lib/rbs/test/setup_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
     module SetupHelper

--- a/lib/rbs/test/spy.rb
+++ b/lib/rbs/test/spy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
   end

--- a/lib/rbs/test/tester.rb
+++ b/lib/rbs/test/tester.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
     class Tester

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Test
     class TypeCheck

--- a/lib/rbs/type_alias_dependency.rb
+++ b/lib/rbs/type_alias_dependency.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class TypeAliasDependency
     attr_reader :env

--- a/lib/rbs/type_alias_regularity.rb
+++ b/lib/rbs/type_alias_regularity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class TypeAliasRegularity
     class Diagnostic

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class TypeName
     attr_reader :namespace

--- a/lib/rbs/type_name_resolver.rb
+++ b/lib/rbs/type_name_resolver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class TypeNameResolver
     Query = _ = Struct.new(:type_name, :context, keyword_init: true)

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Types
     module NoFreeVariables

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Validator
     attr_reader :env

--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class VarianceCalculator
     class Result

--- a/lib/rbs/vendorer.rb
+++ b/lib/rbs/vendorer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Vendorer
     attr_reader :vendor_dir

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   VERSION = "2.6.0"
 end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -282,7 +282,7 @@ module RBS
                "self.#{method_name(member.name)}"
              end
 
-      string = ""
+      string = +""
 
       prefix = "#{visibility}def #{name}:"
       padding = " " * (prefix.size-1)

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   class Writer
     attr_reader :out

--- a/lib/rdoc/discover.rb
+++ b/lib/rdoc/discover.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 begin
   gem 'rdoc', '~> 6.4.0'
   require 'rdoc_plugin/parser'

--- a/test/assets/test-gem/amber.gemspec
+++ b/test/assets/test-gem/amber.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 


### PR DESCRIPTION
RBS allocates many objects. It makes `steep check` slow.

So this PR reduces String allocations with `frozen_string_literal: true` magic comment.

# Benchmarking

I benchmarked `bin/steep -j1`.

```
before: 
[13.82, 13.87, 13.73].sum / 3 # => 13.806666666666667

after:
[13.43, 13.27, 13.21].sum / 3 # => 13.303333333333333

(1 - 13.303333333333333 / 13.806666666666667) * 100 # => 3.645581844519563
```

3.6% faster :rocket:


I've confirmed the effect with memory_profiler gem. It reduces 163918 strings (from 3711262 to 3547344).