### PR TITLE
Use `append_cflags` for other than GCC

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
 $INCFLAGS << " -I$(top_srcdir)" if $extmk
-$CFLAGS += " -std=c99 "
+append_cflags ['-std=c99']
 create_makefile 'rbs_extension'


### PR DESCRIPTION
[For instance](https://github.com/ruby/rbs/runs/8151283320?check_suite_focus=true#step:5:66):

> ```
> compiling ../../../../ext/rbs_extension/constants.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> constants.c
> compiling ../../../../ext/rbs_extension/lexer.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> lexer.c
> compiling ../../../../ext/rbs_extension/lexstate.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> lexstate.c
> compiling ../../../../ext/rbs_extension/location.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> location.c
> compiling ../../../../ext/rbs_extension/main.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> main.c
> compiling ../../../../ext/rbs_extension/parser.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> parser.c
> compiling ../../../../ext/rbs_extension/parserstate.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> parserstate.c
> compiling ../../../../ext/rbs_extension/ruby_objs.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> ruby_objs.c
> compiling ../../../../ext/rbs_extension/unescape.c
> cl : Command line warning D9002 : ignoring unknown option '-std=c99'
> unescape.c
> ```
