### PR TITLE
Fix `RDoc::Markup` type

### DIFF
--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -51,7 +51,7 @@ module RDoc
     def attributes: () -> Array[Attr]
   end
 
-  module Markup
+  class Markup
     class Document
       include Enumerable[Document]
 


### PR DESCRIPTION
`RDoc::Markup` is a class and not a module:
```ruby
> require "rdoc"
=> true
> RDoc::Markup.class
=> Class
```