### PR TITLE
[DOC] Tweak the doc for `Process.kill` signature

### DIFF
--- a/core/process.rbs
+++ b/core/process.rbs
@@ -485,7 +485,7 @@ module Process
 
   # <!--
   #   rdoc-file=process.c
-  #   - Process.kill(signal, pid, ...)    -> integer
+  #   - Process.kill(signal, pid, *pids)    -> integer
   # -->
   # Sends the given signal to the specified process id(s) if *pid* is positive. If
   # *pid* is zero, *signal* is sent to all processes whose group ID is equal to


### PR DESCRIPTION
Follow https://github.com/ruby/ruby/pull/5928

This also matches the name used in the RBS signature.

```
def self.kill: (Integer | Symbol | String signal, *Integer pids) -> Integer
```