### PR TITLE
Add method overload of OptionParser#on

### DIFF
--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -677,8 +677,10 @@ class OptionParser
   #
   def on: (*String params) ?{ (*untyped) -> untyped } -> self
         | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+        | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
         | (*String params, Proc | Method handler) -> self
         | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
+        | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
 
   # <!--
   #   rdoc-file=lib/optparse.rb
@@ -696,8 +698,10 @@ class OptionParser
   #
   def on_head: (*String params) ?{ (*untyped) -> untyped } -> self
              | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+             | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
              | (*String params, Proc | Method handler) -> self
              | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
+             | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
 
   # <!--
   #   rdoc-file=lib/optparse.rb
@@ -715,8 +719,10 @@ class OptionParser
   #
   def on_tail: (*String params) ?{ (*untyped) -> untyped } -> self
              | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
+             | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc) ?{ (*untyped) -> untyped } -> self
              | (*String params, Proc | Method handler) -> self
              | (String params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
+             | (String short_params, String long_params, Class | Array[String] | Hash[Symbol, untyped] | Regexp obj, ?String desc, Proc | Method handler) -> self
 
   # <!--
   #   rdoc-file=lib/optparse.rb

--- a/test/stdlib/OptionParser_test.rb
+++ b/test/stdlib/OptionParser_test.rb
@@ -120,9 +120,13 @@ class OptionParserTest < Test::Unit::TestCase
     assert_send_type "(*String) -> self", opt, :on, '-a'
     assert_send_type "(String, Class) -> self", opt, :on, '-a', Array
     assert_send_type "(String, Class, String) -> self", opt, :on, '-a', Array, 'description'
+    assert_send_type "(String, String, Class, String) -> self", opt, :on, '-a', '--all', Array, 'description'
     assert_send_type "(String, Array[String]) -> self", opt, :on, '-a', ['foo', 'bar']
+    assert_send_type "(String, String, Array[String]) -> self", opt, :on, '-a', '--all', ['foo', 'bar']
     assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, String, Hash[Symbol, untyped]) -> self", opt, :on, '-a', '--all', {foo: 1, bar: 2}
     assert_send_type "(String, Regexp) -> self", opt, :on, '-a', /foo/
+    assert_send_type "(String, String, Regexp) -> self", opt, :on, '-a', '--all', /foo/
     assert_send_type "(*String, Proc) -> self", opt, :on, '-a', proc {}
   end
 
@@ -130,9 +134,13 @@ class OptionParserTest < Test::Unit::TestCase
     assert_send_type "(*String) -> self", opt, :on_head, '-a'
     assert_send_type "(String, Class) -> self", opt, :on_head, '-a', Array
     assert_send_type "(String, Class, String) -> self", opt, :on_head, '-a', Array, 'description'
+    assert_send_type "(String, String, Class, String) -> self", opt, :on_head, '-a', '--all', Array, 'description'
     assert_send_type "(String, Array[String]) -> self", opt, :on_head, '-a', ['foo', 'bar']
+    assert_send_type "(String, String, Array[String]) -> self", opt, :on_head, '-a', '--all', ['foo', 'bar']
     assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on_head, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, String, Hash[Symbol, untyped]) -> self", opt, :on_head, '-a', '--all', {foo: 1, bar: 2}
     assert_send_type "(String, Regexp) -> self", opt, :on_head, '-a', /foo/
+    assert_send_type "(String, String, Regexp) -> self", opt, :on_head, '-a', '--all', /foo/
     assert_send_type "(*String, Proc) -> self", opt, :on_head, '-a', proc {}
   end
 
@@ -140,9 +148,13 @@ class OptionParserTest < Test::Unit::TestCase
     assert_send_type "(*String) -> self", opt, :on_tail, '-a'
     assert_send_type "(String, Class) -> self", opt, :on_tail, '-a', Array
     assert_send_type "(String, Class, String) -> self", opt, :on_tail, '-a', Array, 'description'
+    assert_send_type "(String, String, Class, String) -> self", opt, :on_tail, '-a', '--all', Array, 'description'
     assert_send_type "(String, Array[String]) -> self", opt, :on_tail, '-a', ['foo', 'bar']
+    assert_send_type "(String, String, Array[String]) -> self", opt, :on_tail, '-a', '--all', ['foo', 'bar']
     assert_send_type "(String, Hash[Symbol, untyped]) -> self", opt, :on_tail, '-a', {foo: 1, bar: 2}
+    assert_send_type "(String, String, Hash[Symbol, untyped]) -> self", opt, :on_tail, '-a', '--all', {foo: 1, bar: 2}
     assert_send_type "(String, Regexp) -> self", opt, :on_tail, '-a', /foo/
+    assert_send_type "(String, String, Regexp) -> self", opt, :on_tail, '-a', '--all', /foo/
     assert_send_type "(*String, Proc) -> self", opt, :on_tail, '-a', proc {}
   end
 


### PR DESCRIPTION
Add overload signature of `OptionParser#run`.

support following patterns:

- `on(short, long, pat = /.*/, desc = "") {|v| ...} -> self`
- `on(short, long, klass = String, desc = "") {|v| ...} -> self`
- `on(short, long, *rest) {|v| ...} -> self`