### PR TITLE
Add documentation for `...` in syntax.md

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -349,6 +349,14 @@ def +: (Float) -> Float
      | (Numeric) -> Numeric
 ```
 
+Overloaded method can have `...` to overload an existing method. It is useful for monkey-patching.
+
+```
+def +: (Float) -> Float
+def +: (BigDecimal) -> BigDecimal
+     | ...
+```
+
 You need extra parentheses on return type to avoid ambiguity.
 
 ```


### PR DESCRIPTION
Currently `syntax.md` doesn't have any documentation for `...` syntax. This PR adds the documentation.

I think all syntax is described in this file, so this documentation is necessary.

By the way, this syntax is described in https://github.com/ruby/rbs/blob/d12cebcf68782b2c183bda745efd211633fe9dad/docs/sigs.md#duplicatedmethoddefinitionerror
But the subject of this doc is `DuplicatedMethodDefinitionError`, so I think this patch is necessary too aside from the error documentation.