### PR TITLE
Add a doc that describes tools related to RBS

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,15 @@
+# Integrations
+
+This documentation describes major tools related to RBS.
+
+## Type Checkers
+
+* [Steep](https://github.com/soutaro/steep)
+* [TypeProf](https://github.com/ruby/typeprof)
+
+## Editor integrations
+
+* Emacs: [rbs-mode](https://github.com/ybiquitous/rbs-mode)
+* RubyMine: [It supports RBS by default](https://www.jetbrains.com/help/ruby/rbs.html)
+* Vim: [rbs.vim](https://github.com/pocke/rbs.vim)
+* Visual Studio Code: [vscode-rbs-syntax](https://github.com/soutaro/vscode-rbs-syntax)


### PR DESCRIPTION
This PR adds documentation to describe tools related to RBS.

Currently, there is no document for the tools in this repository. I think the document is necessary.
Actually, RBS is not a very major library. Editors do not support RBS by default, so RBS users must install a plugin to write RBS comfortably. This document is useful in this situation. 

By the way, I recently held an RBS workshop with colleagues. I wanted the documentation, but it didn't exist.


------

I just added major tools, so I probably forgot some tools. Feel free to add links if someone remembers them.


(These links are in alphabetical order to avoid Editor War 😆)