### PR TITLE
Relax need for block

### DIFF
--- a/lib/rbs/prototype/helpers.rb
+++ b/lib/rbs/prototype/helpers.rb
@@ -23,7 +23,7 @@ module RBS
         if body_node
           if (yields = any_node?(body_node) {|n| n.type == :YIELD })
             method_block = Types::Block.new(
-              required: true,
+              required: false,
               type: Types::Function.empty(untyped),
               self_type: nil
             )

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -64,7 +64,7 @@ end
 class Hello
   def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped, ?f: ::Integer, **untyped g) ?{ () -> untyped } -> nil
 
-  def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
+  def self.world: () ?{ (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 
   def kw_req: (a: untyped) -> nil
 end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -404,11 +404,11 @@ end
                 class TestForYield
                   public
 
-                  def m1: () { () -> untyped } -> untyped
+                  def m1: () ?{ () -> untyped } -> untyped
 
-                  def m2: () { (untyped) -> untyped } -> untyped
+                  def m2: () ?{ (untyped) -> untyped } -> untyped
 
-                  def m3: () { (untyped, untyped) -> untyped } -> untyped
+                  def m3: () ?{ (untyped, untyped) -> untyped } -> untyped
 
                   def m4: () -> untyped
                 end


### PR DESCRIPTION
Deciding that block is essential is difficult and often wrong.

This method of following type signature,

```rb
def foo
  yield if block_given?
end
```

I expected to following.

```
def foo: () ?{ () -> untyped } -> untyped 
```

However, it is actually required because of the existence of yield.

```
def foo: () { () -> untyped } -> untyped 
```