### PR TITLE
Add missing constants for IPAddr

### DIFF
--- a/stdlib/ipaddr/0/ipaddr.rbs
+++ b/stdlib/ipaddr/0/ipaddr.rbs
@@ -406,3 +406,18 @@ IPAddr::IN6FORMAT: String
 # 128 bit mask for IPv6
 #
 IPAddr::IN6MASK: Integer
+
+# <!-- rdoc-file=lib/ipaddr.rb -->
+# Regexp *internally* used for parsing IPv4 address.
+#
+IPAddr::RE_IPV4ADDRLIKE: Regexp
+
+# <!-- rdoc-file=lib/ipaddr.rb -->
+# Regexp *internally* used for parsing IPv6 address.
+#
+IPAddr::RE_IPV6ADDRLIKE_COMPRESSED: Regexp
+
+# <!-- rdoc-file=lib/ipaddr.rb -->
+# Regexp *internally* used for parsing IPv6 address.
+#
+IPAddr::RE_IPV6ADDRLIKE_FULL: Regexp


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/131c31a9209c61f84d318aa18b61f468f48b8219/lib/ipaddr.rb#L53-L85