### PR TITLE
Add missing constant for IO

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2984,6 +2984,12 @@ IO::TRUNC: Integer
 
 IO::WRONLY: Integer
 
+IO::READABLE: Integer
+
+IO::WRITABLE: Integer
+
+IO::PRIORITY: Integer
+
 # <!-- rdoc-file=io.c -->
 # exception to wait for reading by EAGAIN. see IO.select.
 #


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/131c31a9209c61f84d318aa18b61f468f48b8219/io.c#L14873-L14875