### PR TITLE
Add missing error class of IO::Buffer

### DIFF
--- a/core/io/buffer.rbs
+++ b/core/io/buffer.rbs
@@ -706,5 +706,20 @@ class IO
     PRIVATE: Integer
 
     READONLY: Integer
+
+    class LockedError < RuntimeError
+    end
+
+    class AllocationError < RuntimeError
+    end
+
+    class AccessError < RuntimeError
+    end
+
+    class InvalidatedError < RuntimeError
+    end
+
+    class MaskError < ArgumentError
+    end
   end
 end


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/5129ca3e056e1ce3189ba39fa311d4d687b97b45/io_buffer.c#L3167-L3171