### PR TITLE
Add `load_implicitly` attribute in `manifest.yaml`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,11 @@ gem "prime"
 gem "rdoc"
 
 # Test gems
-gem "rbs-amber", path: "test/assets/test-gem"
+path "test/assets/test-gem" do
+  gem "rbs-amber"
+  gem "rbs-load_implicit_false"
+  gem "rbs-depends_on_load_implicit_false"
+end
 
 group :ide, optional: true do
   gem "ruby-debug-ide"

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -8,6 +8,7 @@ require_relative './collection/config'
 require_relative './collection/config/lockfile_generator'
 require_relative './collection/installer'
 require_relative './collection/cleaner'
+require_relative './collection/manifest'
 
 module RBS
   module Collection

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -67,7 +67,7 @@ module RBS
           upsert_gem specified, locked
           source = Sources.from_config_entry(locked['source'] || raise)
           source.dependencies_of(locked)&.each do |dep|
-            @gem_queue.push({ name: dep['name'], version: nil} )
+            @gem_queue.push({ name: dep.name, version: nil} )
           end
         end
 

--- a/lib/rbs/collection/manifest.rb
+++ b/lib/rbs/collection/manifest.rb
@@ -1,0 +1,55 @@
+module RBS
+  module Collection
+    class Manifest
+      class Dependency
+        attr_reader :name
+
+        def initialize(name:)
+          @name = name
+        end
+
+        def ==(other)
+          other.is_a?(Dependency) && other.name == name
+        end
+
+        alias eql? ==
+
+        def hash
+          name.hash
+        end
+      end
+
+      attr_reader :dependencies
+
+      def path
+        @path or raise "`#path` is `nil` (reading `#path` of *default* manifest?)"
+      end
+
+      def self.from(path, hash)
+        dependencies = hash["dependencies"].map {|dep| Dependency.new(name: dep["name"]) }
+        new(path, dependencies: dependencies)
+      end
+
+      def initialize(path, dependencies:)
+        @path = path
+        @dependencies = dependencies
+      end
+
+      def ==(other)
+        other.is_a?(Manifest) && other.dependencies == dependencies
+      end
+
+      alias eql? ==
+
+      def hash
+        dependencies.hash
+      end
+
+      def self.default
+        @default
+      end
+
+      @default = new(_ = nil, dependencies: [])
+    end
+  end
+end

--- a/lib/rbs/collection/manifest.rb
+++ b/lib/rbs/collection/manifest.rb
@@ -19,20 +19,30 @@ module RBS
         end
       end
 
-      attr_reader :dependencies
+      attr_reader :dependencies, :load_implicitly
 
       def path
         @path or raise "`#path` is `nil` (reading `#path` of *default* manifest?)"
       end
 
-      def self.from(path, hash)
-        dependencies = hash["dependencies"].map {|dep| Dependency.new(name: dep["name"]) }
-        new(path, dependencies: dependencies)
+      def load_implicitly?
+        case load_implicitly
+        when nil
+          true
+        else
+          load_implicitly
+        end
       end
 
-      def initialize(path, dependencies:)
+      def self.from(path, hash)
+        dependencies = hash["dependencies"].map {|dep| Dependency.new(name: dep["name"]) }
+        new(path, dependencies: dependencies, load_implicitly: hash["load_implicitly"])
+      end
+
+      def initialize(path, dependencies:, load_implicitly:)
         @path = path
         @dependencies = dependencies
+        @load_implicitly = load_implicitly
       end
 
       def ==(other)
@@ -49,7 +59,7 @@ module RBS
         @default
       end
 
-      @default = new(_ = nil, dependencies: [])
+      @default = new(_ = nil, dependencies: [], load_implicitly: true)
     end
   end
 end

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -6,7 +6,7 @@ module RBS
       module Base
         def dependencies_of(config_entry)
           manifest = manifest_of(config_entry) or return
-          manifest['dependencies']
+          manifest.dependencies
         end
       end
     end

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -59,7 +59,9 @@ module RBS
           gem_dir = gem_repo_dir.join(gem_name, version)
 
           manifest_path = gem_dir.join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         private def _install(dest:, config_entry:)

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -39,7 +39,7 @@ module RBS
           gem_dir = dest.join(gem_name, version)
 
           if gem_dir.directory?
-            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME))) == config_entry
+            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME).to_s)) == config_entry
               stdout.puts "Using #{format_config_entry(config_entry)}"
             else
               # @type var prev: RBS::Collection::Config::gem_entry

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -32,7 +32,9 @@ module RBS
           _, sig_path = gem_sig_path(config_entry)
           sig_path or raise
           manifest_path = sig_path.join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         def to_lockfile

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -31,7 +31,9 @@ module RBS
         def manifest_of(config_entry)
           config_entry['version'] or raise
           manifest_path = (lookup(config_entry) or raise).join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         def to_lockfile

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -66,7 +66,7 @@ module RBS
 
         gem['version'] ||= source.versions(gem).last
         source.dependencies_of(gem)&.each do |dep|
-          add(library: dep['name'], version: nil)
+          add(library: dep.name, version: nil)
         end
         return
       end

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -12,9 +12,11 @@ module RBS
         attr_reader lock_path: Pathname
         attr_reader gemfile_lock: Bundler::LockfileParser
 
-        type gem_queue_entry = { name: String, version: String? }
+        type gem_queue_entry = { name: String, version: String?, implicit: bool }
 
         @gem_queue: Array[gem_queue_entry]
+
+        @gemfile_lock_gems: Hash[String, Bundler::LazySpecification]
 
         def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
 
@@ -24,11 +26,11 @@ module RBS
 
         private
 
-        def assign_gem: (name: String, version: String?) -> void
+        def assign_gem: (name: String, version: String?, implicit: bool) -> void
 
         def upsert_gem: (gem_entry? old, gem_entry new) -> void
 
-        def gemfile_lock_gems: () { (untyped) -> void } -> void
+        def gemfile_lock_gems: () { (Bundler::LazySpecification) -> void } -> void
 
         def remove_ignored_gems!: () -> void
 

--- a/sig/collection/manifest.rbs
+++ b/sig/collection/manifest.rbs
@@ -1,0 +1,50 @@
+module RBS
+  module Collection
+    # Manifest class defines the properties of a RBS library that is loaded from `manifest.yaml` file
+    #
+    class Manifest
+      # The type of YAML content
+      type manifest = { "dependencies" => Array[dependency] }
+
+      type dependency = { "name" => String }
+
+      class Dependency
+        attr_reader name: String
+
+        def initialize: (name: String) -> void
+
+        def ==: (untyped other) -> bool
+
+        alias eql? ==
+
+        def hash: () -> Integer
+      end
+
+      attr_reader path: Pathname
+
+      # Required key `"dependencies"` that is an array of depedent library names
+      #
+      # ```yaml
+      # dependencies:
+      #   - name: pathname
+      #   - name: set
+      # ```
+      #
+      attr_reader dependencies: Array[Dependency]
+
+      # *Default* manifest that is used for a library without `manifest.yaml`
+      #
+      attr_reader self.default: Manifest
+
+      def self.from: (Pathname path, manifest hash) -> Manifest
+
+      def initialize: (Pathname path, dependencies: Array[Dependency]) -> void
+
+      def ==: (untyped other) -> bool
+
+      alias eql? ==
+
+      def hash: () -> Integer
+    end
+  end
+end

--- a/sig/collection/manifest.rbs
+++ b/sig/collection/manifest.rbs
@@ -4,7 +4,7 @@ module RBS
     #
     class Manifest
       # The type of YAML content
-      type manifest = { "dependencies" => Array[dependency] }
+      type manifest = { "dependencies" => Array[dependency], "load_implicitly" => bool? }
 
       type dependency = { "name" => String }
 
@@ -32,13 +32,40 @@ module RBS
       #
       attr_reader dependencies: Array[Dependency]
 
+      # Optional key `"load_implicitly"` that is true or false (defaults to `true`)
+      #
+      # ```yaml
+      # load_implicitly: false
+      # ```
+      #
+      # Disables *implicit* load when this is `false`.
+      # Returns `nil` if `"load_implicitly`" is not included in the YAML.
+      #
+      # There are four ways to load RBS of a library:
+      #
+      # 1. Tool specific loading mechanics
+      # 2. Specify the library in `rbs_collection.yaml`
+      # 3. When dependent library is loaded
+      # 4. A library managed by Bundler is loaded by `rbs collection` ⬅️
+      #
+      # The `load_implicitly` property controls the last case.
+      #
+      # This is typically for `rbs` and `steep` gems.
+      # These gems have RBS files, but the tool users rarely want to load them.
+      #
+      attr_reader load_implicitly: bool?
+
       # *Default* manifest that is used for a library without `manifest.yaml`
       #
       attr_reader self.default: Manifest
 
+      # Returns `true` to load the RBS of the library implicitly, `false` to skip loading it
+      #
+      def load_implicitly?: () -> bool
+
       def self.from: (Pathname path, manifest hash) -> Manifest
 
-      def initialize: (Pathname path, dependencies: Array[Dependency]) -> void
+      def initialize: (Pathname path, dependencies: Array[Dependency], load_implicitly: bool?) -> void
 
       def ==: (untyped other) -> bool
 

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -8,20 +8,16 @@ module RBS
         def versions: (Config::gem_entry) -> Array[String]
         def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
-        def dependencies_of: (Config::gem_entry) -> Array[{"name" => String}]?
+        def manifest_of: (Config::gem_entry) -> Manifest?
+        def dependencies_of: (Config::gem_entry) -> Array[Manifest::Dependency]?
       end
 
       type source_entry = Git::source_entry
                         | Stdlib::source_entry
                         | Rubygems::source_entry
 
-      type manifest_entry = {
-        "dependencies" => Array[{"name" => String}]?,
-      }
-
       module Base : _Source
-        def dependencies_of: (Config::gem_entry config_entry) -> Array[{"name" => String}]?
+        def dependencies_of: (Config::gem_entry config_entry) -> Array[Manifest::Dependency]?
       end
 
       class Git
@@ -54,7 +50,7 @@ module RBS
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 
@@ -109,7 +105,7 @@ module RBS
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 
@@ -131,7 +127,7 @@ module RBS
         def versions: (Config::gem_entry) -> Array[String]
         def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 

--- a/test/assets/README.md
+++ b/test/assets/README.md
@@ -1,0 +1,25 @@
+# test/assets
+
+This directory contains rubygems that is used for test of RBS.
+
+## Test scenario 1
+
+* [rbs-s1-amber](s1-test-gem)
+
+**Test** RBS files in `sig` directory of a gem is loaded.
+
+## Test scenario 2
+
+* [rbs-s2-load_implicit](s2-load_implicit)
+
+**Test** RBS files of a gem is not loaded when:
+
+1. The gem has `sig/manifest.yaml` and `load_implicitly: false`, and
+2. It is implicitly loaded via Bundler context
+
+## Test scenario 3
+
+* [rbs-s3-load_implicit](s3-load_implicit)
+* [rbs-s3-load_transitive](s3-load_transitive)
+
+**Test** RBS files of a gem with `load_implicitly: false` is loaded when it is a dependency of other loaded gems.

--- a/test/assets/depends_on_load_implicit_false/lib/a.rb
+++ b/test/assets/depends_on_load_implicit_false/lib/a.rb
@@ -1,0 +1,4 @@
+module RBS
+  module DependsOnLoadImplicitFalse
+  end
+end

--- a/test/assets/depends_on_load_implicit_false/rbs-depends_on_load_implicit_false.gemspec
+++ b/test/assets/depends_on_load_implicit_false/rbs-depends_on_load_implicit_false.gemspec
@@ -1,0 +1,25 @@
+# coding: utf-8
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "rbs-depends_on_load_implicit_false"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Soutaro Matsumoto"]
+  spec.email         = ["matsumoto@soutaro.com"]
+
+  spec.summary       = %q{Test Gem with dependency to rbs-load_implicit_false}
+  spec.description   = %q{Test Gem with dependency to rbs-load_implicit_false}
+  spec.homepage      = "https://example.com"
+  spec.license       = 'MIT'
+
+  spec.files         = [
+    "lib/a.rb",
+    "sig/a.rbs"
+  ]
+
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "rbs-load_implicit_false", "1.0.0"
+  end

--- a/test/assets/depends_on_load_implicit_false/sig/a.rbs
+++ b/test/assets/depends_on_load_implicit_false/sig/a.rbs
@@ -1,0 +1,4 @@
+module RBS
+  module DependsOnLoadImplicitFalse
+  end
+end

--- a/test/assets/depends_on_load_implicit_false/sig/manifest.yaml
+++ b/test/assets/depends_on_load_implicit_false/sig/manifest.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: load_implicit_false
+
+load_implicitly: true

--- a/test/assets/load_implicit_false/lib/a.rb
+++ b/test/assets/load_implicit_false/lib/a.rb
@@ -1,0 +1,4 @@
+module RBS
+  module LoadImplicitFalse
+  end
+end

--- a/test/assets/load_implicit_false/rbs-load_implicit_false.gemspec
+++ b/test/assets/load_implicit_false/rbs-load_implicit_false.gemspec
@@ -1,0 +1,22 @@
+# coding: utf-8
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |spec|
+  spec.name          = "rbs-load_implicit_false"
+  spec.version       = "1.0.0"
+  spec.authors       = ["Soutaro Matsumoto"]
+  spec.email         = ["matsumoto@soutaro.com"]
+
+  spec.summary       = %q{Test Gem with load_implicitly=false}
+  spec.description   = %q{Test Gem with load_implicitly=false}
+  spec.homepage      = "https://example.com"
+  spec.license       = 'MIT'
+
+  spec.files         = [
+    "lib/a.rb",
+    "sig/a.rbs"
+  ]
+  spec.require_paths = ["lib"]
+end

--- a/test/assets/load_implicit_false/sig/a.rbs
+++ b/test/assets/load_implicit_false/sig/a.rbs
@@ -1,0 +1,4 @@
+module RBS
+  module LoadImplicitFalse
+  end
+end

--- a/test/assets/load_implicit_false/sig/manifest.yaml
+++ b/test/assets/load_implicit_false/sig/manifest.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: load_implicit_false
+
+load_implicitly: false

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -585,6 +585,41 @@ Processing `test/a_test.rb`...
     end
   end
 
+  def test_collection_install_skip_implicit
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        dir.join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources:
+            - name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+
+          path: #{dir.join('gem_rbs_collection')}
+        YAML
+        dir.join('Gemfile').write(<<~GEMFILE)
+source "https://rubygems.org"
+
+path "#{File.join(__dir__, "../assets")}" do
+  gem "rbs-load_implicit_false"
+end
+        GEMFILE
+
+        Bundler.with_unbundled_env do
+          system("bundle install")
+
+          with_cli do |cli|
+            cli.run(%w[collection install])
+            assert dir.join('rbs_collection.lock.yaml').exist?
+
+            puts dir.join("rbs_collection.lock.yaml").read
+          end
+        end
+      end
+    end
+  end
+
   def test_collection_update
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do

--- a/test/rbs/collection/manifest_test.rb
+++ b/test/rbs/collection/manifest_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class RBS::Collection::ManifestTest < Test::Unit::TestCase
+  include RBS::Collection
+
+  def test_from
+    manifest = Manifest.from(
+      Pathname("foo/0/manifest.yaml"),
+      {
+        "dependencies" => [
+          { "name" => "set" },
+          { "name" => "json" }
+        ]
+      }
+    )
+
+    assert_equal Pathname("foo/0/manifest.yaml"), manifest.path
+    assert_equal [Manifest::Dependency.new(name: "set"), Manifest::Dependency.new(name: "json")], manifest.dependencies
+  end
+
+  def test_default
+    assert_equal [], Manifest.default.dependencies
+    assert_raises(RuntimeError) { Manifest.default.path }
+  end
+end

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -24,7 +24,8 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
         dependencies: [
           Manifest::Dependency.new(name: "dbm"),
           Manifest::Dependency.new(name: "pstore"),
-        ]
+        ],
+        load_implicitly: false
       ),
       s.manifest_of({ 'name' => 'yaml', 'version' => '0' })
     )

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
+  Manifest = RBS::Collection::Manifest
+
   def test_has?
     s = source
 
@@ -16,8 +18,16 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
 
   def test_manifest_of__exist
     s = source
-    assert_equal({ 'dependencies' => [{ 'name' => 'dbm'}, { 'name' => 'pstore'}] },
-                 s.manifest_of({ 'name' => 'yaml', 'version' => '0' }))
+    assert_equal(
+      Manifest.new(
+        Pathname("yaml/0/manifest.yaml"),
+        dependencies: [
+          Manifest::Dependency.new(name: "dbm"),
+          Manifest::Dependency.new(name: "pstore"),
+        ]
+      ),
+      s.manifest_of({ 'name' => 'yaml', 'version' => '0' })
+    )
   end
 
   def test_manifest_of__nonexist


### PR DESCRIPTION
This is to stop people writing `{ name: "rbs", ignore: false}` in their `rbs_collection.yaml` files.

RBS currently loads all of the RBS type definitions of all gems available from Bundler context, but some gems including rbs, steep, rbs_protobuf, rbs_rails, ... don't assume all of the users needs their types. This PR is to add `load_implicitly` attribute in `manifest.yaml` and skip loading them if it's false.