### PR TITLE
Skip loading bundled gems that have `require: false`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'tempfile'
 gem "prime"
 gem "rdoc"
 
+gem "moji", require: false
+
 # Test gems
 gem "rbs-amber", path: "test/assets/test-gem"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       addressable (>= 2.8)
     marcel (1.0.2)
     minitest (5.16.3)
+    moji (1.6)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -100,6 +101,7 @@ DEPENDENCIES
   json
   json-schema
   minitest
+  moji
   prime
   rake
   rake-compiler

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -29,7 +29,7 @@ module RBS
         end
 
         loader = EnvironmentLoader.new(core_root: core_root, repository: repository)
-        if config_path
+        if config_path && config_path.file?
           config = Collection::Config.from_path(config_path)
           lock = Collection::Config.lockfile_of(config_path)
 

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -29,8 +29,12 @@ module RBS
         end
 
         loader = EnvironmentLoader.new(core_root: core_root, repository: repository)
-        lock = config_path&.then { |p| Collection::Config.lockfile_of(p) }
-        loader.add_collection(lock) if lock
+        if config_path
+          config = Collection::Config.from_path(config_path)
+          lock = Collection::Config.lockfile_of(config_path)
+
+          loader.add_collection(config, lock) if lock
+        end
 
         dirs.each do |dir|
           loader.add(path: Pathname(dir))

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -5,6 +5,7 @@ require 'bundler'
 
 require_relative './collection/sources'
 require_relative './collection/config'
+require_relative './collection/config/lockfile'
 require_relative './collection/config/lockfile_generator'
 require_relative './collection/installer'
 require_relative './collection/cleaner'

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -8,6 +8,7 @@ require_relative './collection/config'
 require_relative './collection/config/lockfile_generator'
 require_relative './collection/installer'
 require_relative './collection/cleaner'
+require_relative './collection/manifest'
 
 module RBS
   module Collection

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -54,10 +54,6 @@ module RBS
         @config_path = config_path
       end
 
-      def add_gem(gem)
-        gems << gem
-      end
-
       def gem(gem_name)
         gems.find { |gem| gem['name'] == gem_name }
       end
@@ -80,14 +76,6 @@ module RBS
             .map { |c| Sources.from_config_entry(c) }
             .push(Sources::Stdlib.instance)
             .push(Sources::Rubygems.instance)
-        )
-      end
-
-      def dump_to(io)
-        gems = self.gems.reject {|gem| gem['ignore'] }.sort_by {|gem| gem['name'] }
-        YAML.dump(
-          @data.merge({ "gems" => gems }),
-          io
         )
       end
 

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -31,8 +31,7 @@ module RBS
       # If `with_lockfile` is true, it respects existing rbs lockfile.
       #
       def self.generate_lockfile(config_path:, gemfile_lock_path:, with_lockfile: true)
-        config, _ = LockfileGenerator.generate(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
-        config
+        LockfileGenerator.generate(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
       end
 
       def self.from_path(path)

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -53,7 +53,7 @@ module RBS
 
           lockfile = Lockfile.new(file_path: file_path, path: path, gemfile_lock_path: gemfile_lock_path)
 
-          yaml['sources'].each do |src|
+          Array(yaml['sources']).each do |src|
             lockfile.sources << Sources::Git.new(
               name: src["name"],
               revision: src["revision"],
@@ -62,7 +62,7 @@ module RBS
             )
           end
 
-          yaml["gems"].each do |gem|
+          Array(yaml["gems"]).each do |gem|
             source = lockfile.all_sources.find {|source| source.has?(gem['name'], gem['version']) } or raise
             lockfile.gems[gem['name']] = {
               name: gem['name'],

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -1,0 +1,80 @@
+module RBS
+  module Collection
+    class Config
+      class Lockfile
+        attr_reader :file_path, :sources, :gems, :path, :gemfile_lock_path
+
+        def initialize(file_path:, path:, gemfile_lock_path:)
+          @file_path = file_path
+          @path = path
+          @gemfile_lock_path = gemfile_lock_path
+
+          @gems = {}
+          @sources = []
+        end
+
+        def dump
+          {
+            "sources" => sources.map {|source|
+              # @type block: lockfile_source_git_source
+              {
+                "name" => source.name,
+                "remote" => source.remote,
+                "revision" => source.resolved_revision,
+                "repo_dir" => source.repo_dir
+              }
+            },
+            "path" => path.to_s,
+            "gems" => gems.values.sort_by {|gem| gem[:name] }.map {|gem|
+              # @type block: lockfile_source_gem
+              {
+                "name" => gem[:name],
+                "version" => gem[:version],
+                "source" => gem[:source].to_lockfile
+              }
+            },
+            "gemfile_lock_path" => gemfile_lock_path&.to_s
+          }
+        end
+
+        def dump_to(io)
+          YAML.dump(dump, io)
+        end
+
+        def all_sources
+          sources + [Sources::Stdlib.instance, Sources::Rubygems.instance]
+        end
+
+        def self.load(file_path, yaml)
+          path = Pathname(yaml["path"])
+          if lock_path = yaml["gemfile_lock_path"]
+            gemfile_lock_path = Pathname(lock_path)
+          end
+
+          lockfile = Lockfile.new(file_path: file_path, path: path, gemfile_lock_path: gemfile_lock_path)
+
+          yaml['sources'].each do |src|
+            lockfile.sources << Sources::Git.new(
+              name: src["name"],
+              revision: src["revision"],
+              remote: src["remote"],
+              repo_dir: src["repo_dir"]
+            )
+          end
+
+          yaml["gems"].each do |gem|
+            source = lockfile.all_sources.find {|source| source.has?(gem['name'], gem['version']) } or raise
+            lockfile.gems[gem['name']] = {
+              name: gem['name'],
+              version: gem['version'],
+              source: source
+            }
+          end
+
+          lockfile
+        end
+      end
+    end
+  end
+end
+

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -50,7 +50,7 @@ module RBS
           end
 
           while gem = @gem_queue.shift
-            assign_gem(**gem)
+            assign_gem(name: gem[:name], version: gem[:version])
           end
           remove_ignored_gems!
 
@@ -81,7 +81,7 @@ module RBS
             return unless source
 
             installed_version = version
-            best_version = find_best_version(version: installed_version, versions: source.versions({ 'name' => name }))
+            best_version = find_best_version(version: installed_version, versions: source.versions(name))
 
             locked = {
               'name' => name,
@@ -94,7 +94,7 @@ module RBS
 
           upsert_gem specified, locked
           source = Sources.from_config_entry(locked['source'] || raise)
-          source.dependencies_of(locked)&.each do |dep|
+          source.dependencies_of(locked["name"], locked["version"] || raise)&.each do |dep|
             @gem_queue.push({ name: dep.name, version: nil} )
           end
         end
@@ -120,7 +120,7 @@ module RBS
         private def find_source(name:)
           sources = config.sources
 
-          sources.find { |c| c.has?({ 'name' => name, 'revision' => nil } ) }
+          sources.find { |c| c.has?(name, nil) }
         end
 
         private def find_best_version(version:, versions:)

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -93,7 +93,7 @@ module RBS
           upsert_gem specified, locked
           source = Sources.from_config_entry(locked['source'] || raise)
           source.dependencies_of(locked)&.each do |dep|
-            @gem_queue.push({ name: dep['name'], version: nil} )
+            @gem_queue.push({ name: dep.name, version: nil} )
           end
         end
 

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -42,7 +42,7 @@ module RBS
           @bundler_definition = bundler_definition
 
           lock_path = Config.to_lockfile_path(config_path)
-          gemfile_lock_path = bundler_definition.lockfile.relative_path_from(lock_path)
+          gemfile_lock_path = bundler_definition.lockfile.relative_path_from(lock_path.parent)
 
           @lockfile = Lockfile.new(file_path: lock_path, path: Pathname(config.data_path), gemfile_lock_path: gemfile_lock_path)
           config.sources.each do |source|

--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -15,7 +15,12 @@ module RBS
         install_to = lockfile.repo_path
         install_to.mkpath
         lockfile.gems.each do |config_entry|
-          source_for(config_entry).install(dest: install_to, config_entry: config_entry, stdout: stdout)
+          source_for(config_entry).install(
+            dest: install_to,
+            name: config_entry["name"],
+            version: config_entry["version"] || raise,
+            stdout: stdout
+          )
         end
         stdout.puts "It's done! #{lockfile.gems.size} gems' RBSs now installed."
       end

--- a/lib/rbs/collection/manifest.rb
+++ b/lib/rbs/collection/manifest.rb
@@ -1,0 +1,55 @@
+module RBS
+  module Collection
+    class Manifest
+      class Dependency
+        attr_reader :name
+
+        def initialize(name:)
+          @name = name
+        end
+
+        def ==(other)
+          other.is_a?(Dependency) && other.name == name
+        end
+
+        alias eql? ==
+
+        def hash
+          name.hash
+        end
+      end
+
+      attr_reader :dependencies
+
+      def path
+        @path or raise "`#path` is `nil` (reading `#path` of *default* manifest?)"
+      end
+
+      def self.from(path, hash)
+        dependencies = hash["dependencies"].map {|dep| Dependency.new(name: dep["name"]) }
+        new(path, dependencies: dependencies)
+      end
+
+      def initialize(path, dependencies:)
+        @path = path
+        @dependencies = dependencies
+      end
+
+      def ==(other)
+        other.is_a?(Manifest) && other.dependencies == dependencies
+      end
+
+      alias eql? ==
+
+      def hash
+        dependencies.hash
+      end
+
+      def self.default
+        @default
+      end
+
+      @default = new(_ = nil, dependencies: [])
+    end
+  end
+end

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -4,8 +4,8 @@ module RBS
   module Collection
     module Sources
       module Base
-        def dependencies_of(config_entry)
-          manifest = manifest_of(config_entry) or return
+        def dependencies_of(name, version)
+          manifest = manifest_of(name, version) or return
           manifest.dependencies
         end
       end

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -6,7 +6,7 @@ module RBS
       module Base
         def dependencies_of(config_entry)
           manifest = manifest_of(config_entry) or return
-          manifest['dependencies']
+          manifest.dependencies
         end
       end
     end

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -59,7 +59,9 @@ module RBS
           gem_dir = gem_repo_dir.join(gem_name, version)
 
           manifest_path = gem_dir.join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         private def _install(dest:, config_entry:)

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -152,7 +152,7 @@ module RBS
           git_dir.join @repo_dir
         end
 
-        private def resolved_revision
+        def resolved_revision
           @resolved_revision ||= resolve_revision
         end
 

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -39,7 +39,7 @@ module RBS
           gem_dir = dest.join(gem_name, version)
 
           if gem_dir.directory?
-            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME))) == config_entry
+            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME).to_s)) == config_entry
               stdout.puts "Using #{format_config_entry(config_entry)}"
             else
               # @type var prev: RBS::Collection::Config::gem_entry

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -10,26 +10,24 @@ module RBS
         include Base
         include Singleton
 
-        def has?(config_entry)
-          gem_sig_path(config_entry)
+        def has?(name, version)
+          gem_sig_path(name, version)
         end
 
-        def versions(config_entry)
-          spec, _ = gem_sig_path(config_entry)
+        def versions(name)
+          spec, _ = gem_sig_path(name, nil)
           spec or raise
           [spec.version.to_s]
         end
 
-        def install(dest:, config_entry:, stdout:)
+        def install(dest:, name:, version:, stdout:)
           # Do nothing because stdlib RBS is available by default
-          name = config_entry['name']
-          version = config_entry['version'] or raise
-          _, from = gem_sig_path(config_entry)
+          _, from = gem_sig_path(name, version)
           stdout.puts "Using #{name}:#{version} (#{from})"
         end
 
-        def manifest_of(config_entry)
-          _, sig_path = gem_sig_path(config_entry)
+        def manifest_of(name, version)
+          _, sig_path = gem_sig_path(name, version)
           sig_path or raise
           manifest_path = sig_path.join('manifest.yaml')
           if manifest_path.exist?
@@ -43,8 +41,8 @@ module RBS
           }
         end
 
-        private def gem_sig_path(config_entry)
-          RBS::EnvironmentLoader.gem_sig_path(config_entry['name'], config_entry['version'])
+        private def gem_sig_path(name, version)
+          RBS::EnvironmentLoader.gem_sig_path(name, version)
         end
       end
     end

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -32,7 +32,9 @@ module RBS
           _, sig_path = gem_sig_path(config_entry)
           sig_path or raise
           manifest_path = sig_path.join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         def to_lockfile

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -12,25 +12,22 @@ module RBS
 
         REPO = Repository.default
 
-        def has?(config_entry)
-          lookup(config_entry)
+        def has?(name, version)
+          lookup(name, version)
         end
 
-        def versions(config_entry)
-          REPO.gems[config_entry['name']].versions.keys.map(&:to_s)
+        def versions(name)
+          REPO.gems[name].versions.keys.map(&:to_s)
         end
 
-        def install(dest:, config_entry:, stdout:)
+        def install(dest:, name:, version:, stdout:)
           # Do nothing because stdlib RBS is available by default
-          name = config_entry['name']
-          version = config_entry['version'] or raise
-          from = lookup(config_entry)
+          from = lookup(name, version)
           stdout.puts "Using #{name}:#{version} (#{from})"
         end
 
-        def manifest_of(config_entry)
-          config_entry['version'] or raise
-          manifest_path = (lookup(config_entry) or raise).join('manifest.yaml')
+        def manifest_of(name, version)
+          manifest_path = (lookup(name, version) or raise).join('manifest.yaml')
           if manifest_path.exist?
             Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
           end
@@ -42,8 +39,8 @@ module RBS
           }
         end
 
-        private def lookup(config_entry)
-          REPO.lookup(config_entry['name'], config_entry['version'])
+        private def lookup(name, version)
+          REPO.lookup(name, version)
         end
       end
     end

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -31,7 +31,9 @@ module RBS
         def manifest_of(config_entry)
           config_entry['version'] or raise
           manifest_path = (lookup(config_entry) or raise).join('manifest.yaml')
-          YAML.safe_load(manifest_path.read) if manifest_path.exist?
+          if manifest_path.exist?
+            Manifest.from(manifest_path, YAML.safe_load(manifest_path.read))
+          end
         end
 
         def to_lockfile

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -60,12 +60,13 @@ module RBS
 
     def resolve_dependencies(library:, version:)
       [Collection::Sources::Rubygems.instance, Collection::Sources::Stdlib.instance].each do |source|
-        # @type var gem: { 'name' => String, 'version' => String? }
-        gem = { 'name' => library, 'version' => version }
-        next unless source.has?(gem)
+        next unless source.has?(library, version)
 
-        gem['version'] ||= source.versions(gem).last
-        source.dependencies_of(gem)&.each do |dep|
+        unless version
+          version = source.versions(library).last or raise
+        end
+        
+        source.dependencies_of(library, version)&.each do |dep|
           add(library: dep.name, version: nil)
         end
         return

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -65,7 +65,7 @@ module RBS
         unless version
           version = source.versions(library).last or raise
         end
-        
+
         source.dependencies_of(library, version)&.each do |dep|
           add(library: dep.name, version: nil)
         end
@@ -73,13 +73,13 @@ module RBS
       end
     end
 
-    def add_collection(collection_config)
+    def add_collection(collection_config, lock)
       collection_config.check_rbs_availability!
 
       repository.add(collection_config.repo_path)
 
-      collection_config.gems.each do |gem|
-        add(library: gem['name'], version: gem['version'], resolve_dependencies: false)
+      lock.gems.each_value do |gem|
+        add(library: gem[:name], version: gem[:version], resolve_dependencies: false)
       end
     end
 

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -66,7 +66,7 @@ module RBS
 
         gem['version'] ||= source.versions(gem).last
         source.dependencies_of(gem)&.each do |dep|
-          add(library: dep['name'], version: nil)
+          add(library: dep.name, version: nil)
         end
         return
       end

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -43,11 +43,11 @@ module RBS
 
         def validate_gemfile_lock_path!: (lock: Lockfile?, gemfile_lock_path: Pathname) -> void
 
-        def assign_gem: (name: String, version: String?) -> void
+        def assign_gem: (name: String, version: String?, ignored_gems: Set[String]) -> void
 
         def assign_stdlib: (name: String) -> void
 
-        def gemfile_lock_gems: () { (Bundler::LazySpecification) -> void } -> void
+        def each_dependent_gem: (name: String) { (Bundler::LazySpecification) -> void } -> void
 
         def find_source: (name: String) -> Sources::t?
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -45,7 +45,7 @@ module RBS
 
         def assign_gem: (name: String, version: String?, ignored_gems: Set[String]) -> void
 
-        def assign_stdlib: (name: String) -> void
+        def assign_stdlib: (name: String, from_gem: String?) -> void
 
         def each_dependent_gem: (name: String) { (Bundler::LazySpecification) -> void } -> void
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -10,15 +10,17 @@ module RBS
         attr_reader config: Config
         attr_reader lock: Config?
         attr_reader lock_path: Pathname
-        attr_reader gemfile_lock: Bundler::LockfileParser
+        attr_reader bundler_definition: Bundler::Definition
 
         type gem_queue_entry = { name: String, version: String? }
 
         @gem_queue: Array[gem_queue_entry]
 
+        @gem_map: Hash[String, Bundler::LazySpecification]
+
         def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
 
-        def initialize: (config_path: Pathname, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
+        def initialize: (config_path: Pathname, bundler_definition: Bundler::Definition, with_lockfile: boolish) -> void
 
         def generate: () -> Config
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -71,7 +71,7 @@ module RBS
 
       def self.find_config_path: () -> Pathname?
 
-      def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
+      def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> [Config, Lockfile]
 
       def self.from_path: (Pathname path) -> Config
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -82,8 +82,6 @@ module RBS
       # config_path is necessary to resolve relative repo_path
       def initialize: (untyped data, config_path: Pathname) -> void
 
-      def add_gem: (gem_entry gem) -> void
-
       def gem: (String gem_name) -> gem_entry?
 
       def data_path: () -> String
@@ -93,8 +91,6 @@ module RBS
       def data_sources: () -> Array[Sources::Git::source_entry]
 
       def sources: () -> Array[Sources::_Source]
-
-      def dump_to: (IO) -> void
 
       def gems: () -> Array[gem_entry]
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -7,36 +7,49 @@ module RBS
       end
 
       class LockfileGenerator
+        class GemfileLockMismatchError < StandardError
+          attr_reader expected: Pathname
+
+          attr_reader actual: Pathname
+
+          def initialize: (expected: Pathname, actual: Pathname) -> void
+        end
+
+        type lockfile_gem = { 'name' => String, 'version' => String, source: Sources::source_entry }
+
+        type lockfile = {
+          'sources' => Array[Sources::Git::source_entry],
+          'path' => String,
+          'gems' => Array[lockfile_gem]
+        }
+
         attr_reader config: Config
-        attr_reader lock: Config?
-        attr_reader lock_path: Pathname
         attr_reader bundler_definition: Bundler::Definition
 
-        type gem_queue_entry = { name: String, version: String? }
-
-        @gem_queue: Array[gem_queue_entry]
+        attr_reader lockfile: Lockfile
+        attr_reader existing_lockfile: Lockfile?
 
         @gem_map: Hash[String, Bundler::LazySpecification]
 
-        def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
+        # Load a Config, generates and save Lockfile, and returns a pair of them
+        #
+        def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> [Config, Lockfile]
 
         def initialize: (config_path: Pathname, bundler_definition: Bundler::Definition, with_lockfile: boolish) -> void
 
-        def generate: () -> Config
+        def generate: () -> void
 
         private
 
-        def validate_gemfile_lock_path!: (lock: Config?, gemfile_lock_path: Pathname) -> void
+        def validate_gemfile_lock_path!: (lock: Lockfile?, gemfile_lock_path: Pathname) -> void
 
         def assign_gem: (name: String, version: String?) -> void
 
-        def upsert_gem: (gem_entry? old, gem_entry new) -> void
+        def assign_stdlib: (name: String) -> void
 
-        def gemfile_lock_gems: () { (untyped) -> void } -> void
+        def gemfile_lock_gems: () { (Bundler::LazySpecification) -> void } -> void
 
-        def remove_ignored_gems!: () -> void
-
-        def find_source: (name: String) -> Sources::_Source?
+        def find_source: (name: String) -> Sources::t?
 
         def find_best_version: (version: String?, versions: Array[String]) -> Gem::Version
       end
@@ -62,7 +75,7 @@ module RBS
 
       def self.from_path: (Pathname path) -> Config
 
-      def self.lockfile_of: (Pathname config_path) -> Config?
+      def self.lockfile_of: (Pathname config_path) -> Lockfile?
 
       def self.to_lockfile_path: (Pathname config_path) -> Pathname
 
@@ -73,11 +86,15 @@ module RBS
 
       def gem: (String gem_name) -> gem_entry?
 
+      def data_path: () -> String
+
       def repo_path: () -> Pathname
+
+      def data_sources: () -> Array[Sources::Git::source_entry]
 
       def sources: () -> Array[Sources::_Source]
 
-      def dump_to: (Pathname) -> void
+      def dump_to: (IO) -> void
 
       def gems: () -> Array[gem_entry]
 

--- a/sig/collection/config/lockfile.rbs
+++ b/sig/collection/config/lockfile.rbs
@@ -1,0 +1,56 @@
+module RBS
+  module Collection
+    class Config
+      # Lockfile represents `rbs_collection.lock.yaml`
+      #
+      class Lockfile
+        type lockfile_source_git_source = {
+          'name' => String,
+          'remote' => String,
+          'revision' => String,
+          'repo_dir' => String?
+        }
+        type lockfile_source_gem = { 'name' => String, 'version' => String, 'source' => Sources::source_entry }
+
+        type lockfile_source = {
+          'sources' => Array[lockfile_source_git_source],
+          'path' => String,
+          'gems' => Array[lockfile_source_gem],
+          'gemfile_lock_path' => String?
+        }
+
+        type gem = { name: String, version: String, source: Sources::t }
+
+        # Path to the `rbs_collection.lock.yaml` file
+        #
+        attr_reader file_path: Pathname
+
+        # Path to the repository directory
+        #
+        # Relative from `file_path`.
+        #
+        attr_reader path: Pathname
+
+        attr_reader sources: Array[Sources::Git]
+
+        attr_reader gems: Hash[String, gem]
+
+        # Path to the `Gemfile.lock` that is used to generate this lockfile
+        #
+        # Relative from `file_path`.
+        #
+        attr_reader gemfile_lock_path: Pathname?
+
+        def initialize: (file_path: Pathname, path: Pathname, gemfile_lock_path: Pathname?) -> void
+
+        def all_sources: () -> Array[Sources::t]
+
+        def dump: () -> lockfile_source
+
+        def dump_to: (IO) -> void
+
+        def self.load: (Pathname file_path, lockfile_source) -> Lockfile
+      end
+    end
+  end
+end

--- a/sig/collection/config/lockfile.rbs
+++ b/sig/collection/config/lockfile.rbs
@@ -13,9 +13,9 @@ module RBS
         type lockfile_source_gem = { 'name' => String, 'version' => String, 'source' => Sources::source_entry }
 
         type lockfile_source = {
-          'sources' => Array[lockfile_source_git_source],
+          'sources' => Array[lockfile_source_git_source]?,
           'path' => String,
-          'gems' => Array[lockfile_source_gem],
+          'gems' => Array[lockfile_source_gem]?,
           'gemfile_lock_path' => String?
         }
 

--- a/sig/collection/manifest.rbs
+++ b/sig/collection/manifest.rbs
@@ -1,0 +1,50 @@
+module RBS
+  module Collection
+    # Manifest class defines the properties of a RBS library that is loaded from `manifest.yaml` file
+    #
+    class Manifest
+      # The type of YAML content
+      type manifest = { "dependencies" => Array[dependency] }
+
+      type dependency = { "name" => String }
+
+      class Dependency
+        attr_reader name: String
+
+        def initialize: (name: String) -> void
+
+        def ==: (untyped other) -> bool
+
+        alias eql? ==
+
+        def hash: () -> Integer
+      end
+
+      attr_reader path: Pathname
+
+      # Required key `"dependencies"` that is an array of depedent library names
+      #
+      # ```yaml
+      # dependencies:
+      #   - name: pathname
+      #   - name: set
+      # ```
+      #
+      attr_reader dependencies: Array[Dependency]
+
+      # *Default* manifest that is used for a library without `manifest.yaml`
+      #
+      attr_reader self.default: Manifest
+
+      def self.from: (Pathname path, manifest hash) -> Manifest
+
+      def initialize: (Pathname path, dependencies: Array[Dependency]) -> void
+
+      def ==: (untyped other) -> bool
+
+      alias eql? ==
+
+      def hash: () -> Integer
+    end
+  end
+end

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -8,20 +8,16 @@ module RBS
         def versions: (Config::gem_entry) -> Array[String]
         def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
-        def dependencies_of: (Config::gem_entry) -> Array[{"name" => String}]?
+        def manifest_of: (Config::gem_entry) -> Manifest?
+        def dependencies_of: (Config::gem_entry) -> Array[Manifest::Dependency]?
       end
 
       type source_entry = Git::source_entry
                         | Stdlib::source_entry
                         | Rubygems::source_entry
 
-      type manifest_entry = {
-        "dependencies" => Array[{"name" => String}]?,
-      }
-
       module Base : _Source
-        def dependencies_of: (Config::gem_entry config_entry) -> Array[{"name" => String}]?
+        def dependencies_of: (Config::gem_entry config_entry) -> Array[Manifest::Dependency]?
       end
 
       class Git
@@ -54,7 +50,7 @@ module RBS
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 
@@ -109,7 +105,7 @@ module RBS
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 
@@ -131,7 +127,7 @@ module RBS
         def versions: (Config::gem_entry) -> Array[String]
         def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (Config::gem_entry) -> Manifest?
 
         private
 

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -4,12 +4,12 @@ module RBS
       def self.from_config_entry: (source_entry) -> _Source
 
       interface _Source
-        def has?: (Config::gem_entry) -> boolish
-        def versions: (Config::gem_entry) -> Array[String]
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def has?: (String name, String? version) -> boolish
+        def versions: (String name) -> Array[String]
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> Manifest?
-        def dependencies_of: (Config::gem_entry) -> Array[Manifest::Dependency]?
+        def manifest_of: (String name, String version) -> Manifest?
+        def dependencies_of: (String name, String version) -> Array[Manifest::Dependency]?
       end
 
       type source_entry = Git::source_entry
@@ -17,7 +17,7 @@ module RBS
                         | Rubygems::source_entry
 
       module Base : _Source
-        def dependencies_of: (Config::gem_entry config_entry) -> Array[Manifest::Dependency]?
+        def dependencies_of: (String name, String version) -> Array[Manifest::Dependency]?
       end
 
       class Git
@@ -42,15 +42,15 @@ module RBS
 
         def initialize: (name: String, revision: String, remote: String, repo_dir: String?) -> untyped
 
-        def has?: (Config::gem_entry) -> bool
+        def has?: (String name, String? version) -> boolish
 
-        def versions: (Config::gem_entry) -> Array[String]
+        def versions: (String name) -> Array[String]
 
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> Manifest?
+        def manifest_of: (String name, String version) -> Manifest?
 
         private
 
@@ -58,7 +58,7 @@ module RBS
 
         @resolved_revision: String?
 
-        def _install: (dest: Pathname , config_entry: Config::gem_entry) -> void
+        def _install: (dest: Pathname , name: String, version: String) -> void
 
         def cp_r: (Pathname, Pathname) -> void
 
@@ -80,7 +80,18 @@ module RBS
 
         def sh!: (*String cmd, **untyped opt) -> String
 
-        def format_config_entry: (Config::gem_entry) -> String
+        def format_config_entry: (String name, String version) -> String
+
+        type metadata = { 'name' => String, 'version' => String, 'source' => source_entry }
+
+        def metadata_content: (name: String, version: String) -> metadata
+
+        # Write `.rbs_meta.yaml`
+        def write_metadata: (dir: Pathname, name: String, version: String) -> void
+
+        # Load `.rbs_meta.yaml` from the `dir`, where is the destination of the RBS file installation, and return the cleaned up content
+        #
+        def load_metadata: (dir: Pathname) -> metadata
       end
 
       # signatures that are bundled in rbs gem under the stdlib/ directory
@@ -97,19 +108,19 @@ module RBS
         # polyfill of singleton module
         def self.instance: () -> instance
 
-        def has?: (Config::gem_entry) -> boolish
+        def has?: (String name, String? version) -> boolish
 
-        def versions: (Config::gem_entry) -> Array[String]
+        def versions: (String name) -> Array[String]
 
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> Manifest?
+        def manifest_of: (String name, String version) -> Manifest?
 
         private
 
-        def lookup: (Config::gem_entry) -> Pathname?
+        def lookup: (String name, String? version) -> Pathname?
       end
 
       # sig/ directory
@@ -123,15 +134,19 @@ module RBS
         # polyfill of singleton module
         def self.instance: () -> instance
 
-        def has?: (Config::gem_entry) -> boolish
-        def versions: (Config::gem_entry) -> Array[String]
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def has?: (String name, String? version) -> boolish
+
+        def versions: (String name) -> Array[String]
+
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
+
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> Manifest?
+
+        def manifest_of: (String name, String version) -> Manifest?
 
         private
 
-        def gem_sig_path: (Config::gem_entry) -> [Gem::Specification, Pathname]?
+        def gem_sig_path: (String name, String? version) -> [Gem::Specification, Pathname]?
       end
     end
   end

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -16,6 +16,8 @@ module RBS
                         | Stdlib::source_entry
                         | Rubygems::source_entry
 
+      type t = Git | Stdlib | Rubygems
+
       module Base : _Source
         def dependencies_of: (String name, String version) -> Array[Manifest::Dependency]?
       end
@@ -52,6 +54,8 @@ module RBS
 
         def manifest_of: (String name, String version) -> Manifest?
 
+        def resolved_revision: () -> String
+
         private
 
         @git_dir: Pathname?
@@ -71,8 +75,6 @@ module RBS
         def gem_repo_dir: () -> Pathname
 
         def with_revision: [T] () { () -> T } -> T
-
-        def resolved_revision: () -> String
 
         def resolve_revision: () -> String
 

--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -81,7 +81,7 @@ module RBS
     def resolve_dependencies: (library: String, version: String?) -> void
 
     # Add repository path and libraries via rbs_collection.lock.yaml.
-    def add_collection: (Collection::Config collection_config) -> void
+    def add_collection: (Collection::Config collection_config, Collection::Config::Lockfile lock) -> void
 
     # This is helper function to test if RBS for a library is available or not.
     #

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -4,6 +4,5 @@ dependencies:
   - name: pathname
   - name: json
   - name: optparse
-  - name: rubygems
   - name: tsort
   - name: rdoc

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -8,6 +8,11 @@ module Gem
   end
 end
 
+module Kernel
+  def self?.Array: [T] (Array[T]?) -> Array[T]
+                 | ...
+end
+
 module Bundler
   class LockfileParser
     def initialize: (String) -> void

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -17,9 +17,11 @@ module Bundler
   class LazySpecification
     def name: () -> String
     def version: () -> String
+    def dependencies: () -> Array[Dependency]
   end
 
   class Dependency
+    def name: () -> String
   end
 
   class Definition

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -40,6 +40,8 @@ module Bundler
   end
 
   def self.definition: () -> Definition
+
+  def self.default_lockfile: () -> Pathname
 end
 
 module RDoc

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -18,6 +18,21 @@ module Bundler
     def name: () -> String
     def version: () -> String
   end
+
+  class Dependency
+  end
+
+  class Definition
+    def self.build: (Pathname gemfile, Pathname? lockfile, Hash[String, untyped] | bool | nil unlock) -> Definition
+
+    def locked_gems: () -> LockfileParser
+
+    def requires: () -> Hash[String, Array[String]]
+
+    def lockfile: () -> Pathname
+  end
+
+  def self.definition: () -> Definition
 end
 
 module RDoc

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -583,31 +583,12 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write(<<~GEMFILE)
-          source "https://rubygems.org"
 
-          gem 'ast', require: false
-        GEMFILE
-        dir.join('Gemfile.lock').write(<<~LOCK)
-          GEM
-            remote: https://rubygems.org/
-            specs:
-              ast (2.4.2)
-
-          PLATFORMS
-            x86_64-linux
-
-          DEPENDENCIES
-            ast
-
-          BUNDLED WITH
-             2.2.0
-        LOCK
-
+        # Load gems from current Bundler context
         with_cli do |cli|
           cli.run(%w[collection install])
           assert dir.join('rbs_collection.lock.yaml').exist?
-          refute dir.join('gem_rbs_collection/ast').exist?
+          refute dir.join('gem_rbs_collection/moji').exist?
         end
       end
     end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -527,7 +527,7 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('')
+        dir.join('Gemfile').write('source "https://rubygems.org"')
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/
@@ -611,7 +611,7 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('')
+        dir.join('Gemfile').write('source "https://rubygems.org"')
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -527,7 +527,11 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('source "https://rubygems.org"')
+        dir.join('Gemfile').write(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem 'ast'
+        GEMFILE
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/
@@ -561,6 +565,49 @@ Processing `test/a_test.rb`...
             assert rbs_collection_lock.exist?
             assert collection_dir.exist?
           end
+        end
+      end
+    end
+  end
+
+  def test_collection_install_require_false
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        dir.join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources:
+            - name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+
+          path: #{dir.join('gem_rbs_collection')}
+        YAML
+        dir.join('Gemfile').write(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem 'ast', require: false
+        GEMFILE
+        dir.join('Gemfile.lock').write(<<~LOCK)
+          GEM
+            remote: https://rubygems.org/
+            specs:
+              ast (2.4.2)
+
+          PLATFORMS
+            x86_64-linux
+
+          DEPENDENCIES
+            ast
+
+          BUNDLED WITH
+             2.2.0
+        LOCK
+
+        with_cli do |cli|
+          cli.run(%w[collection install])
+          assert dir.join('rbs_collection.lock.yaml').exist?
+          refute dir.join('gem_rbs_collection/ast').exist?
         end
       end
     end
@@ -611,7 +658,11 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('source "https://rubygems.org"')
+        dir.join('Gemfile').write(<<~GEMFILE)
+          source "https://rubygems.org"
+
+          gem 'ast'
+        GEMFILE
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -52,7 +52,7 @@ gem "rainbow"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 
@@ -106,7 +106,7 @@ gem "rainbow"
           gemfile_lock_path = tmpdir / 'Gemfile.lock'
         gemfile_lock_path.write GEMFILE_LOCK
 
-        config, lockfile = Dir.chdir(tmpdir) do
+        _, lockfile = Dir.chdir(tmpdir) do
           RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
         end
         io = StringIO.new
@@ -179,7 +179,7 @@ gem "rainbow"
       YAML
       tmpdir.join('rbs_collection.lock.yaml').write lockfile_yaml
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new()
       lockfile.dump_to(io)
 
@@ -202,7 +202,7 @@ gem "rainbow"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
 
       assert_config <<~YAML, YAML.dump(lockfile.dump)
         sources:
@@ -252,7 +252,7 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 
@@ -325,7 +325,7 @@ gem "activesupport"
            2.2.0
       GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 
@@ -385,6 +385,8 @@ gem "activesupport"
       gemfile_path = tmpdir / 'Gemfile'
       gemfile_path.write <<~GEMFILE
 source "https://rubygems.org/"
+
+gem 'csv'
       GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
@@ -403,7 +405,7 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 
@@ -457,7 +459,7 @@ gem "rbs-amber"
            2.2.0
       GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 
@@ -505,7 +507,7 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      _, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
       lockfile.dump_to(io)
 

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -52,9 +52,9 @@ gem "rainbow"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:
@@ -106,11 +106,11 @@ gem "rainbow"
           gemfile_lock_path = tmpdir / 'Gemfile.lock'
         gemfile_lock_path.write GEMFILE_LOCK
 
-        config = Dir.chdir(tmpdir) do
+        config, lockfile = Dir.chdir(tmpdir) do
           RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
         end
         io = StringIO.new
-        config.dump_to(io)
+        lockfile.dump_to(io)
 
         assert_config <<~YAML, io.string
           sources:
@@ -151,7 +151,7 @@ gem "rainbow"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      lockfile = <<~YAML
+      lockfile_yaml = <<~YAML
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -177,13 +177,13 @@ gem "rainbow"
               repo_dir: gems
               type: git
       YAML
-      tmpdir.join('rbs_collection.lock.yaml').write lockfile
+      tmpdir.join('rbs_collection.lock.yaml').write lockfile_yaml
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      io = StringIO.new()
+      lockfile.dump_to(io)
 
-      assert_config lockfile, io.string
+      assert_config lockfile_yaml, io.string
     end
   end
 
@@ -202,11 +202,9 @@ gem "rainbow"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, YAML.dump(lockfile.dump)
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -216,7 +214,6 @@ gem "rainbow"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
           - name: rainbow
-            ignore: false
             version: "3.0"
             source:
               name: ruby/gem_rbs_collection
@@ -255,9 +252,9 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:
@@ -328,9 +325,9 @@ gem "activesupport"
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:
@@ -349,6 +346,14 @@ gem "activesupport"
               revision: cde6057e7546843ace6420c5783dd945c6ccda54
               repo_dir: gems
               type: git
+          - name: date
+            version: "0"
+            source:
+              type: stdlib
+          - name: logger
+            version: "0"
+            source:
+              type: stdlib
           - name: minitest
             version: '0'
             source:
@@ -357,19 +362,11 @@ gem "activesupport"
             version: "0"
             source:
               type: stdlib
-          - name: date
+          - name: mutex_m
             version: "0"
             source:
               type: stdlib
           - name: singleton
-            version: "0"
-            source:
-              type: stdlib
-          - name: logger
-            version: "0"
-            source:
-              type: stdlib
-          - name: mutex_m
             version: "0"
             source:
               type: stdlib
@@ -406,9 +403,9 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:
@@ -460,9 +457,9 @@ gem "rbs-amber"
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:
@@ -473,14 +470,14 @@ gem "rbs-amber"
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
-          - name: rbs-amber
-            version: "1.0.0"
-            source:
-              type: rubygems
           - name: pathname
             version: "0"
             source:
               type: stdlib
+          - name: rbs-amber
+            version: "1.0.0"
+            source:
+              type: rubygems
       YAML
     end
   end
@@ -508,9 +505,9 @@ source "https://rubygems.org/"
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
       io = StringIO.new
-      config.dump_to(io)
+      lockfile.dump_to(io)
 
       assert_config <<~YAML, io.string
         sources:

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -18,6 +18,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     path: /path/to/somewhere
   YAML
 
+  GEMFILE = <<~GEMFILE
+source "https://rubygems.org/"
+
+gem "ast"
+gem "rainbow"
+  GEMFILE
+
   GEMFILE_LOCK = <<~YAML
     GEM
       remote: https://rubygems.org/
@@ -40,6 +47,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
@@ -92,7 +101,9 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
           path: /path/to/somewhere
         YAML
-        gemfile_lock_path = tmpdir / 'Gemfile.lock'
+        gemfile_path = tmpdir / 'Gemfile'
+        gemfile_path.write GEMFILE
+          gemfile_lock_path = tmpdir / 'Gemfile.lock'
         gemfile_lock_path.write GEMFILE_LOCK
 
         config = Dir.chdir(tmpdir) do
@@ -135,6 +146,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
@@ -184,6 +197,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
           - name: rainbow
             ignore: false
       YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
@@ -221,6 +236,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
           - name: ast
           - name: rainbow
       YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+source "https://rubygems.org/"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -273,6 +292,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+source "https://rubygems.org/"
+
+gem "activesupport"
+      GEMFILE
+
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -359,6 +385,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+source "https://rubygems.org/"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -407,6 +437,12 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+source "https://rubygems.org/"
+
+gem "rbs-amber"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -453,6 +489,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+source "https://rubygems.org/"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -532,6 +532,8 @@ source "https://rubygems.org/"
       lock_path.write CONFIG + "gemfile_lock_path: Gemfile.lock"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
+      gemfile_lock_path = tmpdir / 'Gemfile.2'
+      gemfile_lock_path.write GEMFILE
       gemfile_lock_path2 = tmpdir / 'Gemfile.2.lock'
       gemfile_lock_path2.write GEMFILE_LOCK
 

--- a/test/rbs/collection/manifest_test.rb
+++ b/test/rbs/collection/manifest_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class RBS::Collection::ManifestTest < Test::Unit::TestCase
+  include RBS::Collection
+
+  def test_from
+    manifest = Manifest.from(
+      Pathname("foo/0/manifest.yaml"),
+      {
+        "dependencies" => [
+          { "name" => "set" },
+          { "name" => "json" }
+        ]
+      }
+    )
+
+    assert_equal Pathname("foo/0/manifest.yaml"), manifest.path
+    assert_equal [Manifest::Dependency.new(name: "set"), Manifest::Dependency.new(name: "json")], manifest.dependencies
+  end
+
+  def test_default
+    assert_equal [], Manifest.default.dependencies
+    assert_raises(RuntimeError) { Manifest.default.path }
+  end
+end

--- a/test/rbs/collection/sources/git_test.rb
+++ b/test/rbs/collection/sources/git_test.rb
@@ -4,18 +4,18 @@ class RBS::Collection::Sources::GitTest < Test::Unit::TestCase
   def test_has?
     s = source
 
-    assert s.has?({ 'name' => 'activesupport' })
-    refute s.has?({ 'name' => 'rbs' })
+    assert s.has?('activesupport', nil)
+    refute s.has?('rbs', nil)
 
-    assert s.has?({ 'name' => 'protobuf' })
+    assert s.has?('protobuf', nil)
 
     old = source(revision: '41cac76e768cc51485763f92b56d976e8efc96aa')
-    refute old.has?({ 'name' => 'protobuf' })
+    refute old.has?('protobuf', nil)
   end
 
   def test_versions
     s = source
-    assert_equal ['2.4'], s.versions({ 'name' => 'ast' })
+    assert_equal ['2.4'], s.versions('ast')
   end
 
   def source(revision: 'b4d3b346d9657543099a35a1fd20347e75b8c523')

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -6,14 +6,14 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
   def test_has?
     s = source
 
-    assert s.has?({ 'name' => 'pathname' })
-    refute s.has?({ 'name' => 'activesupport' })
-    refute s.has?({ 'name' => 'rbs' })
+    assert s.has?('pathname', nil)
+    refute s.has?('activesupport', nil)
+    refute s.has?('rbs', nil)
   end
 
   def test_versions
     s = source
-    assert_equal ['0'], s.versions({ 'name' => 'pathname' })
+    assert_equal ['0'], s.versions('pathname')
   end
 
   def test_manifest_of__exist
@@ -26,13 +26,13 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
           Manifest::Dependency.new(name: "pstore"),
         ]
       ),
-      s.manifest_of({ 'name' => 'yaml', 'version' => '0' })
+      s.manifest_of('yaml', '0')
     )
   end
 
   def test_manifest_of__nonexist
     s = source
-    assert_equal(nil, s.manifest_of({ 'name' => 'pathname', 'version' => '0' }))
+    assert_equal(nil, s.manifest_of('pathname', '0'))
   end
 
   def source

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
+  Manifest = RBS::Collection::Manifest
+
   def test_has?
     s = source
 
@@ -16,8 +18,16 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
 
   def test_manifest_of__exist
     s = source
-    assert_equal({ 'dependencies' => [{ 'name' => 'dbm'}, { 'name' => 'pstore'}] },
-                 s.manifest_of({ 'name' => 'yaml', 'version' => '0' }))
+    assert_equal(
+      Manifest.new(
+        Pathname("yaml/0/manifest.yaml"),
+        dependencies: [
+          Manifest::Dependency.new(name: "dbm"),
+          Manifest::Dependency.new(name: "pstore"),
+        ]
+      ),
+      s.manifest_of({ 'name' => 'yaml', 'version' => '0' })
+    )
   end
 
   def test_manifest_of__nonexist

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -224,19 +224,20 @@ end
               type: git
       YAML
       RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: StringIO.new).install_from_lockfile
-      lock = RBS::Collection::Config.from_path(lockfile_path)
+      config = RBS::Collection::Config.from_path(config_path)
+      lock = RBS::Collection::Config.lockfile_of(config_path)
 
       repo = RBS::Repository.new()
 
       loader = EnvironmentLoader.new(repository: repo)
-      loader.add_collection(lock)
+      loader.add_collection(config, lock)
 
       env = Environment.new
       loader.load(env: env)
 
       assert_operator env.class_decls, :key?, TypeName("::AST")
       assert_operator env.class_decls, :key?, TypeName("::Rainbow")
-      assert repo.dirs.include? lock.repo_path
+      assert repo.dirs.include? config.repo_path
     end
   end
 
@@ -268,14 +269,14 @@ end
               repo_dir: gems
               type: git
       YAML
-      lock = RBS::Collection::Config.from_path(lockfile_path)
+      config = RBS::Collection::Config.from_path(lockfile_path)
 
       repo = RBS::Repository.new()
 
       loader = EnvironmentLoader.new(repository: repo)
 
       assert_raises RBS::Collection::Config::CollectionNotAvailable do
-        loader.add_collection(lock)
+        loader.add_collection(config, nil)
       end
     end
   end

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -197,6 +197,20 @@ end
 
   def test_loading_from_rbs_collection
     mktmpdir do |path|
+      config_path = path.join('rbs_collection.yaml')
+      config_path.write(<<~YAML)
+      sources:
+        - name: ruby/gem_rbs_collection
+          remote: https://github.com/ruby/gem_rbs_collection.git
+          revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+          repo_dir: gems
+      path: '.gem_rbs_collection'
+      gems:
+        - name: ast
+          version: "2.4"
+        - name: rainbow
+          version: "3.0"
+      YAML
       lockfile_path = path.join('rbs_collection.lock.yaml')
       lockfile_path.write(<<~YAML)
         sources:


### PR DESCRIPTION
We assume the gems with `require: false` are tools, not libraries loaded to the Ruby app. Users can explicitly load those gems by adding them to `gems` section in `rbs_collection.yaml`.

With this PR, users can have `steep` in their `Gemfile` with `require: false`, and delete the `- { name: 'steep', ignore: true }` line from the `rbs_collection.yaml`.

```ruby
...

group :development, :test do
  gem 'steep', require: false
  gem 'rbs_rails', require: false
end
```