### PR TITLE
Fix SEGV when parse with invalid content

### DIFF
--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -275,6 +275,8 @@ VALUE comment_to_ruby(comment *com, VALUE buffer) {
 parserstate *alloc_parser(VALUE buffer, int start_pos, int end_pos, VALUE variables) {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
 
+  StringValue(string);
+
   lexstate *lexer = calloc(1, sizeof(lexstate));
   lexer->string = string;
   lexer->current.line = 1;

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -58,6 +58,13 @@ end
     end
   end
 
+  def test_type_error
+    buffer = RBS::Buffer.new(content: 1, name: nil)
+    assert_raises TypeError do
+      RBS::Parser.parse_signature(buffer)
+    end
+  end
+
   def test_interface_alias
     RBS::Parser.parse_signature(buffer(<<-RBS)).tap do |decls|
 interface _Foo[unchecked in A]


### PR DESCRIPTION
I came across a case that SEGV.
After investigating the minimal code, I found the following

```rb
buffer = RBS::Buffer.new(content: 1, name: nil)
RBS::Parser.parse_signature(buffer)
```

I think it should be validated for String before parsing.