### PR TITLE
Use `untyped` instead of  `any` in syntax.md

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -561,7 +561,7 @@ Interface declaration can have parameters but allows only a few of the members.
 ```
 interface _Hashing
   def hash: () -> Integer
-  def eql?: (any) -> bool
+  def eql?: (untyped) -> bool
 end
 ```
 


### PR DESCRIPTION
[skip ci]