### PR TITLE
Refactor collection

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -29,7 +29,12 @@ module RBS
         end
 
         loader = EnvironmentLoader.new(core_root: core_root, repository: repository)
-        lock = config_path&.then { |p| Collection::Config.lockfile_of(p) }
+        if config_path
+          lock_path = Collection::Config.to_lockfile_path(config_path)
+          if lock_path.file?
+            lock = Collection::Config::Lockfile.from_lockfile(lockfile_path: lock_path, data: YAML.load_file(lock_path.to_s))
+          end
+        end
         loader.add_collection(lock) if lock
 
         dirs.each do |dir|

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -5,6 +5,7 @@ require 'bundler'
 
 require_relative './collection/sources'
 require_relative './collection/config'
+require_relative './collection/config/lockfile'
 require_relative './collection/config/lockfile_generator'
 require_relative './collection/installer'
 require_relative './collection/cleaner'

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -16,6 +16,8 @@ module RBS
 
       PATH = Pathname('rbs_collection.yaml')
 
+      attr_reader :config_path, :data
+
       def self.find_config_path
         current = Pathname.pwd
 
@@ -30,16 +32,14 @@ module RBS
       # Generate a rbs lockfile from Gemfile.lock to `config_path`.
       # If `with_lockfile` is true, it respects existing rbs lockfile.
       def self.generate_lockfile(config_path:, gemfile_lock_path:, with_lockfile: true)
-        LockfileGenerator.generate(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
+        config = from_path(config_path)
+        lockfile = LockfileGenerator.generate(config: config, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
+
+        [config, lockfile]
       end
 
       def self.from_path(path)
         new(YAML.load(path.read), config_path: path)
-      end
-
-      def self.lockfile_of(config_path)
-        lock_path = to_lockfile_path(config_path)
-        from_path lock_path if lock_path.exist?
       end
 
       def self.to_lockfile_path(config_path)
@@ -51,16 +51,16 @@ module RBS
         @config_path = config_path
       end
 
-      def add_gem(gem)
-        gems << gem
-      end
-
       def gem(gem_name)
         gems.find { |gem| gem['name'] == gem_name }
       end
 
       def repo_path
-        @config_path.dirname.join @data['path']
+        @config_path.dirname.join repo_path_data
+      end
+
+      def repo_path_data
+        Pathname(@data["path"])
       end
 
       def sources
@@ -72,36 +72,8 @@ module RBS
         )
       end
 
-      def dump_to(io)
-        YAML.dump(@data, io)
-      end
-
       def gems
         @data['gems'] ||= []
-      end
-
-      def gemfile_lock_path=(path)
-        @data['gemfile_lock_path'] = path.relative_path_from(@config_path.dirname).to_s
-      end
-
-      def gemfile_lock_path
-        path = @data['gemfile_lock_path']
-        return unless path
-        @config_path.dirname.join path
-      end
-
-      # It raises an error when there are non-available libraries
-      def check_rbs_availability!
-        raise CollectionNotAvailable unless repo_path.exist?
-
-        gems.each do |gem|
-          case gem['source']['type']
-          when 'git'
-            meta_path = repo_path.join(gem['name'], gem['version'], Sources::Git::METADATA_FILENAME)
-            raise CollectionNotAvailable unless meta_path.exist?
-            raise CollectionNotAvailable unless gem == YAML.load(meta_path.read)
-          end
-        end
       end
     end
   end

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -81,24 +81,7 @@ module RBS
           if gems = data["gems"]
             gems.each do |gem|
               src = gem["source"]
-              source =
-                case src["type"]
-                when "git"
-                  # @type var src: Sources::Git::source_entry
-                  Sources::Git.new(
-                    name: src["name"],
-                    revision: src["revision"],
-                    remote: src["remote"],
-                    repo_dir: src["repo_dir"]
-                  )
-                when "stdlib"
-                  Sources::Stdlib.instance
-                when "rubygems"
-                  Sources::Rubygems.instance
-                else
-                  raise
-                end
-
+              source = Sources.from_config_entry(src)
               lockfile.gems[gem["name"]] = {
                 name: gem["name"],
                 version: gem["version"],

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -40,15 +40,7 @@ module RBS
           # @type var data: lockfile_data
 
           data = {
-            "sources" => sources.each_value.sort_by {|s| s.name }.map do |source|
-              # @type block: git_source_data
-              {
-                "name" => source.name,
-                "remote" => source.remote,
-                "revision" => source.resolved_revision,
-                "repo_dir" => source.repo_dir
-              }
-            end,
+            "sources" => sources.each_value.sort_by {|s| s.name }.map {|source| source.to_lockfile },
             "path" => path.to_s,
             "gems" => gems.each_value.sort_by {|g| g[:name] }.map {|hash| library_data(hash) },
             "gemfile_lock_path" => gemfile_lock_path.to_s

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -1,0 +1,138 @@
+module RBS
+  module Collection
+    class Config
+      class Lockfile
+        attr_reader :lockfile_path, :lockfile_dir, :path, :gemfile_lock_path, :sources, :gems
+
+        def initialize(lockfile_path:, path:, gemfile_lock_path:)
+          @lockfile_path = lockfile_path
+          @lockfile_dir = lockfile_path.parent
+          @path = path
+          @gemfile_lock_path = gemfile_lock_path
+
+          @sources = {}
+          @gems = {}
+        end
+
+        def fullpath
+          lockfile_dir + path
+        end
+
+        def gemfile_lock_fullpath
+          if gemfile_lock_path
+            lockfile_dir + gemfile_lock_path
+          end
+        end
+
+        def each_source(&block)
+          if block
+            sources.each_value(&block)
+            yield Sources::Rubygems.instance
+            yield Sources::Stdlib.instance
+          else
+            enum_for :each_source
+          end
+        end
+
+        def to_lockfile
+          # @type var data: lockfile_data
+
+          data = {
+            "sources" => sources.each_value.sort_by {|s| s.name }.map do |source|
+              # @type block: git_source_data
+              {
+                "name" => source.name,
+                "remote" => source.remote,
+                "revision" => source.resolved_revision,
+                "repo_dir" => source.repo_dir
+              }
+            end,
+            "path" => path.to_s,
+            "gems" => gems.each_value.sort_by {|g| g[:name] }.map {|hash| library_data(hash) },
+            "gemfile_lock_path" => gemfile_lock_path.to_s
+          }
+
+          data.delete("sources") if sources.empty?
+          data.delete("gems") if gems.empty?
+
+          data
+        end
+
+        def self.from_lockfile(lockfile_path:, data:)
+          path = Pathname(data["path"])
+          if p = data["gemfile_lock_path"]
+            gemfile_lock_path = Pathname(p)
+          end
+
+          lockfile = Lockfile.new(lockfile_path: lockfile_path, path: path, gemfile_lock_path: gemfile_lock_path)
+
+          if sources = data["sources"]
+            sources.each do |src|
+              git = Sources::Git.new(
+                name: src["name"],
+                revision: src["revision"],
+                remote: src["remote"],
+                repo_dir: src["repo_dir"]
+              )
+              lockfile.sources[git.name] = git
+            end
+          end
+
+          if gems = data["gems"]
+            gems.each do |gem|
+              src = gem["source"]
+              source =
+                case src["type"]
+                when "git"
+                  # @type var src: Sources::Git::source_entry
+                  Sources::Git.new(
+                    name: src["name"],
+                    revision: src["revision"],
+                    remote: src["remote"],
+                    repo_dir: src["repo_dir"]
+                  )
+                when "stdlib"
+                  Sources::Stdlib.instance
+                when "rubygems"
+                  Sources::Rubygems.instance
+                else
+                  raise
+                end
+
+              lockfile.gems[gem["name"]] = {
+                name: gem["name"],
+                version: gem["version"],
+                source: source
+              }
+            end
+          end
+
+          lockfile
+        end
+
+        def library_data(lib)
+          {
+            "name" => lib[:name],
+            "version" => lib[:version],
+            "source" => lib[:source].to_lockfile
+          }
+        end
+
+        def check_rbs_availability!
+          raise CollectionNotAvailable unless fullpath.exist?
+
+          gems.each_value do |gem|
+            source = gem[:source]
+
+            case source
+            when Sources::Git
+              meta_path = fullpath.join(gem[:name], gem[:version], Sources::Git::METADATA_FILENAME)
+              raise CollectionNotAvailable unless meta_path.exist?
+              raise CollectionNotAvailable unless library_data(gem) == YAML.load(meta_path.read)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RBS
   module Collection
     class Config

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -20,57 +20,75 @@ module RBS
           end
         end
 
-        attr_reader :config, :lock, :gemfile_lock, :lock_path
+        attr_reader :config, :lockfile, :gemfile_lock, :existing_lockfile
 
-        def self.generate(config_path:, gemfile_lock_path:, with_lockfile: true)
-          new(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile).generate
+        def self.generate(config:, gemfile_lock_path:, with_lockfile: true)
+          generator = new(config: config, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
+          generator.generate
+          generator.lockfile
         end
 
-        def initialize(config_path:, gemfile_lock_path:, with_lockfile:)
-          @config = Config.from_path config_path
-          @lock_path = Config.to_lockfile_path(config_path)
-          @lock = Config.from_path(lock_path) if lock_path.exist? && with_lockfile
+        def initialize(config:, gemfile_lock_path:, with_lockfile:)
+          @config = config
+
+          lockfile_path = Config.to_lockfile_path(config.config_path)
+          lockfile_dir = lockfile_path.parent
+
+          @lockfile = Lockfile.new(
+            lockfile_path: lockfile_path,
+            path: config.repo_path_data,
+            gemfile_lock_path: gemfile_lock_path.relative_path_from(lockfile_dir)
+          )
+          config.sources.each do |source|
+            case source
+            when Sources::Git
+              lockfile.sources[source.name] = source
+            end
+          end
+
+          if with_lockfile && lockfile_path.file?
+            @existing_lockfile = Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))
+            validate_gemfile_lock_path!(lock: @existing_lockfile, gemfile_lock_path: gemfile_lock_path)
+          end
+
           @gemfile_lock = Bundler::LockfileParser.new(gemfile_lock_path.read)
-          @gem_queue = []
-
-          validate_gemfile_lock_path!(lock: lock, gemfile_lock_path: gemfile_lock_path)
-
-          config.gemfile_lock_path = gemfile_lock_path
         end
 
         def generate
+          ignored_gems = config.gems.select {|gem| gem["ignore"] }.map {|gem| gem["name"] }.to_set
+
           config.gems.each do |gem|
-            @gem_queue.push({ name: gem['name'], version: gem['version'] })
+            if Sources::Stdlib.instance.has?(gem["name"], nil)
+              assign_stdlib(name: gem["name"], from_gem: nil) unless ignored_gems.include?(gem["name"])
+            else
+              assign_gem(name: gem["name"], version: gem["version"], ignored_gems: ignored_gems)
+            end
           end
 
           gemfile_lock_gems do |spec|
-            @gem_queue.push({ name: spec.name, version: spec.version })
+            assign_gem(name: spec.name, version: spec.version, ignored_gems: ignored_gems)
           end
 
-          while gem = @gem_queue.shift
-            assign_gem(name: gem[:name], version: gem[:version])
-          end
-          remove_ignored_gems!
-
-          config.dump_to(lock_path)
-          config
+          lockfile.lockfile_path.write(YAML.dump(lockfile.to_lockfile))
         end
 
         private def validate_gemfile_lock_path!(lock:, gemfile_lock_path:)
           return unless lock
-          return unless lock.gemfile_lock_path
-          return if lock.gemfile_lock_path == gemfile_lock_path
-
-          raise GemfileLockMismatchError.new(expected: lock.gemfile_lock_path, actual: gemfile_lock_path)
+          return unless lock.gemfile_lock_fullpath
+          unless lock.gemfile_lock_fullpath == gemfile_lock_path
+            raise GemfileLockMismatchError.new(expected: lock.gemfile_lock_fullpath, actual: gemfile_lock_path)
+          end
         end
 
-        private def assign_gem(name:, version:)
-          # @type var locked: gem_entry?
-          locked = lock&.gem(name)
-          specified = config.gem(name)
+        private def assign_gem(name:, version:, ignored_gems:)
+          return if ignored_gems.include?(name)
+          return if lockfile.gems.key?(name)
 
-          return if specified&.dig('ignore')
-          return if specified&.dig('source') # skip if the source is already filled
+          # @type var locked: Lockfile::library?
+
+          if existing_lockfile
+            locked = existing_lockfile.gems[name]
+          end
 
           # If rbs_collection.lock.yaml contain the gem, use it.
           # Else find the gem from gem_collection.
@@ -82,31 +100,47 @@ module RBS
             best_version = find_best_version(version: installed_version, versions: source.versions(name))
 
             locked = {
-              'name' => name,
-              'version' => best_version.to_s,
-              'source' => source.to_lockfile,
+              name: name,
+              version: best_version.to_s,
+              source: source,
             }
           end
 
           locked or raise
 
-          upsert_gem specified, locked
-          source = Sources.from_config_entry(locked['source'] || raise)
-          source.dependencies_of(locked["name"], locked["version"] || raise)&.each do |dep|
-            @gem_queue.push({ name: dep['name'], version: nil} )
+          lockfile.gems[name] = locked
+          source = locked[:source]
+
+          source.dependencies_of(locked[:name], locked[:version])&.each do |dep|
+            assign_stdlib(name: dep["name"], from_gem: name)
           end
         end
 
-        private def upsert_gem(old, new)
-          if old
-            old.merge! new
-          else
-            config.add_gem new
-          end
-        end
+        private def assign_stdlib(name:, from_gem:)
+          return if lockfile.gems.key?(name)
 
-        private def remove_ignored_gems!
-          config.gems.reject! { |gem| gem['ignore'] }
+          if name == 'rubygems'
+            if from_gem
+                RBS.logger.warn "`rubygems` has been moved to core library, so it is always loaded. Remove explicit loading `rubygems` from `#{from_gem}`"
+            else
+              RBS.logger.warn '`rubygems` has been moved to core library, so it is always loaded. Remove explicit loading `rubygems`'
+            end
+
+            return
+          end
+
+          source = Sources::Stdlib.instance
+          lockfile.gems[name] = { name: name, version: "0", source: source }
+
+          unless source.has?(name, nil)
+            raise "Cannot find `#{name}` from standard libraries"
+          end
+
+          if deps = source.dependencies_of(name, "0")
+            deps.each do |dep|
+              assign_stdlib(name: dep["name"], from_gem: name)
+            end
+          end
         end
 
         private def gemfile_lock_gems(&block)

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -48,7 +48,7 @@ module RBS
           end
 
           while gem = @gem_queue.shift
-            assign_gem(**gem)
+            assign_gem(name: gem[:name], version: gem[:version])
           end
           remove_ignored_gems!
 
@@ -79,7 +79,7 @@ module RBS
             return unless source
 
             installed_version = version
-            best_version = find_best_version(version: installed_version, versions: source.versions({ 'name' => name }))
+            best_version = find_best_version(version: installed_version, versions: source.versions(name))
 
             locked = {
               'name' => name,
@@ -92,7 +92,7 @@ module RBS
 
           upsert_gem specified, locked
           source = Sources.from_config_entry(locked['source'] || raise)
-          source.dependencies_of(locked)&.each do |dep|
+          source.dependencies_of(locked["name"], locked["version"] || raise)&.each do |dep|
             @gem_queue.push({ name: dep['name'], version: nil} )
           end
         end
@@ -118,7 +118,7 @@ module RBS
         private def find_source(name:)
           sources = config.sources
 
-          sources.find { |c| c.has?({ 'name' => name, 'revision' => nil } ) }
+          sources.find { |c| c.has?(name, nil) }
         end
 
         private def find_best_version(version:, versions:)

--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -7,31 +7,22 @@ module RBS
       attr_reader :stdout
 
       def initialize(lockfile_path:, stdout: $stdout)
-        @lockfile = Config.from_path(lockfile_path)
+        @lockfile = Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path))
         @stdout = stdout
       end
 
       def install_from_lockfile
-        install_to = lockfile.repo_path
+        install_to = lockfile.fullpath
         install_to.mkpath
-        lockfile.gems.each do |config_entry|
-          source_for(config_entry).install(
+        lockfile.gems.each_value do |gem|
+          gem[:source].install(
             dest: install_to,
-            name: config_entry["name"],
-            version: config_entry["version"] || raise,
+            name: gem[:name],
+            version: gem[:version],
             stdout: stdout
           )
         end
         stdout.puts "It's done! #{lockfile.gems.size} gems' RBSs now installed."
-      end
-
-      private def source_for(config_entry)
-        @source_for ||= {}
-        key = config_entry['source']
-        unless key
-          raise "Cannot find source of '#{config_entry['name']}' gem"
-        end
-        @source_for[key] ||= Sources.from_config_entry(key)
       end
     end
   end

--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -15,7 +15,12 @@ module RBS
         install_to = lockfile.repo_path
         install_to.mkpath
         lockfile.gems.each do |config_entry|
-          source_for(config_entry).install(dest: install_to, config_entry: config_entry, stdout: stdout)
+          source_for(config_entry).install(
+            dest: install_to,
+            name: config_entry["name"],
+            version: config_entry["version"] || raise,
+            stdout: stdout
+          )
         end
         stdout.puts "It's done! #{lockfile.gems.size} gems' RBSs now installed."
       end

--- a/lib/rbs/collection/sources.rb
+++ b/lib/rbs/collection/sources.rb
@@ -11,7 +11,13 @@ module RBS
       def self.from_config_entry(source_entry)
         case source_entry['type']
         when 'git', nil # git source by default
-          __skip__ = Git.new(**source_entry.slice('name', 'revision', 'remote', 'repo_dir').transform_keys(&:to_sym))
+          # @type var source_entry: Git::source_entry
+          Git.new(
+            name: source_entry["name"],
+            revision: source_entry["revision"],
+            remote: source_entry["remote"],
+            repo_dir: source_entry["repo_dir"]
+          )
         when 'stdlib'
           Stdlib.instance
         when 'rubygems'

--- a/lib/rbs/collection/sources/base.rb
+++ b/lib/rbs/collection/sources/base.rb
@@ -4,8 +4,8 @@ module RBS
   module Collection
     module Sources
       module Base
-        def dependencies_of(config_entry)
-          manifest = manifest_of(config_entry) or return
+        def dependencies_of(name, version)
+          manifest = manifest_of(name, version) or return
           manifest['dependencies']
         end
       end

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -166,15 +166,14 @@ module RBS
         end
 
         def resolved_revision
-          @resolved_revision ||= setup! { resolve_revision }
-        end
-
-        private def resolve_revision
-          if commit_hash?
-            revision
-          else
-            git('rev-parse', revision).chomp
-          end
+          @resolved_revision ||=
+            begin
+              if commit_hash?
+                revision
+              else
+                setup! { git('rev-parse', revision).chomp }
+              end
+            end
         end
 
         private def commit_hash?

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -26,16 +26,16 @@ module RBS
         def has?(name, version)
           setup! do
             if version
-              (gems_versions![name] || Set[]).include?(version)
+              (gems_versions[name] || Set[]).include?(version)
             else
-              gems_versions!.key?(name)
+              gems_versions.key?(name)
             end
           end
         end
 
         def versions(name)
           setup! do
-            versions = gems_versions![name] or raise "Git source `#{name}` doesn't have `#{name}`"
+            versions = gems_versions[name] or raise "Git source `#{name}` doesn't have `#{name}`"
             versions.sort
           end
         end
@@ -222,7 +222,7 @@ module RBS
           _ = content.slice("name", "version", "source")
         end
 
-        private def gems_versions!
+        private def gems_versions
           @gems_versions ||= begin
             repo_path = Pathname(repo_dir)
 

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -150,7 +150,7 @@ module RBS
           git_dir.join @repo_dir
         end
 
-        private def resolved_revision
+        def resolved_revision
           @resolved_revision ||= resolve_revision
         end
 

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -39,7 +39,7 @@ module RBS
           gem_dir = dest.join(gem_name, version)
 
           if gem_dir.directory?
-            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME))) == config_entry
+            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME).to_s)) == config_entry
               stdout.puts "Using #{format_config_entry(config_entry)}"
             else
               # @type var prev: RBS::Collection::Config::gem_entry

--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -23,54 +23,53 @@ module RBS
           setup!(revision: revision)
         end
 
-        def has?(config_entry)
-          gem_name = config_entry['name']
-          gem_repo_dir.join(gem_name).directory?
-        end
-
-        def versions(config_entry)
-          gem_name = config_entry['name']
-          gem_repo_dir.join(gem_name).glob('*/').map { |path| path.basename.to_s }
-        end
-
-        def install(dest:, config_entry:, stdout:)
-          gem_name = config_entry['name']
-          version = config_entry['version'] or raise
-          gem_dir = dest.join(gem_name, version)
-
-          if gem_dir.directory?
-            if (prev = YAML.load_file(gem_dir.join(METADATA_FILENAME).to_s)) == config_entry
-              stdout.puts "Using #{format_config_entry(config_entry)}"
+        def has?(name, version)
+          if gem_repo_dir.join(name).directory?
+            if version
+              versions(name).include?(version)
             else
-              # @type var prev: RBS::Collection::Config::gem_entry
-              stdout.puts "Updating to #{format_config_entry(config_entry)} from #{format_config_entry(prev)}"
-              FileUtils.remove_entry_secure(gem_dir.to_s)
-              _install(dest: dest, config_entry: config_entry)
+              true
             end
-          else
-            stdout.puts "Installing #{format_config_entry(config_entry)}"
-            _install(dest: dest, config_entry: config_entry)
           end
         end
 
-        def manifest_of(config_entry)
-          gem_name = config_entry['name']
-          version = config_entry['version'] or raise
-          gem_dir = gem_repo_dir.join(gem_name, version)
+        def versions(name)
+          gem_repo_dir.join(name).glob('*/').map { |path| path.basename.to_s }
+        end
+
+        def install(dest:, name:, version:, stdout:)
+          gem_dir = dest.join(name, version)
+
+          if gem_dir.directory?
+            prev = load_metadata(dir: gem_dir)
+
+            if prev == metadata_content(name: name, version: version)
+              stdout.puts "Using #{format_config_entry(name, version)}"
+            else
+              stdout.puts "Updating to #{format_config_entry(name, version)} from #{format_config_entry(prev["name"], prev["version"])}"
+              FileUtils.remove_entry_secure(gem_dir.to_s)
+              _install(dest: dest, name: name, version: version)
+            end
+          else
+            stdout.puts "Installing #{format_config_entry(name, version)}"
+            _install(dest: dest, name: name, version: version)
+          end
+        end
+
+        def manifest_of(name, version)
+          gem_dir = gem_repo_dir.join(name, version)
 
           manifest_path = gem_dir.join('manifest.yaml')
           YAML.safe_load(manifest_path.read) if manifest_path.exist?
         end
 
-        private def _install(dest:, config_entry:)
-          gem_name = config_entry['name']
-          version = config_entry['version'] or raise
-          dest = dest.join(gem_name, version)
-          dest.mkpath
-          src = gem_repo_dir.join(gem_name, version)
+        private def _install(dest:, name:, version:)
+          dir = dest.join(name, version)
+          dir.mkpath
+          src = gem_repo_dir.join(name, version)
 
-          cp_r(src, dest)
-          dest.join(METADATA_FILENAME).write(YAML.dump(config_entry))
+          cp_r(src, dir)
+          write_metadata(dir: dir, name: name, version: version)
         end
 
         private def cp_r(src, dest)
@@ -97,14 +96,11 @@ module RBS
           }
         end
 
-        private def format_config_entry(config_entry)
-          name = config_entry['name']
-          v = config_entry['version']
-
+        private def format_config_entry(name, version)
           rev = resolved_revision[0..10]
           desc = "#{name}@#{rev}"
 
-          "#{name}:#{v} (#{desc})"
+          "#{name}:#{version} (#{desc})"
         end
 
         private def setup!(revision:)
@@ -174,6 +170,28 @@ module RBS
 
             out
           end
+        end
+
+        def metadata_content(name:, version:)
+          {
+            "name" => name,
+            "version" => version,
+            "source" => to_lockfile
+          }
+        end
+
+        def write_metadata(dir:, name:, version:)
+          dir.join(METADATA_FILENAME).write(
+            YAML.dump(
+              metadata_content(name: name, version: version)
+            )
+          )
+        end
+
+        def load_metadata(dir:)
+          # @type var content: Hash[String, untyped]
+          content = YAML.load_file(dir.join(METADATA_FILENAME).to_s)
+          _ = content.slice("name", "version", "source")
         end
       end
     end

--- a/lib/rbs/collection/sources/rubygems.rb
+++ b/lib/rbs/collection/sources/rubygems.rb
@@ -10,26 +10,24 @@ module RBS
         include Base
         include Singleton
 
-        def has?(config_entry)
-          gem_sig_path(config_entry)
+        def has?(name, version)
+          gem_sig_path(name, version)
         end
 
-        def versions(config_entry)
-          spec, _ = gem_sig_path(config_entry)
+        def versions(name)
+          spec, _ = gem_sig_path(name, nil)
           spec or raise
           [spec.version.to_s]
         end
 
-        def install(dest:, config_entry:, stdout:)
+        def install(dest:, name:, version:, stdout:)
           # Do nothing because stdlib RBS is available by default
-          name = config_entry['name']
-          version = config_entry['version'] or raise
-          _, from = gem_sig_path(config_entry)
+          _, from = gem_sig_path(name, version)
           stdout.puts "Using #{name}:#{version} (#{from})"
         end
 
-        def manifest_of(config_entry)
-          _, sig_path = gem_sig_path(config_entry)
+        def manifest_of(name, version)
+          _, sig_path = gem_sig_path(name, version)
           sig_path or raise
           manifest_path = sig_path.join('manifest.yaml')
           YAML.safe_load(manifest_path.read) if manifest_path.exist?
@@ -41,8 +39,8 @@ module RBS
           }
         end
 
-        private def gem_sig_path(config_entry)
-          RBS::EnvironmentLoader.gem_sig_path(config_entry['name'], config_entry['version'])
+        private def gem_sig_path(name, version)
+          RBS::EnvironmentLoader.gem_sig_path(name, version)
         end
       end
     end

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -12,25 +12,22 @@ module RBS
 
         REPO = Repository.default
 
-        def has?(config_entry)
-          lookup(config_entry)
+        def has?(name, version)
+          lookup(name, version)
         end
 
-        def versions(config_entry)
-          REPO.gems[config_entry['name']].versions.keys.map(&:to_s)
+        def versions(name)
+          REPO.gems[name].versions.keys.map(&:to_s)
         end
 
-        def install(dest:, config_entry:, stdout:)
+        def install(dest:, name:, version:, stdout:)
           # Do nothing because stdlib RBS is available by default
-          name = config_entry['name']
-          version = config_entry['version'] or raise
-          from = lookup(config_entry)
+          from = lookup(name, version)
           stdout.puts "Using #{name}:#{version} (#{from})"
         end
 
-        def manifest_of(config_entry)
-          config_entry['version'] or raise
-          manifest_path = (lookup(config_entry) or raise).join('manifest.yaml')
+        def manifest_of(name, version)
+          manifest_path = (lookup(name, version) or raise).join('manifest.yaml')
           YAML.safe_load(manifest_path.read) if manifest_path.exist?
         end
 
@@ -40,8 +37,8 @@ module RBS
           }
         end
 
-        private def lookup(config_entry)
-          REPO.lookup(config_entry['name'], config_entry['version'])
+        private def lookup(name, version)
+          REPO.lookup(name, version)
         end
       end
     end

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -60,12 +60,13 @@ module RBS
 
     def resolve_dependencies(library:, version:)
       [Collection::Sources::Rubygems.instance, Collection::Sources::Stdlib.instance].each do |source|
-        # @type var gem: { 'name' => String, 'version' => String? }
-        gem = { 'name' => library, 'version' => version }
-        next unless source.has?(gem)
+        next unless source.has?(library, version)
 
-        gem['version'] ||= source.versions(gem).last
-        source.dependencies_of(gem)&.each do |dep|
+        unless version
+          version = source.versions(library).last or raise
+        end
+
+        source.dependencies_of(library, version)&.each do |dep|
           add(library: dep['name'], version: nil)
         end
         return

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -73,13 +73,13 @@ module RBS
       end
     end
 
-    def add_collection(collection_config)
-      collection_config.check_rbs_availability!
+    def add_collection(lockfile)
+      lockfile.check_rbs_availability!
 
-      repository.add(collection_config.repo_path)
+      repository.add(lockfile.fullpath)
 
-      collection_config.gems.each do |gem|
-        add(library: gem['name'], version: gem['version'], resolve_dependencies: false)
+      lockfile.gems.each_value do |gem|
+        add(library: gem[:name], version: gem[:version], resolve_dependencies: false)
       end
     end
 

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -15,42 +15,32 @@ module RBS
         'source' => Sources::source_entry?
       }
 
-      @config_path: Pathname
+      attr_reader config_path: Pathname
 
-      @data: untyped
+      attr_reader data: untyped
 
       @sources: Array[Sources::_Source]
 
       def self.find_config_path: () -> Pathname?
 
-      def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
+      def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> [Config, Lockfile]
 
       def self.from_path: (Pathname path) -> Config
-
-      def self.lockfile_of: (Pathname config_path) -> Config?
 
       def self.to_lockfile_path: (Pathname config_path) -> Pathname
 
       # config_path is necessary to resolve relative repo_path
       def initialize: (untyped data, config_path: Pathname) -> void
 
-      def add_gem: (gem_entry gem) -> void
-
       def gem: (String gem_name) -> gem_entry?
 
       def repo_path: () -> Pathname
 
-      def sources: () -> Array[Sources::_Source]
+      def repo_path_data: () -> Pathname
 
-      def dump_to: (Pathname) -> void
+      def sources: () -> Array[Sources::t]
 
       def gems: () -> Array[gem_entry]
-
-      def gemfile_lock_path=: (Pathname) -> Pathname
-
-      def gemfile_lock_path: () -> Pathname?
-
-      def check_rbs_availability!: () -> void
     end
   end
 end

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -6,39 +6,6 @@ module RBS
         def initialize: () -> void
       end
 
-      class LockfileGenerator
-        attr_reader config: Config
-        attr_reader lock: Config?
-        attr_reader lock_path: Pathname
-        attr_reader gemfile_lock: Bundler::LockfileParser
-
-        type gem_queue_entry = { name: String, version: String? }
-
-        @gem_queue: Array[gem_queue_entry]
-
-        def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
-
-        def initialize: (config_path: Pathname, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
-
-        def generate: () -> Config
-
-        private
-
-        def validate_gemfile_lock_path!: (lock: Config?, gemfile_lock_path: Pathname) -> void
-
-        def assign_gem: (name: String, version: String?) -> void
-
-        def upsert_gem: (gem_entry? old, gem_entry new) -> void
-
-        def gemfile_lock_gems: () { (untyped) -> void } -> void
-
-        def remove_ignored_gems!: () -> void
-
-        def find_source: (name: String) -> Sources::_Source?
-
-        def find_best_version: (version: String?, versions: Array[String]) -> Gem::Version
-      end
-
       PATH: Pathname
 
       type gem_entry = {

--- a/sig/collection/config/lockfile.rbs
+++ b/sig/collection/config/lockfile.rbs
@@ -1,0 +1,87 @@
+module RBS
+  module Collection
+    class Config
+      # Lockfile represents the `rbs_collection.lock.yaml`, that contains configurations and *resolved* gems with their sources
+      #
+      class Lockfile
+        # Data structure stored in `rbs_collection.lock.yaml`
+        #
+        type lockfile_data = {
+          "sources" => Array[git_source_data]?,   # null if empty
+          "path" => String,
+          "gems" => Array[library_data]?,         # null if empty
+          "gemfile_lock_path" => String?          # gemfile_lock_path is optional because older versions doesn't have it
+        }
+
+        type git_source_data = {
+          'name' => String,
+          'remote' => String,
+          'revision' => String,
+          'repo_dir' => String?
+        }
+
+        type library_data = {
+          'name' => String,
+          'version' => String,
+          'source' => Sources::source_entry
+        }
+
+        # In-memory data structure that represents a library
+        #
+        type library = {
+          name: String,
+          version: String,
+          source: Sources::t
+        }
+
+        attr_reader lockfile_path: Pathname
+
+        # Path of the directory where lockfile is saved in
+        #
+        # `lockfile_path.parent`
+        #
+        attr_reader lockfile_dir: Pathname
+
+        # Relative to lockfile_dir
+        #
+        attr_reader path: Pathname
+
+        # Relative to lockfile_dir
+        #
+        attr_reader gemfile_lock_path: Pathname?
+
+        attr_reader sources: Hash[String, Sources::Git]
+
+        attr_reader gems: Hash[String, library]
+
+        def initialize: (lockfile_path: Pathname, path: Pathname, gemfile_lock_path: Pathname?) -> void
+
+        # `lockfile_dir` + `path`
+        #
+        def fullpath: () -> Pathname
+
+        # `lockfile_dir` + `gemfile_lock_path`
+        #
+        %a{pure} def gemfile_lock_fullpath: () -> Pathname?
+
+        def to_lockfile: () -> lockfile_data
+
+        def each_source: () { (Sources::t) -> void } -> void
+                       | () -> Enumerator[Sources::t, void]
+
+        def self.from_lockfile: (lockfile_path: Pathname, data: lockfile_data) -> Lockfile
+
+        # Validates if directories are set up correctly
+        #
+        # * Ensures if `path` is a directory
+        # * Ensures if `git` sources are set up correctly
+        #
+        def check_rbs_availability!: () -> void
+
+        private
+
+        def library_data: (library) -> library_data
+      end
+    end
+  end
+end

--- a/sig/collection/config/lockfile.rbs
+++ b/sig/collection/config/lockfile.rbs
@@ -7,17 +7,10 @@ module RBS
         # Data structure stored in `rbs_collection.lock.yaml`
         #
         type lockfile_data = {
-          "sources" => Array[git_source_data]?,   # null if empty
+          "sources" => Array[Sources::Git::source_entry]?,   # null if empty
           "path" => String,
           "gems" => Array[library_data]?,         # null if empty
           "gemfile_lock_path" => String?          # gemfile_lock_path is optional because older versions doesn't have it
-        }
-
-        type git_source_data = {
-          'name' => String,
-          'remote' => String,
-          'revision' => String,
-          'repo_dir' => String?
         }
 
         type library_data = {

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -1,0 +1,38 @@
+module RBS
+  module Collection
+    class Config
+      class LockfileGenerator
+        attr_reader config: Config
+        attr_reader lock: Config?
+        attr_reader lock_path: Pathname
+        attr_reader gemfile_lock: Bundler::LockfileParser
+
+        type gem_queue_entry = { name: String, version: String? }
+
+        @gem_queue: Array[gem_queue_entry]
+
+        def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
+
+        def initialize: (config_path: Pathname, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
+
+        def generate: () -> Config
+
+        private
+
+        def validate_gemfile_lock_path!: (lock: Config?, gemfile_lock_path: Pathname) -> void
+
+        def assign_gem: (name: String, version: String?) -> void
+
+        def upsert_gem: (gem_entry? old, gem_entry new) -> void
+
+        def gemfile_lock_gems: () { (untyped) -> void } -> void
+
+        def remove_ignored_gems!: () -> void
+
+        def find_source: (name: String) -> Sources::_Source?
+
+        def find_best_version: (version: String?, versions: Array[String]) -> Gem::Version
+      end
+    end
+  end
+end

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -34,7 +34,7 @@ module RBS
         #
         def validate_gemfile_lock_path!: (lock: Lockfile?, gemfile_lock_path: Pathname) -> void
 
-        def assign_gem: (name: String, version: String?, ignored_gems: Set[String]) -> void
+        def assign_gem: (name: String, version: String?, ignored_gems: Set[String], src_data: Sources::source_entry?) -> void
 
         def assign_stdlib: (name: String, from_gem: String?) -> void
 
@@ -42,6 +42,10 @@ module RBS
 
         def remove_ignored_gems!: () -> void
 
+        # Find a source of a gem from ones registerd in `config.sources`
+        #
+        # Returns `nil` if no source contains the definition of the gem.
+        #
         def find_source: (name: String) -> Sources::t?
 
         def find_best_version: (version: String?, versions: Array[String]) -> Gem::Version

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -6,40 +6,43 @@ module RBS
           @expected: Pathname
 
           @actual: Pathname
-          
+
           def initialize: (expected: Pathname, actual: Pathname) -> void
 
           def message: () -> String
         end
 
         attr_reader config: Config
-        attr_reader lock: Config?
-        attr_reader lock_path: Pathname
         attr_reader gemfile_lock: Bundler::LockfileParser
+
+        attr_reader lockfile: Lockfile
+        attr_reader existing_lockfile: Lockfile?
 
         type gem_queue_entry = { name: String, version: String? }
 
         @gem_queue: Array[gem_queue_entry]
 
-        def self.generate: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Config
+        def self.generate: (config: Config, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Lockfile
 
-        def initialize: (config_path: Pathname, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
+        def initialize: (config: Config, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
 
-        def generate: () -> Config
+        def generate: () -> void
 
         private
 
-        def validate_gemfile_lock_path!: (lock: Config?, gemfile_lock_path: Pathname) -> void
+        # Ensure if current `gemfile_lock_path` is the same with the path saved in `lock`
+        #
+        def validate_gemfile_lock_path!: (lock: Lockfile?, gemfile_lock_path: Pathname) -> void
 
-        def assign_gem: (name: String, version: String?) -> void
+        def assign_gem: (name: String, version: String?, ignored_gems: Set[String]) -> void
 
-        def upsert_gem: (gem_entry? old, gem_entry new) -> void
+        def assign_stdlib: (name: String, from_gem: String?) -> void
 
         def gemfile_lock_gems: () { (untyped) -> void } -> void
 
         def remove_ignored_gems!: () -> void
 
-        def find_source: (name: String) -> Sources::_Source?
+        def find_source: (name: String) -> Sources::t?
 
         def find_best_version: (version: String?, versions: Array[String]) -> Gem::Version
       end

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -42,7 +42,7 @@ module RBS
 
         def remove_ignored_gems!: () -> void
 
-        # Find a source of a gem from ones registerd in `config.sources`
+        # Find a source of a gem from ones registered in `config.sources`
         #
         # Returns `nil` if no source contains the definition of the gem.
         #

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -2,6 +2,16 @@ module RBS
   module Collection
     class Config
       class LockfileGenerator
+        class GemfileLockMismatchError < StandardError
+          @expected: Pathname
+
+          @actual: Pathname
+          
+          def initialize: (expected: Pathname, actual: Pathname) -> void
+
+          def message: () -> String
+        end
+
         attr_reader config: Config
         attr_reader lock: Config?
         attr_reader lock_path: Pathname

--- a/sig/collection/installer.rbs
+++ b/sig/collection/installer.rbs
@@ -1,7 +1,7 @@
 module RBS
   module Collection
     class Installer
-      attr_reader lockfile: Config
+      attr_reader lockfile: Config::Lockfile
       attr_reader stdout: CLI::_IO
 
       def initialize: (lockfile_path: Pathname, ?stdout: CLI::_IO) -> void

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -45,8 +45,6 @@ module RBS
         class CommandError < StandardError
         end
 
-        attr_reader gems_versions: Hash[String, Set[String]]?
-
         attr_reader name: String
         attr_reader remote: String
         attr_reader repo_dir: String
@@ -73,6 +71,8 @@ module RBS
         @git_dir: Pathname?
 
         @resolved_revision: String?
+
+        @gems_versions: Hash[String, Set[String]]?
 
         def _install: (dest: Pathname , name: String, version: String) -> void
 
@@ -117,7 +117,7 @@ module RBS
         #
         def load_metadata: (dir: Pathname) -> metadata
 
-        def gems_versions!: () -> Hash[String, Set[String]]
+        def gems_versions: () -> Hash[String, Set[String]]
       end
 
       # signatures that are bundled in rbs gem under the stdlib/ directory

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -4,12 +4,12 @@ module RBS
       def self.from_config_entry: (source_entry) -> _Source
 
       interface _Source
-        def has?: (Config::gem_entry) -> boolish
-        def versions: (Config::gem_entry) -> Array[String]
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def has?: (String name, String? version) -> boolish
+        def versions: (String name) -> Array[String]
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
-        def dependencies_of: (Config::gem_entry) -> Array[{"name" => String}]?
+        def manifest_of: (String name, String version) -> manifest_entry?
+        def dependencies_of: (String name, String version) -> Array[manifest_dependency]?
       end
 
       type source_entry = Git::source_entry
@@ -17,11 +17,13 @@ module RBS
                         | Rubygems::source_entry
 
       type manifest_entry = {
-        "dependencies" => Array[{"name" => String}]?,
+        "dependencies" => Array[manifest_dependency]?,
       }
 
+      type manifest_dependency = { "name" => String }
+
       module Base : _Source
-        def dependencies_of: (Config::gem_entry config_entry) -> Array[{"name" => String}]?
+        def dependencies_of: (String name, String version) -> Array[manifest_dependency]?
       end
 
       class Git
@@ -46,15 +48,15 @@ module RBS
 
         def initialize: (name: String, revision: String, remote: String, repo_dir: String?) -> untyped
 
-        def has?: (Config::gem_entry) -> bool
+        def has?: (String name, String? version) -> boolish
 
-        def versions: (Config::gem_entry) -> Array[String]
+        def versions: (String name) -> Array[String]
 
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (String name, String version) -> manifest_entry?
 
         private
 
@@ -62,7 +64,7 @@ module RBS
 
         @resolved_revision: String?
 
-        def _install: (dest: Pathname , config_entry: Config::gem_entry) -> void
+        def _install: (dest: Pathname , name: String, version: String) -> void
 
         def cp_r: (Pathname, Pathname) -> void
 
@@ -84,7 +86,18 @@ module RBS
 
         def sh!: (*String cmd, **untyped opt) -> String
 
-        def format_config_entry: (Config::gem_entry) -> String
+        def format_config_entry: (String name, String version) -> String
+
+        type metadata = { 'name' => String, 'version' => String, 'source' => source_entry }
+
+        def metadata_content: (name: String, version: String) -> metadata
+
+        # Write `.rbs_meta.yaml`
+        def write_metadata: (dir: Pathname, name: String, version: String) -> void
+
+        # Load `.rbs_meta.yaml` from the `dir`, where is the destination of the RBS file installation, and return the cleaned up content
+        #
+        def load_metadata: (dir: Pathname) -> metadata
       end
 
       # signatures that are bundled in rbs gem under the stdlib/ directory
@@ -101,19 +114,19 @@ module RBS
         # polyfill of singleton module
         def self.instance: () -> instance
 
-        def has?: (Config::gem_entry) -> boolish
+        def has?: (String name, String? version) -> boolish
 
-        def versions: (Config::gem_entry) -> Array[String]
+        def versions: (String name) -> Array[String]
 
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
 
         def to_lockfile: () -> source_entry
 
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+        def manifest_of: (String name, String version) -> manifest_entry?
 
         private
 
-        def lookup: (Config::gem_entry) -> Pathname?
+        def lookup: (String name, String? version) -> Pathname?
       end
 
       # sig/ directory
@@ -127,15 +140,19 @@ module RBS
         # polyfill of singleton module
         def self.instance: () -> instance
 
-        def has?: (Config::gem_entry) -> boolish
-        def versions: (Config::gem_entry) -> Array[String]
-        def install: (dest: Pathname, config_entry: Config::gem_entry, stdout: CLI::_IO) -> void
+        def has?: (String name, String? version) -> boolish
+
+        def versions: (String name) -> Array[String]
+
+        def install: (dest: Pathname, name: String, version: String, stdout: CLI::_IO) -> void
+
         def to_lockfile: () -> source_entry
-        def manifest_of: (Config::gem_entry) -> manifest_entry?
+
+        def manifest_of: (String name, String version) -> manifest_entry?
 
         private
 
-        def gem_sig_path: (Config::gem_entry) -> [Gem::Specification, Pathname]?
+        def gem_sig_path: (String name, String? version) -> [Gem::Specification, Pathname]?
       end
     end
   end

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -94,8 +94,6 @@ module RBS
 
         def with_revision: [T] () { () -> T } -> T
 
-        def resolve_revision: () -> String
-
         # Returns `true` if `revision` looks like a commit hash
         #
         def commit_hash?: () -> bool

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -45,9 +45,12 @@ module RBS
         class CommandError < StandardError
         end
 
+        attr_reader gems_versions: Hash[String, Set[String]]?
+
         attr_reader name: String
         attr_reader remote: String
         attr_reader repo_dir: String
+        attr_reader revision: String
 
         def initialize: (name: String, revision: String, remote: String, repo_dir: String?) -> untyped
 
@@ -61,7 +64,11 @@ module RBS
 
         def manifest_of: (String name, String version) -> manifest_entry?
 
+        def resolved_revision: () -> String
+
         private
+
+        @need_setup: bool
 
         @git_dir: Pathname?
 
@@ -71,9 +78,15 @@ module RBS
 
         def cp_r: (Pathname, Pathname) -> void
 
-        def setup!: (revision: String) -> void
+        # Ensure the git repository status is expected one
+        #
+        # * It exists, and
+        # * The `HEAD` is the `revision`
+        #
+        def setup!: [T] () { () -> T } -> T
+                  | () -> void
 
-        def need_to_fetch?: (String revision ) -> bool
+        def need_to_fetch?: (String revision) -> bool
 
         def git_dir: () -> Pathname
 
@@ -81,11 +94,15 @@ module RBS
 
         def with_revision: [T] () { () -> T } -> T
 
-        public def resolved_revision: () -> String
-
         def resolve_revision: () -> String
 
+        # Returns `true` if `revision` looks like a commit hash
+        #
+        def commit_hash?: () -> bool
+
         def git: (*String cmd, **untyped opt) -> String
+
+        def git?: (*String cmd, **untyped opt) -> String?
 
         def sh!: (*String cmd, **untyped opt) -> String
 
@@ -101,6 +118,8 @@ module RBS
         # Load `.rbs_meta.yaml` from the `dir`, where is the destination of the RBS file installation, and return the cleaned up content
         #
         def load_metadata: (dir: Pathname) -> metadata
+
+        def gems_versions!: () -> Hash[String, Set[String]]
       end
 
       # signatures that are bundled in rbs gem under the stdlib/ directory

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -12,6 +12,8 @@ module RBS
         def dependencies_of: (String name, String version) -> Array[manifest_dependency]?
       end
 
+      type t = Git | Stdlib | Rubygems
+
       type source_entry = Git::source_entry
                         | Stdlib::source_entry
                         | Rubygems::source_entry
@@ -78,7 +80,7 @@ module RBS
 
         def with_revision: [T] () { () -> T } -> T
 
-        def resolved_revision: () -> String
+        public def resolved_revision: () -> String
 
         def resolve_revision: () -> String
 

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -1,7 +1,8 @@
 module RBS
   module Collection
     module Sources
-      def self.from_config_entry: (source_entry) -> _Source
+      def self.from_config_entry: (Git::source_entry) -> Git
+                                | (source_entry) -> t
 
       interface _Source
         def has?: (String name, String? version) -> boolish

--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -81,7 +81,7 @@ module RBS
     def resolve_dependencies: (library: String, version: String?) -> void
 
     # Add repository path and libraries via rbs_collection.lock.yaml.
-    def add_collection: (Collection::Config collection_config) -> void
+    def add_collection: (Collection::Config::Lockfile lockfile) -> void
 
     # This is helper function to test if RBS for a library is available or not.
     #

--- a/sig/shims.rbs
+++ b/sig/shims.rbs
@@ -1,25 +1,3 @@
-module Gem
-  class Specification
-    attr_reader version (): Version
-
-    attr_reader gem_dir (): String
-
-    def self.find_by_name: (String name, *String requirements) -> instance
-  end
-end
-
-module Bundler
-  class LockfileParser
-    def initialize: (String) -> void
-    def specs: () -> Array[LazySpecification]
-  end
-
-  class LazySpecification
-    def name: () -> String
-    def version: () -> String
-  end
-end
-
 module RDoc
   class Store
     def initialize: (?String? path, ?Symbol? type) -> void

--- a/sig/shims/bundler.rbs
+++ b/sig/shims/bundler.rbs
@@ -8,4 +8,6 @@ module Bundler
     def name: () -> String
     def version: () -> String
   end
+
+  def self.default_lockfile: () -> Pathname
 end

--- a/sig/shims/bundler.rbs
+++ b/sig/shims/bundler.rbs
@@ -1,0 +1,11 @@
+module Bundler
+  class LockfileParser
+    def initialize: (String) -> void
+    def specs: () -> Array[LazySpecification]
+  end
+
+  class LazySpecification
+    def name: () -> String
+    def version: () -> String
+  end
+end

--- a/sig/shims/rubygems.rbs
+++ b/sig/shims/rubygems.rbs
@@ -1,0 +1,9 @@
+module Gem
+  class Specification
+    attr_reader version (): Version
+
+    attr_reader gem_dir (): String
+
+    def self.find_by_name: (String name, *String requirements) -> instance
+  end
+end

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -48,7 +48,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -101,7 +102,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
         assert_config <<~YAML, string
           sources:
-            - name: ruby/gem_rbs_collection
+            - type: git
+              name: ruby/gem_rbs_collection
               remote: #{remote}
               revision: b4d3b346d9657543099a35a1fd20347e75b8c523
               repo_dir: gems
@@ -138,7 +140,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       lockfile_yaml = <<~YAML
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -189,7 +192,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -236,7 +240,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -301,7 +306,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -374,7 +380,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -421,7 +428,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems
@@ -464,7 +472,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert_config <<~YAML, string
         sources:
-          - name: ruby/gem_rbs_collection
+          - type: git
+            name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
             revision: cde6057e7546843ace6420c5783dd945c6ccda54
             repo_dir: gems

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -43,11 +43,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -95,13 +94,12 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
         gemfile_lock_path = tmpdir / 'Gemfile.lock'
         gemfile_lock_path.write GEMFILE_LOCK
 
-        config = Dir.chdir(tmpdir) do
+        _config, lockfile = Dir.chdir(tmpdir) do
           RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
         end
-        io = StringIO.new
-        config.dump_to(io)
+        string = YAML.dump(lockfile.to_lockfile)
 
-        assert_config <<~YAML, io.string
+        assert_config <<~YAML, string
           sources:
             - name: ruby/gem_rbs_collection
               remote: #{remote}
@@ -138,7 +136,7 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      lockfile = <<~YAML
+      lockfile_yaml = <<~YAML
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -164,13 +162,12 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
               repo_dir: gems
               type: git
       YAML
-      tmpdir.join('rbs_collection.lock.yaml').write lockfile
+      tmpdir.join('rbs_collection.lock.yaml').write lockfile_yaml
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config lockfile, io.string
+      assert_config lockfile_yaml, string
     end
   end
 
@@ -187,11 +184,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -201,7 +197,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
         gemfile_lock_path: 'Gemfile.lock'
         gems:
           - name: rainbow
-            ignore: false
             version: "3.0"
             source:
               name: ruby/gem_rbs_collection
@@ -236,11 +231,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -302,11 +296,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -323,6 +316,14 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
               revision: cde6057e7546843ace6420c5783dd945c6ccda54
               repo_dir: gems
               type: git
+          - name: date
+            version: "0"
+            source:
+              type: stdlib
+          - name: logger
+            version: "0"
+            source:
+              type: stdlib
           - name: minitest
             version: '0'
             source:
@@ -331,19 +332,11 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
             version: "0"
             source:
               type: stdlib
-          - name: date
+          - name: mutex_m
             version: "0"
             source:
               type: stdlib
           - name: singleton
-            version: "0"
-            source:
-              type: stdlib
-          - name: logger
-            version: "0"
-            source:
-              type: stdlib
-          - name: mutex_m
             version: "0"
             source:
               type: stdlib
@@ -376,11 +369,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -424,11 +416,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -437,15 +428,15 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
-          - name: rbs-amber
-            version: "1.0.0"
-            source:
-              type: rubygems
           - name: pathname
             version: "0"
             source:
               type: stdlib
-      YAML
+          - name: rbs-amber
+            version: "1.0.0"
+            source:
+              type: rubygems
+        YAML
     end
   end
 
@@ -468,11 +459,10 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      config = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
-      io = StringIO.new
-      config.dump_to(io)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      string = YAML.dump(lockfile.to_lockfile)
 
-      assert_config <<~YAML, io.string
+      assert_config <<~YAML, string
         sources:
           - name: ruby/gem_rbs_collection
             remote: https://github.com/ruby/gem_rbs_collection.git
@@ -480,7 +470,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
             repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
-        gems: []
       YAML
     end
   end

--- a/test/rbs/collection/sources/git_test.rb
+++ b/test/rbs/collection/sources/git_test.rb
@@ -4,18 +4,18 @@ class RBS::Collection::Sources::GitTest < Test::Unit::TestCase
   def test_has?
     s = source
 
-    assert s.has?({ 'name' => 'activesupport' })
-    refute s.has?({ 'name' => 'rbs' })
+    assert s.has?('activesupport', nil)
+    refute s.has?('rbs', nil)
 
-    assert s.has?({ 'name' => 'protobuf' })
+    assert s.has?('protobuf', nil)
 
     old = source(revision: '41cac76e768cc51485763f92b56d976e8efc96aa')
-    refute old.has?({ 'name' => 'protobuf' })
+    refute old.has?('protobuf', nil)
   end
 
   def test_versions
     s = source
-    assert_equal ['2.4'], s.versions({ 'name' => 'ast' })
+    assert_equal ['2.4'], s.versions('ast')
   end
 
   def source(revision: 'b4d3b346d9657543099a35a1fd20347e75b8c523')

--- a/test/rbs/collection/sources/git_test.rb
+++ b/test/rbs/collection/sources/git_test.rb
@@ -5,6 +5,8 @@ class RBS::Collection::Sources::GitTest < Test::Unit::TestCase
     s = source
 
     assert s.has?('activesupport', nil)
+    refute s.has?('activesupport', "1.2.3.4")
+
     refute s.has?('rbs', nil)
 
     assert s.has?('protobuf', nil)
@@ -16,6 +18,17 @@ class RBS::Collection::Sources::GitTest < Test::Unit::TestCase
   def test_versions
     s = source
     assert_equal ['2.4'], s.versions('ast')
+  end
+
+  def test_manifest_of
+    s = source(revision: '45c7e873ce411dea05d7fd276efc71e57291e993')
+
+    assert_instance_of Hash, s.manifest_of('activesupport', '6.0')
+    assert_nil s.manifest_of('ast', '2.4')
+
+    assert_raises do
+      s.manifest_of('ast', '0.0')
+    end
   end
 
   def source(revision: 'b4d3b346d9657543099a35a1fd20347e75b8c523')

--- a/test/rbs/collection/sources/stdlib_test.rb
+++ b/test/rbs/collection/sources/stdlib_test.rb
@@ -4,25 +4,25 @@ class RBS::Collection::Sources::StdlibTest < Test::Unit::TestCase
   def test_has?
     s = source
 
-    assert s.has?({ 'name' => 'pathname' })
-    refute s.has?({ 'name' => 'activesupport' })
-    refute s.has?({ 'name' => 'rbs' })
+    assert s.has?('pathname', nil)
+    refute s.has?('activesupport', nil)
+    refute s.has?('rbs', nil)
   end
 
   def test_versions
     s = source
-    assert_equal ['0'], s.versions({ 'name' => 'pathname' })
+    assert_equal ['0'], s.versions('pathname')
   end
 
   def test_manifest_of__exist
     s = source
     assert_equal({ 'dependencies' => [{ 'name' => 'dbm'}, { 'name' => 'pstore'}] },
-                 s.manifest_of({ 'name' => 'yaml', 'version' => '0' }))
+                 s.manifest_of('yaml', '0'))
   end
 
   def test_manifest_of__nonexist
     s = source
-    assert_equal(nil, s.manifest_of({ 'name' => 'pathname', 'version' => '0' }))
+    assert_equal(nil, s.manifest_of('pathname', '0'))
   end
 
   def source

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -224,7 +224,7 @@ end
               type: git
       YAML
       RBS::Collection::Installer.new(lockfile_path: lockfile_path, stdout: StringIO.new).install_from_lockfile
-      lock = RBS::Collection::Config.from_path(lockfile_path)
+      lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path))
 
       repo = RBS::Repository.new()
 
@@ -236,7 +236,7 @@ end
 
       assert_operator env.class_decls, :key?, TypeName("::AST")
       assert_operator env.class_decls, :key?, TypeName("::Rainbow")
-      assert repo.dirs.include? lock.repo_path
+      assert repo.dirs.include? lock.fullpath
     end
   end
 
@@ -268,7 +268,7 @@ end
               repo_dir: gems
               type: git
       YAML
-      lock = RBS::Collection::Config.from_path(lockfile_path)
+      lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))
 
       repo = RBS::Repository.new()
 


### PR DESCRIPTION
This is a step toward https://github.com/ruby/rbs/issues/1148, it refactor the Ruby code and RBS type definition.

* More strict `Sources::*` method types, to declare if `version` is required or not.
* `Collection::Config::Lockfile` is introduced to make `rbs_collection.lock.yaml` data structure clear.
* `Sources::Git` is refactored that reduces `git checkout` operation as much as possible

The `Collection::*` API changes a lot. Not very sure if we need to bump the major version of the gem...