### PR TITLE
Remove `rubygems` from `rbs`’s manifest

### DIFF
--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -4,6 +4,5 @@ dependencies:
   - name: pathname
   - name: json
   - name: optparse
-  - name: rubygems
   - name: tsort
   - name: rdoc


### PR DESCRIPTION
As recommended in https://github.com/ruby/rbs/blob/master/lib/rbs/environment_loader.rb#L51