### PR TITLE
Fix SEGV when give invalid object to `variables`.

### DIFF
--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -299,6 +299,12 @@ parserstate *alloc_parser(VALUE buffer, int start_pos, int end_pos, VALUE variab
   parser_advance(parser);
 
   if (!NIL_P(variables)) {
+    if (!RB_TYPE_P(variables, T_ARRAY)) {
+      rb_raise(rb_eTypeError,
+               "wrong argument type %"PRIsVALUE" (must be array or nil)",
+               rb_obj_class(variables));
+    }
+
     parser_push_typevar_table(parser, true);
 
     for (long i = 0; i < rb_array_len(variables); i++) {

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -58,10 +58,16 @@ end
     end
   end
 
-  def test_type_error
+  def test_type_error_for_content
     buffer = RBS::Buffer.new(content: 1, name: nil)
     assert_raises TypeError do
       RBS::Parser.parse_signature(buffer)
+    end
+  end
+
+  def test_type_error_for_variables
+    assert_raises TypeError do
+      RBS::Parser.parse_type("bool", variables: 1)
     end
   end
 


### PR DESCRIPTION
I found another pattern to SEGV.

```rb
RBS::Parser.parse_type("bool", variables: 1)
```

This patch raises a `TypeError` and produces the following message

```
wrong argument type Integer (must be array or nil) (TypeError)
```