### PR TITLE
Skip collection tests if bundler is unavailable

### DIFF
--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -15,18 +15,15 @@ class RBS::CliTest < Test::Unit::TestCase
     @stderr ||= StringIO.new
   end
 
-  def bundler_available?
-    Bundler.default_lockfile
-    true
-  rescue Bundler::GemfileNotFound
-    false
-  end
-
   def with_cli
     yield CLI.new(stdout: stdout, stderr: stderr)
   ensure
     @stdout = nil
     @stderr = nil
+  end
+
+  def ci?
+    ENV["CI"] == "true"
   end
 
   def test_ast
@@ -522,7 +519,7 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install
-    omit unless bundler_available?
+    omit if ci?
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
@@ -576,7 +573,7 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install_frozen
-    omit unless bundler_available?
+    omit if ci?
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
@@ -610,7 +607,7 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_update
-    omit unless bundler_available?
+    omit if ci?
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -15,6 +15,13 @@ class RBS::CliTest < Test::Unit::TestCase
     @stderr ||= StringIO.new
   end
 
+  def bundler_available?
+    Bundler.default_lockfile
+    true
+  rescue Bundler::GemfileNotFound
+    false
+  end
+
   def with_cli
     yield CLI.new(stdout: stdout, stderr: stderr)
   ensure
@@ -515,6 +522,8 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install
+    omit unless bundler_available?
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)
@@ -567,6 +576,8 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install_frozen
+    omit unless bundler_available?
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)
@@ -599,6 +610,8 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_update
+    omit unless bundler_available?
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)


### PR DESCRIPTION
The collection tests don't make much sense because they load different `Gemfile`, and also fail if the test is not executed with `bundle exec`.

So, skipping them would make sense.