### PR TITLE
Delay loading `Gemfile` for unbundled environments

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1101,6 +1101,8 @@ EOB
 
             # Update the RBSs
             $ rbs collection update
+
+          Options:
         HELP
         opts.on('--frozen') if args[0] == 'install'
       end

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1034,15 +1034,17 @@ EOB
       opts.order args.drop(1), into: params
       config_path = options.config_path or raise
       lock_path = Collection::Config.to_lockfile_path(config_path)
-      gemfile_lock_path = Bundler.default_lockfile
 
       case args[0]
       when 'install'
         unless params[:frozen]
+          gemfile_lock_path = Bundler.default_lockfile
           Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'update'
+        gemfile_lock_path = Bundler.default_lockfile
+
         # TODO: Be aware of argv to update only specified gem
         Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -58,7 +58,7 @@ module RBS
           self.core_root = nil
         end
 
-        opts.on('--collection PATH', "File path of collection configuration (default: #{Collection::Config::PATH})") do |path|
+        opts.on('--collection PATH', "File path of collection configuration (default: #{@config_path})") do |path|
           self.config_path = Pathname(path).expand_path
         end
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -45,8 +45,8 @@ class RBS::CliTest < Test::Unit::TestCase
     @stderr = nil
   end
 
-  def ci?
-    ENV["CI"] == "true"
+  def bundler?
+    ENV.key?("BUNDLE_GEMFILE")
   end
 
   def test_ast
@@ -542,7 +542,7 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install
-    omit if ci?
+    omit unless bundler?
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
@@ -597,8 +597,6 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_install_frozen
-    omit if ci?
-
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)
@@ -630,7 +628,7 @@ Processing `test/a_test.rb`...
   end
 
   def test_collection_update
-    omit if ci?
+    omit unless bundler?
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -15,6 +15,29 @@ class RBS::CliTest < Test::Unit::TestCase
     @stderr ||= StringIO.new
   end
 
+  def run_rbs(*commands, bundler: true)
+    stdout, stderr, status =
+      Bundler.with_unbundled_env do
+        bundle_exec = []
+        bundle_exec = ["bundle", "exec"] if bundler
+
+        rbs_path = Pathname("#{__dir__}/../../lib").cleanpath.to_s
+        if rblib = ENV["RUBYLIB"]
+          rbs_path << (":" + rblib)
+        end
+
+        Open3.capture3({ "RUBYLIB" => rbs_path }, *bundle_exec, "#{__dir__}/../../exe/rbs", *commands, chdir: Dir.pwd)
+      end
+
+    if block_given?
+      yield status
+    else
+      assert_predicate status, :success?, stderr
+    end
+
+    [stdout, stderr]
+  end
+
   def with_cli
     yield CLI.new(stdout: stdout, stderr: stderr)
   ensure
@@ -533,7 +556,10 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('')
+        dir.join('Gemfile').write(<<~GEMFILE)
+          source 'https://rubygems.org'
+          gem 'ast'
+        GEMFILE
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/
@@ -550,23 +576,21 @@ Processing `test/a_test.rb`...
              2.2.0
         LOCK
 
-        with_cli do |cli|
-          cli.run(%w[collection install])
+        _stdout, _stderr = run_rbs("collection", "install")
 
-          rbs_collection_lock = dir.join('rbs_collection.lock.yaml')
+        rbs_collection_lock = dir.join('rbs_collection.lock.yaml')
+        assert rbs_collection_lock.exist?
+        rbs_collection_lock.delete
+
+        collection_dir = dir.join('gem_rbs_collection/ast')
+        assert collection_dir.exist?
+        collection_dir.rmtree
+
+        Dir.mkdir("child")
+        Dir.chdir("child") do
+          _stdout, _stderr = run_rbs("collection", "install")
           assert rbs_collection_lock.exist?
-          rbs_collection_lock.delete
-
-          collection_dir = dir.join('gem_rbs_collection/ast')
           assert collection_dir.exist?
-          collection_dir.rmtree
-
-          Dir.mkdir("child")
-          Dir.chdir("child") do
-            cli.run(%w[collection install])
-            assert rbs_collection_lock.exist?
-            assert collection_dir.exist?
-          end
         end
       end
     end
@@ -596,12 +620,11 @@ Processing `test/a_test.rb`...
         YAML
         dir.join('rbs_collection.lock.yaml').write(lock_content)
 
-        with_cli do |cli|
-          cli.run(%w[collection install --frozen])
-          refute dir.join(RBS::Collection::Config::PATH).exist?
-          assert dir.join('gem_rbs_collection/ast').exist?
-          assert_equal lock_content, dir.join('rbs_collection.lock.yaml').read
-        end
+        run_rbs("collection", "install", "--frozen", bundler: false)
+
+        refute dir.join(RBS::Collection::Config::PATH).exist?
+        assert dir.join('gem_rbs_collection/ast').exist?
+        assert_equal lock_content, dir.join('rbs_collection.lock.yaml').read
       end
     end
   end
@@ -621,7 +644,10 @@ Processing `test/a_test.rb`...
 
           path: #{dir.join('gem_rbs_collection')}
         YAML
-        dir.join('Gemfile').write('')
+        dir.join('Gemfile').write(<<~GEMFILE)
+          source 'https://rubygems.org'
+          gem 'ast'
+        GEMFILE
         dir.join('Gemfile.lock').write(<<~LOCK)
           GEM
             remote: https://rubygems.org/
@@ -638,11 +664,10 @@ Processing `test/a_test.rb`...
              2.2.0
         LOCK
 
-        with_cli do |cli|
-          cli.run(%w[collection update])
-          assert dir.join('rbs_collection.lock.yaml').exist?
-          assert dir.join('gem_rbs_collection/ast').exist?
-        end
+        run_rbs("collection", "update", bundler: true)
+
+        assert dir.join('rbs_collection.lock.yaml').exist?
+        assert dir.join('gem_rbs_collection/ast').exist?
       end
     end
   end


### PR DESCRIPTION
`rbs collection *` raised `Bundler::GemfileNotFound` error if `Gemfile` cannot be located, even for `install --frozen` that doesn't access Bundler at all. This PR delays loading `Gemfile` and lets `install --frozen` run without Bundler.

Also fixes collection tests to set up another Bundler context.