### PR TITLE
Support #detailed_message for RBS::ParsingError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -20,7 +20,25 @@ module RBS
   class LoadingError < BaseError; end
   class DefinitionError < BaseError; end
 
+  module DetailedMessageable
+    def detailed_message(highlight: false, **)
+      indent = " " * location.start_column
+      marker = "^" * (location.end_column - location.start_column)
+
+      io = StringIO.new
+      io.puts super
+      io.puts
+      io.print "\e[1m" if highlight
+      io.puts "  #{location.buffer.lines[location.end_line - 1]}"
+      io.puts "  #{indent}#{marker}"
+      io.print "\e[m" if highlight
+      io.string
+    end
+  end
+
   class ParsingError < BaseError
+    include DetailedMessageable
+
     attr_reader :location
     attr_reader :error_message
     attr_reader :token_type

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class RBS::ErrorsTest < Test::Unit::TestCase
+  def buffer(source)
+    RBS::Buffer.new(content: source, name: "test.rbs")
+  end
+
+  def test_parse_signature_with_parsing_error_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_signature(buffer(<<~RBS))
+        class Foo
+          deff bar: () -> void
+        end
+      RBS
+    end.tap do |exn|
+      assert_equal <<~DETAILED_MESSAGE, exn.detailed_message
+        test.rbs:2:2...2:6: Syntax error: unexpected token for class/module declaration member, token=`deff` (tLIDENT) (RBS::ParsingError)
+
+            deff bar: () -> void
+            ^^^^
+      DETAILED_MESSAGE
+    end
+  end
+
+  def test_parse_type_with_parsing_error_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_type(buffer("singleton(foo)"))
+    end.tap do |exn|
+      assert_equal <<~DETAILED_MESSAGE, exn.detailed_message
+        test.rbs:1:10...1:13: Syntax error: expected one of class/module/constant name, token=`foo` (tLIDENT) (RBS::ParsingError)
+
+          singleton(foo)
+                    ^^^
+      DETAILED_MESSAGE
+    end
+  end
+
+  def test_parse_method_type_with_parsing_error_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_method_type(buffer("()) -> void"))
+    end.tap do |exn|
+      assert_equal <<~DETAILED_MESSAGE, exn.detailed_message
+        test.rbs:1:2...1:3: Syntax error: expected a token `pARROW`, token=`)` (pRPAREN) (RBS::ParsingError)
+
+          ()) -> void
+            ^
+      DETAILED_MESSAGE
+    end
+  end
+end


### PR DESCRIPTION
`Exception#detailed_message` is a new feature supported from Ruby v3.2.0 and above.
https://bugs.ruby-lang.org/issues/18564

I would like to propose that this feature be applied to RBS.

CLI usage.

```
$ ruby -v
ruby 3.2.0preview2 (2022-09-09 master 35cfc9a3bb) [arm64-darwin21]

$ cat parsing_error.rbs
class Foo
  deff aaa: () -> void
end

$ rbs -I parsing_error.rbs validate --silent
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:17:in `_parse_signature': parsing_error.rbs:2:2...2:6: Syntax error: unexpected token for class/module declaration member, token=`deff` (tLIDENT) (RBS::ParsingError)

    deff aaa: () -> void
    ^^^^

	from /Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:17:in `parse_signature'
	from /Users/ksss/src/github.com/ksss/rbs/lib/rbs/environment_loader.rb:162:in `block (2 levels) in each_decl'
	from /Users/ksss/src/github.com/ksss/rbs/lib/rbs/environment_loader.rb:132:in `each_file'
        (snip)
```

Script usage.

```
$ bundle exec irb -r rbs
irb(main):001:0> RBS::Parser.parse_type("singleton(foo)")
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:7:in `_parse_type': a.rbs:1:10...1:13: Syntax error: expected one of class/module/constant name, token=`foo` (tLIDENT) (RBS::ParsingError)

  singleton(foo)
            ^^^

	from /Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:7:in `parse_type'
	from (irb):1:in `<main>'
        (snip)
```

This feature is inspired by [error_highlight](https://github.com/ruby/error_highlight).

Scope is limited to Ruby 3.2.0 or later and `ParsingError` combinations.

To support Ruby 3.1 or earlier, incompatible changes need to be made, so they are out of scope.

It is likely that other errors could also be supported, but I have limited the scope to `ParsingError` only to keep the PR scope small.