### PR TITLE
Fix super class location

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2343,7 +2343,7 @@ VALUE parse_class_decl_super(parserstate *state, range *lt_range) {
     args = rb_ary_new();
     class_instance_name(state, CLASS_NAME, &name, args, &name_range, &args_range);
 
-    super_range.end = args_range.end;
+    super_range.end = state->current_token.range.end;
 
     location = rbs_new_location(state->buffer, super_range);
     loc = rbs_check_location(location);

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -1809,6 +1809,9 @@ end
 
 class B[X] < Foo[X]
 end
+
+class C < Bar
+end
     EOF
       decls[0].tap do |decl|
         assert_instance_of Location, decl.location
@@ -1831,6 +1834,23 @@ end
 
         assert_equal "Foo", decl.super_class.location[:name].source
         assert_equal "[X]", decl.super_class.location[:args].source
+        assert_equal [4, 13], decl.super_class.location.start_loc
+        assert_equal [4, 19], decl.super_class.location.end_loc
+      end
+
+      decls[2].tap do |decl|
+        assert_instance_of Location, decl.location
+
+        assert_equal "class", decl.location[:keyword].source
+        assert_equal "C", decl.location[:name].source
+        assert_equal "end", decl.location[:end].source
+        assert_nil decl.location[:type_params]
+        assert_equal "<", decl.location[:lt].source
+
+        assert_equal "Bar", decl.super_class.location[:name].source
+        assert_nil decl.super_class.location[:args]
+        assert_equal [7, 10], decl.super_class.location.start_loc
+        assert_equal [7, 13], decl.super_class.location.end_loc
       end
     end
   end


### PR DESCRIPTION
I have fixed super class location when no type argument is attached.

```rb
require 'rbs'

rbs = <<RBS
class A
end

class B < A
end
RBS

# actual: #<RBS::Location:2100 buffer=a.rbs, start=4:10, pos=23...-1, children=name,?args source='A'>
# expect: #<RBS::Location:2100 buffer=a.rbs, start=4:10, pos=23...24, children=name,?args source='A'>
p RBS::Parser.parse_signature(rbs).last.super_class.location

# acutal: [1, -1]
# expect: [4, 12]
p RBS::Parser.parse_signature(rbs).last.super_class.location.end_loc
```

When no type argument is given, the `class_instance_name` function sets `args_range` to `NULL_RANGE`, which seems to have been passed directly to the end range of the superclass.