### PR TITLE
Escaping for keywords is no longer necessary

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -757,11 +757,7 @@ module RBS
 
         def to_s
           if name
-            if Parser::KEYWORDS.include?(name.to_s)
-              "#{type} `#{name}`"
-            else
-              "#{type} #{name}"
-            end
+            "#{type} #{name}"
           else
             "#{type}"
           end

--- a/test/rbs/types_test.rb
+++ b/test/rbs/types_test.rb
@@ -29,6 +29,6 @@ class RBS::TypesTest < Test::Unit::TestCase
     assert_equal "((Integer | String) & bool)?", parse_type("((Integer | String) & bool)?").to_s
     assert_equal "^() -> void", parse_type("^() -> void").to_s
     assert_equal "^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void", parse_type("^(bool flag, ?untyped, *Symbol, name: String, ?email: nil, **Symbol) -> void").to_s
-    assert_equal "^(untyped `untyped`, untyped footype) -> void", parse_type("^(untyped `untyped`, untyped footype) -> void").to_s
+    assert_equal "^(untyped untyped, untyped footype) -> void", parse_type("^(untyped `untyped`, untyped footype) -> void").to_s
   end
 end


### PR DESCRIPTION
When the Ruby-implemented parser was used, reserved words had to be escaped.
However, when the C-implemented parser was introduced, escaping is no longer required even if the variable is a reserved word.

I removed the legacy of the Ruby-implemented parser in `RBS::Types::Function::Param#to_s`.