### PR TITLE
Revert "Fix test_argument_forwarding for changes in Ruby 3.2 (#1163)"

### DIFF
--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -907,19 +907,11 @@ end
 
       parser.parse(rb)
 
-      if support_argument_forwarding_with_anonymous_kwrest?
-        assert_write parser.decls, <<~RBS
-module M
-  def foo: (*untyped, **untyped **) ?{ () -> untyped } -> nil
-end
-        RBS
-      else
-        assert_write parser.decls, <<~RBS
+      assert_write parser.decls, <<~RBS
 module M
   def foo: (*untyped) ?{ () -> untyped } -> nil
 end
-        RBS
-      end
+      RBS
     end
   end
 
@@ -939,14 +931,5 @@ module M
 end
       RBS
     end
-  end
-
-  private
-
-  def support_argument_forwarding_with_anonymous_kwrest?
-    eval("def foo(...); bar(**); end")
-    true
-  rescue Exception
-    false
   end
 end


### PR DESCRIPTION
Reverts ruby/rbs#1164

Seems like https://github.com/ruby/ruby/pull/6818 will be reverted?