### PR TITLE
Add the methods of the `prepend`ed module itself

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -263,7 +263,7 @@ module RBS
             end
 
             one_ancestors.each_prepended_module do |mod|
-              defn = build_instance(mod.name)
+              defn = build_instance(mod.name, no_self_types: true)
               merge_definition(src: defn,
                                dest: definition,
                                subst: Substitution.build(defn.type_params, mod.args))


### PR DESCRIPTION
Importing methods of prepended module ancestors causes a issue that the custom `#initialize` is hidden and the type of `.self` get broken.