### PR TITLE
Correct Socket.new signature

### DIFF
--- a/stdlib/socket/0/socket.rbs
+++ b/stdlib/socket/0/socket.rbs
@@ -1416,7 +1416,7 @@ class Socket < BasicSocket
   #     Socket.new(:UNIX, :STREAM) # UNIX stream socket
   #     Socket.new(:UNIX, :DGRAM)  # UNIX datagram socket
   #
-  def initialize: (Symbol domain, Symbol socktype, ?Integer protocol) -> untyped
+  def initialize: (Symbol | Integer domain, Symbol | Integer socktype, ?Integer protocol) -> untyped
 end
 
 # <!-- rdoc-file=ext/socket/constdefs.c -->


### PR DESCRIPTION
I have a code snippet that works but doesn't fit in this signature:

```ruby
socket = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM, 0)
...
```