### PR TITLE
Make Array#zip to accept Enumerable

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -3689,61 +3689,6 @@ class Array[unchecked out Elem] < Object
 
   # <!--
   #   rdoc-file=array.c
-  #   - array.zip(*other_arrays) -> new_array
-  #   - array.zip(*other_arrays) {|other_array| ... } -> nil
-  # -->
-  # When no block given, returns a new Array `new_array` of size `self.size` whose
-  # elements are Arrays.
-  #
-  # Each nested array `new_array[n]` is of size `other_arrays.size+1`, and
-  # contains:
-  # *   The *nth* element of `self`.
-  # *   The *nth* element of each of the `other_arrays`.
-  #
-  #
-  # If all `other_arrays` and `self` are the same size:
-  #     a = [:a0, :a1, :a2, :a3]
-  #     b = [:b0, :b1, :b2, :b3]
-  #     c = [:c0, :c1, :c2, :c3]
-  #     d = a.zip(b, c)
-  #     d # => [[:a0, :b0, :c0], [:a1, :b1, :c1], [:a2, :b2, :c2], [:a3, :b3, :c3]]
-  #
-  # If any array in `other_arrays` is smaller than `self`, fills to `self.size`
-  # with `nil`:
-  #     a = [:a0, :a1, :a2, :a3]
-  #     b = [:b0, :b1, :b2]
-  #     c = [:c0, :c1]
-  #     d = a.zip(b, c)
-  #     d # => [[:a0, :b0, :c0], [:a1, :b1, :c1], [:a2, :b2, nil], [:a3, nil, nil]]
-  #
-  # If any array in `other_arrays` is larger than `self`, its trailing elements
-  # are ignored:
-  #     a = [:a0, :a1, :a2, :a3]
-  #     b = [:b0, :b1, :b2, :b3, :b4]
-  #     c = [:c0, :c1, :c2, :c3, :c4, :c5]
-  #     d = a.zip(b, c)
-  #     d # => [[:a0, :b0, :c0], [:a1, :b1, :c1], [:a2, :b2, :c2], [:a3, :b3, :c3]]
-  #
-  # When a block is given, calls the block with each of the sub-arrays (formed as
-  # above); returns nil
-  #     a = [:a0, :a1, :a2, :a3]
-  #     b = [:b0, :b1, :b2, :b3]
-  #     c = [:c0, :c1, :c2, :c3]
-  #     a.zip(b, c) {|sub_array| p sub_array} # => nil
-  #
-  # Output:
-  #     [:a0, :b0, :c0]
-  #     [:a1, :b1, :c1]
-  #     [:a2, :b2, :c2]
-  #     [:a3, :b3, :c3]
-  #
-  def zip: [U] (::Array[U] arg) -> ::Array[[ Elem, U? ]]
-         | (::Array[untyped] arg, *::Array[untyped] args) -> ::Array[::Array[untyped]]
-         | [U] (::Array[U] arg) { ([ Elem, U? ]) -> void } -> void
-         | (::Array[untyped] arg, *::Array[untyped] args) { (::Array[untyped]) -> void } -> void
-
-  # <!--
-  #   rdoc-file=array.c
   #   - array | other_array -> new_array
   # -->
   # Returns the union of `array` and Array `other_array`; duplicates are removed;

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -1998,8 +1998,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     [:a2, :b2, :c2]
   #     [:a3, :b3, :c3]
   #
-  def zip: [Elem2] (::Enumerable[Elem2] enum) -> ::Array[[ Elem, Elem2 | nil ]]
-         | [U, Elem2] (::Enumerable[Elem2]) { ([ Elem, Elem2 | nil ]) -> U } -> nil
+  def zip: [U] (::Enumerable[U] enum) -> ::Array[[ Elem, U? ]]
+         | (::Enumerable[untyped] arg, *::Enumerable[untyped] args) -> ::Array[::Array[untyped]]
+         | [U] (::Enumerable[U]) { ([ Elem, U? ]) -> void } -> nil
+         | (::Enumerable[untyped] arg, *::Enumerable[untyped] args) { (::Array[untyped]) -> void } -> nil
 
   # <!--
   #   rdoc-file=enum.c

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -83,11 +83,6 @@ class EnumerableTest < StdlibTest
     enumerable.each_entry { |x| x }
   end
 
-  def test_zip
-    enumerable.zip([4,5,6])
-    enumerable.zip([4,5,6]) { |arr| arr.sum }
-  end
-
   def test_chunk
     enumerable.chunk
     enumerable.chunk { |x| x.even? }
@@ -226,5 +221,19 @@ class EnumerableTest2 < Test::Unit::TestCase
     assert_send_type '() -> ::String?' , TestEmptyEnumerable.new, :first
     assert_send_type '(ToInt n) -> ::Array[::String]' , TestEnumerable.new, :first, ToInt.new(42)
     assert_send_type '(ToInt n) -> ::Array[::String]' , TestEmptyEnumerable.new, :first, ToInt.new(42)
+  end
+
+  def test_zip
+    assert_send_type "(Enumerator[Integer, Array[Integer]]) -> Array[[String, Integer?]]",
+                     TestEnumerable.new, :zip, [1, 2].to_enum
+    assert_send_type "(Enumerator[Integer, Array[Integer]]) -> Array[[String, Integer]]",
+                     TestEnumerable.new, :zip, [1, 2, 3, 4].to_enum
+    assert_send_type "(Enumerator[Integer, Array[Integer]], Array[Symbol]) -> Array[Array[untyped]]",
+                     TestEnumerable.new, :zip, [1, 2].to_enum, [:foo, :bar]
+
+    assert_send_type "(Enumerator[Integer, Array[Integer]]) { ([String, Integer?]) -> true } -> nil",
+                     TestEnumerable.new, :zip, [1, 2].to_enum do true end
+    assert_send_type "(Enumerator[Integer, Array[Integer]], Array[Symbol]) { ([String, Integer?, Symbol?]) -> true } -> nil",
+                     TestEnumerable.new, :zip, [1, 2].to_enum, [:foo, :bar] do true end
   end
 end


### PR DESCRIPTION
This PR supports the last two calls in the following example:

```ruby
Array(3).zip([1] * 3)
Array(3).zip([1] * 3, [2] * 3)
Array(3).zip([1].cycle) # incompatible
Array(3).zip([1].cycle, [2].cycle) # incompatible
```

Here is the output of `steep check` for the preceding script:

```
% cat Steepfile
target :lib do
  signature "sig"
  check "main.rb"

  library "set", "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest'
  signature 'stdlib/yaml/0'
  signature "stdlib/strscan/0/"
  signature "stdlib/optparse/0/"
  signature "stdlib/rdoc/0/"
end
% steep check
# Type checking files:

..................................................................................................................F......................................................................

main.rb:3:0: [error] Cannot find compatible overloading of method `zip` of type `::Array[::Integer]`
│ Method types:
│   def zip: [U] (::Array[U]) -> ::Array[[::Integer, (U | nil)]]
│          | (::Array[untyped], *::Array[untyped]) -> ::Array[::Array[untyped]]
│          | [U] (::Array[U]) { ([::Integer, (U | nil)]) -> void } -> void
│          | (::Array[untyped], *::Array[untyped]) { (::Array[untyped]) -> void } -> void
│
│ Diagnostic ID: Ruby::UnresolvedOverloading
│
└ Array(3).zip([1].cycle) # incompatible
  ~~~~~~~~~~~~~~~~~~~~~~~

main.rb:4:0: [error] Cannot find compatible overloading of method `zip` of type `::Array[::Integer]`
│ Method types:
│   def zip: [U] (::Array[U]) -> ::Array[[::Integer, (U | nil)]]
│          | (::Array[untyped], *::Array[untyped]) -> ::Array[::Array[untyped]]
│          | [U] (::Array[U]) { ([::Integer, (U | nil)]) -> void } -> void
│          | (::Array[untyped], *::Array[untyped]) { (::Array[untyped]) -> void } -> void
│
│ Diagnostic ID: Ruby::UnresolvedOverloading
│
└ Array(3).zip([1].cycle, [2].cycle) # incompatible
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Detected 2 problems from 1 file
```
