### PR TITLE
Remove Encoding#replicate from Ruby 3.3

### DIFF
--- a/test/stdlib/Encoding_test.rb
+++ b/test/stdlib/Encoding_test.rb
@@ -73,8 +73,4 @@ class EncodingTest < StdlibTest
   def test_names
     Encoding::UTF_8.names
   end
-
-  def test_replicate
-    Encoding::UTF_8.replicate("a")
-  end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18949