### PR TITLE
Add signature for RubyVM::AbstractSyntaxTree

### DIFF
--- a/core/ruby_vm.rbs
+++ b/core/ruby_vm.rbs
@@ -97,7 +97,7 @@ module RubyVM::AbstractSyntaxTree
   #     RubyVM::AbstractSyntaxTree.parse_file("my-app/app.rb")
   #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-31:3>
   #
-  def self.parse_file: (String | Pathname string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> Node
+  def self.parse_file: (String | ::_ToPath string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> Node
 
   # <!--
   #   rdoc-file=ast.rb

--- a/core/ruby_vm.rbs
+++ b/core/ruby_vm.rbs
@@ -51,3 +51,142 @@ RubyVM::OPTS: Array[String]
 #
 class RubyVM::InstructionSequence < Object
 end
+
+# <!-- rdoc-file=ast.rb -->
+# AbstractSyntaxTree provides methods to parse Ruby code into abstract syntax
+# trees. The nodes in the tree are instances of
+# RubyVM::AbstractSyntaxTree::Node.
+#
+# This module is MRI specific as it exposes implementation details of the MRI
+# abstract syntax tree.
+#
+# This module is experimental and its API is not stable, therefore it might
+# change without notice. As examples, the order of children nodes is not
+# guaranteed, the number of children nodes might change, there is no way to
+# access children nodes by name, etc.
+#
+# If you are looking for a stable API or an API working under multiple Ruby
+# implementations, consider using the *parser* gem or Ripper. If you would like
+# to make RubyVM::AbstractSyntaxTree stable, please join the discussion at
+# https://bugs.ruby-lang.org/issues/14844.
+#
+module RubyVM::AbstractSyntaxTree
+  # <!--
+  #   rdoc-file=ast.rb
+  #   - RubyVM::AbstractSyntaxTree.parse(string) -> RubyVM::AbstractSyntaxTree::Node
+  # -->
+  # Parses the given *string* into an abstract syntax tree, returning the root
+  # node of that tree.
+  #
+  # SyntaxError is raised if the given *string* is invalid syntax.
+  #
+  #     RubyVM::AbstractSyntaxTree.parse("x = 1 + 2")
+  #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-1:9>
+  #
+  def self.parse: (String string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> Node
+
+  # <!--
+  #   rdoc-file=ast.rb
+  #   - RubyVM::AbstractSyntaxTree.parse_file(pathname) -> RubyVM::AbstractSyntaxTree::Node
+  # -->
+  # Reads the file from *pathname*, then parses it like ::parse, returning the
+  # root node of the abstract syntax tree.
+  #
+  # SyntaxError is raised if *pathname*'s contents are not valid Ruby syntax.
+  #
+  #     RubyVM::AbstractSyntaxTree.parse_file("my-app/app.rb")
+  #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-31:3>
+  #
+  def self.parse_file: (String | Pathname string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> Node
+
+  # <!--
+  #   rdoc-file=ast.rb
+  #   - RubyVM::AbstractSyntaxTree.of(proc)   -> RubyVM::AbstractSyntaxTree::Node
+  #   - RubyVM::AbstractSyntaxTree.of(method) -> RubyVM::AbstractSyntaxTree::Node
+  # -->
+  # Returns AST nodes of the given *proc* or *method*.
+  #
+  #     RubyVM::AbstractSyntaxTree.of(proc {1 + 2})
+  #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:35-1:42>
+  #
+  #     def hello
+  #       puts "hello, world"
+  #     end
+  #
+  #     RubyVM::AbstractSyntaxTree.of(method(:hello))
+  #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-3:3>
+  #
+  def self.of: (Proc | Method | UnboundMethod body, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> Node?
+
+  def self.node_id_for_backtrace_location: (Thread::Backtrace::Location backtrace_location) -> Integer
+
+  # <!-- rdoc-file=ast.rb -->
+  # RubyVM::AbstractSyntaxTree::Node instances are created by parse methods in
+  # RubyVM::AbstractSyntaxTree.
+  #
+  # This class is MRI specific.
+  #
+  class Node
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.type -> symbol
+    # -->
+    # Returns the type of this node as a symbol.
+    #
+    #     root = RubyVM::AbstractSyntaxTree.parse("x = 1 + 2")
+    #     root.type # => :SCOPE
+    #     lasgn = root.children[2]
+    #     lasgn.type # => :LASGN
+    #     call = lasgn.children[1]
+    #     call.type # => :OPCALL
+    #
+    def type: () -> Symbol
+
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.first_lineno -> integer
+    # -->
+    # The line number in the source code where this AST's text began.
+    #
+    def first_lineno: () -> Integer
+
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.first_column -> integer
+    # -->
+    # The column number in the source code where this AST's text began.
+    #
+    def first_column: () -> Integer
+
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.last_lineno -> integer
+    # -->
+    # The line number in the source code where this AST's text ended.
+    #
+    def last_lineno: () -> Integer
+
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.last_column -> integer
+    # -->
+    # The column number in the source code where this AST's text ended.
+    #
+    def last_column: () -> Integer
+
+    def tokens: () -> Array[[Integer, Symbol, String, [Integer, Integer, Integer, Integer]]]?
+
+    def all_tokens: () -> Array[[Integer, Symbol, String, [Integer, Integer, Integer, Integer]]]?
+
+    # <!--
+    #   rdoc-file=ast.rb
+    #   - node.children -> array
+    # -->
+    # Returns AST nodes under this one.  Each kind of node has different children,
+    # depending on what kind of node it is.
+    #
+    # The returned array may contain other nodes or `nil`.
+    #
+    def children: () -> Array[untyped]
+  end
+end

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -31,14 +31,20 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_chdir
-    assert_send_type "() -> Integer",
-                     Dir, :chdir
-    assert_send_type "(::String) -> Integer",
-                     Dir, :chdir, __dir__
-    assert_send_type "(::ToStr) -> Integer",
-                     Dir, :chdir, ToStr.new(__dir__)
-    assert_send_type "(::ToStr) { (::String) -> 30 } -> 30",
-                     Dir, :chdir, ToStr.new(__dir__) do 30 end
+    dir = Dir.pwd
+
+    begin
+      assert_send_type "() -> Integer",
+                      Dir, :chdir
+      assert_send_type "(::String) -> Integer",
+                      Dir, :chdir, __dir__
+      assert_send_type "(::ToStr) -> Integer",
+                      Dir, :chdir, ToStr.new(__dir__)
+      assert_send_type "(::ToStr) { (::String) -> 30 } -> 30",
+                      Dir, :chdir, ToStr.new(__dir__) do 30 end
+    ensure
+      Dir.chdir(dir)
+    end
   end
 
   def test_children

--- a/test/stdlib/ERB_test.rb
+++ b/test/stdlib/ERB_test.rb
@@ -145,6 +145,6 @@ class ERBDefMethodSingletonTest < Test::Unit::TestCase
 
   def test_def_erb_method
     assert_send_type "(String, String) -> untyped",
-                     ERB::DefMethod, :def_erb_method, "render()", File.expand_path(__FILE__, "../..")
+                     ERB::DefMethod, :def_erb_method, "render()", File.expand_path(__FILE__)
   end
 end

--- a/test/stdlib/FileTest_test.rb
+++ b/test/stdlib/FileTest_test.rb
@@ -7,168 +7,168 @@ class FileTestSingletonTest < Test::Unit::TestCase
 
   def test_blockdev?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :blockdev?, File.expand_path(__FILE__, "../..")
+                      FileTest, :blockdev?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :blockdev?, io_open
   end
 
   def test_chardev?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :chardev?, File.expand_path(__FILE__, "../..")
+                      FileTest, :chardev?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :chardev?, io_open
   end
 
   def test_directory?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :directory?, File.expand_path(__FILE__, "../..")
+                      FileTest, :directory?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :directory?, io_open
   end
 
   def test_empty?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :empty?, File.expand_path(__FILE__, "../..")
+                      FileTest, :empty?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :empty?, io_open
   end
 
   def test_executable?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :executable?, File.expand_path(__FILE__, "../..")
+                      FileTest, :executable?, File.expand_path(__FILE__)
   end
 
   def test_executable_real?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :executable_real?, File.expand_path(__FILE__, "../..")
+                      FileTest, :executable_real?, File.expand_path(__FILE__)
   end
 
   def test_exist?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :exist?, File.expand_path(__FILE__, "../..")
+                      FileTest, :exist?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :exist?, io_open
   end
 
   def test_file?
     assert_send_type  "(::String file) -> bool",
-                      FileTest, :file?, File.expand_path(__FILE__, "../..")
+                      FileTest, :file?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file) -> bool",
                       FileTest, :file?, io_open
   end
 
   def test_grpowned?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :grpowned?, File.expand_path(__FILE__, "../..")
+                      FileTest, :grpowned?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :grpowned?, io_open
   end
 
   def test_identical?
     assert_send_type  "(::String file_1, ::String file_2) -> bool",
-                      FileTest, :identical?, File.expand_path(__FILE__, "../.."), File.expand_path(__FILE__, "../..")
+                      FileTest, :identical?, File.expand_path(__FILE__), File.expand_path(__FILE__)
     assert_send_type  "(::IO file_1, ::IO file_2) -> bool",
                       FileTest, :identical?, io_open, io_open
   end
 
   def test_owned?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :owned?, File.expand_path(__FILE__, "../..")
+                      FileTest, :owned?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :owned?, io_open
   end
 
   def test_pipe?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :pipe?, File.expand_path(__FILE__, "../..")
+                      FileTest, :pipe?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :pipe?, io_open
   end
 
   def test_readable?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :readable?, File.expand_path(__FILE__, "../..")
+                      FileTest, :readable?, File.expand_path(__FILE__)
   end
 
   def test_readable_real?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :readable_real?, File.expand_path(__FILE__, "../..")
+                      FileTest, :readable_real?, File.expand_path(__FILE__)
   end
 
   def test_setgid?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :setgid?, File.expand_path(__FILE__, "../..")
+                      FileTest, :setgid?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :setgid?, io_open
   end
 
   def test_setuid?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :setuid?, File.expand_path(__FILE__, "../..")
+                      FileTest, :setuid?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :setuid?, io_open
   end
 
   def test_size
     assert_send_type  "(::String file_name) -> ::Integer",
-                      FileTest, :size, File.expand_path(__FILE__, "../..")
+                      FileTest, :size, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> ::Integer",
                       FileTest, :size, io_open
   end
 
   def test_size?
     assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :size?, File.expand_path(__FILE__, "../..")
+                      FileTest, :size?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> ::Integer?",
                       FileTest, :size?, io_open
   end
 
   def test_socket?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :socket?, File.expand_path(__FILE__, "../..")
+                      FileTest, :socket?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :socket?, io_open
   end
 
   def test_sticky?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :sticky?, File.expand_path(__FILE__, "../..")
+                      FileTest, :sticky?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :sticky?, io_open
   end
 
   def test_symlink?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :symlink?, File.expand_path(__FILE__, "../..")
+                      FileTest, :symlink?, File.expand_path(__FILE__)
   end
 
   def test_world_readable?
     assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :world_readable?, File.expand_path(__FILE__, "../..")
+                      FileTest, :world_readable?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> ::Integer?",
                       FileTest, :world_readable?, io_open
   end
 
   def test_world_writable?
     assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :world_writable?, File.expand_path(__FILE__, "../..")
+                      FileTest, :world_writable?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> ::Integer?",
                       FileTest, :world_writable?, io_open
   end
 
   def test_writable?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :writable?, File.expand_path(__FILE__, "../..")
+                      FileTest, :writable?, File.expand_path(__FILE__)
   end
 
   def test_writable_real?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :writable_real?, File.expand_path(__FILE__, "../..")
+                      FileTest, :writable_real?, File.expand_path(__FILE__)
   end
 
   def test_zero?
     assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :zero?, File.expand_path(__FILE__, "../..")
+                      FileTest, :zero?, File.expand_path(__FILE__)
     assert_send_type  "(::IO file_name) -> bool",
                       FileTest, :zero?, io_open
   end
@@ -176,6 +176,6 @@ class FileTestSingletonTest < Test::Unit::TestCase
   private
 
   def io_open
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../..")))
+    IO.open(IO.sysopen(File.expand_path(__FILE__)))
   end
 end

--- a/test/stdlib/FileUtils_test.rb
+++ b/test/stdlib/FileUtils_test.rb
@@ -34,10 +34,16 @@ class FileUtilsSingletonTest < Test::Unit::TestCase
   end
 
   def test_chdir
-    assert_send_type  "(String) -> void",
-                      FileUtils, :chdir, __dir__
-    assert_send_type  "(String) { (String) -> Integer } -> Integer",
-                      FileUtils, :chdir, __dir__ do |dir| 1 end
+    dir = Dir.pwd
+
+    begin
+      assert_send_type  "(String) -> void",
+                        FileUtils, :chdir, __dir__
+      assert_send_type  "(String) { (String) -> Integer } -> Integer",
+                        FileUtils, :chdir, __dir__ do |dir| 1 end
+    ensure
+      Dir.chdir(dir)
+    end
   end
 
   def test_chmod
@@ -606,8 +612,14 @@ class FileUtilsInstanceTest < Test::Unit::TestCase
   end
 
   def test_chdir
-    assert_send_type  "(String) -> void",
-                      Foo.new, :chdir, __dir__
+    dir = Dir.pwd
+
+    begin
+      assert_send_type  "(String) -> void",
+                        Foo.new, :chdir, __dir__
+    ensure
+      Dir.chdir(dir)
+    end
   end
 
   def test_chmod

--- a/test/stdlib/FileUtils_test.rb
+++ b/test/stdlib/FileUtils_test.rb
@@ -19,18 +19,24 @@ class FileUtilsSingletonTest < Test::Unit::TestCase
   testing "singleton(::FileUtils)"
 
   def test_cd
-    assert_send_type  "(String) -> void",
-                      FileUtils, :cd, __dir__
-    assert_send_type  "(ToStr) -> void",
-                      FileUtils, :cd, ToStr.new(__dir__)
-    assert_send_type  "(ToPath, verbose: bool) -> void",
-                      FileUtils, :cd, ToPath.new(__dir__), verbose: false
-    assert_send_type  "(String) { (String) -> Integer } -> Integer",
-                      FileUtils, :cd, __dir__ do |dir| 1 end
-    assert_send_type  "(ToStr) { (String) -> Integer } -> Integer",
-                      FileUtils, :cd, ToStr.new(__dir__) do |dir| 1 end
-    assert_send_type  "(ToPath, verbose: nil) { (String) -> Integer } -> Integer",
-                      FileUtils, :cd, ToPath.new(__dir__), verbose: nil do |dir| 1 end
+    dir = Dir.pwd
+
+    begin
+      assert_send_type  "(String) -> void",
+                        FileUtils, :cd, __dir__
+      assert_send_type  "(ToStr) -> void",
+                        FileUtils, :cd, ToStr.new(__dir__)
+      assert_send_type  "(ToPath, verbose: bool) -> void",
+                        FileUtils, :cd, ToPath.new(__dir__), verbose: false
+      assert_send_type  "(String) { (String) -> Integer } -> Integer",
+                        FileUtils, :cd, __dir__ do |dir| 1 end
+      assert_send_type  "(ToStr) { (String) -> Integer } -> Integer",
+                        FileUtils, :cd, ToStr.new(__dir__) do |dir| 1 end
+      assert_send_type  "(ToPath, verbose: nil) { (String) -> Integer } -> Integer",
+                        FileUtils, :cd, ToPath.new(__dir__), verbose: nil do |dir| 1 end
+    ensure
+      Dir.chdir dir
+    end
   end
 
   def test_chdir
@@ -607,8 +613,14 @@ class FileUtilsInstanceTest < Test::Unit::TestCase
   end
 
   def test_cd
-    assert_send_type  "(String) -> void",
-                      Foo.new, :cd, __dir__
+    dir = Dir.pwd
+
+    begin
+      assert_send_type  "(String) -> void",
+                        Foo.new, :cd, __dir__
+    ensure
+      Dir.chdir(dir)
+    end
   end
 
   def test_chdir

--- a/test/stdlib/File_Stat_test.rb
+++ b/test/stdlib/File_Stat_test.rb
@@ -7,7 +7,7 @@ class FileStatSingletonTest < Test::Unit::TestCase
 
   def test_new
     assert_send_type "(String) -> void",
-                    File::Stat, :new, File.expand_path(__FILE__, "../..")
+                    File::Stat, :new, File.expand_path(__FILE__)
   end
 end
 
@@ -18,175 +18,175 @@ class FileStatInstanceTest < Test::Unit::TestCase
 
   def test_spaceship
     assert_send_type "(File::Stat) -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :<=>, File::Stat.new(File.expand_path(__FILE__, "../.."))
+                      File::Stat.new(File.expand_path(__FILE__)), :<=>, File::Stat.new(File.expand_path(__FILE__))
     assert_send_type "(untyped) -> nil",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :<=>, "not a File::Stat object"
+                      File::Stat.new(File.expand_path(__FILE__)), :<=>, "not a File::Stat object"
   end
 
   def test_atime
     assert_send_type "() -> Time",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :atime
+                      File::Stat.new(File.expand_path(__FILE__)), :atime
   end
 
   def test_birthtime
     assert_send_type "() -> Time",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :birthtime
+                      File::Stat.new(File.expand_path(__FILE__)), :birthtime
   rescue NotImplementedError
   end
 
   def test_blksize
     assert_send_type "() -> Integer?",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :blksize
+                      File::Stat.new(File.expand_path(__FILE__)), :blksize
   end
 
   def test_blockdev?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :blockdev?
+                      File::Stat.new(File.expand_path(__FILE__)), :blockdev?
   end
 
   def test_blocks
     assert_send_type "() -> Integer?",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :blocks
+                      File::Stat.new(File.expand_path(__FILE__)), :blocks
   end
 
   def test_chardev?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :chardev?
+                      File::Stat.new(File.expand_path(__FILE__)), :chardev?
   end
 
   def test_ctime
     assert_send_type "() -> Time",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :ctime
+                      File::Stat.new(File.expand_path(__FILE__)), :ctime
   end
 
   def test_dev
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :dev
+                      File::Stat.new(File.expand_path(__FILE__)), :dev
   end
 
   def test_dev_major
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :dev_major
+                      File::Stat.new(File.expand_path(__FILE__)), :dev_major
   end
 
   def test_dev_minor
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :dev_minor
+                      File::Stat.new(File.expand_path(__FILE__)), :dev_minor
   end
 
   def test_directory?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :directory?
+                      File::Stat.new(File.expand_path(__FILE__)), :directory?
   end
 
   def test_executable?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :executable?
+                      File::Stat.new(File.expand_path(__FILE__)), :executable?
   end
 
   def test_executable_real?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :executable_real?
+                      File::Stat.new(File.expand_path(__FILE__)), :executable_real?
   end
 
   def test_file?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :file?
+                      File::Stat.new(File.expand_path(__FILE__)), :file?
   end
 
   def test_ftype
     assert_send_type "() -> String",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :ftype
+                      File::Stat.new(File.expand_path(__FILE__)), :ftype
   end
 
   def test_gid
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :gid
+                      File::Stat.new(File.expand_path(__FILE__)), :gid
   end
 
   def test_grpowned?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :grpowned?
+                      File::Stat.new(File.expand_path(__FILE__)), :grpowned?
   end
 
   def test_ino
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :ino
+                      File::Stat.new(File.expand_path(__FILE__)), :ino
   end
 
   def test_inspect
     assert_send_type "() -> String",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :inspect
+                      File::Stat.new(File.expand_path(__FILE__)), :inspect
   end
 
   def test_mode
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :mode
+                      File::Stat.new(File.expand_path(__FILE__)), :mode
   end
 
   def test_mtime
     assert_send_type "() -> Time",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :mtime
+                      File::Stat.new(File.expand_path(__FILE__)), :mtime
   end
 
   def test_nlink
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :nlink
+                      File::Stat.new(File.expand_path(__FILE__)), :nlink
   end
 
   def test_owned?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :owned?
+                      File::Stat.new(File.expand_path(__FILE__)), :owned?
   end
 
   def test_pipe?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :pipe?
+                      File::Stat.new(File.expand_path(__FILE__)), :pipe?
   end
 
   def test_rdev
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :rdev
+                      File::Stat.new(File.expand_path(__FILE__)), :rdev
   end
 
   def test_rdev_major
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :rdev_major
+                      File::Stat.new(File.expand_path(__FILE__)), :rdev_major
   end
 
   def test_rdev_minor
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :rdev_minor
+                      File::Stat.new(File.expand_path(__FILE__)), :rdev_minor
   end
 
   def test_readable?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :readable?
+                      File::Stat.new(File.expand_path(__FILE__)), :readable?
   end
 
   def test_readable_real?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :readable_real?
+                      File::Stat.new(File.expand_path(__FILE__)), :readable_real?
   end
 
   def test_setgid?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :setgid?
+                      File::Stat.new(File.expand_path(__FILE__)), :setgid?
   end
 
   def test_setuid?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :setuid?
+                      File::Stat.new(File.expand_path(__FILE__)), :setuid?
   end
 
   def test_size
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :size
+                      File::Stat.new(File.expand_path(__FILE__)), :size
   end
 
   def test_size?
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :size?
+                      File::Stat.new(File.expand_path(__FILE__)), :size?
     Dir.mktmpdir do |dir|
       File.open("#{dir}/empty", "w"){}
 
@@ -197,27 +197,27 @@ class FileStatInstanceTest < Test::Unit::TestCase
 
   def test_socket?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :socket?
+                      File::Stat.new(File.expand_path(__FILE__)), :socket?
   end
 
   def test_sticky?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :sticky?
+                      File::Stat.new(File.expand_path(__FILE__)), :sticky?
   end
 
   def test_symlink?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :symlink?
+                      File::Stat.new(File.expand_path(__FILE__)), :symlink?
   end
 
   def test_uid
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :uid
+                      File::Stat.new(File.expand_path(__FILE__)), :uid
   end
 
   def test_world_readable?
     assert_send_type "() -> Integer",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :world_readable?
+                      File::Stat.new(File.expand_path(__FILE__)), :world_readable?
 
     Dir.mktmpdir do |dir|
       File.open("#{dir}/unreadable", "w"){}
@@ -246,16 +246,16 @@ class FileStatInstanceTest < Test::Unit::TestCase
 
   def test_writable?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :writable?
+                      File::Stat.new(File.expand_path(__FILE__)), :writable?
   end
 
   def test_writable_real?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :writable_real?
+                      File::Stat.new(File.expand_path(__FILE__)), :writable_real?
   end
 
   def test_zero?
     assert_send_type "() -> bool",
-                      File::Stat.new(File.expand_path(__FILE__, "../..")), :zero?
+                      File::Stat.new(File.expand_path(__FILE__)), :zero?
   end
 end

--- a/test/stdlib/File_test.rb
+++ b/test/stdlib/File_test.rb
@@ -8,124 +8,124 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_new
     assert_send_type "(String) -> File",
-                     File, :new, File.expand_path(__FILE__, "../..")
+                     File, :new, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> File",
-                     File, :new, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :new, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> File",
-                     File, :new, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :new, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(Integer) -> File",
-                     File, :new, IO.sysopen(File.expand_path(__FILE__, "../.."))
+                     File, :new, IO.sysopen(File.expand_path(__FILE__))
     assert_send_type "(ToInt) -> File",
-                     File, :new, ToInt.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :new, ToInt.new(IO.sysopen(File.expand_path(__FILE__)))
     assert_send_type "(String, String) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), "r"
+                     File, :new, File.expand_path(__FILE__), "r"
     assert_send_type "(String, ToStr) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), ToStr.new("r")
+                     File, :new, File.expand_path(__FILE__), ToStr.new("r")
     assert_send_type "(String, Integer) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), File::RDONLY
+                     File, :new, File.expand_path(__FILE__), File::RDONLY
     assert_send_type "(String, ToInt) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), ToInt.new(File::RDONLY)
+                     File, :new, File.expand_path(__FILE__), ToInt.new(File::RDONLY)
     assert_send_type "(String, String, Integer) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), "r", 0644
+                     File, :new, File.expand_path(__FILE__), "r", 0644
     assert_send_type "(String, String, ToInt) -> File",
-                     File, :new, File.expand_path(__FILE__, "../.."), "r", ToInt.new(0644)
+                     File, :new, File.expand_path(__FILE__), "r", ToInt.new(0644)
   end
 
   def test_open
     assert_send_type "(String) -> File",
-                     File, :open, File.expand_path(__FILE__, "../..")
+                     File, :open, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> File",
-                     File, :open, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :open, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> File",
-                     File, :open, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :open, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(Integer) -> File",
-                     File, :open, IO.sysopen(File.expand_path(__FILE__, "../.."))
+                     File, :open, IO.sysopen(File.expand_path(__FILE__))
     assert_send_type "(ToInt) -> File",
-                     File, :open, ToInt.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :open, ToInt.new(IO.sysopen(File.expand_path(__FILE__)))
     assert_send_type "(String, String) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), "r"
+                     File, :open, File.expand_path(__FILE__), "r"
     assert_send_type "(String, ToStr) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), ToStr.new("r")
+                     File, :open, File.expand_path(__FILE__), ToStr.new("r")
     assert_send_type "(String, Integer) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), File::RDONLY
+                     File, :open, File.expand_path(__FILE__), File::RDONLY
     assert_send_type "(String, ToInt) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), ToInt.new(File::RDONLY)
+                     File, :open, File.expand_path(__FILE__), ToInt.new(File::RDONLY)
     assert_send_type "(String, String, Integer) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), "r", 0644
+                     File, :open, File.expand_path(__FILE__), "r", 0644
     assert_send_type "(String, String, ToInt) -> File",
-                     File, :open, File.expand_path(__FILE__, "../.."), "r", ToInt.new(0644)
+                     File, :open, File.expand_path(__FILE__), "r", ToInt.new(0644)
     assert_send_type "(String) { (File) -> String } -> String",
-                     File, :open, File.expand_path(__FILE__, "../..") do |file| file.read end
+                     File, :open, File.expand_path(__FILE__) do |file| file.read end
   end
 
   def test_absolute_path
     assert_send_type "(String) -> String",
-                     File, :absolute_path, File.expand_path(__FILE__, "../..")
+                     File, :absolute_path, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :absolute_path, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :absolute_path, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :absolute_path, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :absolute_path, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String) -> String",
-                     File, :absolute_path, File.expand_path(__FILE__, "../.."), __dir__
+                     File, :absolute_path, File.expand_path(__FILE__), __dir__
     assert_send_type "(String, ToStr) -> String",
-                     File, :absolute_path, File.expand_path(__FILE__, "../.."), ToStr.new(__dir__)
+                     File, :absolute_path, File.expand_path(__FILE__), ToStr.new(__dir__)
     assert_send_type "(String, ToPath) -> String",
-                     File, :absolute_path, File.expand_path(__FILE__, "../.."), ToPath.new(__dir__)
+                     File, :absolute_path, File.expand_path(__FILE__), ToPath.new(__dir__)
   end
 
   def test_absolute_path?
     assert_send_type "(String) -> bool",
-                     File, :absolute_path?, File.expand_path(__FILE__, "../..")
+                     File, :absolute_path?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :absolute_path?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :absolute_path?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :absolute_path?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :absolute_path?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_atime
     assert_send_type "(String) -> Time",
-                     File, :atime, File.expand_path(__FILE__, "../..")
+                     File, :atime, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Time",
-                     File, :atime, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :atime, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Time",
-                     File, :atime, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :atime, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Time",
-                     File, :atime, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :atime, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_basename
     assert_send_type "(String) -> String",
-                     File, :basename, File.expand_path(__FILE__, "../..")
+                     File, :basename, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :basename, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :basename, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :basename, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :basename, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String) -> String",
-                     File, :basename, File.expand_path(__FILE__, "../.."), ".rb"
+                     File, :basename, File.expand_path(__FILE__), ".rb"
     assert_send_type "(String, ToStr) -> String",
-                     File, :basename, File.expand_path(__FILE__, "../.."), ToStr.new(".rb")
+                     File, :basename, File.expand_path(__FILE__), ToStr.new(".rb")
   end
 
   def test_blockdev?
     assert_send_type "(String) -> bool",
-                     File, :blockdev?, File.expand_path(__FILE__, "../..")
+                     File, :blockdev?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :blockdev?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :blockdev?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :blockdev?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :blockdev?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :blockdev?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :blockdev?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_chardev?
     assert_send_type "(String) -> bool",
-                     File, :chardev?, File.expand_path(__FILE__, "../..")
+                     File, :chardev?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :chardev?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :chardev?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :chardev?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :chardev?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :chardev?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :chardev?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_chmod
@@ -146,32 +146,32 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_chown
     assert_send_type "(Integer, Integer, String) -> Integer",
-                     File, :chown, Process.uid, Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :chown, Process.uid, Process.gid, File.expand_path(__FILE__)
     assert_send_type "(ToInt, Integer, String) -> Integer",
-                     File, :chown, ToInt.new(Process.uid), Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :chown, ToInt.new(Process.uid), Process.gid, File.expand_path(__FILE__)
     assert_send_type "(nil, Integer, String) -> Integer",
-                     File, :chown, nil, Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :chown, nil, Process.gid, File.expand_path(__FILE__)
     assert_send_type "(Integer, ToInt, String) -> Integer",
-                     File, :chown, Process.uid, ToInt.new(Process.gid), File.expand_path(__FILE__, "../..")
+                     File, :chown, Process.uid, ToInt.new(Process.gid), File.expand_path(__FILE__)
     assert_send_type "(Integer, nil, String) -> Integer",
-                     File, :chown, Process.uid, nil, File.expand_path(__FILE__, "../..")
+                     File, :chown, Process.uid, nil, File.expand_path(__FILE__)
     assert_send_type "(Integer, Integer, ToStr) -> Integer",
-                     File, :chown, Process.uid, Process.gid, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :chown, Process.uid, Process.gid, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(Integer, Integer, ToPath) -> Integer",
-                     File, :chown, Process.uid, Process.gid, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :chown, Process.uid, Process.gid, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(Integer, nil, String, String) -> Integer",
-                     File, :chown, Process.uid, nil, File.expand_path(__FILE__, "../.."), File.expand_path(__FILE__, "../..")
+                     File, :chown, Process.uid, nil, File.expand_path(__FILE__), File.expand_path(__FILE__)
   end
 
   def test_ctime
     assert_send_type "(String) -> Time",
-                     File, :ctime, File.expand_path(__FILE__, "../..")
+                     File, :ctime, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Time",
-                     File, :ctime, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :ctime, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Time",
-                     File, :ctime, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :ctime, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Time",
-                     File, :ctime, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :ctime, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_delete
@@ -208,148 +208,148 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_dirname
     assert_send_type "(String) -> String",
-                     File, :dirname, File.expand_path(__FILE__, "../..")
+                     File, :dirname, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :dirname, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :dirname, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :dirname, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :dirname, ToPath.new(File.expand_path(__FILE__))
 
     assert_send_type(
       "(String, Integer) -> String",
-      File, :dirname, File.expand_path(__FILE__, "../.."), 2
+      File, :dirname, File.expand_path(__FILE__), 2
     )
   end
 
   def test_empty?
     assert_send_type "(String) -> bool",
-                     File, :empty?, File.expand_path(__FILE__, "../..")
+                     File, :empty?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :empty?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :empty?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :empty?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :empty?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :empty?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :empty?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_executable?
     assert_send_type "(String) -> bool",
-                     File, :executable?, File.expand_path(__FILE__, "../..")
+                     File, :executable?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :executable?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :executable?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :executable?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :executable?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_executable_real?
     assert_send_type "(String) -> bool",
-                     File, :executable_real?, File.expand_path(__FILE__, "../..")
+                     File, :executable_real?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :executable_real?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :executable_real?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :executable_real?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :executable_real?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_exist?
     assert_send_type "(String) -> bool",
-                     File, :exist?, File.expand_path(__FILE__, "../..")
+                     File, :exist?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :exist?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :exist?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :exist?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :exist?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :exist?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :exist?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_expand_path
     assert_send_type "(String) -> String",
-                     File, :expand_path, File.expand_path(__FILE__, "../..")
+                     File, :expand_path, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :expand_path, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :expand_path, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :expand_path, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :expand_path, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String) -> String",
-                     File, :expand_path, File.expand_path(__FILE__, "../.."), __dir__
+                     File, :expand_path, File.expand_path(__FILE__), __dir__
     assert_send_type "(String, ToStr) -> String",
-                     File, :expand_path, File.expand_path(__FILE__, "../.."), ToStr.new(__dir__)
+                     File, :expand_path, File.expand_path(__FILE__), ToStr.new(__dir__)
     assert_send_type "(String, ToPath) -> String",
-                     File, :expand_path, File.expand_path(__FILE__, "../.."), ToPath.new(__dir__)
+                     File, :expand_path, File.expand_path(__FILE__), ToPath.new(__dir__)
   end
 
   def test_extname
     assert_send_type "(String) -> String",
-                     File, :extname, File.expand_path(__FILE__, "../..")
+                     File, :extname, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :extname, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :extname, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :extname, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :extname, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_file?
     assert_send_type "(String) -> bool",
-                     File, :file?, File.expand_path(__FILE__, "../..")
+                     File, :file?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :file?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :file?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :file?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :file?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :file?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :file?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_fnmatch
     assert_send_type "(String, String) -> bool",
-                     File, :fnmatch, "File_test", File.expand_path(__FILE__, "../..")
+                     File, :fnmatch, "File_test", File.expand_path(__FILE__)
     assert_send_type "(ToStr, String) -> bool",
-                     File, :fnmatch, ToStr.new("File_test"), File.expand_path(__FILE__, "../..")
+                     File, :fnmatch, ToStr.new("File_test"), File.expand_path(__FILE__)
     assert_send_type "(String, ToStr) -> bool",
-                     File, :fnmatch, "File_test", ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :fnmatch, "File_test", ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(String, ToPath) -> bool",
-                     File, :fnmatch, "File_test", ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :fnmatch, "File_test", ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String, Integer) -> bool",
-                     File, :fnmatch, "File_test", File.expand_path(__FILE__, "../.."), File::FNM_CASEFOLD
+                     File, :fnmatch, "File_test", File.expand_path(__FILE__), File::FNM_CASEFOLD
     assert_send_type "(String, String, ToInt) -> bool",
-                     File, :fnmatch, "File_test", File.expand_path(__FILE__, "../.."), ToInt.new(File::FNM_CASEFOLD)
+                     File, :fnmatch, "File_test", File.expand_path(__FILE__), ToInt.new(File::FNM_CASEFOLD)
   end
 
   def test_fnmatch?
     assert_send_type "(String, String) -> bool",
-                     File, :fnmatch?, "File_test", File.expand_path(__FILE__, "../..")
+                     File, :fnmatch?, "File_test", File.expand_path(__FILE__)
   end
 
   def test_ftype
     assert_send_type "(String) -> String",
-                     File, :ftype, File.expand_path(__FILE__, "../..")
+                     File, :ftype, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :ftype, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :ftype, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :ftype, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :ftype, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_grpowned?
     assert_send_type "(String) -> bool",
-                     File, :grpowned?, File.expand_path(__FILE__, "../..")
+                     File, :grpowned?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :grpowned?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :grpowned?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :grpowned?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :grpowned?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :grpowned?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :grpowned?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_identical?
     assert_send_type "(String, String) -> bool",
-                     File, :identical?, File.expand_path(__FILE__, "../.."), File.expand_path(__FILE__, "../..")
+                     File, :identical?, File.expand_path(__FILE__), File.expand_path(__FILE__)
     assert_send_type "(ToStr, String) -> bool",
-                     File, :identical?, ToStr.new(File.expand_path(__FILE__, "../..")), File.expand_path(__FILE__, "../..")
+                     File, :identical?, ToStr.new(File.expand_path(__FILE__)), File.expand_path(__FILE__)
     assert_send_type "(ToPath, String) -> bool",
-                     File, :identical?, ToPath.new(File.expand_path(__FILE__, "../..")), File.expand_path(__FILE__, "../..")
+                     File, :identical?, ToPath.new(File.expand_path(__FILE__)), File.expand_path(__FILE__)
     assert_send_type "(IO, String) -> bool",
-                     File, :identical?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../.."))), File.expand_path(__FILE__, "../..")
+                     File, :identical?, IO.new(IO.sysopen(File.expand_path(__FILE__))), File.expand_path(__FILE__)
     assert_send_type "(String, ToStr) -> bool",
-                     File, :identical?, File.expand_path(__FILE__, "../.."), ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :identical?, File.expand_path(__FILE__), ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(String, ToPath) -> bool",
-                     File, :identical?, File.expand_path(__FILE__, "../.."), ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :identical?, File.expand_path(__FILE__), ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, IO) -> bool",
-                     File, :identical?, File.expand_path(__FILE__, "../.."), IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :identical?, File.expand_path(__FILE__), IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_join
@@ -363,51 +363,51 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_lchown
     assert_send_type "(Integer, Integer, String) -> Integer",
-                     File, :lchown, Process.uid, Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :lchown, Process.uid, Process.gid, File.expand_path(__FILE__)
     assert_send_type "(ToInt, Integer, String) -> Integer",
-                     File, :lchown, ToInt.new(Process.uid), Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :lchown, ToInt.new(Process.uid), Process.gid, File.expand_path(__FILE__)
     assert_send_type "(nil, Integer, String) -> Integer",
-                     File, :lchown, nil, Process.gid, File.expand_path(__FILE__, "../..")
+                     File, :lchown, nil, Process.gid, File.expand_path(__FILE__)
     assert_send_type "(Integer, ToInt, String) -> Integer",
-                     File, :lchown, Process.uid, ToInt.new(Process.gid), File.expand_path(__FILE__, "../..")
+                     File, :lchown, Process.uid, ToInt.new(Process.gid), File.expand_path(__FILE__)
     assert_send_type "(Integer, nil, String) -> Integer",
-                     File, :lchown, Process.uid, nil, File.expand_path(__FILE__, "../..")
+                     File, :lchown, Process.uid, nil, File.expand_path(__FILE__)
     assert_send_type "(Integer, Integer, ToStr) -> Integer",
-                     File, :lchown, Process.uid, Process.gid, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :lchown, Process.uid, Process.gid, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(Integer, Integer, ToPath) -> Integer",
-                     File, :lchown, Process.uid, Process.gid, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :lchown, Process.uid, Process.gid, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(Integer, nil, String, String) -> Integer",
-                     File, :lchown, Process.uid, nil, File.expand_path(__FILE__, "../.."), File.expand_path(__FILE__, "../..")
+                     File, :lchown, Process.uid, nil, File.expand_path(__FILE__), File.expand_path(__FILE__)
   end
 
   def test_link
     assert_send_type "(String, String) -> 0",
-                     File, :link, File.expand_path(__FILE__, "../.."), "new_name"
+                     File, :link, File.expand_path(__FILE__), "new_name"
     File.unlink("new_name")
 
     assert_send_type "(ToStr, ToStr) -> 0",
-                     File, :link, ToStr.new(File.expand_path(__FILE__, "../..")), ToStr.new("new_name")
+                     File, :link, ToStr.new(File.expand_path(__FILE__)), ToStr.new("new_name")
     File.unlink("new_name")
 
     assert_send_type "(ToPath, ToPath) -> 0",
-                     File, :link, ToPath.new(File.expand_path(__FILE__, "../..")), ToPath.new("new_name")
+                     File, :link, ToPath.new(File.expand_path(__FILE__)), ToPath.new("new_name")
     File.unlink("new_name")
   end
 
   def test_lstat
     assert_send_type "(String) -> File::Stat",
-                     File, :lstat, File.expand_path(__FILE__, "../..")
+                     File, :lstat, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> File::Stat",
-                     File, :lstat, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :lstat, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> File::Stat",
-                     File, :lstat, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :lstat, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_lutime
     Dir.mktmpdir do |dir|
       File.open("#{dir}/a", "w"){}
       assert_send_type "(Time, Time, String) -> Integer",
-                       File, :lutime, File.atime(File.expand_path(__FILE__, "../..")), File.atime(File.expand_path(__FILE__, "../..")), "#{dir}/a"
+                       File, :lutime, File.atime(File.expand_path(__FILE__)), File.atime(File.expand_path(__FILE__)), "#{dir}/a"
       assert_send_type "(Numeric, Numeric, ToStr) -> Integer",
                        File, :lutime, 1, 2, ToStr.new("#{dir}/a")
       assert_send_type "(Numeric, Numeric, ToPath) -> Integer",
@@ -415,7 +415,7 @@ class FileSingletonTest < Test::Unit::TestCase
 
       File.open("#{dir}/b", "w"){}
       assert_send_type "(Time, Time, String, String) -> Integer",
-                       File, :lutime, File.atime(File.expand_path(__FILE__, "../..")), File.atime(File.expand_path(__FILE__, "../..")), "#{dir}/a", "#{dir}/b"
+                       File, :lutime, File.atime(File.expand_path(__FILE__)), File.atime(File.expand_path(__FILE__)), "#{dir}/a", "#{dir}/b"
     end
   end
 
@@ -434,62 +434,62 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_mtime
     assert_send_type "(String) -> Time",
-                     File, :mtime, File.expand_path(__FILE__, "../..")
+                     File, :mtime, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Time",
-                     File, :mtime, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :mtime, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Time",
-                     File, :mtime, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :mtime, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Time",
-                     File, :mtime, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :mtime, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_owned?
     assert_send_type "(String) -> bool",
-                     File, :owned?, File.expand_path(__FILE__, "../..")
+                     File, :owned?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :owned?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :owned?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :owned?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :owned?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :owned?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :owned?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_path
     assert_send_type "(String) -> String",
-                     File, :path, File.expand_path(__FILE__, "../..")
+                     File, :path, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :path, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :path, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :path, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :path, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_pipe?
     assert_send_type "(String) -> bool",
-                     File, :pipe?, File.expand_path(__FILE__, "../..")
+                     File, :pipe?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :pipe?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :pipe?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :pipe?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :pipe?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :pipe?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :pipe?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_readable?
     assert_send_type "(String) -> bool",
-                     File, :readable?, File.expand_path(__FILE__, "../..")
+                     File, :readable?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :readable?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :readable?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :readable?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :readable?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_readable_real?
     assert_send_type "(String) -> bool",
-                     File, :readable_real?, File.expand_path(__FILE__, "../..")
+                     File, :readable_real?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :readable_real?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :readable_real?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :readable_real?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :readable_real?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_readlink
@@ -508,11 +508,11 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_realdirpath
     assert_send_type "(String) -> String",
-                     File, :realdirpath , File.expand_path(__FILE__, "../..")
+                     File, :realdirpath , File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :realdirpath, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :realdirpath, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :realdirpath, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :realdirpath, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String) -> String",
                      File, :realdirpath, "..", __dir__
     assert_send_type "(String, ToStr) -> String",
@@ -523,11 +523,11 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_realpath
     assert_send_type "(String) -> String",
-                     File, :realpath , File.expand_path(__FILE__, "../..")
+                     File, :realpath , File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> String",
-                     File, :realpath, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :realpath, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> String",
-                     File, :realpath, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :realpath, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(String, String) -> String",
                      File, :realpath, "..", __dir__
     assert_send_type "(String, ToStr) -> String",
@@ -568,7 +568,7 @@ class FileSingletonTest < Test::Unit::TestCase
     end
 
     assert_send_type "(String) -> false",
-                     File, :setgid?, File.expand_path(__FILE__, "../..")
+                     File, :setgid?, File.expand_path(__FILE__)
   end
 
   def test_setuid?
@@ -587,29 +587,29 @@ class FileSingletonTest < Test::Unit::TestCase
     end
 
     assert_send_type "(String) -> false",
-                     File, :setuid?, File.expand_path(__FILE__, "../..")
+                     File, :setuid?, File.expand_path(__FILE__)
   end
 
   def test_size
     assert_send_type "(String) -> Integer",
-                     File, :size, File.expand_path(__FILE__, "../..")
+                     File, :size, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Integer",
-                     File, :size, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :size, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Integer",
-                     File, :size, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :size, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Integer",
-                     File, :size, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :size, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 
   def test_size?
     assert_send_type "(String) -> Integer",
-                     File, :size?, File.expand_path(__FILE__, "../..")
+                     File, :size?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Integer",
-                     File, :size?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :size?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Integer",
-                     File, :size?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :size?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Integer",
-                     File, :size?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :size?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
 
     Dir.mktmpdir do |dir|
       File.open("#{dir}/size", "w"){}
@@ -620,13 +620,13 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_socket?
     assert_send_type "(String) -> false",
-                     File, :socket?, File.expand_path(__FILE__, "../..")
+                     File, :socket?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> false",
-                     File, :socket?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :socket?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> false",
-                     File, :socket?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :socket?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> false",
-                     File, :socket?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :socket?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
 
     Socket.unix_server_socket("testsocket") do
       assert_send_type "(String) -> true",
@@ -636,20 +636,20 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_split
     assert_send_type "(String) -> [String, String]",
-                     File, :split, File.expand_path(__FILE__, "../..")
+                     File, :split, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> [String, String]",
-                     File, :split, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :split, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> [String, String]",
-                     File, :split, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :split, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_stat
     assert_send_type "(String) -> File::Stat",
-                     File, :stat, File.expand_path(__FILE__, "../..")
+                     File, :stat, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> File::Stat",
-                     File, :stat, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :stat, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> File::Stat",
-                     File, :stat, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :stat, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_sticky?
@@ -668,27 +668,27 @@ class FileSingletonTest < Test::Unit::TestCase
     end
 
     assert_send_type "(String) -> false",
-                     File, :sticky?, File.expand_path(__FILE__, "../..")
+                     File, :sticky?, File.expand_path(__FILE__)
   end
 
   def test_symlink
     Dir.mktmpdir do |dir|
       assert_send_type "(String, String) -> 0",
-                       File, :symlink, File.expand_path(__FILE__, "../.."), "#{dir}/symlink_a"
+                       File, :symlink, File.expand_path(__FILE__), "#{dir}/symlink_a"
       assert_send_type "(ToStr, String) -> 0",
-                       File, :symlink, ToStr.new(File.expand_path(__FILE__, "../..")), "#{dir}/symlink_b"
+                       File, :symlink, ToStr.new(File.expand_path(__FILE__)), "#{dir}/symlink_b"
       assert_send_type "(ToPath, String) -> 0",
-                       File, :symlink, ToPath.new(File.expand_path(__FILE__, "../..")), "#{dir}/symlink_c"
+                       File, :symlink, ToPath.new(File.expand_path(__FILE__)), "#{dir}/symlink_c"
       assert_send_type "(String, ToStr) -> 0",
-                       File, :symlink, File.expand_path(__FILE__, "../.."), ToStr.new("#{dir}/symlink_d")
+                       File, :symlink, File.expand_path(__FILE__), ToStr.new("#{dir}/symlink_d")
       assert_send_type "(String, ToPath) -> 0",
-                       File, :symlink, File.expand_path(__FILE__, "../.."), ToPath.new("#{dir}/symlink_e")
+                       File, :symlink, File.expand_path(__FILE__), ToPath.new("#{dir}/symlink_e")
     end
   end
 
   def test_symlink?
     Dir.mktmpdir do |dir|
-      File.symlink(File.expand_path(__FILE__, "../.."), "#{dir}/symlink")
+      File.symlink(File.expand_path(__FILE__), "#{dir}/symlink")
 
       assert_send_type "(String) -> true",
                        File, :symlink?, "#{dir}/symlink"
@@ -699,7 +699,7 @@ class FileSingletonTest < Test::Unit::TestCase
     end
 
     assert_send_type "(String) -> false",
-                     File, :symlink?, File.expand_path(__FILE__, "../..")
+                     File, :symlink?, File.expand_path(__FILE__)
   end
 
   def test_truncate
@@ -755,7 +755,7 @@ class FileSingletonTest < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       File.open("#{dir}/a", "w"){}
       assert_send_type "(Time, Time, String) -> Integer",
-                       File, :utime, File.atime(File.expand_path(__FILE__, "../..")), File.atime(File.expand_path(__FILE__, "../..")), "#{dir}/a"
+                       File, :utime, File.atime(File.expand_path(__FILE__)), File.atime(File.expand_path(__FILE__)), "#{dir}/a"
       assert_send_type "(Numeric, Numeric, ToStr) -> Integer",
                        File, :utime, 1, 2, ToStr.new("#{dir}/a")
       assert_send_type "(Numeric, Numeric, ToPath) -> Integer",
@@ -763,19 +763,19 @@ class FileSingletonTest < Test::Unit::TestCase
 
       File.open("#{dir}/b", "w"){}
       assert_send_type "(Time, Time, String, String) -> Integer",
-                       File, :utime, File.atime(File.expand_path(__FILE__, "../..")), File.atime(File.expand_path(__FILE__, "../..")), "#{dir}/a", "#{dir}/b"
+                       File, :utime, File.atime(File.expand_path(__FILE__)), File.atime(File.expand_path(__FILE__)), "#{dir}/a", "#{dir}/b"
     end
   end
 
   def test_world_readable?
     assert_send_type "(String) -> Integer",
-                     File, :world_readable?, File.expand_path(__FILE__, "../..")
+                     File, :world_readable?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> Integer",
-                     File, :world_readable?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :world_readable?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> Integer",
-                     File, :world_readable?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :world_readable?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> Integer",
-                     File, :world_readable?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :world_readable?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
 
     Dir.mktmpdir do |dir|
       File.open("#{dir}/unreadable", "w"){}
@@ -810,31 +810,31 @@ class FileSingletonTest < Test::Unit::TestCase
 
   def test_writable?
     assert_send_type "(String) -> bool",
-                     File, :writable?, File.expand_path(__FILE__, "../..")
+                     File, :writable?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :writable?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :writable?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :writable?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :writable?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_writable_real?
     assert_send_type "(String) -> bool",
-                     File, :writable_real?, File.expand_path(__FILE__, "../..")
+                     File, :writable_real?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :writable_real?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :writable_real?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :writable_real?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :writable_real?, ToPath.new(File.expand_path(__FILE__))
   end
 
   def test_zero?
     assert_send_type "(String) -> bool",
-                     File, :zero?, File.expand_path(__FILE__, "../..")
+                     File, :zero?, File.expand_path(__FILE__)
     assert_send_type "(ToStr) -> bool",
-                     File, :zero?, ToStr.new(File.expand_path(__FILE__, "../.."))
+                     File, :zero?, ToStr.new(File.expand_path(__FILE__))
     assert_send_type "(ToPath) -> bool",
-                     File, :zero?, ToPath.new(File.expand_path(__FILE__, "../.."))
+                     File, :zero?, ToPath.new(File.expand_path(__FILE__))
     assert_send_type "(IO) -> bool",
-                     File, :zero?, IO.new(IO.sysopen(File.expand_path(__FILE__, "../..")))
+                     File, :zero?, IO.new(IO.sysopen(File.expand_path(__FILE__)))
   end
 end
 
@@ -845,7 +845,7 @@ class FileInstanceTest < Test::Unit::TestCase
 
   def test_atime
     assert_send_type "() -> Time",
-                     File.open(File.expand_path(__FILE__, "../..")), :atime
+                     File.open(File.expand_path(__FILE__)), :atime
   end
 
   def test_chmod
@@ -860,20 +860,20 @@ class FileInstanceTest < Test::Unit::TestCase
 
   def test_chown
     assert_send_type "(Integer, Integer) -> 0",
-                     File.open(File.expand_path(__FILE__, "../..")), :chown, Process.uid, Process.gid
+                     File.open(File.expand_path(__FILE__)), :chown, Process.uid, Process.gid
     assert_send_type "(ToInt, Integer) -> 0",
-                     File.open(File.expand_path(__FILE__, "../..")), :chown, ToInt.new(Process.uid), Process.gid
+                     File.open(File.expand_path(__FILE__)), :chown, ToInt.new(Process.uid), Process.gid
     assert_send_type "(nil, Integer) -> 0",
-                     File.open(File.expand_path(__FILE__, "../..")), :chown, nil, Process.gid
+                     File.open(File.expand_path(__FILE__)), :chown, nil, Process.gid
     assert_send_type "(Integer, ToInt) -> 0",
-                     File.open(File.expand_path(__FILE__, "../..")), :chown, Process.uid, ToInt.new(Process.gid)
+                     File.open(File.expand_path(__FILE__)), :chown, Process.uid, ToInt.new(Process.gid)
     assert_send_type "(Integer, nil) -> 0",
-                     File.open(File.expand_path(__FILE__, "../..")), :chown, Process.uid, nil
+                     File.open(File.expand_path(__FILE__)), :chown, Process.uid, nil
   end
 
   def test_ctime
     assert_send_type "() -> Time",
-                     File.open(File.expand_path(__FILE__, "../..")), :ctime
+                     File.open(File.expand_path(__FILE__)), :ctime
   end
 
   def test_flock
@@ -892,27 +892,27 @@ class FileInstanceTest < Test::Unit::TestCase
 
   def test_lstat
     assert_send_type "() -> File::Stat",
-                     File.open(File.expand_path(__FILE__, "../..")), :lstat
+                     File.open(File.expand_path(__FILE__)), :lstat
   end
 
   def test_mtime
     assert_send_type "() -> Time",
-                     File.open(File.expand_path(__FILE__, "../..")), :mtime
+                     File.open(File.expand_path(__FILE__)), :mtime
   end
 
   def test_path
     assert_send_type "() -> String",
-                     File.open(File.expand_path(__FILE__, "../..")), :path
+                     File.open(File.expand_path(__FILE__)), :path
   end
 
   def test_size
     assert_send_type "() -> Integer",
-                     File.open(File.expand_path(__FILE__, "../..")), :size
+                     File.open(File.expand_path(__FILE__)), :size
   end
 
   def test_to_path
     assert_send_type "() -> String",
-                     File.open(File.expand_path(__FILE__, "../..")), :to_path
+                     File.open(File.expand_path(__FILE__)), :to_path
   end
 
   def test_truncate

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -10,11 +10,11 @@ class IOSingletonTest < Test::Unit::TestCase
 
   def test_binread
     assert_send_type "(String) -> String",
-                     IO, :binread, File.expand_path(__FILE__, "../..")
+                     IO, :binread, File.expand_path(__FILE__)
     assert_send_type "(String, Integer) -> String",
-                     IO, :binread, File.expand_path(__FILE__, "../.."), 3
+                     IO, :binread, File.expand_path(__FILE__), 3
     assert_send_type "(String, Integer, Integer) -> String",
-                     IO, :binread, File.expand_path(__FILE__, "../.."), 3, 0
+                     IO, :binread, File.expand_path(__FILE__), 3, 0
   end
 
   def test_binwrite
@@ -35,7 +35,7 @@ class IOSingletonTest < Test::Unit::TestCase
 
   def test_open
     Dir.mktmpdir do |dir|
-      fd = IO.sysopen(File.expand_path(__FILE__, "../.."))
+      fd = IO.sysopen(File.expand_path(__FILE__))
 
       assert_send_type "(Integer) -> IO",
                        IO, :open, fd
@@ -135,7 +135,7 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_advise
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type "(Symbol) -> nil",
                        io, :advise, :normal
       assert_send_type "(Symbol) -> nil",
@@ -156,7 +156,7 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_autoclose=
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type "(bool) -> bool",
                        io, :autoclose=, true
       assert_send_type "(bool) -> bool",
@@ -169,14 +169,14 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_autoclose?
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type "() -> bool",
                        io, :autoclose?
     end
   end
 
   def test_read
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type "() -> String",
                        io, :read
       assert_send_type "(Integer) -> String",
@@ -195,7 +195,7 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_readpartial
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type "(Integer) -> String",
                        io, :readpartial, 10
       assert_send_type "(Integer, String) -> String",
@@ -217,7 +217,7 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_close_on_exec
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type '() -> bool',
                        io, :close_on_exec?
       assert_send_type '(::Integer) -> untyped',
@@ -232,7 +232,7 @@ class IOInstanceTest < Test::Unit::TestCase
   end
 
   def test_sync
-    IO.open(IO.sysopen(File.expand_path(__FILE__, "../.."))) do |io|
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
       assert_send_type '() -> bool',
                        io, :sync
       assert_send_type '(::Integer) -> ::Integer',

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -484,9 +484,9 @@ class KernelTest < StdlibTest
   end
 
   def test_open
-    open(File.expand_path(__FILE__, "../..")).close
-    open(File.expand_path(__FILE__, "../.."), 'r').close
-    open(File.expand_path(__FILE__, "../..")) do |f|
+    open(File.expand_path(__FILE__)).close
+    open(File.expand_path(__FILE__), 'r').close
+    open(File.expand_path(__FILE__)) do |f|
       f.read
     end
   end
@@ -575,11 +575,11 @@ class KernelTest < StdlibTest
   end
 
   def test_test
-    test ?r, File.expand_path(__FILE__, "../..")
-    test ?r.ord, File.expand_path(__FILE__, "../..")
-    test ?s, File.expand_path(__FILE__, "../..")
+    test ?r, File.expand_path(__FILE__)
+    test ?r.ord, File.expand_path(__FILE__)
+    test ?s, File.expand_path(__FILE__)
 
-    File.open(File.expand_path(__FILE__, "../..")) do |f|
+    File.open(File.expand_path(__FILE__)) do |f|
       test ?r, f
       test ?=, f, f
     end

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -111,11 +111,11 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_binread
     assert_send_type '() -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :binread
+                     Pathname(File.expand_path(__FILE__)), :binread
     assert_send_type '(Integer) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :binread, 42
+                     Pathname(File.expand_path(__FILE__)), :binread, 42
     assert_send_type '(Integer, Integer) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :binread, 42, 43
+                     Pathname(File.expand_path(__FILE__)), :binread, 42, 43
   end
 
   def test_binwrite
@@ -241,7 +241,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
   end
 
   def test_each_line
-    path = Pathname(File.expand_path(__FILE__, "../.."))
+    path = Pathname(File.expand_path(__FILE__))
 
     assert_send_type '() { (String) -> untyped } -> nil',
                      path, :each_line do end
@@ -278,14 +278,14 @@ class PathnameInstanceTest < Test::Unit::TestCase
     assert_send_type '() -> bool',
                      Pathname('/usr/bin/env'), :executable?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :executable?
+                     Pathname(File.expand_path(__FILE__)), :executable?
   end
 
   def test_executable_real?
     assert_send_type '() -> bool',
                      Pathname('/usr/bin/env'), :executable_real?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :executable_real?
+                     Pathname(File.expand_path(__FILE__)), :executable_real?
   end
 
   def test_exist?
@@ -309,7 +309,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_file?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :file?
+                     Pathname(File.expand_path(__FILE__)), :file?
     assert_send_type '() -> bool',
                      Pathname('/unknown'), :file?
   end
@@ -346,7 +346,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_ftype
     assert_send_type '() -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :ftype
+                     Pathname(File.expand_path(__FILE__)), :ftype
     assert_send_type '() -> String',
                      Pathname(__dir__), :ftype
   end
@@ -364,7 +364,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_grpowned?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :grpowned?
+                     Pathname(File.expand_path(__FILE__)), :grpowned?
     assert_send_type '() -> bool',
                      Pathname('/'), :grpowned?
   end
@@ -413,7 +413,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_lstat
     assert_send_type '() -> ::File::Stat',
-                     Pathname(File.expand_path(__FILE__, "../..")), :lstat
+                     Pathname(File.expand_path(__FILE__)), :lstat
   end
 
   def test_make_link
@@ -521,42 +521,42 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_read
     assert_send_type '() -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read
+                     Pathname(File.expand_path(__FILE__)), :read
     assert_send_type '(Integer) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read, 42
+                     Pathname(File.expand_path(__FILE__)), :read, 42
     assert_send_type '(Integer, Integer) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read, 42, 43
+                     Pathname(File.expand_path(__FILE__)), :read, 42, 43
     assert_send_type '(encoding: String) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read, encoding: 'UTF-8'
+                     Pathname(File.expand_path(__FILE__)), :read, encoding: 'UTF-8'
     assert_send_type '(encoding: ToStr) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read, encoding: ToStr.new('UTF-8')
+                     Pathname(File.expand_path(__FILE__)), :read, encoding: ToStr.new('UTF-8')
     assert_send_type '(encoding: Encoding) -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :read, encoding: Encoding::UTF_8
+                     Pathname(File.expand_path(__FILE__)), :read, encoding: Encoding::UTF_8
   end
 
   def test_readable?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readable?
+                     Pathname(File.expand_path(__FILE__)), :readable?
   end
 
   def test_readable_real?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readable_real?
+                     Pathname(File.expand_path(__FILE__)), :readable_real?
   end
 
   def test_readlines
     assert_send_type '() -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines
+                     Pathname(File.expand_path(__FILE__)), :readlines
     assert_send_type '(String) -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines, 'a'
+                     Pathname(File.expand_path(__FILE__)), :readlines, 'a'
     assert_send_type '(Integer) -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines, 42
+                     Pathname(File.expand_path(__FILE__)), :readlines, 42
     assert_send_type '(String, Integer) -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines, 'a', 42
+                     Pathname(File.expand_path(__FILE__)), :readlines, 'a', 42
     assert_send_type '(String, Integer, chomp: true) -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines, 'a', 42, chomp: true
+                     Pathname(File.expand_path(__FILE__)), :readlines, 'a', 42, chomp: true
     assert_send_type '(String, Integer, binmode: true) -> Array[String]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :readlines, 'a', 42, binmode: true
+                     Pathname(File.expand_path(__FILE__)), :readlines, 'a', 42, binmode: true
   end
 
   def test_readlink
@@ -574,24 +574,24 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_realdirpath
     assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realdirpath
+                     Pathname(File.expand_path(__FILE__)), :realdirpath
     assert_send_type '(String) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realdirpath, '.'
+                     Pathname(File.expand_path(__FILE__)), :realdirpath, '.'
     assert_send_type '(ToStr) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realdirpath, ToStr.new('.')
+                     Pathname(File.expand_path(__FILE__)), :realdirpath, ToStr.new('.')
     assert_send_type '(Pathname) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realdirpath, Pathname.new('.')
+                     Pathname(File.expand_path(__FILE__)), :realdirpath, Pathname.new('.')
   end
 
   def test_realpath
     assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realpath
+                     Pathname(File.expand_path(__FILE__)), :realpath
     assert_send_type '(String) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realpath, '.'
+                     Pathname(File.expand_path(__FILE__)), :realpath, '.'
     assert_send_type '(ToStr) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realpath, ToStr.new('.')
+                     Pathname(File.expand_path(__FILE__)), :realpath, ToStr.new('.')
     assert_send_type '(Pathname) -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :realpath, Pathname.new('.')
+                     Pathname(File.expand_path(__FILE__)), :realpath, Pathname.new('.')
   end
 
   def test_relative?
@@ -665,12 +665,12 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_size
     assert_send_type '() -> Integer',
-                     Pathname(File.expand_path(__FILE__, "../..")), :size
+                     Pathname(File.expand_path(__FILE__)), :size
   end
 
   def test_size?
     assert_send_type '() -> Integer',
-                     Pathname(File.expand_path(__FILE__, "../..")), :size?
+                     Pathname(File.expand_path(__FILE__)), :size?
 
     assert_send_type '() -> nil',
                      Pathname('/does/not/exist'), :size?
@@ -678,24 +678,24 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_socket?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :socket?
+                     Pathname(File.expand_path(__FILE__)), :socket?
   end
 
   def test_split
     assert_send_type '() -> [Pathname, Pathname]',
-                     Pathname(File.expand_path(__FILE__, "../..")), :split
+                     Pathname(File.expand_path(__FILE__)), :split
     assert_send_type '() -> [Pathname, Pathname]',
                      Pathname('/'), :split
   end
 
   def test_stat
     assert_send_type '() -> File::Stat',
-                     Pathname(File.expand_path(__FILE__, "../..")), :stat
+                     Pathname(File.expand_path(__FILE__)), :stat
   end
 
   def test_sticky?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :sticky?
+                     Pathname(File.expand_path(__FILE__)), :sticky?
   end
 
   def test_sub
@@ -718,26 +718,26 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_symlink?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :symlink?
+                     Pathname(File.expand_path(__FILE__)), :symlink?
   end
 
   def test_sysopen
     assert_send_type '() -> Integer',
-                     Pathname(File.expand_path(__FILE__, "../..")), :sysopen
+                     Pathname(File.expand_path(__FILE__)), :sysopen
     assert_send_type '(String) -> Integer',
-                     Pathname(File.expand_path(__FILE__, "../..")), :sysopen, 'r'
+                     Pathname(File.expand_path(__FILE__)), :sysopen, 'r'
     assert_send_type '(String, Integer) -> Integer',
-                     Pathname(File.expand_path(__FILE__, "../..")), :sysopen, 'r', 0644
+                     Pathname(File.expand_path(__FILE__)), :sysopen, 'r', 0644
   end
 
   def test_taint
     assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :taint
+                     Pathname(File.expand_path(__FILE__)), :taint
   end
 
   def test_to_path
     assert_send_type '() -> String',
-                     Pathname(File.expand_path(__FILE__, "../..")), :to_path
+                     Pathname(File.expand_path(__FILE__)), :to_path
   end
 
   def test_truncate
@@ -760,7 +760,7 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_untaint
     assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__, "../..")), :untaint
+                     Pathname(File.expand_path(__FILE__)), :untaint
   end
 
   def test_utime
@@ -776,21 +776,21 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_world_readable?
     assert_send_type '() -> (Integer | nil)',
-                     Pathname(File.expand_path(__FILE__, "../..")), :world_readable?
+                     Pathname(File.expand_path(__FILE__)), :world_readable?
     assert_send_type '() -> (Integer | nil)',
                      Pathname('/'), :world_readable?
   end
 
   def test_world_writable?
     assert_send_type '() -> (Integer | nil)',
-                     Pathname(File.expand_path(__FILE__, "../..")), :world_writable?
+                     Pathname(File.expand_path(__FILE__)), :world_writable?
     assert_send_type '() -> (Integer | nil)',
                      Pathname('/'), :world_writable?
   end
 
   def test_writable?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :writable?
+                     Pathname(File.expand_path(__FILE__)), :writable?
     assert_send_type '() -> bool',
                      Pathname('/'), :writable?
   end
@@ -809,6 +809,6 @@ class PathnameInstanceTest < Test::Unit::TestCase
 
   def test_zero?
     assert_send_type '() -> bool',
-                     Pathname(File.expand_path(__FILE__, "../..")), :zero?
+                     Pathname(File.expand_path(__FILE__)), :zero?
   end
 end

--- a/test/stdlib/RubyVM_test.rb
+++ b/test/stdlib/RubyVM_test.rb
@@ -1,0 +1,77 @@
+require_relative "test_helper"
+
+class RubyVM::AbstractSyntaxTreeSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::RubyVM::AbstractSyntaxTree)"
+
+  def test_parse
+    assert_send_type "(::String string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node",
+                     RubyVM::AbstractSyntaxTree, :parse, "1 + 2"
+  end
+
+  def test_parse_file
+    assert_send_type "(::String | ::Pathname string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node",
+                     RubyVM::AbstractSyntaxTree, :parse_file, __FILE__
+  end
+
+  def test_of
+    assert_send_type "(::Proc | ::Method | ::UnboundMethod body, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node?",
+                     RubyVM::AbstractSyntaxTree, :of, method(:test_of)
+  end
+
+  if RUBY_VERSION >= '3.2'
+    def test_node_id_for_backtrace_location
+      assert_send_type "(::Thread::Backtrace::Location backtrace_location) -> ::Integer",
+                      RubyVM::AbstractSyntaxTree, :node_id_for_backtrace_location, caller_locations[0]
+    end
+  end
+end
+
+class RubyVM::AbstractSyntaxTree::NodeTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::RubyVM::AbstractSyntaxTree::Node"
+
+  def test_type
+    assert_send_type "() -> ::Symbol",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :type
+  end
+
+  def test_first_lineno
+    assert_send_type "() -> ::Integer",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :first_lineno
+  end
+
+  def test_first_column
+    assert_send_type "() -> ::Integer",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :first_column
+  end
+
+  def test_last_lineno
+    assert_send_type "() -> ::Integer",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :last_lineno
+  end
+
+  def test_last_column
+    assert_send_type "() -> ::Integer",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :last_column
+  end
+
+  if RUBY_VERSION >= '3.2'
+    def test_tokens
+      assert_send_type "() -> ::Array[[ ::Integer, ::Symbol, ::String, [ ::Integer, ::Integer, ::Integer, ::Integer ] ]]?",
+                      RubyVM::AbstractSyntaxTree.parse("1 + 2", keep_tokens: true), :tokens
+    end
+
+    def test_all_tokens
+      assert_send_type "() -> ::Array[[ ::Integer, ::Symbol, ::String, [ ::Integer, ::Integer, ::Integer, ::Integer ] ]]?",
+                      RubyVM::AbstractSyntaxTree.parse("1 + 2", keep_tokens: true), :all_tokens
+    end
+  end
+
+  def test_children
+    assert_send_type "() -> ::Array[untyped]",
+                     RubyVM::AbstractSyntaxTree.parse("1 + 2"), :children
+  end
+end

--- a/test/stdlib/RubyVM_test.rb
+++ b/test/stdlib/RubyVM_test.rb
@@ -11,7 +11,7 @@ class RubyVM::AbstractSyntaxTreeSingletonTest < Test::Unit::TestCase
   end
 
   def test_parse_file
-    assert_send_type "(::String | ::Pathname string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node",
+    assert_send_type "(::String | ::_ToPath string, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node",
                      RubyVM::AbstractSyntaxTree, :parse_file, __FILE__
   end
 

--- a/test/stdlib/rubygems/Gem_test.rb
+++ b/test/stdlib/rubygems/Gem_test.rb
@@ -462,7 +462,7 @@ class GemSingletonTest < Test::Unit::TestCase
 
   def test_read_binary
     assert_send_type  "(String) -> String",
-                      Gem, :read_binary, File.expand_path(__FILE__, "../..")
+                      Gem, :read_binary, File.expand_path(__FILE__)
   end
 
   def test_refresh


### PR DESCRIPTION
Added method types for `RubyVM::AbstractSyntaxTree` and `RubyVM::AbstractSyntaxTree::Node`.

RubyVM::AbstractSyntaxTree` itself is marked as experimental, but we believe that there are a certain number of uses, including rbs.

However, The following methods marked as *internal use* have not been added.

- `RubyVM::AbstractSyntaxTree::Node#node_id`
- `RubyVM::AbstractSyntaxTree::Node#script_lines`
- `RubyVM::AbstractSyntaxTree::Node#source`

The documentation is from ruby v3.1, but the types are based on ruby v3.2 code.