### PR TITLE
Remove calling Regexp.{new,compile} with 3 arguments in test

### DIFF
--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -6,16 +6,12 @@ class RegexpTest < StdlibTest
   def test_new
     Regexp.new('dog')
     Regexp.new('dog', option = Regexp::IGNORECASE)
-    Regexp.new('dog', option = nil, code = 'n')
-    Regexp.new('dog', option = Regexp::IGNORECASE, code = 'n')
     Regexp.new(/^a-z+:\\s+\w+/)
   end
 
   def test_compile
     Regexp.compile('dog')
     Regexp.compile('dog', option = Regexp::IGNORECASE)
-    Regexp.compile('dog', option = nil, code = 'n')
-    Regexp.compile('dog', option = Regexp::IGNORECASE, code = 'n')
     Regexp.compile(/^a-z+:\\s+\w+/)
   end
 


### PR DESCRIPTION
This was deprecated in Ruby 3.2 and will be removed in Ruby 3.3. See Ruby bug 18979.