### PR TITLE
Support interface in class/module for Sorter

### DIFF
--- a/lib/rbs/sorter.rb
+++ b/lib/rbs/sorter.rb
@@ -34,7 +34,7 @@ module RBS
         -3
       when Declarations::Constant
         -2
-      when Declarations::Class, Declarations::Module
+      when Declarations::Class, Declarations::Module, Declarations::Interface
         -1
       when Members::Include
         0.0
@@ -102,7 +102,7 @@ module RBS
         member.name.to_s
       when Declarations::TypeAlias
         member.name.to_s
-      when Declarations::Class, Declarations::Module
+      when Declarations::Class, Declarations::Module, Declarations::Interface
         member.name.to_s
       else
         raise

--- a/test/rbs/sorter_test.rb
+++ b/test/rbs/sorter_test.rb
@@ -19,6 +19,10 @@ class RBS::SorterTest < Test::Unit::TestCase
           def x: () -> void
         end
 
+        interface _I
+          def i: () -> void
+        end
+
         include M2
         prepend M1
         extend M3
@@ -101,6 +105,10 @@ class RBS::SorterTest < Test::Unit::TestCase
         include M2
 
         extend M3
+
+        interface _I
+          def i: () -> void
+        end
 
         class B
           def x: () -> void


### PR DESCRIPTION
Fixed an error that occurred when an interface was defined in a class/module and could no longer be processed.

Sort order was adapted to the top-level case.