### PR TITLE
Use dev version docker images on CI

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: "ubuntu-latest"
     container:
-      image: rubylang/ruby:3.1-focal
+      image: rubylang/ruby:3.1-dev-focal
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set working directory as safe
-        run: /usr/bin/git config --global --add safe.directory $(pwd)
+        run: git config --global --add safe.directory $(pwd)
       - name: Install dependencies
         run: |
           apt-get update

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         container_tag:
           - master-nightly-focal
-          - 3.1-focal
-          - 3.0-focal
-          - 2.7-bionic
+          - 3.1-dev-focal
+          - 3.0-dev-focal
+          - 2.7-dev-bionic
           - 2.6-bionic
         job:
           - test
@@ -28,9 +28,9 @@ jobs:
             job: confirm_lexer
           - container_tag: 2.6-bionic
             job: stdlib_test
-          - container_tag: 2.7-bionic
+          - container_tag: 2.7-dev-bionic
             job: stdlib_test
-          - container_tag: 3.0-focal
+          - container_tag: 3.0-dev-focal
             job: stdlib_test
     container:
       image: rubylang/ruby:${{ matrix.container_tag }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request: {}
 
+env:
+  LANG: 'C.UTF-8'
+
 jobs:
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Docker images without `dev` tag have been slimmer by removing
build-essential and so on, which includes `git`. But our CI needs `git`
command. Therefore we need to use `dev` version images for CI.

By the way, we should add Ruby 3.2 image to the build matrix but I'll add it on another PR.