### PR TITLE
Support Symbol and _ToStr for Regexp#=~

### DIFF
--- a/core/regexp.rbs
+++ b/core/regexp.rbs
@@ -948,7 +948,7 @@ class Regexp
   #     "  x = y  " =~ /(?<lhs>\w+)\s*=\s*(?<rhs>\w+)/
   #     p lhs, rhs # undefined local variable
   #
-  def =~: (String? str) -> Integer?
+  def =~: (String? | Symbol | _ToStr str) -> Integer?
 
   # <!--
   #   rdoc-file=re.c

--- a/test/stdlib/Regexp_test.rb
+++ b/test/stdlib/Regexp_test.rb
@@ -87,6 +87,7 @@ class RegexpTest < StdlibTest
   def test_equal_tilde
     /at/ =~ "input data" #=> 7
     /ax/ =~ "input data" #=> nil
+    /a/ =~ :a            #=> 0
   end
 
   def test_casefold?


### PR DESCRIPTION
`Regexp#match` and `Regexp#match?` already support Symbol and _ToStr.
Fixed so that `Regexp#=~` can also support them.