### PR TITLE
Allow _ToStr to Object::name

### DIFF
--- a/core/object.rbs
+++ b/core/object.rbs
@@ -1202,4 +1202,4 @@ interface _Writeable
   def write: (untyped) -> void
 end
 
-type Object::name = Symbol | String
+type Object::name = Symbol | string


### PR DESCRIPTION
Ruby's C-API, `rb_check_id()`, allows Symbol and String and objects with `to_str` methods. All methods using the `Object::name` type below should allow the `_ToStr` interface because they use `rb_check_id()`.

- Object#public_method
- Object#public_send
- Object#remove_instance_variable
- Object#respond_to?
- Object#send
- Object#singleton_method