### PR TITLE
Remove `LANG=C.UTF-8` env on CI because it's set by the base image

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,9 +6,6 @@ on:
       - master
   pull_request: {}
 
-env:
-  LANG: 'C.UTF-8'
-
 jobs:
   test:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
I introduced this env var in #1192, but it is no longer needed because the env var has been set in upstream.