### PR TITLE
Let `#resolved_revision` return the last fetched commit

### DIFF
--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -171,7 +171,7 @@ module RBS
               if commit_hash?
                 revision
               else
-                setup! { git('rev-parse', revision).chomp }
+                setup! { git('rev-parse', "refs/remotes/origin/#{revision}").chomp }
               end
             end
         end


### PR DESCRIPTION
The `git rev-parse #{revision}` returns the commit of the local branch, and it doesn't update after `git fetch`. This results in a problem that `rbs collection update` doesn't update to the newer RBS files if it uses the cache repository created before.