### PR TITLE
`Module#attr` returns an Array of Symbol after 3.0

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -1536,5 +1536,5 @@ class Module < Object
   # `attr_reader(name)` but deprecated. Returns an array of defined method names
   # as symbols.
   #
-  def attr: (*Symbol | String arg0) -> NilClass
+  def attr: (*Symbol | String arg0) -> Array[Symbol]
 end

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -144,4 +144,14 @@ class ModuleInstanceTest < Test::Unit::TestCase
       mod, :public, :foo, "bar"
     )
   end
+
+  def test_attr
+    if RUBY_VERSION >= '3.0'
+      mod = Module.new
+      assert_send_type(
+        "(*Symbol | String arg0) -> Array[Symbol]",
+        mod, :attr, :foo
+      )
+    end
+  end
 end


### PR DESCRIPTION
Since RBS is supposed to have a policy of matching types to the latest Ruby releases, I fixed the type of Module#attr to 3.0 or later.

See also https://bugs.ruby-lang.org/issues/17314

