### PR TITLE
Skip loading `require: false` gems in collection

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,4 +115,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.3.14
+   2.4.6

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1060,15 +1060,12 @@ EOB
       case args[0]
       when 'install'
         unless params[:frozen]
-          gemfile_lock_path = Bundler.default_lockfile
-          Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+          Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'update'
-        gemfile_lock_path = Bundler.default_lockfile
-
         # TODO: Be aware of argv to update only specified gem
-        Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path, with_lockfile: false)
+        Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'init'
         if config_path.exist?

--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -31,9 +31,9 @@ module RBS
 
       # Generate a rbs lockfile from Gemfile.lock to `config_path`.
       # If `with_lockfile` is true, it respects existing rbs lockfile.
-      def self.generate_lockfile(config_path:, gemfile_lock_path:, with_lockfile: true)
+      def self.generate_lockfile(config_path:, definition:, with_lockfile: true)
         config = from_path(config_path)
-        lockfile = LockfileGenerator.generate(config: config, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
+        lockfile = LockfileGenerator.generate(config: config, definition: definition, with_lockfile: with_lockfile)
 
         [config, lockfile]
       end

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -20,15 +20,15 @@ module RBS
           end
         end
 
-        attr_reader :config, :lockfile, :gemfile_lock, :existing_lockfile
+        attr_reader :config, :lockfile, :definition, :existing_lockfile, :gem_hash
 
-        def self.generate(config:, gemfile_lock_path:, with_lockfile: true)
-          generator = new(config: config, gemfile_lock_path: gemfile_lock_path, with_lockfile: with_lockfile)
+        def self.generate(config:, definition:, with_lockfile: true)
+          generator = new(config: config, definition: definition, with_lockfile: with_lockfile)
           generator.generate
           generator.lockfile
         end
 
-        def initialize(config:, gemfile_lock_path:, with_lockfile:)
+        def initialize(config:, definition:, with_lockfile:)
           @config = config
 
           lockfile_path = Config.to_lockfile_path(config.config_path)
@@ -37,7 +37,7 @@ module RBS
           @lockfile = Lockfile.new(
             lockfile_path: lockfile_path,
             path: config.repo_path_data,
-            gemfile_lock_path: gemfile_lock_path.relative_path_from(lockfile_dir)
+            gemfile_lock_path: definition.lockfile.relative_path_from(lockfile_dir)
           )
           config.sources.each do |source|
             case source
@@ -48,10 +48,13 @@ module RBS
 
           if with_lockfile && lockfile_path.file?
             @existing_lockfile = Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))
-            validate_gemfile_lock_path!(lock: @existing_lockfile, gemfile_lock_path: gemfile_lock_path)
+            validate_gemfile_lock_path!(lock: @existing_lockfile, gemfile_lock_path: definition.lockfile)
           end
 
-          @gemfile_lock = Bundler::LockfileParser.new(gemfile_lock_path.read)
+          @definition = definition
+          @gem_hash = definition.locked_gems.specs.each.with_object({}) do |spec, hash|  #$ Hash[String, Bundler::LazySpecification]
+            hash[spec.name] = spec
+          end
         end
 
         def generate
@@ -67,8 +70,12 @@ module RBS
             end
           end
 
-          gemfile_lock_gems do |spec|
-            assign_gem(name: spec.name, version: spec.version, ignored_gems: ignored_gems, src_data: nil)
+          definition.requires.each do |gem, requires|
+            # `require: false`` gems has empty array here
+            unless requires.empty?
+              spec = gem_hash[gem] or raise "Cannot find `#{gem}` in bundler context"
+              assign_gem(name: gem, version: spec.version, ignored_gems: ignored_gems, src_data: nil)
+            end
           end
 
           lockfile.lockfile_path.write(YAML.dump(lockfile.to_lockfile))
@@ -82,7 +89,7 @@ module RBS
           end
         end
 
-        private def assign_gem(name:, version:, ignored_gems:, src_data:)
+        private def assign_gem(name:, version:, src_data:, ignored_gems:)
           return if ignored_gems.include?(name)
           return if lockfile.gems.key?(name)
 
@@ -99,9 +106,8 @@ module RBS
               if src_data
                 Sources.from_config_entry(src_data)
               else
-                find_source(name: name)
+                find_source(name: name) or return
               end
-            return unless source
 
             installed_version = version
             best_version = find_best_version(version: installed_version, versions: source.versions(name))
@@ -116,10 +122,14 @@ module RBS
           locked or raise
 
           lockfile.gems[name] = locked
-          source = locked[:source]
 
-          source.dependencies_of(locked[:name], locked[:version])&.each do |dep|
+          locked[:source].dependencies_of(locked[:name], locked[:version])&.each do |dep|
             assign_stdlib(name: dep["name"], from_gem: name)
+          end
+
+          gem_hash[name].dependencies.each do |dep|
+            spec = gem_hash[dep.name]
+            assign_gem(name: dep.name, version: spec.version, src_data: nil, ignored_gems: ignored_gems)
           end
         end
 
@@ -147,12 +157,6 @@ module RBS
             deps.each do |dep|
               assign_stdlib(name: dep["name"], from_gem: name)
             end
-          end
-        end
-
-        private def gemfile_lock_gems(&block)
-          gemfile_lock.specs.each do |spec|
-            yield spec
           end
         end
 

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -70,12 +70,13 @@ module RBS
             end
           end
 
-          definition.requires.each do |gem, requires|
-            # `require: false`` gems has empty array here
-            unless requires.empty?
-              spec = gem_hash[gem] or raise "Cannot find `#{gem}` in bundler context"
-              assign_gem(name: gem, version: spec.version, ignored_gems: ignored_gems, src_data: nil)
+          definition.dependencies.each do |dep|
+            if dep.autorequire && dep.autorequire.empty?
+              next
             end
+
+            spec = gem_hash[dep.name] or raise "Cannot find `#{dep.name}` in bundler context"
+            assign_gem(name: dep.name, version: spec.version, ignored_gems: ignored_gems, src_data: nil)
           end
 
           lockfile.lockfile_path.write(YAML.dump(lockfile.to_lockfile))

--- a/sig/collection/config.rbs
+++ b/sig/collection/config.rbs
@@ -23,7 +23,7 @@ module RBS
 
       def self.find_config_path: () -> Pathname?
 
-      def self.generate_lockfile: (config_path: Pathname, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> [Config, Lockfile]
+      def self.generate_lockfile: (config_path: Pathname, definition: Bundler::Definition, ?with_lockfile: boolish) -> [Config, Lockfile]
 
       def self.from_path: (Pathname path) -> Config
 

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -13,18 +13,18 @@ module RBS
         end
 
         attr_reader config: Config
-        attr_reader gemfile_lock: Bundler::LockfileParser
 
         attr_reader lockfile: Lockfile
         attr_reader existing_lockfile: Lockfile?
 
-        type gem_queue_entry = { name: String, version: String? }
+        attr_reader definition: Bundler::Definition
 
-        @gem_queue: Array[gem_queue_entry]
+        # A hash table to look up a spec from name of the gem
+        attr_reader gem_hash: Hash[String, Bundler::LazySpecification]
 
-        def self.generate: (config: Config, gemfile_lock_path: Pathname, ?with_lockfile: boolish) -> Lockfile
+        def self.generate: (config: Config, definition: Bundler::Definition, ?with_lockfile: boolish) -> Lockfile
 
-        def initialize: (config: Config, gemfile_lock_path: Pathname, with_lockfile: boolish) -> void
+        def initialize: (config: Config, definition: Bundler::Definition, with_lockfile: boolish) -> void
 
         def generate: () -> void
 
@@ -34,13 +34,11 @@ module RBS
         #
         def validate_gemfile_lock_path!: (lock: Lockfile?, gemfile_lock_path: Pathname) -> void
 
-        def assign_gem: (name: String, version: String?, ignored_gems: Set[String], src_data: Sources::source_entry?) -> void
+        # Inserts a entry to lockfile of a gem and its dependencies, if not included in `ignored_gems:`
+        #
+        def assign_gem: (name: String, version: String?, src_data: Sources::source_entry?, ignored_gems: Set[String]) -> void
 
         def assign_stdlib: (name: String, from_gem: String?) -> void
-
-        def gemfile_lock_gems: () { (untyped) -> void } -> void
-
-        def remove_ignored_gems!: () -> void
 
         # Find a source of a gem from ones registered in `config.sources`
         #

--- a/sig/collection/sources.rbs
+++ b/sig/collection/sources.rbs
@@ -78,28 +78,34 @@ module RBS
 
         def cp_r: (Pathname, Pathname) -> void
 
-        # Ensure the git repository status is expected one
+        # Ensure the git repository exists, and
         #
-        # * It exists, and
-        # * The `HEAD` is the `revision`
+        # * When `revision` is a commit hash, the commit exists in the local repository, or
+        # * When `revision` is a branch name, the latest version is fetched from `origin`
+        #
+        # It may require a network connection to fetch or clone the repository from remote.
+        #
+        # * If `revision` is a commit hash and the commit doesn't exists in the local repository, it runs `git fetch`
+        # * If `revision` is a branch name, it runs `git fetch` once per instance
         #
         def setup!: [T] () { () -> T } -> T
                   | () -> void
 
         def need_to_fetch?: (String revision) -> bool
 
+        # The full path of local git repository
         def git_dir: () -> Pathname
 
+        # The full path of `repo_dir` in the local git repository
         def gem_repo_dir: () -> Pathname
 
-        def with_revision: [T] () { () -> T } -> T
-
         # Returns `true` if `revision` looks like a commit hash
-        #
         def commit_hash?: () -> bool
 
+        # Executes a git command, raises an error if failed
         def git: (*String cmd, **untyped opt) -> String
 
+        # Executes a git command, returns `nil` if failed
         def git?: (*String cmd, **untyped opt) -> String?
 
         def sh!: (*String cmd, **untyped opt) -> String

--- a/sig/shims/bundler.rbs
+++ b/sig/shims/bundler.rbs
@@ -1,13 +1,27 @@
 module Bundler
   class LockfileParser
     def initialize: (String) -> void
+
     def specs: () -> Array[LazySpecification]
   end
 
   class LazySpecification
     def name: () -> String
+
     def version: () -> String
+
+    def dependencies: () -> Array[Gem::Dependency]
+  end
+
+  class Definition
+    def lockfile: () -> Pathname
+
+    def requires: () -> Hash[String, Array[String]]
+
+    def locked_gems: () -> LockfileParser
   end
 
   def self.default_lockfile: () -> Pathname
+
+  def self.definition: () -> Definition
 end

--- a/sig/shims/bundler.rbs
+++ b/sig/shims/bundler.rbs
@@ -13,12 +13,16 @@ module Bundler
     def dependencies: () -> Array[Gem::Dependency]
   end
 
+  class Dependency < Gem::Dependency
+    attr_reader autorequire: Array[String]?
+  end
+
   class Definition
     def lockfile: () -> Pathname
 
-    def requires: () -> Hash[String, Array[String]]
-
     def locked_gems: () -> LockfileParser
+
+    def dependencies: () -> Array[Dependency]
   end
 
   def self.default_lockfile: () -> Pathname

--- a/sig/shims/rubygems.rbs
+++ b/sig/shims/rubygems.rbs
@@ -5,5 +5,11 @@ module Gem
     attr_reader gem_dir (): String
 
     def self.find_by_name: (String name, *String requirements) -> instance
+
+    def dependencies: () -> Array[Dependency]
+  end
+
+  class Dependency
+    def name: () -> String
   end
 end

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -233,65 +233,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     end
   end
 
-  def test_generate_lock_from_collection_repository_specified
-    mktmpdir do |tmpdir|
-      config_path = tmpdir / 'rbs_collection.yaml'
-      config_path.write [CONFIG, <<~YAML].join("\n")
-        gems:
-          - name: ast
-          - name: rainbow
-      YAML
-      gemfile_path = tmpdir / 'Gemfile'
-      gemfile_path.write "source 'https://rubygems.org'"
-      gemfile_lock_path = tmpdir / 'Gemfile.lock'
-      gemfile_lock_path.write <<~GEMFILE_LOCK
-        GEM
-          remote: https://rubygems.org/
-          specs:
-
-        PLATFORMS
-          x86_64-linux
-
-        DEPENDENCIES
-
-        BUNDLED WITH
-           2.2.0
-      GEMFILE_LOCK
-
-      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
-      string = YAML.dump(lockfile.to_lockfile)
-
-      assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
-        path: "/path/to/somewhere"
-        gemfile_lock_path: 'Gemfile.lock'
-        gems:
-          - name: ast
-            version: "2.4"
-            source:
-              name: ruby/gem_rbs_collection
-              remote: https://github.com/ruby/gem_rbs_collection.git
-              revision: cde6057e7546843ace6420c5783dd945c6ccda54
-              repo_dir: gems
-              type: git
-          - name: rainbow
-            version: "3.0"
-            source:
-              name: ruby/gem_rbs_collection
-              remote: https://github.com/ruby/gem_rbs_collection.git
-              revision: cde6057e7546843ace6420c5783dd945c6ccda54
-              repo_dir: gems
-              type: git
-      YAML
-    end
-  end
-
   def test_generate_lock_from_collection_with_manifest_yaml
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -18,6 +18,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     path: /path/to/somewhere
   YAML
 
+  GEMFILE = <<~RUBY
+    source 'https://rubygems.org'
+
+    gem 'ast'
+    gem 'rainbow'
+  RUBY
+
   GEMFILE_LOCK = <<~YAML
     GEM
       remote: https://rubygems.org/
@@ -40,10 +47,14 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -92,11 +103,14 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
           path: /path/to/somewhere
         YAML
+        gemfile_path = tmpdir / 'Gemfile'
+        gemfile_path.write GEMFILE
         gemfile_lock_path = tmpdir / 'Gemfile.lock'
         gemfile_lock_path.write GEMFILE_LOCK
 
         _config, lockfile = Dir.chdir(tmpdir) do
-          RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+          definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+          RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
         end
         string = YAML.dump(lockfile.to_lockfile)
 
@@ -135,6 +149,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
@@ -167,7 +183,9 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       YAML
       tmpdir.join('rbs_collection.lock.yaml').write lockfile_yaml
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config lockfile_yaml, string
@@ -184,10 +202,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
           - name: rainbow
             ignore: false
       YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -220,6 +241,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
           - name: ast
           - name: rainbow
       YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write "source 'https://rubygems.org'"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -235,7 +258,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -272,6 +296,12 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+        source "https://rubygems.org"
+
+        gem "activesupport"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -301,7 +331,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -358,6 +389,13 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+        source "https://rubygems.org"
+
+        gem "csv"
+      GEMFILE
+
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -375,7 +413,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -406,6 +445,12 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+        source "https://rubygems.org"
+
+        gem "rbs-amber"
+      GEMFILE
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -423,7 +468,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -452,6 +498,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'
       config_path.write CONFIG
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write 'source "https://ruubygems.org"'
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write <<~GEMFILE_LOCK
         GEM
@@ -467,7 +515,8 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
            2.2.0
       GEMFILE_LOCK
 
-      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path)
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
@@ -491,11 +540,14 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       lock_path.write CONFIG + "gemfile_lock_path: Gemfile.lock"
       gemfile_lock_path = tmpdir / 'Gemfile.lock'
       gemfile_lock_path.write GEMFILE_LOCK
+      gemfile_path2 = tmpdir / 'Gemfile.2'
+      gemfile_path2.write 'source "https://rubygems.org"'
       gemfile_lock_path2 = tmpdir / 'Gemfile.2.lock'
       gemfile_lock_path2.write GEMFILE_LOCK
 
       assert_raises(RBS::Collection::Config::LockfileGenerator::GemfileLockMismatchError) do
-        RBS::Collection::Config.generate_lockfile(config_path: config_path, gemfile_lock_path: gemfile_lock_path2)
+        definition = Bundler::Definition.build(gemfile_path2, gemfile_lock_path2, false)
+        RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
       end
     end
   end
@@ -512,6 +564,83 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       assert config.repo_path.absolute?
       assert_equal tmpdir.join('.gem_rbs_collection'), config.repo_path
+    end
+  end
+
+  def test_generate_lock_from_bundler_require_false
+    mktmpdir do |tmpdir|
+      config_path = tmpdir / 'rbs_collection.yaml'
+      config_path.write [CONFIG, <<~YAML].join("\n")
+        sources:
+          - type: git
+            name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: cde6057e7546843ace6420c5783dd945c6ccda54
+            repo_dir: gems
+        path: '.gem_rbs_collection'
+        gems: []
+      YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+        source 'https://rubygems.org'
+
+        gem "activesupport", require: false
+        gem "ast"
+      GEMFILE
+      gemfile_lock_path = tmpdir / 'Gemfile.lock'
+      gemfile_lock_path.write <<~GEMFILE_LOCK
+        GEM
+          remote: https://rubygems.org/
+          specs:
+            activesupport (6.1.4.1)
+              concurrent-ruby (~> 1.0, >= 1.0.2)
+              i18n (>= 1.6, < 2)
+              minitest (>= 5.1)
+              tzinfo (~> 2.0)
+              zeitwerk (~> 2.3)
+            concurrent-ruby (1.1.9)
+            i18n (1.8.11)
+              concurrent-ruby (~> 1.0)
+            minitest (5.14.4)
+            tzinfo (2.0.4)
+              concurrent-ruby (~> 1.0)
+            zeitwerk (2.5.1)
+            ast (2.4.2)
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+          activesupport
+          ast
+
+        BUNDLED WITH
+           2.2.0
+      GEMFILE_LOCK
+
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
+      string = YAML.dump(lockfile.to_lockfile)
+
+      assert_config <<~YAML, string
+        sources:
+          - type: git
+            name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: cde6057e7546843ace6420c5783dd945c6ccda54
+            repo_dir: gems
+        path: ".gem_rbs_collection"
+        gemfile_lock_path: 'Gemfile.lock'
+        gems:
+          - name: ast
+            version: "2.4"
+            source:
+              name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: cde6057e7546843ace6420c5783dd945c6ccda54
+              repo_dir: gems
+              type: git
+      YAML
     end
   end
 


### PR DESCRIPTION
Assuming gems declared in `Gemfile` with `require: false` are apps -- not libraries, we can skip loading the RBS files of that gems in collection.

1. The `LockfileGenerator` starts from the gems declared in `Gemfile` without `require: false`, and adds them and their dependencies recursively. 
2. It skips a gem if it's ignored in `rbs_collection.yaml`.

