### PR TITLE
give `_ToProc#to_proc` a return type

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -23,7 +23,7 @@ interface _ToHash[K, V]
 end
 
 interface _ToProc
-  def to_proc: () -> untyped
+  def to_proc: () -> Proc
 end
 
 interface _ToPath


### PR DESCRIPTION
I don’t know what purpose are the interfaces in `builtin.rbs`, but I *do* use them for implicit conversion. The return of `_ToProc#to_proc`, however, is untyped and I cannot see why. This is the contract for implicit conversion to a *block when prefixed with `&`* (`an_array.map(&a_to_proc)`).