### PR TITLE
Add link to RBS by Example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ puts singleton.methods[:gsub]
 - [Writing signatures guide](docs/sigs.md)
 - [Stdlib signatures guide](docs/stdlib.md)
 - [Syntax](docs/syntax.md)
+- [RBS by Example](docs/rbs_by_example.md)
 
 ## Development
 


### PR DESCRIPTION
Most of the people I work with prefer learning based on examples. I think it might be helpful to have the link to "RBS by Example" document in the top level README