### PR TITLE
Add `implicitly-returns-nil` annotations

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -850,7 +850,7 @@ class Array[unchecked out Elem] < Object
   #
   # Array#slice is an alias for Array#[].
   #
-  def []: (int index) -> Elem
+  def []: %a{implicitly-returns-nil} (int index) -> Elem
         | (int start, int length) -> ::Array[Elem]?
         | (::Range[::Integer?] range) -> ::Array[Elem]?
 

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -698,7 +698,7 @@ class Hash[unchecked out K, unchecked out V] < Object
   #     h = {foo: 0, bar: 1, baz: 2}
   #     h[:nosuch] # => nil
   #
-  def []: (K arg0) -> V
+  def []: %a{implicitly-returns-nil} (K arg0) -> V
 
   # <!--
   #   rdoc-file=hash.c


### PR DESCRIPTION
The annotation tells the `Array#[]` and `Hash#[]` may return `nil`.

RBS itself doesn't do anything for this annotation. The type checkers may give precise types of the methods with the annotations.