### PR TITLE
Module#attr* returns an Array of Symbol after 3.0

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -255,7 +255,7 @@ class Module < Object
   #     end
   #     Mod.instance_methods.sort   #=> [:one, :one=, :two, :two=]
   #
-  def attr_accessor: (*Symbol | String arg0) -> NilClass
+  def attr_accessor: (*Symbol | String arg0) -> Array[Symbol]
 
   # <!--
   #   rdoc-file=object.c
@@ -269,7 +269,7 @@ class Module < Object
   # in turn. String arguments are converted to symbols. Returns an array of
   # defined method names as symbols.
   #
-  def attr_reader: (*Symbol | String arg0) -> NilClass
+  def attr_reader: (*Symbol | String arg0) -> Array[Symbol]
 
   # <!--
   #   rdoc-file=object.c
@@ -280,7 +280,7 @@ class Module < Object
   # *symbol*`.id2name`. String arguments are converted to symbols. Returns an
   # array of defined method names as symbols.
   #
-  def attr_writer: (*Symbol | String arg0) -> NilClass
+  def attr_writer: (*Symbol | String arg0) -> Array[Symbol]
 
   # <!--
   #   rdoc-file=load.c

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -154,4 +154,97 @@ class ModuleInstanceTest < Test::Unit::TestCase
       )
     end
   end
+
+  def test_attr_reader
+    if RUBY_VERSION >= '3.0'
+      mod = Module.new
+
+      assert_send_type(
+        "(Symbol) -> Array[Symbol]",
+        mod, :attr_reader, :foo
+      )
+
+      assert_send_type(
+        "(Symbol, Symbol) -> Array[Symbol]",
+        mod, :attr_reader, :foo, :bar
+      )
+
+      assert_send_type(
+        "(String) -> Array[Symbol]",
+        mod, :attr_reader, "foo"
+      )
+
+      assert_send_type(
+        "(String, String) -> Array[Symbol]",
+        mod, :attr_reader, "foo", "bar"
+      )
+
+      assert_send_type(
+        "(Symbol, String) -> Array[Symbol]",
+        mod, :attr_reader, :foo, "bar"
+      )
+    end
+  end
+
+  def test_attr_writer
+    if RUBY_VERSION >= '3.0'
+      mod = Module.new
+
+      assert_send_type(
+        "(Symbol) -> Array[Symbol]",
+        mod, :attr_writer, :foo
+      )
+
+      assert_send_type(
+        "(Symbol, Symbol) -> Array[Symbol]",
+        mod, :attr_writer, :foo, :bar
+      )
+
+      assert_send_type(
+        "(String) -> Array[Symbol]",
+        mod, :attr_writer, "foo"
+      )
+
+      assert_send_type(
+        "(String, String) -> Array[Symbol]",
+        mod, :attr_writer, "foo", "bar"
+      )
+
+      assert_send_type(
+        "(Symbol, String) -> Array[Symbol]",
+        mod, :attr_writer, :foo, "bar"
+      )
+    end
+  end
+
+  def test_attr_accessor
+    if RUBY_VERSION >= '3.0'
+      mod = Module.new
+
+      assert_send_type(
+        "(Symbol) -> Array[Symbol]",
+        mod, :attr_accessor, :foo
+      )
+
+      assert_send_type(
+        "(Symbol, Symbol) -> Array[Symbol]",
+        mod, :attr_accessor, :foo, :bar
+      )
+
+      assert_send_type(
+        "(String) -> Array[Symbol]",
+        mod, :attr_accessor, "foo"
+      )
+
+      assert_send_type(
+        "(String, String) -> Array[Symbol]",
+        mod, :attr_accessor, "foo", "bar"
+      )
+
+      assert_send_type(
+        "(Symbol, String) -> Array[Symbol]",
+        mod, :attr_accessor, :foo, "bar"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Since below methods returns an Array of Symbol after 3.0, I fixed the return type of them.

- Module#attr_reader
- Module#attr_writer
- Module#attr_accessor

cf. https://bugs.ruby-lang.org/issues/17314
cf. https://github.com/ruby/rbs/pull/1218