### PR TITLE
Add "Expected one argument." to rbs ancestors command

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -260,6 +260,11 @@ EOU
         opts.on("--singleton", "Ancestors of singleton of the given type_name") { kind = :singleton }
       end.order!(args)
 
+      unless args.size == 1
+        stdout.puts "Expected one argument."
+        return
+      end
+
       loader = options.loader()
 
       env = Environment.from_loader(loader).resolve_type_names


### PR DESCRIPTION
If we run `rbs methods` command with no arguments, It shows "Expected one argument."   
On the other hand, we run `rbs ancestors` command without any arguments, TypeError is raised.

Therfore, I have added "Expected one argument." to `rbs ancestors` command also.