### PR TITLE
Ignore `set` library on loading

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -139,12 +139,11 @@ module RBS
         private def assign_stdlib(name:, from_gem:)
           return if lockfile.gems.key?(name)
 
-          if name == 'rubygems'
-            if from_gem
-                RBS.logger.warn "`rubygems` has been moved to core library, so it is always loaded. Remove explicit loading `rubygems` from `#{from_gem}`"
-            else
-              RBS.logger.warn '`rubygems` has been moved to core library, so it is always loaded. Remove explicit loading `rubygems`'
-            end
+          case name
+          when 'rubygems', 'set'
+            msg = "`#{name}` has been moved to core library, so it is always loaded. Remove explicit loading `#{name}`"
+            msg << " from `#{from_gem}`" if from_gem
+            RBS.logger.warn msg
 
             return
           end

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,6 +1,5 @@
 dependencies:
   - name: logger
-  - name: set
   - name: pathname
   - name: json
   - name: optparse


### PR DESCRIPTION
Fix https://github.com/ruby/rbs/issues/1250

# Problem

`set` library has been moved from the standard library to the core library since Ruby 3.2. RBS also follows this change.
But there are many references to `set` library in `manifest.yaml`. So `rbs collection` command fails due to missing `set` library.


# Solution

Ignore `set` library on loading the standard library.

It looks ad-hoc approach. But I think it is acceptable because moving to core is a rare case.

I also removed `set` library from rbs's `manifest.yaml`. 


