### PR TITLE
Add -e, --type, and --method-type options to `rbs parse`

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -922,6 +922,7 @@ Options:
 
     def run_parse(args, options)
       parse_method = :parse_signature
+      # @type var e_code: String?
       e_code = nil
 
       OptionParser.new do |opts|
@@ -955,7 +956,12 @@ Options:
 
       bufs.each do |buf|
         RBS.logger.info "Parsing #{buf.name}..."
-        Parser.public_send(parse_method, buf)
+        case parse_method
+        when :parse_signature
+          Parser.parse_signature(buf)
+        else
+          Parser.public_send(parse_method, buf, require_eof: true)
+        end
       rescue RBS::ParsingError => ex
         stdout.puts ex.message
         syntax_error = true

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -921,7 +921,9 @@ Options:
     end
 
     def run_parse(args, options)
+      parse_method = :parse_signature
       e_code = nil
+
       OptionParser.new do |opts|
         opts.banner = <<-EOB
 Usage: rbs parse [files...]
@@ -936,6 +938,8 @@ Options:
         EOB
 
         opts.on('-e CODE', 'One line RBS script to parse') { |e| e_code = e }
+        opts.on('--type', 'Parse code as a type') { |e| parse_method = :parse_type }
+        opts.on('--method-type', 'Parse code as a method type') { |e| parse_method = :parse_method_type }
       end.parse!(args)
 
       loader = options.loader()
@@ -951,7 +955,7 @@ Options:
 
       bufs.each do |buf|
         RBS.logger.info "Parsing #{buf.name}..."
-        Parser.parse_signature(buf)
+        Parser.public_send(parse_method, buf)
       rescue RBS::ParsingError => ex
         stdout.puts ex.message
         syntax_error = true

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -921,6 +921,7 @@ Options:
     end
 
     def run_parse(args, options)
+      e_code = nil
       OptionParser.new do |opts|
         opts.banner = <<-EOB
 Usage: rbs parse [files...]
@@ -930,22 +931,30 @@ Parse given RBS files and print syntax errors.
 Examples:
 
   $ rbs parse sig/app/models.rbs sig/app/controllers.rbs
+
+Options:
         EOB
+
+        opts.on('-e CODE', 'One line RBS script to parse') { |e| e_code = e }
       end.parse!(args)
 
       loader = options.loader()
 
       syntax_error = false
-      args.each do |path|
+      bufs = args.flat_map do |path|
         path = Pathname(path)
-        loader.each_file(path, skip_hidden: false, immediate: true) do |file_path|
-          RBS.logger.info "Parsing #{file_path}..."
-          buffer = Buffer.new(content: file_path.read, name: file_path)
-          Parser.parse_signature(buffer)
-        rescue RBS::ParsingError => ex
-          stdout.puts ex.message
-          syntax_error = true
+        loader.each_file(path, skip_hidden: false, immediate: true).map do |file_path|
+          Buffer.new(content: file_path.read, name: file_path)
         end
+      end
+      bufs << Buffer.new(content: e_code, name: '-e') if e_code
+
+      bufs.each do |buf|
+        RBS.logger.info "Parsing #{buf.name}..."
+        Parser.parse_signature(buf)
+      rescue RBS::ParsingError => ex
+        stdout.puts ex.message
+        syntax_error = true
       end
 
       exit 1 if syntax_error

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -130,6 +130,8 @@ module RBS
     end
 
     def each_file(path, immediate:, skip_hidden:, &block)
+      return enum_for(__method__, path, immediate: immediate, skip_hidden: skip_hidden) unless block
+
       case
       when path.file?
         if path.extname == ".rbs" || immediate

--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -105,5 +105,6 @@ module RBS
     def each_dir: { (source, Pathname) -> void } -> void
 
     def each_file: (Pathname path, immediate: boolish, skip_hidden: boolish) { (Pathname) -> void } -> void
+                 | (Pathname path, immediate: boolish, skip_hidden: boolish) -> Enumerator[Pathname, void]
   end
 end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -488,6 +488,18 @@ singleton(::BasicObject)
     end
   end
 
+  def test_parse_e
+    with_cli do |cli|
+      cli.run(['parse', '-e', 'class C end'])
+      assert_empty stdout.string
+
+      assert_raises(SystemExit) { cli.run(['parse', '-e', 'class C en']) }
+      assert_equal [
+        "-e:1:8...1:10: Syntax error: unexpected token for class/module declaration member, token=`en` (tLIDENT)"
+      ], stdout.string.split("\n").sort
+    end
+  end
+
   def test_prototype_no_parser
     Dir.mktmpdir do |dir|
       with_cli do |cli|

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -500,6 +500,30 @@ singleton(::BasicObject)
     end
   end
 
+  def test_parse_type
+    with_cli do |cli|
+      cli.run(['parse', '--type', '-e', 'bool'])
+      assert_empty stdout.string
+
+      assert_raises(SystemExit) { cli.run(['parse', '--type', '-e', '?']) }
+      assert_equal [
+        "-e:1:0...1:1: Syntax error: unexpected token for simple type, token=`?` (pQUESTION)",
+      ], stdout.string.split("\n").sort
+    end
+  end
+
+  def test_parse_method_type
+    with_cli do |cli|
+      cli.run(['parse', '--method-type', '-e', '() -> void'])
+      assert_empty stdout.string
+
+      assert_raises(SystemExit) { cli.run(['parse', '--method-type', '-e', '()']) }
+      assert_equal [
+        "-e:1:2...1:3: Syntax error: expected a token `pARROW`, token=`` (pEOF)",
+      ], stdout.string.split("\n").sort
+    end
+  end
+
   def test_prototype_no_parser
     Dir.mktmpdir do |dir|
       with_cli do |cli|


### PR DESCRIPTION
Fix #925