### PR TITLE
Skip testing Gem.datadir if not defined

### DIFF
--- a/test/stdlib/rubygems/Gem_test.rb
+++ b/test/stdlib/rubygems/Gem_test.rb
@@ -89,7 +89,7 @@ class GemSingletonTest < Test::Unit::TestCase
                       Gem, :datadir, ""
     assert_send_type  "(String) -> String",
                       Gem, :datadir, "test-unit"
-  end
+  end if Gem.respond_to?(:datadir)
 
   def test_default_bindir
     assert_send_type  "() -> String",


### PR DESCRIPTION
This was removed in https://github.com/ruby/ruby/commit/8c6b349805e2f17a57576b8dfad31e5681d6b0e9.