### PR TITLE
Support abbreviation for subcommands of collection

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -9,7 +9,7 @@ target :lib do
     "lib/rbs/test.rb"
   )
 
-  library "set", "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest'
+  library "set", "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest', 'abbrev'
   signature 'stdlib/yaml/0'
   signature "stdlib/strscan/0/"
   signature "stdlib/optparse/0/"

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1079,12 +1079,12 @@ EOB
       lock_path = Collection::Config.to_lockfile_path(config_path)
 
       case args[0]
-      when 'install'
+      when *abbr_matcher('install')
         unless params[:frozen]
           Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
-      when 'update'
+      when *abbr_matcher('update')
         # TODO: Be aware of argv to update only specified gem
         Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
@@ -1123,7 +1123,7 @@ EOB
           exit 1
         end
         Collection::Cleaner.new(lockfile_path: lock_path)
-      when 'help'
+      when *abbr_matcher('help')
         puts opts.help
       else
         puts opts.help
@@ -1153,6 +1153,10 @@ EOB
         HELP
         opts.on('--frozen') if args[0] == 'install'
       end
+    end
+
+    def abbr_matcher(str)
+      str.chars.inject(['']) { |r, ch|  [*r, r.last+ch] }[1..] or raise
     end
   end
 end

--- a/sig/cli.rbs
+++ b/sig/cli.rbs
@@ -79,7 +79,5 @@ module RBS
     def test_opt: (LibraryOptions) -> String?
 
     def collection_options: (Array[String]) -> OptionParser
-
-    def abbr_matcher: (String) -> Array[String]
   end
 end

--- a/sig/cli.rbs
+++ b/sig/cli.rbs
@@ -79,5 +79,7 @@ module RBS
     def test_opt: (LibraryOptions) -> String?
 
     def collection_options: (Array[String]) -> OptionParser
+
+    def abbr_matcher: (String) -> Array[String]
   end
 end

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -5,3 +5,4 @@ dependencies:
   - name: optparse
   - name: tsort
   - name: rdoc
+  - name: abbrev


### PR DESCRIPTION
This PR adds abbreviations to the collection's subcommand.

For example:

```console
# Same as `rbs collection install`
$ rbs collection i
$ rbs collection ins

# Same as `rbs collection update`
$ rbs collection u
$ rbs collection upd
```


Bundler provides the same abbreviations, so we can provide them too. 