### PR TITLE
Validate duplicate type aliases

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -374,7 +374,7 @@ module RBS
         name = decl.name.with_prefix(namespace)
 
         if entry = type_alias_decls[name]
-          DuplicatedDeclarationError.new(name, decl, entry.decl)
+          raise DuplicatedDeclarationError.new(name, decl, entry.decl)
         end
 
         type_alias_decls[name] = TypeAliasEntry.new(name: name, decl: decl, outer: outer)

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -365,7 +365,7 @@ module RBS
         name = decl.name.with_prefix(namespace)
 
         if interface_entry = interface_decls[name]
-          DuplicatedDeclarationError.new(name, decl, interface_entry.decl)
+          raise DuplicatedDeclarationError.new(name, decl, interface_entry.decl)
         end
 
         interface_decls[name] = InterfaceEntry.new(name: name, decl: decl, outer: outer)

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -189,6 +189,22 @@ EOF
     end
   end
 
+  def test_interface_twice_duplication_error
+    env = Environment.new
+
+    _, _, decls = RBS::Parser.parse_signature(<<EOF)
+interface _I
+end
+interface _I
+end
+EOF
+
+    assert_raises RBS::DuplicatedDeclarationError do
+      env << decls[0]
+      env << decls[1]
+    end
+  end
+
   def test_generic_class
     env = Environment.new
 

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -175,6 +175,20 @@ EOF
     end
   end
 
+  def test_type_alias_twice_duplication_error
+    env = Environment.new
+
+    _, _, decls = RBS::Parser.parse_signature(<<EOF)
+type foo = String
+type foo = Integer
+EOF
+
+    assert_raises RBS::DuplicatedDeclarationError do
+      env << decls[0]
+      env << decls[1]
+    end
+  end
+
   def test_generic_class
     env = Environment.new
 


### PR DESCRIPTION
An environment should reject duplicate type aliases, but actually, it just ignores the duplication due to a forgotten `raise`.

This PR fixes the validation to raise an error on duplicate type aliases, like the following.

```rbs
type foo = String
type foo = Integer
```

## Additional Information

Interface has the same problem. 
https://github.com/ruby/rbs/blob/0dd11d38c11f55ead0a0d78bb9b19d2eaf3a2104/lib/rbs/environment.rb#L364-L371

For example, the second `_I` conceals the first one in the following example.

```rbs
interface _I
  def foo: () -> void
end

interface _I
  def bar: () -> void
end

module M
  include _I
end
```

We can confirm this problem with the following command.

```console
# It should print `foo` and `bar`,
# but actually it prints only `bar`.
$ rbs -I. methods --no-inherit M
bar (public)
```


~~I think the interface should behave the same as the open class, instead of rejecting duplicated interfaces.~~
~~I will create a PR to fix the interface problem soon.~~