### PR TITLE
Support detailed_message for NoTypeError, InheritModuleError, NoSelfTypeFoundError and NoMixinFoundError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -165,12 +165,18 @@ module RBS
   end
 
   class InheritModuleError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :super_decl
 
     def initialize(super_decl)
       @super_decl = super_decl
 
       super "#{Location.to_string(super_decl.location)}: Cannot inherit a module: #{super_decl.name}"
+    end
+
+    def location
+      @super_decl.location
     end
 
     def self.check!(super_decl, env:)

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -207,6 +207,8 @@ module RBS
   end
 
   class NoMixinFoundError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :member
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -126,6 +126,8 @@ module RBS
   end
 
   class NoTypeFoundError < BaseError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :location
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -22,11 +22,16 @@ module RBS
 
   module DetailedMessageable
     def detailed_message(highlight: false, **)
+      msg = super
+
+      # Support only one line
+      return msg unless location.start_line == location.end_line
+
       indent = " " * location.start_column
       marker = "^" * (location.end_column - location.start_column)
 
       io = StringIO.new
-      io.puts super
+      io.puts msg
       io.puts
       io.print "\e[1m" if highlight
       io.puts "  #{location.buffer.lines[location.end_line - 1]}"

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -187,6 +187,8 @@ module RBS
   end
 
   class NoSelfTypeFoundError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :location
 

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -67,4 +67,20 @@ class RBS::ErrorsTest < Test::Unit::TestCase
                    ^^^^^^^^
     DETAILED_MESSAGE
   end
+
+  def test_inherit_module_error_with_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    _, _, decls = RBS::Parser.parse_signature(<<~SIGNATURE)
+      class Foo < Kernel
+      end
+    SIGNATURE
+    error = RBS::InheritModuleError.new(decls.first.super_class)
+    assert_equal <<~DETAILED_MESSAGE, error.detailed_message
+      #{error.message} (RBS::InheritModuleError)
+
+        class Foo < Kernel
+                    ^^^^^^
+    DETAILED_MESSAGE
+  end
 end

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -100,4 +100,22 @@ class RBS::ErrorsTest < Test::Unit::TestCase
                      ^^^^^^^^
     DETAILED_MESSAGE
   end
+
+  def test_no_mixin_found_error_with_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    _, _, decls = RBS::Parser.parse_signature(<<~SIGNATURE)
+      module Bar
+        include NotFound
+      end
+    SIGNATURE
+    member_decl = decls.first.members.first
+    error = RBS::NoMixinFoundError.new(type_name: member_decl.name, member: member_decl)
+    assert_equal <<~DETAILED_MESSAGE, error.detailed_message
+      #{error.message} (RBS::NoMixinFoundError)
+
+          include NotFound
+          ^^^^^^^^^^^^^^^^
+    DETAILED_MESSAGE
+  end
 end

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -57,6 +57,14 @@ class RBS::ErrorsTest < Test::Unit::TestCase
   def test_no_type_found_error_with_detailed_message
     omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
 
+    _, _, decls = RBS::Parser.parse_signature(<<~SIGNATURE)
+      class NotFound
+      end
+    SIGNATURE
+    type = decls.first
+    error = RBS::NoTypeFoundError.new(type_name: type.name, location: type.location)
+    assert_equal "#{error.message} (RBS::NoTypeFoundError)", error.detailed_message
+
     _, _, decls = RBS::Parser.parse_signature("type foo = NotFound")
     type = decls.first.type
     error = RBS::NoTypeFoundError.new(type_name: type.name, location: type.location)

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -83,4 +83,21 @@ class RBS::ErrorsTest < Test::Unit::TestCase
                     ^^^^^^
     DETAILED_MESSAGE
   end
+
+  def test_no_self_type_found_error_with_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    _, _, decls = RBS::Parser.parse_signature(<<~SIGNATURE)
+      module Foo : NotFound
+      end
+    SIGNATURE
+    self_type_decl = decls.first.self_types.first
+    error = RBS::NoSelfTypeFoundError.new(type_name: self_type_decl.name, location: self_type_decl.location)
+    assert_equal <<~DETAILED_MESSAGE, error.detailed_message
+      #{error.message} (RBS::NoSelfTypeFoundError)
+
+        module Foo : NotFound
+                     ^^^^^^^^
+    DETAILED_MESSAGE
+  end
 end

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -53,4 +53,18 @@ class RBS::ErrorsTest < Test::Unit::TestCase
       DETAILED_MESSAGE
     end
   end
+
+  def test_no_type_found_error_with_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    _, _, decls = RBS::Parser.parse_signature("type foo = NotFound")
+    type = decls.first.type
+    error = RBS::NoTypeFoundError.new(type_name: type.name, location: type.location)
+    assert_equal <<~DETAILED_MESSAGE, error.detailed_message
+      #{error.message} (RBS::NoTypeFoundError)
+
+        type foo = NotFound
+                   ^^^^^^^^
+    DETAILED_MESSAGE
+  end
 end


### PR DESCRIPTION
Added support for `#detailed_message` for four errors.
This will aid in locating the problem when an error occurs.

### NoTypeFoundError

```
a.rbs:1:11...1:19: Could not find NotFound (RBS::NoTypeFoundError)

  type foo = NotFound
             ^^^^^^^^
```

### InheritModuleError

```
a.rbs:1:12...1:18: Cannot inherit a module: Kernel (RBS::InheritModuleError)

  class Foo < Kernel
              ^^^^^^
```

### NoSelfTypeFoundError

```
a.rbs:1:13...1:21: Could not find self type: NotFound (RBS::NoSelfTypeFoundError)

  module Foo : NotFound
               ^^^^^^^^
```

### NoMixinFoundError

```
a.rbs:2:2...2:18: Could not find mixin: NotFound (RBS::NoMixinFoundError)

    include NotFound
    ^^^^^^^^^^^^^^^^
```

ref: https://github.com/ruby/rbs/pull/1166