### PR TITLE
Support detailed_message for DuplicatedMethodDefinitionError, DuplicatedInterfaceMethodDefinitionError, UnknownMethodAliasError and InvalidOverloadMethodError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -258,6 +258,8 @@ module RBS
   end
 
   class DuplicatedInterfaceMethodDefinitionError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type
     attr_reader :method_name
     attr_reader :member
@@ -268,6 +270,10 @@ module RBS
       @member = member
 
       super "#{member.location}: Duplicated method definition: #{qualified_method_name}"
+    end
+
+    def location
+      member.location
     end
 
     def qualified_method_name

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -217,6 +217,8 @@ module RBS
   end
 
   class DuplicatedMethodDefinitionError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type
     attr_reader :method_name
     attr_reader :members

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -320,6 +320,8 @@ module RBS
   end
 
   class InvalidOverloadMethodError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :method_name
     attr_reader :kind
@@ -339,6 +341,10 @@ module RBS
                   end
 
       super "#{Location.to_string members[0].location}: Invalid method overloading: #{type_name}#{delimiter}#{method_name}"
+    end
+
+    def location
+      members[0].location
     end
   end
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -291,6 +291,8 @@ module RBS
   end
 
   class UnknownMethodAliasError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :original_name
     attr_reader :aliased_name

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1542,6 +1542,13 @@ end
 
         assert_raises RBS::InvalidOverloadMethodError do
           builder.build_instance(type_name("::Hello"))
+        end.tap do |error|
+          assert_equal error.detailed_message, <<~DETAILED_MESSAGE if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidOverloadMethodError)
+
+                def foo: (Integer) -> String | ...
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1666,6 +1666,13 @@ end
 
         assert_raises RBS::DuplicatedInterfaceMethodDefinitionError do
           builder.build_instance(type_name("::Hello"))
+        end.tap do |error|
+          assert_equal error.detailed_message, <<~DETAILED_MESSAGE if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::DuplicatedInterfaceMethodDefinitionError)
+
+                include _I2
+                ^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1689,6 +1689,13 @@ end
 
         assert_raises RBS::DuplicatedMethodDefinitionError do
           builder.build_instance(type_name("::Hello"))
+        end.tap do |error|
+          assert_equal error.detailed_message, <<~DETAILED_MESSAGE if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::DuplicatedMethodDefinitionError)
+
+                def foo: () -> String
+                ^^^^^^^^^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -971,6 +971,13 @@ EOF
 
         assert_raises UnknownMethodAliasError do
           builder.build_singleton(type_name("::Error"))
+        end.tap do |error|
+          assert_equal error.detailed_message, <<~DETAILED_MESSAGE if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::UnknownMethodAliasError)
+
+                alias self.xxx self.yyy
+                ^^^^^^^^^^^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end


### PR DESCRIPTION
I also added support to `#detailed_message` for following errors.

### DuplicatedMethodDefinitionError

```
a.rbs:2:2...2:21: ::Foo#foo has duplicated definitions in a.rbs:3:2...3:21 (RBS::DuplicatedMethodDefinitionError)

  def foo: () -> String
  ^^^^^^^^^^^^^^^^^^^^^
```

### DuplicatedInterfaceMethodDefinitionError

```
a.rbs:9:2...9:14: Duplicated method definition: ::Hello#foo (RBS::DuplicatedInterfaceMethodDefinitionError)

  include _I2
  ^^^^^^^^^^^
```

### UnknownMethodAliasError

```
a.rbs:2:2...2:15: Unknown method alias name: yyy => xxx (::Error) (RBS::UnknownMethodAliasError)

  alias self.xxx self.yyy
  ^^^^^^^^^^^^^^^^^^^^^^^
```

### InvalidOverloadMethodError

```
a.rbs:2:2...2:36: Invalid method overloading: ::Hello#foo (RBS::InvalidOverloadMethodError)

  def foo: (Integer) -> String | ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

ref: https://github.com/ruby/rbs/pull/1280
ref: https://github.com/ruby/rbs/pull/1166