### PR TITLE
Add `require_eof:` keyword to parsers

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2739,7 +2739,7 @@ VALUE parse_signature(parserstate *state) {
 }
 
 static VALUE
-rbsparser_parse_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, VALUE variables)
+rbsparser_parse_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, VALUE variables, VALUE require_eof)
 {
   parserstate *parser = alloc_parser(buffer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
 
@@ -2749,13 +2749,17 @@ rbsparser_parse_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, V
 
   VALUE type = parse_type(parser);
 
+  if (RB_TEST(require_eof)) {
+    parser_advance_assert(parser, pEOF);
+  }
+
   free_parser(parser);
 
   return type;
 }
 
 static VALUE
-rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, VALUE variables)
+rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, VALUE variables, VALUE require_eof)
 {
   parserstate *parser = alloc_parser(buffer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
 
@@ -2764,6 +2768,10 @@ rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end
   }
 
   VALUE method_type = parse_method_type(parser);
+
+  if (RB_TEST(require_eof)) {
+    parser_advance_assert(parser, pEOF);
+  }
 
   free_parser(parser);
 
@@ -2782,7 +2790,7 @@ rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE end_pos)
 
 void rbs__init_parser(void) {
   RBS_Parser = rb_define_class_under(RBS, "Parser", rb_cObject);
-  rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 4);
-  rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 4);
+  rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 5);
+  rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 5);
   rb_define_singleton_method(RBS_Parser, "_parse_signature", rbsparser_parse_signature, 2);
 }

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -2,14 +2,14 @@
 
 module RBS
   class Parser
-    def self.parse_type(source, range: 0..., variables: [])
+    def self.parse_type(source, range: 0..., variables: [], require_eof: false)
       buf = buffer(source)
-      _parse_type(buf, range.begin || 0, range.end || buf.last_position, variables)
+      _parse_type(buf, range.begin || 0, range.end || buf.last_position, variables, require_eof)
     end
 
-    def self.parse_method_type(source, range: 0..., variables: [])
+    def self.parse_method_type(source, range: 0..., variables: [], require_eof: false)
       buf = buffer(source)
-      _parse_method_type(buf, range.begin || 0, range.end || buf.last_position, variables)
+      _parse_method_type(buf, range.begin || 0, range.end || buf.last_position, variables, require_eof)
     end
 
     def self.parse_signature(source)

--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -2,8 +2,7 @@ module RBS
   class Parser
     # Parse a method type and return it
     #
-    # When `pos` keyword is specified, skips the first `pos` characters from the input.
-    # If no token is left in the input, it returns `nil`.
+    # When `range` keyword is specified, it starts parsing from the `begin` to the `endo` the range.
     #
     # ```ruby
     # RBS::Parser.parse_method_type("() -> void")                                # => `() -> void`
@@ -12,18 +11,37 @@ module RBS
     # RBS::Parser.parse_method_type("() -> void () -> String", range: 23...)     # => nil
     # ```
     #
+    # When `require_eof` is `true`, an error is raised if more tokens are left in the input.
+    # (Defaults to `false`.)
+    #
+    # ```ruby
+    # RBS::Parser.parse_method_type("() -> void () -> String", require_eof: false)    # => `() -> void`
+    # RBS::Parser.parse_method_type("() -> void () -> String", require_eof: true)     # => Raises an error
+    #
+    # RBS::Parser.parse_method_type("", require_eof: true)                            # => nil
+    # ```
+    #
     def self.parse_method_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol], ?require_eof: bool) -> MethodType?
 
     # Parse a type and return it
     #
-    # When `pos` keyword is specified, skips the first `pos` characters from the input.
-    # If no token is left in the input, it returns `nil`.
+    # When `range` keyword is specified, it starts parsing from the `begin` to the `endo` the range.
     #
     # ```ruby
     # RBS::Parser.parse_type("String")                          # => `String`
     # RBS::Parser.parse_type("String", range: 0...)             # => `String`
     # RBS::Parser.parse_type("String Integer", pos: 7...)       # => `Integer`
     # RBS::Parser.parse_type("String Integer", pos: 14...)      # => nil
+    # ```
+    #
+    # When `require_eof` is `true`, an error is raised if more tokens are left in the input.
+    # (Defaults to `false`.)
+    #
+    # ```ruby
+    # RBS::Parser.parse_type("String untyped", require_eof: false)    # => `String`
+    # RBS::Parser.parse_type("String untyped", require_eof: true)     # => Raises an error
+    #
+    # RBS::Parser.parse_type("", require_eof: true)                   # => nil
     # ```
     #
     def self.parse_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol], ?require_eof: bool) -> Types::t?

--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -12,7 +12,7 @@ module RBS
     # RBS::Parser.parse_method_type("() -> void () -> String", range: 23...)     # => nil
     # ```
     #
-    def self.parse_method_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol]) -> MethodType?
+    def self.parse_method_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol], ?require_eof: bool) -> MethodType?
 
     # Parse a type and return it
     #
@@ -26,7 +26,7 @@ module RBS
     # RBS::Parser.parse_type("String Integer", pos: 14...)      # => nil
     # ```
     #
-    def self.parse_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol]) -> Types::t?
+    def self.parse_type: (Buffer | String, ?range: Range[Integer?], ?variables: Array[Symbol], ?require_eof: bool) -> Types::t?
 
     # Parse whole RBS file and return an array of declarations
     #
@@ -38,9 +38,9 @@ module RBS
 
     def self.buffer: (String | Buffer source) -> Buffer
 
-    def self._parse_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables) -> Types::t?
+    def self._parse_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables, bool require_eof) -> Types::t?
 
-    def self._parse_method_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables) -> MethodType?
+    def self._parse_method_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables, bool require_eof) -> MethodType?
 
     def self._parse_signature: (Buffer, Integer end_pos) -> [Array[AST::Directives::t], Array[AST::Declarations::t]]
 

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -713,4 +713,16 @@ RBS
       assert_nil type
     end
   end
+
+  def test_parse_require_eof
+    RBS::Parser.parse_type("String", range: 0..., require_eof: false)
+    assert_raises(RBS::ParsingError) do
+      RBS::Parser.parse_type("String void", range: 0..., require_eof: true)
+    end
+
+    RBS::Parser.parse_method_type("() -> void () -> void", range: 0..., require_eof: false)
+    assert_raises(RBS::ParsingError) do
+      RBS::Parser.parse_method_type("() -> void () -> void", range: 0..., require_eof: true)
+    end
+  end
 end


### PR DESCRIPTION
The parsing methods raise an error if more tokens are left in the input when `requires_eof: true`.