### PR TITLE
Support detailed_message for InvalidVarianceAnnotationError, RecursiveAliasDefinitionError, MixinClassError and RecursiveTypeAliasError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -406,6 +406,8 @@ module RBS
   end
 
   class RecursiveAliasDefinitionError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type
     attr_reader :defs
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -390,6 +390,8 @@ module RBS
   end
 
   class InvalidVarianceAnnotationError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :param
     attr_reader :location

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -426,6 +426,8 @@ module RBS
   end
 
   class MixinClassError < DefinitionError
+    include DetailedMessageable
+
     attr_reader :type_name
     attr_reader :member
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -465,6 +465,8 @@ module RBS
   end
 
   class RecursiveTypeAliasError < BaseError
+    include DetailedMessageable
+
     attr_reader :alias_names
     attr_reader :location
 

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -700,6 +700,13 @@ EOF
 
         assert_raises MixinClassError do
           builder.instance_ancestors(type_name("::Qux"))
+        end.tap do |error|
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::MixinClassError)
+
+                include Foo
+                ^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end
@@ -723,6 +730,13 @@ EOF
 
           assert_raises MixinClassError do
             builder.instance_ancestors(type_name("::Qux"))
+          end.tap do |error|
+            assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+              #{error.message} (RBS::MixinClassError)
+
+                  prepend Foo
+                  ^^^^^^^^^^^
+            DETAILED_MESSAGE
           end
         end
       end
@@ -747,6 +761,13 @@ EOF
 
           assert_raises MixinClassError do
             builder.one_singleton_ancestors(type_name("::Qux"))
+          end.tap do |error|
+            assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+              #{error.message} (RBS::MixinClassError)
+
+                  extend Foo
+                  ^^^^^^^^^^
+            DETAILED_MESSAGE
           end
         end
       end

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -238,6 +238,13 @@ EOF
 
         assert_raises(RBS::RecursiveAliasDefinitionError) do
           builder.build_interface(type_name("::_I3"))
+        end.tap do |error|
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::RecursiveAliasDefinitionError)
+
+                alias a b
+                ^^^^^^^^^
+          DETAILED_MESSAGE
         end
 
         assert_raises(RBS::DuplicatedMethodDefinitionError) do

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -572,16 +572,34 @@ end
         assert_raises(InvalidVarianceAnnotationError) { builder.build_instance(type_name("::Test1")) }.tap do |error|
           assert_equal :X, error.param.name
           assert_equal "C[X]", error.location.source
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidVarianceAnnotationError)
+
+              class Test1[in X] < C[X]
+                                  ^^^^
+          DETAILED_MESSAGE
         end
 
         assert_raises(InvalidVarianceAnnotationError) { builder.build_instance(type_name("::Test2")) }.tap do |error|
           assert_equal :X, error.param.name
           assert_equal "include M[X]", error.location.source
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidVarianceAnnotationError)
+
+                include M[X]
+                ^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
 
         assert_raises(InvalidVarianceAnnotationError) { builder.build_instance(type_name("::Test3")) }.tap do |error|
           assert_equal :X, error.param.name
           assert_equal "include _I[X]", error.location.source
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidVarianceAnnotationError)
+
+                include _I[X]
+                ^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end
@@ -614,11 +632,23 @@ end
         assert_raises(InvalidVarianceAnnotationError) { builder.build_instance(type_name("::Test1")) }.tap do |error|
           assert_equal :X, error.param.name
           assert_equal "(X) -> void", error.location.source
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidVarianceAnnotationError)
+
+                def foo: (X) -> void
+                         ^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
 
         assert_raises(InvalidVarianceAnnotationError) { builder.build_instance(type_name("::Test2")) }.tap do |error|
           assert_equal :X, error.param.name
           assert_equal "attr_reader x: X", error.location.source
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::InvalidVarianceAnnotationError)
+
+                attr_reader x: X
+                ^^^^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
       end
     end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -88,6 +88,13 @@ type u_2 = string & u & Numeric
         env.type_alias_decls.each do |name, decl|
           assert_raises RBS::RecursiveTypeAliasError do
             validator.validate_type_alias(entry: decl)
+          end.tap do |error|
+            assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+              #{error.message} (RBS::RecursiveTypeAliasError)
+
+                #{decl.decl.location.source}
+                #{"^" * decl.decl.location.source.length}
+            DETAILED_MESSAGE
           end
         end
       end


### PR DESCRIPTION
I also added support to #detailed_message for following errors.

### InvalidVarianceAnnotationError

```
a.rbs:5:2...5:14: Type parameter variance error: X is contravariant but used as incompatible variance (RBS::InvalidVarianceAnnotationError)

    include M[X]
    ^^^^^^^^^^^^
```

### RecursiveAliasDefinitionError

```
a.rbs:2:2...2:15: Recursive aliases in ::Foo: foo, bar (RBS::RecursiveAliasDefinitionError)

    alias foo bar
    ^^^^^^^^^^^^^
```

### MixinClassError

```
a.rbs:4:2...4:13: Cannot include a class `::Foo` in the definition of `::Bar` (RBS::MixinClassError)

    include Foo
    ^^^^^^^^^^^
```

### RecursiveTypeAliasError

```
a.rbs:2:2...2:16: Recursive type alias definition found for: foo (RBS::RecursiveTypeAliasError)

    type foo = bar
    ^^^^^^^^^^^^^^
```

ref: https://github.com/ruby/rbs/pull/1281
ref: https://github.com/ruby/rbs/pull/1166