### PR TITLE
Support class/module alias by RBS::Writer

### DIFF
--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -167,6 +167,18 @@ module RBS
           puts "type #{name_and_params(decl.name, decl.type_params)} = #{decl.type}"
         }
 
+      when AST::Declarations::ClassAlias
+        write_comment decl.comment
+        write_loc_source(decl) {
+          puts "class #{decl.new_name} = #{decl.old_name}"
+        }
+
+      when AST::Declarations::ModuleAlias
+        write_comment decl.comment
+        write_loc_source(decl) {
+          puts "module #{decl.new_name} = #{decl.old_name}"
+        }
+
       when AST::Declarations::Interface
         write_comment decl.comment
         write_annotation decl.annotations

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -36,6 +36,8 @@ $name: String
   def test_alias_decl
     assert_writer <<-SIG
 type ::Module::foo = String | Integer
+class A = B
+module C = D
     SIG
   end
 


### PR DESCRIPTION
RBS has supported the Class/Module alias since v3, but the writer ignores the Class/Module alias unexpectedly.

This PR adds the support of the Class/Module alias to the writer.