### PR TITLE
Support detailed_message for NonregularTypeAliasError, CyclicTypeParameterBound, InconsistentClassModuleAliasError and CyclicClassAliasDefinitionError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -475,6 +475,8 @@ module RBS
   end
 
   class NonregularTypeAliasError < BaseError
+    include DetailedMessageable
+
     attr_reader :diagnostic
     attr_reader :location
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -504,6 +504,8 @@ module RBS
   end
 
   class InconsistentClassModuleAliasError < BaseError
+    include DetailedMessageable
+
     attr_reader :alias_entry
 
     def initialize(entry)
@@ -518,6 +520,10 @@ module RBS
         end
 
       super "#{Location.to_string(entry.decl.location&.[](:old_name))}: A #{expected_kind} `#{entry.decl.new_name}` cannot be an alias of a #{actual_kind} `#{entry.decl.old_name}`"
+    end
+
+    def location
+      @alias_entry.decl.location
     end
   end
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -528,12 +528,18 @@ module RBS
   end
 
   class CyclicClassAliasDefinitionError < BaseError
+    include DetailedMessageable
+
     attr_reader :alias_entry
 
     def initialize(entry)
       @alias_entry = entry
 
       super "#{Location.to_string(entry.decl.location&.[](:old_name))}: A #{alias_entry.decl.new_name} is a cyclic definition"
+    end
+
+    def location
+      @alias_entry.decl.location
     end
   end
 end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -489,6 +489,8 @@ module RBS
   end
 
   class CyclicTypeParameterBound < BaseError
+    include DetailedMessageable
+
     attr_reader :params, :type_name, :method_name, :location
 
     def initialize(type_name:, method_name:, params:, location:)

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -257,6 +257,13 @@ class Baz = Baz
         env.class_alias_decls[TypeName("::Baz")].tap do |entry|
           assert_raises RBS::CyclicClassAliasDefinitionError do
             validator.validate_class_alias(entry: entry)
+          end.tap do |error|
+            assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+              #{error.message} (RBS::CyclicClassAliasDefinitionError)
+
+                class Baz = Baz
+                ^^^^^^^^^^^^^^^
+            DETAILED_MESSAGE
           end
         end
       end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -134,6 +134,13 @@ type baz[out T] = ^(T) -> void
 
         assert_raises RBS::NonregularTypeAliasError do
           validator.validate_type_alias(entry: env.type_alias_decls[type_name("::bar")])
+        end.tap do |error|
+          assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+            #{error.message} (RBS::NonregularTypeAliasError)
+
+              type bar[T] = [bar[T?]]
+              ^^^^^^^^^^^^^^^^^^^^^^^
+          DETAILED_MESSAGE
         end
 
         assert_raises RBS::InvalidVarianceAnnotationError do

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -170,6 +170,12 @@ type bar[T < _Foo[S], S < _Bar[T]] = nil
 
         assert_equal error.type_name, TypeName("::bar")
         assert_equal "[T < _Foo[S], S < _Bar[T]]", error.location.source
+        assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+          #{error.message} (RBS::CyclicTypeParameterBound)
+
+            type bar[T < _Foo[S], S < _Bar[T]] = nil
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+        DETAILED_MESSAGE
       end
     end
   end

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -238,6 +238,13 @@ class Baz = Baz
         env.class_alias_decls[TypeName("::Foo")].tap do |entry|
           assert_raises RBS::InconsistentClassModuleAliasError do
             validator.validate_class_alias(entry: entry)
+          end.tap do |error|
+            assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
+              #{error.message} (RBS::InconsistentClassModuleAliasError)
+
+                class Foo = Kernel
+                ^^^^^^^^^^^^^^^^^^
+            DETAILED_MESSAGE
           end
         end
 


### PR DESCRIPTION
I also added support to #detailed_message for following errors.

### NonregularTypeAliasError

```
a.rbs:1:0...1:23: Nonregular generic type alias is prohibited: ::bar, ::bar[T?] (RBS::NonregularTypeAliasError)

  type bar[T] = [bar[T?]]
  ^^^^^^^^^^^^^^^^^^^^^^^
```

### CyclicTypeParameterBound

```
a.rbs:1:9...1:36: Cyclic type parameter bound is prohibited (RBS::CyclicTypeParameterBound)

  class Foo[A < _Each[B], B < _Foo[A]]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### InconsistentClassModuleAliasError

```
a.rbs:4:13...4:16: A module `::Bar` cannot be an alias of a class `::Foo` (RBS::InconsistentClassModuleAliasError)

  module Bar = Foo
  ^^^^^^^^^^^^^^^^
```

### CyclicClassAliasDefinitionError

```
a.rbs:1:12...1:15: A ::Foo is a cyclic definition (RBS::CyclicClassAliasDefinitionError)

  class Foo = Foo
  ^^^^^^^^^^^^^^^
```

ref: https://github.com/ruby/rbs/pull/1285
ref: https://github.com/ruby/rbs/pull/1166