### PR TITLE
Fix super class of NoTypeFoundError from BaseError to DefinitionError

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -130,7 +130,7 @@ module RBS
     end
   end
 
-  class NoTypeFoundError < BaseError
+  class NoTypeFoundError < DefinitionError
     include DetailedMessageable
 
     attr_reader :type_name


### PR DESCRIPTION
NoTypeFoundError inherits different classes between Ruby and RBS.
It inherits BaseError on the Ruby level but inherits DefinitionError on the RBS level.


This PR fixes the Ruby-level superclass. This error occurs during building definitions, so DefinitionError is the correct superclass. 