### PR TITLE
Avoid to test `Pathname#{taint,untaint}` when it is not defined

### DIFF
--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -731,8 +731,10 @@ class PathnameInstanceTest < Test::Unit::TestCase
   end
 
   def test_taint
-    assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__)), :taint
+    if Pathname.method_defined?(:taint)
+      assert_send_type '() -> Pathname',
+                      Pathname(File.expand_path(__FILE__)), :taint
+    end
   end
 
   def test_to_path
@@ -759,8 +761,10 @@ class PathnameInstanceTest < Test::Unit::TestCase
   end
 
   def test_untaint
-    assert_send_type '() -> Pathname',
-                     Pathname(File.expand_path(__FILE__)), :untaint
+    if Pathname.method_defined?(:untaint)
+      assert_send_type '() -> Pathname',
+                      Pathname(File.expand_path(__FILE__)), :untaint
+    end
   end
 
   def test_utime


### PR DESCRIPTION
`Pathname#{taint,untaint}` will be removed in Ruby 3.2, so we do not need to test them on the latest Ruby.

related https://github.com/ruby/rbs/pull/860

-----

By the way, `Pathname#{taint,untaint}` have not been removed yet in Ruby 3.2 in spite of the following warning.

```console
$ ruby -rpathname -e 'Pathname("a").taint'
-e:1: warning: Pathname#taint is deprecated and will be removed in Ruby 3.2.
```


I think we forgot to remove these methods for Ruby 3.2. I'll open an issue to ruby/pathname soon.
ADD: Opened https://github.com/ruby/pathname/issues/28