### PR TITLE
Fix InvalidOverloadMethodError on overloading extended method

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -239,14 +239,6 @@ module RBS
             definition.class_variables.merge!(defn.class_variables)
           end
 
-          all_interfaces = one_ancestors.each_extended_interface.flat_map do |interface|
-            other_interfaces = ancestor_builder.interface_ancestors(interface.name).ancestors #: Array[Definition::Ancestor::Instance]
-            other_interfaces = other_interfaces.select {|ancestor| ancestor.source }
-            [interface, *other_interfaces]
-          end
-          interface_methods = interface_methods(all_interfaces)
-          import_methods(definition, type_name, methods, interface_methods, Substitution.new)
-
           one_ancestors.each_extended_module do |mod|
             mod.args.each do |arg|
               validate_type_presence(arg)
@@ -256,7 +248,12 @@ module RBS
             define_instance(definition, mod.name, subst)
           end
 
-          interface_methods = interface_methods(one_ancestors.each_extended_interface.to_a)
+          all_interfaces = one_ancestors.each_extended_interface.flat_map do |interface|
+            other_interfaces = ancestor_builder.interface_ancestors(interface.name).ancestors #: Array[Definition::Ancestor::Instance]
+            other_interfaces = other_interfaces.select {|ancestor| ancestor.source }
+            [interface, *other_interfaces]
+          end
+          interface_methods = interface_methods(all_interfaces)
           import_methods(definition, type_name, methods, interface_methods, Substitution.new)
 
           entry.decls.each do |d|


### PR DESCRIPTION
Fix #1293 

This PR fixes InvalidOverloadMethodError when a class has an overloading singleton method for an extended method. 


#1268 introduced this problem. It added an `import_methods` call before defining methods of extended modules, but `import_methods` depends on it. So the `import_methods` cannot find methods defined by extended modules.


This PR moves `import_methods` after `define_instance` for extended modules, and removes duplicated `import_methods` because it was called twice since #1294. 