### PR TITLE
Improve String#scan type when the pattern is a String

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -2600,8 +2600,10 @@ class String
   #     <<cruel>> <<world>>
   #     rceu lowlr
   #
-  def scan: (Regexp | string pattern) -> Array[String | Array[String]]
-          | (Regexp | string pattern) { (String | Array[String]) -> void } -> self
+  def scan: (Regexp pattern) -> Array[String | Array[String]]
+          | (Regexp pattern) { (String | Array[String]) -> void } -> self
+          | (string pattern) -> Array[String]
+          | (string pattern) { (String) -> void } -> self
 
   # <!--
   #   rdoc-file=string.c


### PR DESCRIPTION
String#scan's returned value is complex. It returns not only an `Array[String]` but also `Array[Array[String]]`. The returned value type depends on the existence of Regexp's grouping. So the RBS user needs to assert the returned type manually.

This patch simplifies the returned type when the pattern argument is a string. When the pattern is a string, it never contains Regexp's grouping. It means it always returns an `Array[String]` when the argument is a string.

By this change, the user does not need to care about the `Array[Array[String]]` case if the pattern is a string.


