### PR TITLE
Should allow String and _ToStr for `Object#define_singleton_method`

### DIFF
--- a/core/object.rbs
+++ b/core/object.rbs
@@ -205,8 +205,8 @@ class Object < BasicObject
   #     chris.define_singleton_method(:greet) {|greeting| "#{greeting}, I'm Chris!" }
   #     chris.greet("Hi") #=> "Hi, I'm Chris!"
   #
-  def define_singleton_method: (Symbol, Method | UnboundMethod) -> Symbol
-                             | (Symbol) { (*untyped) -> untyped } -> Symbol
+  def define_singleton_method: (name, Method | UnboundMethod) -> Symbol
+                             | (name) { (*untyped) -> untyped } -> Symbol
 
   # <!--
   #   rdoc-file=io.c


### PR DESCRIPTION
define_singleton_method call C function `rb_check_id` for argument. It allows Symbol, String and _ToStr.