### PR TITLE
Run `bundle install` automatically in bin/steep

### DIFF
--- a/bin/steep
+++ b/bin/steep
@@ -5,13 +5,15 @@ GEMFILE=$(readlink -f ${BINSTUB_DIR}/../steep/Gemfile)
 ROOT_DIR=$(readlink -f ${BINSTUB_DIR}/..)
 
 STEEP="bundle exec --gemfile=${GEMFILE} steep"
+PREFIX=""
 
 if type "rbenv" > /dev/null 2>&1; then
-  STEEP="rbenv exec ${STEEP}"
+  PREFIX="rbenv exec "
 else
   if type "rvm" > /dev/null 2>&1; then
-    STEEP="rvm ${ROOT_DIR} do ${STEEP}"
+    PREFIX="rvm ${ROOT_DIR} do "
   fi
 fi
 
-exec $STEEP $@
+${PREFIX}bundle install --gemfile=${GEMFILE} > /dev/null 2>&1
+exec ${PREFIX}${STEEP} $@


### PR DESCRIPTION
This PR adds `bundle install` into bin/steep to ensure install gems for Steep.


# Problem

Currently, we need to run `bundle install` manually to run Steep. Because steep uses a different Gemfile.

But IDEs, such as VSCode, execute `bin/steep` transparently. Sometimes I overlooked the missing gems error because VSCode conceals the error (maybe VSCode displays the error as a small popup, but I never check the popup contents 😇).




# Solution


Run `bundle install` in `bin/steep`. By this change, `bin/steep` doesn't fail by the missing gems error.



I've applied the same solution to our company project, and it works well. 