### PR TITLE
Use fenced code block instead of indented one in .rbs files

### DIFF
--- a/sig/environment_loader.rbs
+++ b/sig/environment_loader.rbs
@@ -3,23 +3,25 @@ module RBS
   #
   # Set up your configuration through repository and `#add` method.
   #
-  #   # Set up the repository to load library RBSs from.
-  #   repo = RBS::Repository.default
-  #   repo.add(Pathname("vendor/rbs/gem-rbs"))
-  #   repo.add(Pathname("vendor/rbs/internal-rbs"))
+  # ```ruby
+  # # Set up the repository to load library RBSs from.
+  # repo = RBS::Repository.default
+  # repo.add(Pathname("vendor/rbs/gem-rbs"))
+  # repo.add(Pathname("vendor/rbs/internal-rbs"))
   #
-  #   loader = RBS::EnvironmentLoader.new(repository: repo)
+  # loader = RBS::EnvironmentLoader.new(repository: repo)
   #
-  #   # Add libraries to load RBS files.
-  #   loader.add(library: "minitest")
-  #   loader.add(library: "rbs", version: "1.0.0")
+  # # Add libraries to load RBS files.
+  # loader.add(library: "minitest")
+  # loader.add(library: "rbs", version: "1.0.0")
   #
-  #   # Add dirs to load RBS files from.
-  #   loader.add(path: Pathname("sig"))
+  # # Add dirs to load RBS files from.
+  # loader.add(path: Pathname("sig"))
   #
-  #   # Load RBSs into an environment.
-  #   environment = RBS::Environment.new()
-  #   loader.load(env: environment)
+  # # Load RBSs into an environment.
+  # environment = RBS::Environment.new()
+  # loader.load(env: environment)
+  # ```
   #
   class EnvironmentLoader
     class UnknownLibraryError < StandardError

--- a/sig/repository.rbs
+++ b/sig/repository.rbs
@@ -3,12 +3,14 @@ module RBS
   #
   # A repository object can handle multiple repository roots.
   #
-  #   repo = RBS::Repository.new()
-  #   repo.add(Pathname("vendor/rbs/gem-rbs"))
-  #   repo.add(Pathname("vendor/rbs/internal-rbs"))
-  #   repo.add(Pathname("vendor/rbs/definitely-rbs"))
+  # ```ruby
+  # repo = RBS::Repository.new()
+  # repo.add(Pathname("vendor/rbs/gem-rbs"))
+  # repo.add(Pathname("vendor/rbs/internal-rbs"))
+  # repo.add(Pathname("vendor/rbs/definitely-rbs"))
   #
-  #   repo.lookup("minitest", "2.1.3") => Pathname or nil
+  # repo.lookup("minitest", "2.1.3") # => Pathname or nil
+  # ```
   #
   # If one gem version can resolve to several directories, the last added dir wins.
   #

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -18,9 +18,11 @@ module RBS
       # Yields all direct sub types included in the type.
       # It doesn't yield the type itself.
       #
-      #   parse("Hash[String, Array[Symbol]]").each_type do |ty|
-      #     ...       # Yields String and Array[Symbol]
-      #   end
+      # ```ruby
+      # parse("Hash[String, Array[Symbol]]").each_type do |ty|
+      #   ...       # Yields String and Array[Symbol]
+      # end
+      # ```
       #
       def each_type: () { (t) -> void } -> void
                    | () -> Enumerator[t, void]
@@ -32,9 +34,11 @@ module RBS
       # Returns a String representation.
       # `level` is used internally.
       #
-      #   parse("String").to_s               # => "String"
-      #   parse("String | Integer").to_s()   # => "String | Integer"
-      #   parse("String | Integer").to_s(1)  # => "(String | Integer)"
+      # ```ruby
+      # parse("String").to_s               # => "String"
+      # parse("String | Integer").to_s()   # => "String | Integer"
+      # parse("String | Integer").to_s(1)  # => "(String | Integer)"
+      # ```
       #
       def to_s: (?Integer level) -> String
     end


### PR DESCRIPTION
Previously these indented code blocks were not valid. Indented code block requires four spaces at least, but they had only two spaces. They are evaluated as plain text by markdown processors.


So I replaced them with fenced code blocks. With this change, they are evaluated as code blocks correctly, and now they have the language annotations too.

An indented code block can also solve this problem, but I think a fenced code block is better due to the language annotation. 


For example, Steep's LSP displays the following hover hints.


before:


![Screen Shot 2023-04-21 at 0 13 26](https://user-images.githubusercontent.com/4361134/233410107-2f5eb9c2-7f6b-4cb1-9e0a-6e359306c3fa.png)


after:

![Screen Shot 2023-04-21 at 0 12 58](https://user-images.githubusercontent.com/4361134/233410095-1c12d393-d926-416c-a581-5bfcbadc7aa3.png)
