### PR TITLE
Delete all remaining set-related descriptions.

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -9,7 +9,7 @@ target :lib do
     "lib/rbs/test.rb"
   )
 
-  library "set", "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest', 'abbrev'
+  library "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest', 'abbrev'
   signature 'stdlib/yaml/0'
   signature "stdlib/strscan/0/"
   signature "stdlib/optparse/0/"
@@ -31,7 +31,7 @@ end
 #   check "app/models/**/*.rb"        # Glob
 #   # ignore "lib/templates/*.rb"
 #
-#   # library "pathname", "set"       # Standard libraries
+#   # library "pathname", "uri"       # Standard libraries
 #   # library "strong_json"           # Gems
 # end
 
@@ -40,6 +40,6 @@ end
 #
 #   check "spec"
 #
-#   # library "pathname", "set"       # Standard libraries
+#   # library "pathname", "uri"       # Standard libraries
 #   # library "rspec"
 # end

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -47,7 +47,6 @@ end
 class StringTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "::String"
 
   def test_gsub

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -72,12 +72,12 @@ end
   def test_loading_stdlib
     mktmpdir do |path|
       loader = EnvironmentLoader.new
-      loader.add(library: "set")
+      loader.add(library: "uri")
 
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Set")
+      assert_operator env.class_decls, :key?, TypeName("::URI")
     end
   end
 

--- a/test/stdlib/Encoding_Converter_test.rb
+++ b/test/stdlib/Encoding_Converter_test.rb
@@ -3,7 +3,6 @@ require_relative "test_helper"
 class Encoding::ConverterSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "singleton(::Encoding::Converter)"
 
   def test_new
@@ -178,7 +177,6 @@ end
 class Encoding::ConverterTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "::Encoding::Converter"
 
   def test_double_equal

--- a/test/stdlib/Encoding_InvalidByteSequenceError_test.rb
+++ b/test/stdlib/Encoding_InvalidByteSequenceError_test.rb
@@ -4,7 +4,6 @@ require_relative "test_helper"
 class Encoding::InvalidByteSequenceErrorTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "::Encoding::InvalidByteSequenceError"
 
   def test_destination_encoding

--- a/test/stdlib/Encoding_UndefinedConversionError_test.rb
+++ b/test/stdlib/Encoding_UndefinedConversionError_test.rb
@@ -3,7 +3,6 @@ require_relative "test_helper"
 class Encoding::UndefinedConversionErrorTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "::Encoding::UndefinedConversionError"
 
   def test_destination_encoding

--- a/test/stdlib/Thread_Backtrace_Location_test.rb
+++ b/test/stdlib/Thread_Backtrace_Location_test.rb
@@ -3,7 +3,6 @@ require_relative "test_helper"
 class Thread::Backtrace::LocationTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "::Thread::Backtrace::Location"
 
   def test_absolute_path

--- a/test/stdlib/Thread_Backtrace_test.rb
+++ b/test/stdlib/Thread_Backtrace_test.rb
@@ -3,7 +3,6 @@ require_relative "test_helper"
 class Thread::BacktraceSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
-  # library "pathname", "set", "securerandom"     # Declare library signatures to load
   testing "singleton(::Thread::Backtrace)"
 
   def test_limit


### PR DESCRIPTION
`set` library has been moved from the standard library.
Therefore, all statements should be deleted.