### PR TITLE
Allow keyword argument for Object#enum_for

### DIFF
--- a/core/object.rbs
+++ b/core/object.rbs
@@ -320,7 +320,7 @@ class Object < BasicObject
   #     enum.first(4) # => [1, 1, 1, 2]
   #     enum.size # => 42
   #
-  def enum_for: (Symbol method, *untyped args) ?{ (*untyped args) -> Integer } -> Enumerator[untyped, untyped]
+  def enum_for: (Symbol method, *untyped, **untyped) ?{ (*untyped, **untyped) -> Integer } -> Enumerator[untyped, untyped]
               | () ?{ () -> Integer } -> Enumerator[untyped, self]
 
   # <!--


### PR DESCRIPTION
Example

```rb
enum_for(:instance_exec, x: 123){ |x:| p x}.size
#=> 123
```

Real case

```
lib/rbs/file_finder.rb:8:13: [error] Cannot find compatible overloading of method `enum_for` of type `singleton(::RBS::FileFinder)`
│ Method types:
│   def enum_for: (::Symbol, *untyped) ?{ (*untyped) -> ::Integer } -> ::Enumerator[untyped, untyped]
│               | () ?{ () -> ::Integer } -> ::Enumerator[untyped, self]
│
│ Diagnostic ID: Ruby::UnresolvedOverloading
│
└       return enum_for(__method__, path, immediate: immediate, skip_hidden: skip_hidden) unless block
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```