### PR TITLE
Print detailed_message on parse command

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -961,7 +961,7 @@ Options:
           Parser.public_send(parse_method, buf, require_eof: true)
         end
       rescue RBS::ParsingError => ex
-        stdout.puts ex.message
+        stdout.print ex.detailed_message(highlight: true)
         syntax_error = true
       end
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -26,7 +26,7 @@ module RBS
         super
       else
         # Failback to `#message` in Ruby 3.1 or earlier
-        message
+        "#{message} (#{self.class.name})"
       end
 
       # Support only one line

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -22,7 +22,12 @@ module RBS
 
   module DetailedMessageable
     def detailed_message(highlight: false, **)
-      msg = super
+      msg = if Exception.method_defined?(:detailed_message)
+        super
+      else
+        # Failback to `#message` in Ruby 3.1 or earlier
+        message
+      end
 
       # Support only one line
       return msg unless location.start_line == location.end_line

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -485,7 +485,6 @@ singleton(::BasicObject)
           "",
           "    def self.foo: () -> void",
           "            ^",
-          "",
           "#{dir}/syntax_error.rbs:3:0...3:3: Syntax error: unexpected token for simple type, token=`end` (kEND) (RBS::ParsingError)",
           "",
           "  end",

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -481,9 +481,16 @@ singleton(::BasicObject)
         assert_raises(SystemExit) { cli.run(%W(parse #{dir})) }
 
         assert_equal [
-          "#{dir}/semantics_error.rbs:2:10...2:11: Syntax error: expected a token `pCOLON`, token=`.` (pDOT)",
-          "#{dir}/syntax_error.rbs:3:0...3:3: Syntax error: unexpected token for simple type, token=`end` (kEND)",
-        ], stdout.string.split("\n").sort
+          "#{dir}/semantics_error.rbs:2:10...2:11: Syntax error: expected a token `pCOLON`, token=`.` (pDOT) (RBS::ParsingError)",
+          "",
+          "    def self.foo: () -> void",
+          "            ^",
+          "",
+          "#{dir}/syntax_error.rbs:3:0...3:3: Syntax error: unexpected token for simple type, token=`end` (kEND) (RBS::ParsingError)",
+          "",
+          "  end",
+          "  ^^^"
+        ], stdout.string.gsub(/\e\[.*?m/, '').split("\n")
       end
     end
   end
@@ -495,8 +502,11 @@ singleton(::BasicObject)
 
       assert_raises(SystemExit) { cli.run(['parse', '-e', 'class C en']) }
       assert_equal [
-        "-e:1:8...1:10: Syntax error: unexpected token for class/module declaration member, token=`en` (tLIDENT)"
-      ], stdout.string.split("\n").sort
+        "-e:1:8...1:10: Syntax error: unexpected token for class/module declaration member, token=`en` (tLIDENT) (RBS::ParsingError)",
+        "",
+        "  class C en",
+        "          ^^"
+      ], stdout.string.gsub(/\e\[.*?m/, '').split("\n")
     end
   end
 
@@ -507,8 +517,11 @@ singleton(::BasicObject)
 
       assert_raises(SystemExit) { cli.run(['parse', '--type', '-e', '?']) }
       assert_equal [
-        "-e:1:0...1:1: Syntax error: unexpected token for simple type, token=`?` (pQUESTION)",
-      ], stdout.string.split("\n").sort
+        "-e:1:0...1:1: Syntax error: unexpected token for simple type, token=`?` (pQUESTION) (RBS::ParsingError)",
+        "",
+        "  ?",
+        "  ^"
+      ], stdout.string.gsub(/\e\[.*?m/, '').split("\n")
     end
   end
 
@@ -519,8 +532,11 @@ singleton(::BasicObject)
 
       assert_raises(SystemExit) { cli.run(['parse', '--method-type', '-e', '()']) }
       assert_equal [
-        "-e:1:2...1:3: Syntax error: expected a token `pARROW`, token=`` (pEOF)",
-      ], stdout.string.split("\n").sort
+        "-e:1:2...1:3: Syntax error: expected a token `pARROW`, token=`` (pEOF) (RBS::ParsingError)",
+        "",
+        "  ()",
+        "    ^"
+      ], stdout.string.gsub(/\e\[.*?m/, '').split("\n")
     end
   end
 


### PR DESCRIPTION
Extends the error display when parsing fails with the `parse` command.
This improves the user experience by making it easier to identify which part was at fault.

### before

<img width="540" src="https://github.com/ruby/rbs/assets/935310/f03f101b-b547-42ed-832f-8e708d7e992c">

### after

<img width="689" src="https://github.com/ruby/rbs/assets/935310/5fddc36c-b2eb-4919-9e7f-2743fea4ceb3">
