### PR TITLE
Report an error which gem is not found

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -133,6 +133,10 @@ module RBS
             end
           end
 
+          unless gem_hash.include?(name)
+            raise "Cannot find `#{name}` gem"
+          end
+
           gem_hash[name].dependencies.each do |dep|
             if spec = gem_hash[dep.name]
               assign_gem(name: dep.name, version: spec.version, src_data: nil, ignored_gems: ignored_gems)

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -435,6 +435,33 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     end
   end
 
+  def test_generate_lock_for_non_existent_gem
+    mktmpdir do |tmpdir|
+      config_path = tmpdir / 'rbs_collection.yaml'
+      config_path.write <<~YAML
+        sources:
+          - name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: cde6057e7546843ace6420c5783dd945c6ccda54
+            repo_dir: gems
+
+        path: /path/to/somewhere
+
+        gems:
+          - name: nonexistent-foobarbazquxquux
+      YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write GEMFILE
+      gemfile_lock_path = tmpdir / 'Gemfile.lock'
+      gemfile_lock_path.write GEMFILE_LOCK
+
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      assert_raise("Cannot find `nonexistent-foobarbazquxquux` gem") do
+        RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
+      end
+    end
+  end
+
   def test_generate_lock_with_empty_gemfile_lock
     mktmpdir do |tmpdir|
       config_path = tmpdir / 'rbs_collection.yaml'


### PR DESCRIPTION
When `rbs collection install` fails to find a gem, I want to see which gem it failed. In fact, I mistyped `name: strscan` as `name: stringscanner`, which was difficult for me to understand what was wrong.

Previously:
```
$ bundle exec rbs collection install
bundler: failed to load command: rbs (/home/mame/.rbenv/versions/3.3.0-dev/bin/rbs)
/home/mame/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rbs-3.1.0/lib/rbs/collection/config/lockfile_generator.rb:136:in `assign_gem': undefined method `dependencies' for nil (NoMethodError)

          gem_hash[name].dependencies.each do |dep|
                        ^^^^^^^^^^^^^
```

After this patch is applied:
```
$ bundle exec rbs collection install
bundler: failed to load command: rbs (/home/mame/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/bin/rbs)
/home/mame/.rbenv/versions/3.3.0-dev/lib/ruby/gems/3.3.0+0/gems/rbs-3.1.0/lib/rbs/collection/config/lockfile_generator.rb:137:in `assign_gem': Cannot find `stringscanner` gem (RuntimeError)
```