### PR TITLE
Fix Kernel.p and Kernel.pp type with no argument

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1241,7 +1241,8 @@ module Kernel : BasicObject
   #     [0..4, 0..4, 0..4]
   #
   def self?.p: [T] (T arg0) -> T
-             | (*untyped arg0) -> Array[untyped]
+             | (untyped, untyped, *untyped) -> Array[untyped]
+             | () -> nil
 
   # <!--
   #   rdoc-file=lib/pp.rb
@@ -1252,7 +1253,8 @@ module Kernel : BasicObject
   # pp returns argument(s).
   #
   def self?.pp: [T] (T arg0) -> T
-              | (*untyped arg0) -> Array[untyped]
+              | (untyped, untyped, *untyped) -> Array[untyped]
+              | () -> nil
 
   # <!--
   #   rdoc-file=random.c


### PR DESCRIPTION
`Kernel.p(T)` returns `T`, `Kernel.p(*more_than_two)` returns array, `Kernel.p()` retuns nil.
I added the missing definition `() -> nil`.


I think `(*untyped arg0) -> Array[untyped]` conflicts with `(T arg0) -> T` and `() -> nil`, so I changed it to `(untyped, untyped, *untyped) -> Array[untyped]`

```ruby
# I referenced core/module.rbs
class Module < Object
  def public: () -> nil
            | (Symbol method_name) -> Symbol
            | (Symbol, Symbol, *Symbol method_name) -> Array[Symbol]
            | ...
end
```