### PR TITLE
Drop support of Ruby 2.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,8 +17,6 @@ jobs:
           - 3.2-dev-focal
           - 3.1-dev-focal
           - 3.0-dev-focal
-          - 2.7-dev-bionic
-          - 2.6-bionic
         job:
           - test
           - stdlib_test
@@ -28,10 +26,6 @@ jobs:
         exclude:
           - container_tag: master-nightly-focal
             job: confirm_lexer
-          - container_tag: 2.6-bionic
-            job: stdlib_test
-          - container_tag: 2.7-dev-bionic
-            job: stdlib_test
           - container_tag: 3.0-dev-focal
             job: stdlib_test
           - container_tag: 3.1-dev-focal

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 3.0"
 end


### PR DESCRIPTION

Close #1338.

They are EOL. We can use new feature of Ruby 3.0 to develop RBS by dropping support of Ruby 2.x.