### PR TITLE
Print warning when specified gem not found

### DIFF
--- a/lib/rbs/collection/installer.rb
+++ b/lib/rbs/collection/installer.rb
@@ -14,7 +14,10 @@ module RBS
       def install_from_lockfile
         install_to = lockfile.fullpath
         install_to.mkpath
-        lockfile.gems.each_value do |gem|
+        selected = lockfile.gems.select do |name, gem|
+          gem[:source].has?(name, gem[:version])
+        end
+        selected.each_value do |gem|
           gem[:source].install(
             dest: install_to,
             name: gem[:name],
@@ -22,7 +25,7 @@ module RBS
             stdout: stdout
           )
         end
-        stdout.puts "It's done! #{lockfile.gems.size} gems' RBSs now installed."
+        stdout.puts "It's done! #{selected.size} gems' RBSs now installed."
       end
     end
   end

--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -27,7 +27,11 @@ module RBS
         end
 
         def manifest_of(name, version)
-          manifest_path = (lookup(name, version) or raise).join('manifest.yaml')
+          unless path = lookup(name, version)
+            RBS.logger.warn "`#{name}` is specified in rbs_collection.lock.yaml. But it is not found in #{REPO.dirs.join(",")}"
+            return
+          end
+          manifest_path = path.join('manifest.yaml')
           YAML.safe_load(manifest_path.read) if manifest_path.exist?
         end
 


### PR DESCRIPTION
## Problem

When I do collection install on a project I haven't started in a while, I get the following error.
The cause is that the gem is incorrectly specified, but even if the destination, such as `prime`, is changed, its name is not displayed and the user does not know what to do.

```
$ bundle exec rbs collection install
bundler: failed to load command: rbs (/Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs)
/Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:136:in `assign_gem': undefined method `dependencies' for nil:NilClass (NoMethodError)

          gem_hash[name].dependencies.each do |dep|
                        ^^^^^^^^^^^^^
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:69:in `block in generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:63:in `each'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:63:in `generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:27:in `generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config.rb:36:in `generate_lockfile'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:1103:in `run_collection'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:137:in `run'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/exe/rbs:7:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs:25:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs:25:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:483:in `exec'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:31:in `dispatch'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:25:in `start'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/exe/bundle:48:in `block in <top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/exe/bundle:36:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
```

Similarly, if a gem is removed from the Gemfile.lock even though it is specified in rbs_collection.yaml, it is similarly difficult to determine the cause.

```
$ bundle exec rbs collection install
bundler: failed to load command: rbs (/Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs)
/Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/sources/stdlib.rb:30:in `manifest_of': unhandled exception
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/sources/base.rb:8:in `dependencies_of'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:130:in `assign_gem'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:69:in `block in generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:63:in `each'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:63:in `generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config/lockfile_generator.rb:27:in `generate'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/collection/config.rb:36:in `generate_lockfile'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:1103:in `run_collection'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:137:in `run'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/exe/rbs:7:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs:25:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs:25:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:483:in `exec'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:31:in `dispatch'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/cli.rb:25:in `start'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/exe/bundle:48:in `block in <top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/lib/bundler/friendly_errors.rb:103:in `with_friendly_errors'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.3.9/exe/bundle:36:in `<top (required)>'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/bin/bundle:25:in `load'
	from /Users/yuki.kurihara/.rbenv/versions/3.2.2/bin/bundle:25:in `<main>'
```

## Proposal

I propose to prompt the user to correct the problem by displaying a warning about the cause.

```
$ bundle exec rbs collection install
W, [2023-07-10T13:52:32.391591 #12012]  WARN -- rbs: `prime` is specified in rbs_collection.lock.yaml. But it is not found in /Users/yuki.kurihara/src/github.com/ksss/rbs/stdlib
W, [2023-07-10T13:52:32.391602 #12012]  WARN -- rbs: `prime` is specified in rbs_collection.yaml. But, it was not found in Gemfile.lock
```