### PR TITLE
Remove references to the transient heap

### DIFF
--- a/core/gc.rbs
+++ b/core/gc.rbs
@@ -235,13 +235,6 @@ module GC
   def self.verify_internal_consistency: () -> nil
 
   # <!--
-  #   rdoc-file=gc.c
-  #   - verify_transient_heap_internal_consistency()
-  # -->
-  #
-  def self.verify_transient_heap_internal_consistency: () -> nil
-
-  # <!--
   #   rdoc-file=gc.rb
   #   - GC.latest_gc_info -> hash
   #   - GC.latest_gc_info(hash) -> hash

--- a/test/stdlib/GC_test.rb
+++ b/test/stdlib/GC_test.rb
@@ -37,10 +37,6 @@ class GCTest < StdlibTest
     GC.verify_internal_consistency
   end
 
-  def test_verify_transient_heap_internal_consistency
-    GC.verify_transient_heap_internal_consistency
-  end
-
   def test_latest_gc_info
     GC.latest_gc_info
     GC.latest_gc_info({})


### PR DESCRIPTION
The transient heap was removed in ruby/ruby@7942, so it's causing CI failures on Ruby head.