### PR TITLE
Spec may be missing when `rbs_collection.yaml` declares dependency

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -133,10 +133,14 @@ module RBS
             end
           end
 
-          gem_hash[name].dependencies.each do |dep|
-            if spec = gem_hash[dep.name]
-              assign_gem(name: dep.name, version: spec.version, src_data: nil, ignored_gems: ignored_gems)
+          if spec = gem_hash.fetch(name, nil)
+            spec.dependencies.each do |dep|
+              if dep_spec = gem_hash[dep.name]
+                assign_gem(name: dep.name, version: dep_spec.version, src_data: nil, ignored_gems: ignored_gems)
+              end
             end
+          else
+            RBS.logger.warn "Cannot find `#{name}` gem. Using incorrect Bundler context? (#{definition.lockfile})"
           end
         end
 

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -702,6 +702,65 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
     end
   end
 
+  def test_generate_lockfile__gems_not_included_in_gemfile
+    mktmpdir do |tmpdir|
+      config_path = tmpdir / 'rbs_collection.yaml'
+      config_path.write [CONFIG, <<~YAML].join("\n")
+        sources:
+          - type: git
+            name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: cde6057e7546843ace6420c5783dd945c6ccda54
+            repo_dir: gems
+        path: '.gem_rbs_collection'
+        gems:
+          - name: ast
+      YAML
+      gemfile_path = tmpdir / 'Gemfile'
+      gemfile_path.write <<~GEMFILE
+        source 'https://rubygems.org'
+      GEMFILE
+      gemfile_lock_path = tmpdir / 'Gemfile.lock'
+      gemfile_lock_path.write <<~GEMFILE_LOCK
+        GEM
+          remote: https://rubygems.org/
+          specs:
+
+        PLATFORMS
+          x86_64-linux
+
+        DEPENDENCIES
+
+        BUNDLED WITH
+           2.2.0
+      GEMFILE_LOCK
+
+      definition = Bundler::Definition.build(gemfile_path, gemfile_lock_path, false)
+      _config, lockfile = RBS::Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
+      string = YAML.dump(lockfile.to_lockfile)
+
+      assert_config <<~YAML, string
+        sources:
+          - type: git
+            name: ruby/gem_rbs_collection
+            remote: https://github.com/ruby/gem_rbs_collection.git
+            revision: cde6057e7546843ace6420c5783dd945c6ccda54
+            repo_dir: gems
+        path: ".gem_rbs_collection"
+        gemfile_lock_path: 'Gemfile.lock'
+        gems:
+          - name: ast
+            version: "2.4"
+            source:
+              name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: cde6057e7546843ace6420c5783dd945c6ccda54
+              repo_dir: gems
+              type: git
+      YAML
+    end
+  end
+
   private def assert_config(expected_str, actual_str)
     assert_equal YAML.load(expected_str), YAML.load(actual_str)
   end


### PR DESCRIPTION
This typically happens when:

1. One Git repository contains multiple gems
2. Steep/RBS is loaded in the root `Gemfile` which doesn't load the gems
3. Dependencies are explicitly declared in `rbs_collection.yaml` that is loaded in the *root* Bundler context