### PR TITLE
subtract: Filter redundant access modifiers

### DIFF
--- a/sig/subtractor.rbs
+++ b/sig/subtractor.rbs
@@ -24,6 +24,10 @@ module RBS
 
     private def mixin_exist?: (TypeName owner, AST::Members::Include | AST::Members::Extend | AST::Members::Prepend, context: Resolver::context) -> boolish
 
+    private def filter_redundunt_access_modifiers: (Array[AST::Declarations::t | AST::Members::t]) -> Array[AST::Declarations::t | AST::Members::t]
+
+    private def access_modifier?: (AST::Declarations::t | AST::Members::t?) -> bool
+
     private def update_decl: (decl_with_members, members: Array[AST::Declarations::t | AST::Members::t]) -> decl_with_members
 
     private def absolute_typename: (TypeName, context: Resolver::context) -> TypeName

--- a/test/rbs/subtractor_test.rb
+++ b/test/rbs/subtractor_test.rb
@@ -499,9 +499,35 @@ class RBS::SubtractorTest < Test::Unit::TestCase
     RBS
   end
 
+  def test_empty_public_and_private
+    decls = to_decls(<<~RBS)
+      class C
+        public
+        private
+      end
+    RBS
+
+    env = to_env(<<~RBS)
+      class C
+        public
+        private
+      end
+    RBS
+
+    subtracted = RBS::Subtractor.new(decls, env).call
+
+    assert_subtracted "", subtracted
+  end
+
   def test_public_and_private
     decls = to_decls(<<~RBS)
       class C
+        public
+        public
+        def a: () -> Integer
+        private
+        private
+        def b: () -> Integer
         public
         private
       end
@@ -519,7 +545,10 @@ class RBS::SubtractorTest < Test::Unit::TestCase
     assert_subtracted <<~RBS, subtracted
       class C
         public
+        def a: () -> Integer
+
         private
+        def b: () -> Integer
       end
     RBS
   end


### PR DESCRIPTION
Filter access modifiers (public and private) from subtracted RBS code.

* repeated access modifiers
* access modifiers not having any members