### PR TITLE
Fix type name for prototype rbi

### DIFF
--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -479,7 +479,7 @@ module RBS
           else
             Types::ClassInstance.new(name: const_to_name(type_node), args: [], location: nil)
           end
-        when type_node.type == :COLON2
+        when type_node.type == :COLON2 || type_node.type == :COLON3
           Types::ClassInstance.new(name: const_to_name(type_node), args: [], location: nil)
         when call_node?(type_node, name: :[], receiver: -> (_) { true })
           # The type_node represents a type application

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -553,11 +553,7 @@ module RBS
           TypeName.new(name: node.children[0], namespace: Namespace.empty)
         when :COLON2
           if node.children[0]
-            if node.children[0].type == :COLON3
-              namespace = Namespace.root
-            else
-              namespace = const_to_name(node.children[0]).to_namespace
-            end
+            namespace = const_to_name(node.children[0]).to_namespace
           else
             namespace = Namespace.empty
           end

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -329,6 +329,12 @@ class Test
 
   sig { returns(::Foo) }
   def m2; end
+
+  sig { returns(Foo::Bar) }
+  def m3; end
+
+  sig { returns(::Foo::Bar) }
+  def m4; end
 end
     EOF
 
@@ -337,6 +343,10 @@ class Test
   def m1: () -> Foo
 
   def m2: () -> ::Foo
+
+  def m3: () -> Foo::Bar
+
+  def m4: () -> ::Foo::Bar
 end
     EOF
   end

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -319,6 +319,28 @@ end
     EOF
   end
 
+  def test_colon
+    parser = RBI.new
+
+    parser.parse(<<-EOF)
+class Test
+  sig { returns(Foo) }
+  def m1; end
+
+  sig { returns(::Foo) }
+  def m2; end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Test
+  def m1: () -> Foo
+
+  def m2: () -> ::Foo
+end
+    EOF
+  end
+
   def test_attached_class
     parser = RBI.new
 


### PR DESCRIPTION
This PR solves two problems.

## Fix untyped in case of COLON3

```rbi
class Test
  sig { returns(Foo) }
  def m1; end

  sig { returns(::Foo) }
  def m2; end
end
```

```rbs
class Test
  def m1: () -> Foo

  # before
  def m2: () -> untyped

  # after
  def m2: () -> ::Foo
end
```

## Fixed a problem where namespace disappears when an absolute path is specified

```rbi
class Test
  sig { returns(Foo::Bar) }
  def m3; end

  sig { returns(::Foo::Bar) }
  def m4; end
end
```

```rbs
class Test
  def m3: () -> Foo::Bar

  # before
  def m4: () -> ::Bar

  # after
  def m4: () -> ::Foo::Bar
end
```
