### PR TITLE
Make the arg for `Kernel::exit!` optional

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -807,7 +807,7 @@ module Kernel : BasicObject
   #
   #     Process.exit!(true)
   #
-  def self?.exit!: (Integer | TrueClass | FalseClass status) -> bot
+  def self?.exit!: (?Integer | TrueClass | FalseClass status) -> bot
 
   # <!-- rdoc-file=eval.c -->
   # With no arguments, raises the exception in `$!` or raises a RuntimeError if


### PR DESCRIPTION
Fixes #1298
The associated test is blank because – you can’t test this…

#good-first-issue