### PR TITLE
Syntax highlight `README.md` example as `rbs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It also allows declaring constants and global variables.
 The following is a small example of RBS for a chat app.
 
 <!-- run-start:a.rbs:bundle exec rbs -I a.rbs validate -->
-```rb
+```rbs
 module ChatApp
   VERSION: String
 


### PR DESCRIPTION
It’s still highlighted as Ruby (`rb`) currently (while the rest have switched to `rbs` at b829cc4)

(One-char PR lol)