### PR TITLE
Update `io.rbs`

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1202,7 +1202,7 @@ class IO < Object
   #     IO.new(fd, internal_encoding: nil) # => #<IO:fd 3>
   #     IO.new(fd, autoclose: true)        # => #<IO:fd 3>
   #
-  def initialize: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> void
+  def initialize: ( int fd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> void
 
   # <!--
   #   rdoc-file=io.c
@@ -2540,10 +2540,10 @@ class IO < Object
   #
   # Raises exceptions that IO.pipe and Kernel.spawn raise.
   #
-  def self.popen: (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
-                | (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
-                | [X] (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
-                | [X] (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
+  def self.popen: (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
+                | (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
+                | [X] (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
+                | [X] (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
 
   # <!--
   #   rdoc-file=io.c
@@ -2636,8 +2636,8 @@ class IO < Object
   #
   # Returns an Enumerator if no block is given.
   #
-  def self.foreach: (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) { (String line) -> void } -> nil
-                  | (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> ::Enumerator[String, nil]
+  def self.foreach: (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?chomp: boolish) { (String line) -> void } -> nil
+                  | (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?chomp: boolish) -> ::Enumerator[String, nil]
 
   # <!--
   #   rdoc-file=io.c
@@ -2717,8 +2717,8 @@ class IO < Object
   #     Sending message to parent
   #     Parent got: <Hi Dad>
   #
-  def self.pipe: (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> [IO, IO]
-               | [X] (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) { (IO read_io, IO write_io) -> X } -> X
+  def self.pipe: (?String | Encoding | nil ext_or_ext_int_enc, ?String | Encoding | nil int_enc, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?chomp: boolish) -> [IO, IO]
+               | [X] (?String | Encoding | nil ext_or_ext_int_enc, ?String | Encoding | nil int_enc, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?chomp: boolish) { (IO read_io, IO write_io) -> X } -> X
 
   # <!--
   #   rdoc-file=io.c
@@ -2775,7 +2775,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> String
+  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2846,7 +2846,7 @@ class IO < Object
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   # *   [Line Options](rdoc-ref:IO@Line+Options).
   #
-  def self.readlines: (String | _ToPath name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> ::Array[String]
+  def self.readlines: (String | _ToPath name, ?String sep, ?Integer limit, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String, ?chomp: boolish) -> ::Array[String]
 
   # <!--
   #   rdoc-file=io.c
@@ -3079,7 +3079,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.write: (String path, _ToS data, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> Integer
+  def self.write: (String path, _ToS data, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -3101,8 +3101,8 @@ class IO < Object
   # With a block given, calls the block with the IO object and returns the block's
   # value.
   #
-  def self.open: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> instance
-               | [X] (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) { (instance) -> X } -> X
+  def self.open: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> instance
+               | [X] (int fd, ?string | int mode, ?path: string?, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) { (instance) -> X } -> X
 
   # <!-- rdoc-file=io.c -->
   # Calls the block with each remaining line read from the stream; returns `self`.

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -879,7 +879,7 @@ class IO < Object
   # Related: IO#close_read, IO#close_write, IO#close.
   #
   def closed?: () -> bool
-  
+
   # <!--
   #   rdoc-file=io.c
   #   - each_byte {|byte| ... } -> self
@@ -2544,6 +2544,7 @@ class IO < Object
                 | (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
                 | [X] (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
                 | [X] (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
+
   # <!--
   #   rdoc-file=io.c
   #   - IO.foreach(path, sep = $/, **opts) {|line| block }       -> nil
@@ -3203,6 +3204,111 @@ class IO < Object
   #
   def each_line: (?String sep, ?Integer limit) { (String line) -> void } -> self
                | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
+
+  # <!--
+  #   rdoc-file=io.c
+  #   - each_line(sep = $/, chomp: false) {|line| ... }   -> self
+  #   - each_line(limit, chomp: false) {|line| ... }      -> self
+  #   - each_line(sep, limit, chomp: false) {|line| ... } -> self
+  #   - each_line                                   -> enumerator
+  # -->
+  # Calls the block with each remaining line read from the stream; returns `self`.
+  # Does nothing if already at end-of-stream; See [Line IO](rdoc-ref:IO@Line+IO).
+  #
+  # With no arguments given, reads lines as determined by line separator `$/`:
+  #
+  #     f = File.new('t.txt')
+  #     f.each_line {|line| p line }
+  #     f.each_line {|line| fail 'Cannot happen' }
+  #     f.close
+  #
+  # Output:
+  #
+  #     "First line\n"
+  #     "Second line\n"
+  #     "\n"
+  #     "Fourth line\n"
+  #     "Fifth line\n"
+  #
+  # With only string argument `sep` given, reads lines as determined by line
+  # separator `sep`; see [Line Separator](rdoc-ref:IO@Line+Separator):
+  #
+  #     f = File.new('t.txt')
+  #     f.each_line('li') {|line| p line }
+  #     f.close
+  #
+  # Output:
+  #
+  #     "First li"
+  #     "ne\nSecond li"
+  #     "ne\n\nFourth li"
+  #     "ne\nFifth li"
+  #     "ne\n"
+  #
+  # The two special values for `sep` are honored:
+  #
+  #     f = File.new('t.txt')
+  #     # Get all into one string.
+  #     f.each_line(nil) {|line| p line }
+  #     f.close
+  #
+  # Output:
+  #
+  #     "First line\nSecond line\n\nFourth line\nFifth line\n"
+  #
+  #     f.rewind
+  #     # Get paragraphs (up to two line separators).
+  #     f.each_line('') {|line| p line }
+  #
+  # Output:
+  #
+  #     "First line\nSecond line\n\n"
+  #     "Fourth line\nFifth line\n"
+  #
+  # With only integer argument `limit` given, limits the number of bytes in each
+  # line; see [Line Limit](rdoc-ref:IO@Line+Limit):
+  #
+  #     f = File.new('t.txt')
+  #     f.each_line(8) {|line| p line }
+  #     f.close
+  #
+  # Output:
+  #
+  #     "First li"
+  #     "ne\n"
+  #     "Second l"
+  #     "ine\n"
+  #     "\n"
+  #     "Fourth l"
+  #     "ine\n"
+  #     "Fifth li"
+  #     "ne\n"
+  #
+  # With arguments `sep` and `limit` given, combines the two behaviors:
+  #
+  # *   Calls with the next line as determined by line separator `sep`.
+  # *   But returns no more bytes than are allowed by the limit.
+  #
+  #
+  # Optional keyword argument `chomp` specifies whether line separators are to be
+  # omitted:
+  #
+  #     f = File.new('t.txt')
+  #     f.each_line(chomp: true) {|line| p line }
+  #     f.close
+  #
+  # Output:
+  #
+  #     "First line"
+  #     "Second line"
+  #     ""
+  #     "Fourth line"
+  #     "Fifth line"
+  #
+  # Returns an Enumerator if no block is given.
+  #
+  # IO#each is an alias for IO#each_line.
+  #
   alias each each_line
 
   # <!-- rdoc-file=io.c -->

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -694,7 +694,7 @@ class IO < Object
   #     # ...
   #     f.gets # won't cause Errno::EBADF
   #
-  def autoclose=: (boolish) -> boolish
+  def autoclose=: (boolish bool) -> boolish
 
   # <!--
   #   rdoc-file=io.c
@@ -775,7 +775,7 @@ class IO < Object
   # (via system() method for example). If you really needs file descriptor
   # inheritance to child process, use spawn()'s argument such as fd=>fd.
   #
-  def close_on_exec=: (boolish) -> nil
+  def close_on_exec=: (boolish bool) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -879,114 +879,7 @@ class IO < Object
   # Related: IO#close_read, IO#close_write, IO#close.
   #
   def closed?: () -> bool
-
-  # <!--
-  #   rdoc-file=io.c
-  #   - each_line(sep = $/, chomp: false) {|line| ... }   -> self
-  #   - each_line(limit, chomp: false) {|line| ... }      -> self
-  #   - each_line(sep, limit, chomp: false) {|line| ... } -> self
-  #   - each_line                                   -> enumerator
-  # -->
-  # Calls the block with each remaining line read from the stream; returns `self`.
-  # Does nothing if already at end-of-stream; See [Line IO](rdoc-ref:IO@Line+IO).
-  #
-  # With no arguments given, reads lines as determined by line separator `$/`:
-  #
-  #     f = File.new('t.txt')
-  #     f.each_line {|line| p line }
-  #     f.each_line {|line| fail 'Cannot happen' }
-  #     f.close
-  #
-  # Output:
-  #
-  #     "First line\n"
-  #     "Second line\n"
-  #     "\n"
-  #     "Fourth line\n"
-  #     "Fifth line\n"
-  #
-  # With only string argument `sep` given, reads lines as determined by line
-  # separator `sep`; see [Line Separator](rdoc-ref:IO@Line+Separator):
-  #
-  #     f = File.new('t.txt')
-  #     f.each_line('li') {|line| p line }
-  #     f.close
-  #
-  # Output:
-  #
-  #     "First li"
-  #     "ne\nSecond li"
-  #     "ne\n\nFourth li"
-  #     "ne\nFifth li"
-  #     "ne\n"
-  #
-  # The two special values for `sep` are honored:
-  #
-  #     f = File.new('t.txt')
-  #     # Get all into one string.
-  #     f.each_line(nil) {|line| p line }
-  #     f.close
-  #
-  # Output:
-  #
-  #     "First line\nSecond line\n\nFourth line\nFifth line\n"
-  #
-  #     f.rewind
-  #     # Get paragraphs (up to two line separators).
-  #     f.each_line('') {|line| p line }
-  #
-  # Output:
-  #
-  #     "First line\nSecond line\n\n"
-  #     "Fourth line\nFifth line\n"
-  #
-  # With only integer argument `limit` given, limits the number of bytes in each
-  # line; see [Line Limit](rdoc-ref:IO@Line+Limit):
-  #
-  #     f = File.new('t.txt')
-  #     f.each_line(8) {|line| p line }
-  #     f.close
-  #
-  # Output:
-  #
-  #     "First li"
-  #     "ne\n"
-  #     "Second l"
-  #     "ine\n"
-  #     "\n"
-  #     "Fourth l"
-  #     "ine\n"
-  #     "Fifth li"
-  #     "ne\n"
-  #
-  # With arguments `sep` and `limit` given, combines the two behaviors:
-  #
-  # *   Calls with the next line as determined by line separator `sep`.
-  # *   But returns no more bytes than are allowed by the limit.
-  #
-  #
-  # Optional keyword argument `chomp` specifies whether line separators are to be
-  # omitted:
-  #
-  #     f = File.new('t.txt')
-  #     f.each_line(chomp: true) {|line| p line }
-  #     f.close
-  #
-  # Output:
-  #
-  #     "First line"
-  #     "Second line"
-  #     ""
-  #     "Fourth line"
-  #     "Fifth line"
-  #
-  # Returns an Enumerator if no block is given.
-  #
-  # IO#each is an alias for IO#each_line.
-  #
-  def each: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
-          | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
-
+  
   # <!--
   #   rdoc-file=io.c
   #   - each_byte {|byte| ... } -> self
@@ -1005,7 +898,7 @@ class IO < Object
   #
   # Related: IO#each_char, IO#each_codepoint.
   #
-  def each_byte: () { (Integer arg0) -> void } -> self
+  def each_byte: () { (Integer byte) -> void } -> self
                | () -> ::Enumerator[Integer, self]
 
   # <!--
@@ -1026,7 +919,7 @@ class IO < Object
   #
   # Related: IO#each_byte, IO#each_codepoint.
   #
-  def each_char: () { (String arg0) -> void } -> self
+  def each_char: () { (String c) -> void } -> self
                | () -> ::Enumerator[String, self]
 
   # <!--
@@ -1046,7 +939,7 @@ class IO < Object
   #
   # Related: IO#each_byte, IO#each_char.
   #
-  def each_codepoint: () { (Integer arg0) -> void } -> self
+  def each_codepoint: () { (Integer c) -> void } -> self
                     | () -> ::Enumerator[Integer, self]
 
   # <!--
@@ -1101,7 +994,7 @@ class IO < Object
   #
   # Not implemented on all platforms.
   #
-  def fcntl: (Integer integer_cmd, String | Integer arg) -> Integer
+  def fcntl: (Integer integer_cmd, String | Integer argument) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -1349,7 +1242,7 @@ class IO < Object
   #
   # Not implemented on all platforms.
   #
-  def ioctl: (Integer integer_cmd, String | Integer arg) -> Integer
+  def ioctl: (Integer integer_cmd, String | Integer argument) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -1383,7 +1276,7 @@ class IO < Object
   # Sets and returns the line number for the stream; see [Line
   # Number](rdoc-ref:IO@Line+Number).
   #
-  def lineno=: (Integer arg0) -> Integer
+  def lineno=: (Integer integer) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -1452,7 +1345,7 @@ class IO < Object
   #
   # Related: IO#seek, IO#tell.
   #
-  def pos=: (Integer arg0) -> Integer
+  def pos=: (Integer new_position) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -1508,7 +1401,7 @@ class IO < Object
   #     f.print
   #     f.close
   #
-  def print: (*untyped args) -> nil
+  def print: (*untyped objects) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1519,7 +1412,7 @@ class IO < Object
   # For details on `format_string`, see [Format
   # Specifications](rdoc-ref:format_specifications.rdoc).
   #
-  def printf: (String format_string, *untyped args) -> nil
+  def printf: (String format_string, *untyped objects) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1539,7 +1432,7 @@ class IO < Object
   #
   #     AA
   #
-  def putc: (Numeric | String arg0) -> (Numeric | String)
+  def putc: (Numeric | String object) -> (Numeric | String)
 
   # <!--
   #   rdoc-file=io.c
@@ -1586,7 +1479,7 @@ class IO < Object
   #     # Nested arrays.
   #     show([[[0, 1], 2, 3], 4, 5])  # => "0\n1\n2\n3\n4\n5\n"
   #
-  def puts: (*untyped args) -> nil
+  def puts: (*untyped objects) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -2132,7 +2025,7 @@ class IO < Object
   #
   # Related: IO#fsync.
   #
-  def sync=: (boolish) -> boolish
+  def sync=: (boolish boolean) -> boolish
 
   # <!--
   #   rdoc-file=io.c
@@ -2172,7 +2065,7 @@ class IO < Object
   #
   # This methods should not be used with other stream-writer methods.
   #
-  def syswrite: (_ToS arg0) -> Integer
+  def syswrite: (_ToS object) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -2219,7 +2112,7 @@ class IO < Object
   # effort to prevent an application from hanging on slow I/O operations, such as
   # those that occur during a slowloris attack.
   #
-  def timeout=: (Numeric?) -> void
+  def timeout=: (Numeric? duration) -> void
 
   # <!--
   #   rdoc-file=io.c
@@ -2280,7 +2173,7 @@ class IO < Object
   #     f.read              # => "BCDE012"
   #     f.close
   #
-  def ungetbyte: (String | Integer arg0) -> nil
+  def ungetbyte: (String | Integer object) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -2323,7 +2216,7 @@ class IO < Object
   #     f.getc.ord      # => 1090
   #     f.close
   #
-  def ungetc: (String arg0) -> nil
+  def ungetc: (String object) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -3185,7 +3078,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.write: (String name, _ToS arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> Integer
+  def self.write: (String path, _ToS data, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -3209,15 +3102,6 @@ class IO < Object
   #
   def self.open: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> instance
                | [X] (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) { (instance) -> X } -> X
-
-  def bytes: () { (Integer arg0) -> void } -> self
-           | () -> ::Enumerator[Integer, self]
-
-  def chars: () { (String arg0) -> void } -> self
-           | () -> ::Enumerator[String, self]
-
-  def codepoints: () { (Integer arg0) -> void } -> self
-                | () -> ::Enumerator[Integer, self]
 
   # <!-- rdoc-file=io.c -->
   # Calls the block with each remaining line read from the stream; returns `self`.
@@ -3317,8 +3201,9 @@ class IO < Object
   #
   # IO#each is an alias for IO#each_line.
   #
-  def each_line: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
+  def each_line: (?String sep, ?Integer limit) { (String line) -> void } -> self
                | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
+  alias each each_line
 
   # <!-- rdoc-file=io.c -->
   # Returns `true` if the stream is positioned at its end, `false` otherwise; see
@@ -3354,9 +3239,6 @@ class IO < Object
   # IO#eof? is an alias for IO#eof.
   #
   def eof?: () -> bool
-
-  def lines: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
-           | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!-- rdoc-file=io.c -->
   # Returns the integer file descriptor for the stream:

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -694,7 +694,7 @@ class IO < Object
   #     # ...
   #     f.gets # won't cause Errno::EBADF
   #
-  def autoclose=: (boolish) -> untyped
+  def autoclose=: (boolish) -> boolish
 
   # <!--
   #   rdoc-file=io.c
@@ -756,7 +756,7 @@ class IO < Object
   #
   # Related: IO#close_read, IO#close_write, IO#closed?.
   #
-  def close: () -> NilClass
+  def close: () -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -775,7 +775,7 @@ class IO < Object
   # (via system() method for example). If you really needs file descriptor
   # inheritance to child process, use spawn()'s argument such as fd=>fd.
   #
-  def close_on_exec=: (boolish) -> untyped
+  def close_on_exec=: (boolish) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -821,7 +821,7 @@ class IO < Object
   #
   # Related: IO#close, IO#close_write, IO#closed?.
   #
-  def close_read: () -> NilClass
+  def close_read: () -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -853,7 +853,7 @@ class IO < Object
   #
   # Related: IO#close, IO#close_read, IO#closed?.
   #
-  def close_write: () -> NilClass
+  def close_write: () -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -984,7 +984,7 @@ class IO < Object
   #
   # IO#each is an alias for IO#each_line.
   #
-  def each: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
+  def each: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
           | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!--
@@ -1005,7 +1005,7 @@ class IO < Object
   #
   # Related: IO#each_char, IO#each_codepoint.
   #
-  def each_byte: () { (Integer arg0) -> untyped } -> self
+  def each_byte: () { (Integer arg0) -> void } -> self
                | () -> ::Enumerator[Integer, self]
 
   # <!--
@@ -1026,7 +1026,7 @@ class IO < Object
   #
   # Related: IO#each_byte, IO#each_codepoint.
   #
-  def each_char: () { (String arg0) -> untyped } -> self
+  def each_char: () { (String arg0) -> void } -> self
                | () -> ::Enumerator[String, self]
 
   # <!--
@@ -1046,7 +1046,7 @@ class IO < Object
   #
   # Related: IO#each_byte, IO#each_char.
   #
-  def each_codepoint: () { (Integer arg0) -> untyped } -> self
+  def each_codepoint: () { (Integer arg0) -> void } -> self
                     | () -> ::Enumerator[Integer, self]
 
   # <!--
@@ -1309,7 +1309,7 @@ class IO < Object
   #     IO.new(fd, internal_encoding: nil) # => #<IO:fd 3>
   #     IO.new(fd, autoclose: true)        # => #<IO:fd 3>
   #
-  def initialize: (int fd, ?string | int mode, ?path: string?, **untyped opts) -> void
+  def initialize: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> void
 
   # <!--
   #   rdoc-file=io.c
@@ -1508,7 +1508,7 @@ class IO < Object
   #     f.print
   #     f.close
   #
-  def print: (*untyped arg0) -> NilClass
+  def print: (*untyped args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1519,7 +1519,7 @@ class IO < Object
   # For details on `format_string`, see [Format
   # Specifications](rdoc-ref:format_specifications.rdoc).
   #
-  def printf: (String format_string, *untyped arg0) -> NilClass
+  def printf: (String format_string, *untyped args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1539,7 +1539,7 @@ class IO < Object
   #
   #     AA
   #
-  def putc: (Numeric | String arg0) -> untyped
+  def putc: (Numeric | String arg0) -> (Numeric | String)
 
   # <!--
   #   rdoc-file=io.c
@@ -1586,7 +1586,7 @@ class IO < Object
   #     # Nested arrays.
   #     show([[[0, 1], 2, 3], 4, 5])  # => "0\n1\n2\n3\n4\n5\n"
   #
-  def puts: (*untyped arg0) -> NilClass
+  def puts: (*untyped args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -2132,7 +2132,7 @@ class IO < Object
   #
   # Related: IO#fsync.
   #
-  def sync=: (boolish) -> untyped
+  def sync=: (boolish) -> boolish
 
   # <!--
   #   rdoc-file=io.c
@@ -2280,7 +2280,7 @@ class IO < Object
   #     f.read              # => "BCDE012"
   #     f.close
   #
-  def ungetbyte: (String | Integer arg0) -> NilClass
+  def ungetbyte: (String | Integer arg0) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -2323,7 +2323,7 @@ class IO < Object
   #     f.getc.ord      # => 1090
   #     f.close
   #
-  def ungetc: (String arg0) -> NilClass
+  def ungetc: (String arg0) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -2647,8 +2647,10 @@ class IO < Object
   #
   # Raises exceptions that IO.pipe and Kernel.spawn raise.
   #
-  def self.popen: (*untyped args) -> untyped
-
+  def self.popen: (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
+                | (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) -> instance
+                | [X] (string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
+                | [X] (Hash[string, string?] env, string cmd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?unsetenv_others: boolish, ?pgroup: true | Integer, ?umask: Integer, ?in: Kernel::redirect_fd, ?out: Kernel::redirect_fd, ?err: Kernel::redirect_fd, ?close_others: boolish, ?chdir: String) { (instance) -> X } -> X
   # <!--
   #   rdoc-file=io.c
   #   - IO.foreach(path, sep = $/, **opts) {|line| block }       -> nil
@@ -2740,8 +2742,8 @@ class IO < Object
   #
   # Returns an Enumerator if no block is given.
   #
-  def self.foreach: (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) { (String line) -> void } -> nil
-                  | (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) -> ::Enumerator[String, nil]
+  def self.foreach: (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) { (String line) -> void } -> nil
+                  | (string | _ToPath path, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> ::Enumerator[String, nil]
 
   # <!--
   #   rdoc-file=io.c
@@ -2821,8 +2823,8 @@ class IO < Object
   #     Sending message to parent
   #     Parent got: <Hi Dad>
   #
-  def self.pipe: (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) -> [IO, IO]
-               | [X] (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) { (IO read_io, IO write_io) -> X } -> X
+  def self.pipe: (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> [IO, IO]
+               | [X] (?String | Encoding ext_or_ext_int_enc, ?String | Encoding int_enc, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) { (IO read_io, IO write_io) -> X } -> X
 
   # <!--
   #   rdoc-file=io.c
@@ -2879,7 +2881,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> String
+  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2950,7 +2952,7 @@ class IO < Object
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   # *   [Line Options](rdoc-ref:IO@Line+Options).
   #
-  def self.readlines: (String | _ToPath name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode, ?chomp: boolish) -> ::Array[String]
+  def self.readlines: (String | _ToPath name, ?String sep, ?Integer limit, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode, ?chomp: boolish) -> ::Array[String]
 
   # <!--
   #   rdoc-file=io.c
@@ -3121,7 +3123,8 @@ class IO < Object
   #     IO.try_convert(ARGF)     # => #<IO:<STDIN>>
   #     IO.try_convert('STDOUT') # => nil
   #
-  def self.try_convert: (untyped arg0) -> IO?
+  def self.try_convert: (_ToIO obj) -> IO
+                      | (untyped obj) -> IO?
 
   # <!--
   #   rdoc-file=io.c
@@ -3182,7 +3185,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.write: (String name, _ToS arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: untyped textmode, ?binmode: untyped binmode, ?autoclose: untyped autoclose, ?mode: String mode) -> Integer
+  def self.write: (String name, _ToS arg0, ?Integer offset, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -3204,16 +3207,16 @@ class IO < Object
   # With a block given, calls the block with the IO object and returns the block's
   # value.
   #
-  def self.open: (int fd, ?string | int mode, ?path: string?, **untyped opts) -> instance
-               | [A] (int fd, ?string | int mode, ?path: string?, **untyped opts) { (instance) -> A } -> A
+  def self.open: (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) -> instance
+               | [X] (int fd, ?string | int mode, ?path: string?, ?external_encoding: String external_encoding, ?internal_encoding: String internal_encoding, ?encoding: String encoding, ?textmode: boolish textmode, ?binmode: boolish binmode, ?autoclose: boolish autoclose, ?mode: String mode) { (instance) -> X } -> X
 
-  def bytes: () { (Integer arg0) -> untyped } -> self
+  def bytes: () { (Integer arg0) -> void } -> self
            | () -> ::Enumerator[Integer, self]
 
-  def chars: () { (String arg0) -> untyped } -> self
+  def chars: () { (String arg0) -> void } -> self
            | () -> ::Enumerator[String, self]
 
-  def codepoints: () { (Integer arg0) -> untyped } -> self
+  def codepoints: () { (Integer arg0) -> void } -> self
                 | () -> ::Enumerator[Integer, self]
 
   # <!-- rdoc-file=io.c -->
@@ -3314,7 +3317,7 @@ class IO < Object
   #
   # IO#each is an alias for IO#each_line.
   #
-  def each_line: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
+  def each_line: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
                | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!-- rdoc-file=io.c -->
@@ -3352,7 +3355,7 @@ class IO < Object
   #
   def eof?: () -> bool
 
-  def lines: (?String sep, ?Integer limit) { (String arg0) -> untyped } -> self
+  def lines: (?String sep, ?Integer limit) { (String arg0) -> void } -> self
            | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
 
   # <!-- rdoc-file=io.c -->

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1314,22 +1314,6 @@ class IO < Object
   #
   def pid: () -> Integer
 
-  # <!-- rdoc-file=io.c -->
-  # Returns the current position (in bytes) in `self` (see
-  # [Position](rdoc-ref:IO@Position)):
-  #
-  #     f = File.open('t.txt')
-  #     f.tell # => 0
-  #     f.gets # => "First line\n"
-  #     f.tell # => 12
-  #     f.close
-  #
-  # Related: IO#pos=, IO#seek.
-  #
-  # IO#pos is an alias for IO#tell.
-  #
-  def pos: () -> Integer
-
   # <!--
   #   rdoc-file=io.c
   #   - pos = new_position -> new_position
@@ -2086,6 +2070,22 @@ class IO < Object
   #
   def tell: () -> Integer
 
+  # <!-- rdoc-file=io.c -->
+  # Returns the current position (in bytes) in `self` (see
+  # [Position](rdoc-ref:IO@Position)):
+  #
+  #     f = File.open('t.txt')
+  #     f.tell # => 0
+  #     f.gets # => "First line\n"
+  #     f.tell # => 12
+  #     f.close
+  #
+  # Related: IO#pos=, IO#seek.
+  #
+  # IO#pos is an alias for IO#tell.
+  #
+  alias pos tell
+
   # <!--
   #   rdoc-file=io.c
   #   - timeout -> duration or nil
@@ -2133,7 +2133,7 @@ class IO < Object
   #
   # IO#tty? is an alias for IO#isatty.
   #
-  def tty?: () -> bool
+  alias tty? isatty
 
   # <!--
   #   rdoc-file=io.c
@@ -3344,7 +3344,7 @@ class IO < Object
   #
   # IO#eof? is an alias for IO#eof.
   #
-  def eof?: () -> bool
+  alias eof? eof
 
   # <!-- rdoc-file=io.c -->
   # Returns the integer file descriptor for the stream:
@@ -3357,7 +3357,7 @@ class IO < Object
   #
   # IO#to_i is an alias for IO#fileno.
   #
-  def to_i: () -> Integer
+  alias to_i fileno
 end
 
 IO::APPEND: Integer


### PR DESCRIPTION
* Fill in `untyped` as appropriate
  * Many of them are simply `boolish` or `void`
  * Patching in `::popen` is my main motivation. Yes, it is ridiculous.
  * Copy-pasted kwargs for `#initialize` and `::open`
* Use `nil` rather than `NilClass`
* Delete nonexistent methods `#bytes`, `#chars`, `#codepoints` and `#lines`
* Actually make aliases `alias`es
* Fill in arg names for `arg0`