### PR TITLE
Generate gem specific sources in lockfile

### DIFF
--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -22,6 +22,9 @@ module RBS
         # A hash table to look up a spec from name of the gem
         attr_reader gem_hash: Hash[String, Bundler::LazySpecification]
 
+        # A hash table to look up a gem entry in collection config from the name of the gem
+        attr_reader gem_entries: Hash[String, gem_entry?]
+
         def self.generate: (config: Config, definition: Bundler::Definition, ?with_lockfile: boolish) -> Lockfile
 
         def initialize: (config: Config, definition: Bundler::Definition, with_lockfile: boolish) -> void
@@ -38,7 +41,7 @@ module RBS
         #
         # * If `skip:` is true, it skips adding the gem, but adds it's dependencies.
         #
-        def assign_gem: (name: String, version: String?, src_data: Sources::source_entry?, ignored_gems: Set[String], ?skip: bool) -> void
+        def assign_gem: (name: String, version: String?, ?skip: bool) -> void
 
         def assign_stdlib: (name: String, from_gem: String?) -> void
 


### PR DESCRIPTION
The gem specific sources are ignored when:

* The gem X is a dependency of another gem Y that is also listed in `gems` section prior to the gem

For example:

```yaml
gems:
  - name: X
  - name: Y
    source:
      type: git
      ...
```

1. `X` is added to the lockfile before `Y`
2. The `source` definition of `Y` is ignored because it's traversed as a dependency of `X`
3. `Y` is skipped from the `gems` section, because it's already added to the lockfile (without custom `source` section)

This PR fixes the problem by introducing `gem_entries` hash and referees the `ignore` and `source` attribute through it instead of passing it as method arguments.