### PR TITLE
Support type params for known signatures

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -395,7 +395,7 @@ module RBS
         unless decl
           decl = AST::Declarations::Class.new(
             name: to_type_name(only_name(mod)),
-            type_params: [],
+            type_params: type_params(mod),
             super_class: generate_super_class(mod),
             members: [],
             annotations: [],
@@ -449,7 +449,7 @@ module RBS
         unless decl
           decl = AST::Declarations::Module.new(
             name: to_type_name(only_name(mod)),
-            type_params: [],
+            type_params: type_params(mod),
             self_types: [],
             members: [],
             annotations: [],
@@ -504,7 +504,7 @@ module RBS
             if outer_module.is_a?(Class)
               outer_decl = AST::Declarations::Class.new(
                 name: to_type_name(outer_module_name),
-                type_params: [],
+                type_params: type_params(outer_module),
                 super_class: generate_super_class(outer_module),
                 members: [],
                 annotations: [],
@@ -514,7 +514,7 @@ module RBS
             else
               outer_decl = AST::Declarations::Module.new(
                 name: to_type_name(outer_module_name),
-                type_params: [],
+                type_params: type_params(outer_module),
                 self_types: [],
                 members: [],
                 annotations: [],
@@ -557,6 +557,15 @@ module RBS
       def type_args(type_name)
         if class_decl = env.class_decls[type_name.absolute!]
           class_decl.type_params.size.times.map { :untyped }
+        else
+          []
+        end
+      end
+
+      def type_params(mod)
+        type_name = to_type_name(const_name(mod), full_name: true)
+        if class_decl = env.class_decls[type_name.absolute!]
+          class_decl.type_params
         else
           []
         end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -474,4 +474,48 @@ end
       end
     end
   end
+
+  class TestTypeParams
+    class TestTypeParams
+    end
+  end
+
+  def test_type_params
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<~RBS
+        module RBS
+          class RuntimePrototypeTest < ::Test::Unit::TestCase
+            class TestTypeParams[unchecked out Elem]
+              class TestTypeParams
+              end
+            end
+          end
+        end
+      RBS
+
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestTypeParams"], env: env, merge: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class TestTypeParams[unchecked out Elem]
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TestTypeParams::TestTypeParams"], env: env, merge: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class TestTypeParams[unchecked out Elem]
+                class TestTypeParams
+                end
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
```shell
$ bundle exec rbs prototype runtime 'Array' | head -n 1
class Array

$ bundle exec rbs prototype runtime 'Hash' | head -n 1
class Hash
```

But, `class Array` and `class Hash` are RBS raising `RBS::GenericParameterMismatchError`.

I propose giving type_params if it is a known type.

```shell
$ bundle exec rbs prototype runtime 'Array' | head -n 1
class Array[unchecked out Elem]

$ bundle exec rbs prototype runtime 'Hash' | head -n 1
class Hash[unchecked out K, unchecked out V]
```

This is useful for code that extends a core class such as ActiveSupport.