### PR TITLE
Super class should be absolute paths.

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -380,7 +380,7 @@ module RBS
           RBS.logger.warn("Skipping anonymous superclass #{mod.superclass} of #{mod}")
           nil
         else
-          super_name = to_type_name(const_name(mod.superclass), full_name: true)
+          super_name = to_type_name(const_name(mod.superclass), full_name: true).absolute!
           super_args = type_args(super_name)
           AST::Declarations::Class::Super.new(name: super_name, args: super_args, location: nil)
         end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -47,7 +47,7 @@ class RBS::RuntimePrototypeTest < Test::Unit::TestCase
 
         assert_write p.decls, <<-EOF
 module RBS
-  class RuntimePrototypeTest < Test::Unit::TestCase
+  class RuntimePrototypeTest < ::Test::Unit::TestCase
     module TestTargets
       module Bar
       end
@@ -58,7 +58,7 @@ module RBS
         extend Comparable
       end
 
-      class Test < String
+      class Test < ::String
         include RBS::RuntimePrototypeTest::TestTargets::Foo
 
         extend RBS::RuntimePrototypeTest::TestTargets::Bar
@@ -91,7 +91,7 @@ end
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
 class RBS
-  class RuntimePrototypeTest < Test::Unit::TestCase
+  class RuntimePrototypeTest < ::Test::Unit::TestCase
     class TestTargets
       class Test
         def self.baz: () -> void
@@ -111,7 +111,7 @@ EOF
 
         assert_write p.decls, <<-EOF
 module RBS
-  class RuntimePrototypeTest < Test::Unit::TestCase
+  class RuntimePrototypeTest < ::Test::Unit::TestCase
     module TestTargets
       module Bar
       end
@@ -122,7 +122,7 @@ module RBS
         extend Comparable
       end
 
-      class Test < String
+      class Test < ::String
         include RBS::RuntimePrototypeTest::TestTargets::Foo
 
         extend RBS::RuntimePrototypeTest::TestTargets::Bar
@@ -172,9 +172,9 @@ end
 
         assert_write p.decls, <<-EOF
 module RBS
-  class RuntimePrototypeTest < Test::Unit::TestCase
+  class RuntimePrototypeTest < ::Test::Unit::TestCase
     module IncludeTests
-      class ChildClass < RBS::RuntimePrototypeTest::IncludeTests::SuperClass
+      class ChildClass < ::RBS::RuntimePrototypeTest::IncludeTests::SuperClass
         def self.foo: () -> untyped
 
         public
@@ -250,7 +250,7 @@ end
 
           assert_write p.decls, <<-EOF
 module RBS
-  class RuntimePrototypeTest < Test::Unit::TestCase
+  class RuntimePrototypeTest < ::Test::Unit::TestCase
     class TestForArgumentForwarding
       public
 
@@ -291,7 +291,7 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            class RuntimePrototypeTest < Test::Unit::TestCase
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
               module TestForOverrideModuleName
                 class C
                   include RBS::RuntimePrototypeTest::TestForOverrideModuleName::M
@@ -303,7 +303,7 @@ end
                   INSTANCE: C
                 end
 
-                class C2 < RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
+                class C2 < ::RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
                 end
 
                 module M
@@ -341,9 +341,9 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            class RuntimePrototypeTest < Test::Unit::TestCase
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
               module TestForTypeParameters
-                class C < Hash[untyped, untyped]
+                class C < ::Hash[untyped, untyped]
                 end
 
                 class C2
@@ -372,7 +372,7 @@ end
 
         assert_write p.decls, <<~RBS
           module RBS
-            class RuntimePrototypeTest < Test::Unit::TestCase
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
               class TestForInitialize
                 private
 
@@ -400,7 +400,7 @@ end
 
           assert_write p.decls, <<~RBS
             module RBS
-              class RuntimePrototypeTest < Test::Unit::TestCase
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
                 class TestForYield
                   public
 


### PR DESCRIPTION
## Problem

The signature generated by the `rbs prototype runtime` for the `ActiveSupport::Logger` as follows is unreadable due to an error.
`Detected recursive ancestors: ::ActiveSupport::Logger < ::ActiveSupport::Logger (RBS::RecursiveAncestorError)`

```rbs
$ bundle exec rbs prototype runtime -r active_support/all ActiveSupport::Logger
module ActiveSupport
  class Logger < Logger
...snip...
```

In the actual Rails code, super class are specified by absolute paths, as shown below.

https://github.com/rails/rails/blob/2942958827f1934dfcba284d074e6d61104d3e7c/activesupport/lib/active_support/logger.rb#L7-L8

## Proposal

I propose to solve this problem by specifying the superclass as an absolute path even in the `rbs prototype runtime`.
There may be other similar problems, but I have limited the impact to specifying the superclass only.

```rbs
$ bundle exec rbs prototype runtime -r active_support/all ActiveSupport::Logger
module ActiveSupport
  class Logger < ::Logger
...snip...
```