### PR TITLE
prototype rb: Fix a crash by "include foo"

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -461,7 +461,7 @@ module RBS
           when :SELF
             context.namespace.to_type_name
           when :CONST, :COLON2, :COLON3
-            const_to_name!(node)
+            const_to_name!(node) rescue nil
           end
         end
       end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -1035,6 +1035,21 @@ end
     end
   end
 
+  def test_const_to_name
+    parser = RBS::Prototype::RB.new
+    [
+      ["self", TypeName("::Foo")],
+      ["Bar", TypeName("Bar")],
+      ["::Bar", TypeName("::Bar")],
+      ["Bar::Baz", TypeName("Bar::Baz")],
+      ["obj::Baz", nil],
+    ].each do |rb, name|
+      node = RubyVM::AbstractSyntaxTree.parse("_ = #{rb}").children[2]
+      context = RBS::Prototype::RB::Context.initial(namespace: RBS::Namespace.new(path: [:Foo], absolute: true))
+      assert_equal name, parser.const_to_name(node.children[1], context: context)
+    end
+  end
+
   if RUBY_VERSION >= '2.7'
     def test_argument_forwarding
       parser = RB.new


### PR DESCRIPTION
RBS::Prototype::RB#const_to_name() raises an exeception if non-constant reference given.  So it will cause a crash when the parser tries to parse the non-constant argument for the include statement.

Close #1416