### PR TITLE
Avoid to generate anonymous or internal module

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -541,7 +541,17 @@ module RBS
 
       def const_name(const)
         @module_name_method ||= Module.instance_method(:name)
-        @module_name_method.bind(const).call
+        name = @module_name_method.bind(const).call
+        return nil unless name
+
+        begin
+          Object.const_get(name)
+        rescue NameError
+          # Should generate const name if anonymous or internal module (e.g. NameError::message)
+          nil
+        else
+          name
+        end
       end
 
       def type_args(type_name)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -460,4 +460,18 @@ end
       end
     end
   end
+
+  def test_nameerror_message
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["NameError*"], env: env, merge: true)
+
+        writer = RBS::Writer.new(out: StringIO.new)
+        writer.write(p.decls)
+        RBS::Parser.parse_signature(writer.out.string) # check syntax
+
+        assert !writer.out.string.include?("class message")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Anonymous or internal modules cannot have their names defined as RBS, so they cannot be used even if they get a name. These should be treated as if the name could not be obtained.

## Before

```rbs
$ rbs prototype runtime "NameError*"
class NameError < StandardError
  include DidYouMean::Correctable

  include ErrorHighlight::CoreExt

  public

  def local_variables: () -> untyped

  def name: () -> untyped

  def receiver: () -> untyped

  private

  def initialize: (*untyped) -> void

  class message   #=> Syntax error: expected one of class/module/constant name, token=`message` (tLIDENT)
    def self._load: (untyped) -> untyped

    public

    def ==: (untyped) -> untyped

    def _dump: (untyped) -> untyped

    def to_str: () -> untyped

    private

    def initialize_copy: (untyped) -> untyped
  end
end
```

## After

```rbs
$ bundle exec rbs prototype runtime "NameError*"
class NameError < StandardError
  include DidYouMean::Correctable

  include ErrorHighlight::CoreExt

  public

  def local_variables: () -> untyped

  def name: () -> untyped

  def receiver: () -> untyped

  private

  def initialize: (*untyped) -> void
end
```