### PR TITLE
Allow `Logger.new` receive `nil`

### DIFF
--- a/stdlib/logger/0/logger.rbs
+++ b/stdlib/logger/0/logger.rbs
@@ -796,7 +796,7 @@ class Logger
   #     periodic log file rotation; default is `'%Y%m%d'`. See [Periodic
   #     Rotation](rdoc-ref:Logger@Periodic+Rotation).
   #
-  def initialize: (logdev logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: boolish, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer | String | Symbol) -> void
+  def initialize: (logdev? logdev, ?Numeric | String shift_age, ?Integer shift_size, ?shift_period_suffix: String, ?binmode: boolish, ?datetime_format: String, ?formatter: _Formatter, ?progname: String, ?level: Integer | String | Symbol) -> void
 end
 
 Logger::ProgName: String

--- a/test/stdlib/Logger_test.rb
+++ b/test/stdlib/Logger_test.rb
@@ -10,6 +10,8 @@ class LoggerSingletonTest < Test::Unit::TestCase
   testing "singleton(::Logger)"
 
   def test_new
+    assert_send_type  "(nil) -> Logger",
+                      Logger, :new, nil
     assert_send_type  "(String logdev) -> void",
                       Logger, :new, '/dev/null'
     assert_send_type  "(StringIO logdev) -> void",


### PR DESCRIPTION
https://ruby-doc.org/3.2.2/stdlibs/logger/Logger.html#method-c-new

> * `nil` or `File::NULL`: no entries are to be written.