### PR TITLE
Added support for Thread#raise

### DIFF
--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -972,6 +972,30 @@ class Thread < Object
   def self.handle_interrupt: (untyped hash) -> untyped
 
   # <!--
+  # rdoc-file=thread.c
+  #    thr.raise
+  #    thr.raise(string)
+  #    thr.raise(exception [, string [, array]])
+  # -->
+  # Raises an exception from the given thread. The caller does not have to be
+  # +thr+. See Kernel#raise for more information.
+  #
+  #    Thread.abort_on_exception = true
+  #    a = Thread.new { sleep(200) }
+  #    a.raise("Gotcha")
+  #
+  # This will produce:
+  #
+  #    prog.rb:3: Gotcha (RuntimeError)
+  #     from prog.rb:2:in `initialize'
+  #     from prog.rb:2:in `new'
+  #     from prog.rb:2
+  #
+  def self?.raise: () -> bot
+                 | (String message, ?cause: Exception?) -> bot
+                 | (_Exception exception, ?untyped message, ?::Array[String] backtrace, ?cause: Exception?) -> bot
+
+  # <!--
   #   rdoc-file=thread.c
   #   - Thread.kill(thread)   -> thread
   # -->

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -972,24 +972,24 @@ class Thread < Object
   def self.handle_interrupt: (untyped hash) -> untyped
 
   # <!--
-  # rdoc-file=thread.c
-  #    thr.raise
-  #    thr.raise(string)
-  #    thr.raise(exception [, string [, array]])
+  #   rdoc-file=thread.c
+  #   - thr.raise
+  #   - thr.raise(string)
+  #   - thr.raise(exception [, string [, array]])
   # -->
   # Raises an exception from the given thread. The caller does not have to be
-  # +thr+. See Kernel#raise for more information.
+  # `thr`. See Kernel#raise for more information.
   #
-  #    Thread.abort_on_exception = true
-  #    a = Thread.new { sleep(200) }
-  #    a.raise("Gotcha")
+  #     Thread.abort_on_exception = true
+  #     a = Thread.new { sleep(200) }
+  #     a.raise("Gotcha")
   #
   # This will produce:
   #
-  #    prog.rb:3: Gotcha (RuntimeError)
-  #     from prog.rb:2:in `initialize'
-  #     from prog.rb:2:in `new'
-  #     from prog.rb:2
+  #     prog.rb:3: Gotcha (RuntimeError)
+  #      from prog.rb:2:in `initialize'
+  #      from prog.rb:2:in `new'
+  #      from prog.rb:2
   #
   def self?.raise: () -> bot
                  | (String message, ?cause: Exception?) -> bot


### PR DESCRIPTION
This adds support for `Thread#raise`, which essentially calls `Kernel#raise` in the thread. As such, the signature's been copied from the Kernel's