### PR TITLE
Make $DEBUG and $-d boolish

### DIFF
--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -45,7 +45,7 @@ $-a: bool
 # backtrace).  Setting this to a true value enables debug output as
 # if <tt>-d</tt> were given on the command line.  Setting this to a false
 # value disables debug output.
-$-d: bool
+$-d: boolish
 
 # In in-place-edit mode, this variable holds the extension, otherwise +nil+.
 $-i: String?
@@ -134,7 +134,7 @@ $@: Array[String] | nil
 # backtrace).  Setting this to a true value enables debug output as
 # if <tt>-d</tt> were given on the command line.  Setting this to a false
 # value disables debug output. Aliased to $-d.
-$DEBUG: bool
+$DEBUG: boolish
 
 # Current input filename from ARGF. Same as ARGF.filename.
 $FILENAME: String

--- a/schema/decls.json
+++ b/schema/decls.json
@@ -60,7 +60,7 @@
       "required": ["declaration", "name", "type", "comment", "location"]
     },
     "global": {
-      "title": "Global declaration: `$DEBUG: bool`, ...",
+      "title": "Global declaration: `$DEBUG: boolish`, ...",
       "type": "object",
       "properties": {
         "declaration": {


### PR DESCRIPTION
Unlike `$VERBOSE`, the variable `$DEBUG` (and `$-d`) can have any value assigned to them. While most users will simply assign `true` or `false`, I've assigned `Integer`s to it, to support more fine-grained debugging. For example:

Here's a contrived example:
```ruby
# In this program, `$DEBUG` is either set to `false` or a positive integer.
def send_post(url, params, body)
  $logger.debug("Sending a post request to #{url}") if $DEBUG

  if 1 <= $DEBUG
    $loger.debug("Detailed info: [url: #{url}, params: [#{params}], body: [#{body}]")
  end

  response = _send_request(url, params, body)
  $logger.debug("got raw response: #{response.inspect}") if $DEBUG && 2 <= $DEBUG 
  $logger.debug("got raw body: #{response.body}") if $DEBUG

rescue => err
  if $DEBUG
    $logger.warning("Unable to send request: #{err}")
  end

  raise
end
```

I decided on using `boolish` instead of `untyped`, as they're identical and most people use `$DEBUG` for booleans.