### PR TITLE
Convert `| nil` to `?` in global_variables.rbs

### DIFF
--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -1,5 +1,5 @@
 # The Exception object set by Kernel#raise.
-$!: Exception | nil
+$!: Exception?
 
 # The array contains the module names loaded by require.
 $": Array[String]
@@ -8,22 +8,22 @@ $": Array[String]
 $$: Integer
 
 # The string matched by the last successful match.
-$&: String | nil
+$&: String?
 
 # The string to the right of the last successful match.
-$': String | nil
+$': String?
 
 # The same as ARGV.
 $*: Array[String]
 
 # The highest group matched by the last successful match.
-$+: String | nil
+$+: String?
 
 # The output field separator for Kernel#print and Array#join. Non-nil $, will be deprecated.
-$,: String | nil
+$,: String?
 
 # The input record separator, newline by default.
-$-0: String | nil
+$-0: String?
 
 # The default separator for String#split. Non-nil $; will be deprecated.
 $-F: Regexp | String | nil
@@ -45,7 +45,7 @@ $-a: bool
 # backtrace).  Setting this to a true value enables debug output as
 # if <tt>-d</tt> were given on the command line.  Setting this to a false
 # value disables debug output.
-$-d: bool
+$-d: boolish
 
 # In in-place-edit mode, this variable holds the extension, otherwise +nil+.
 $-i: String?
@@ -60,49 +60,49 @@ $-p: bool
 # Setting this to a true value enables warnings as if <tt>-w</tt> or <tt>-v</tt> were given
 # on the command line.  Setting this to +nil+ disables warnings,
 # including from Kernel#warn.
-$-v: bool | nil
+$-v: bool?
 
 # The verbose flag, which is set by the <tt>-w</tt> or <tt>-v</tt> switch.
 # Setting this to a true value enables warnings as if <tt>-w</tt> or <tt>-v</tt> were given
 # on the command line.  Setting this to +nil+ disables warnings,
 # including from Kernel#warn.
-$-w: bool | nil
+$-w: bool?
 
 # The current input line number of the last file that was read.
 $.: Integer
 
 # The input record separator, newline by default. Aliased to $-0.
-$/: String | nil
+$/: String?
 
 # Contains the name of the script being executed. May be assignable.
 $0: String
 
 # The Nth group of the last successful match. May be > 1.
-$1: String | nil
+$1: String?
 
 # The Nth group of the last successful match. May be > 1.
-$2: String | nil
+$2: String?
 
 # The Nth group of the last successful match. May be > 1.
-$3: String | nil
+$3: String?
 
 # The Nth group of the last successful match. May be > 1.
-$4: String | nil
+$4: String?
 
 # The Nth group of the last successful match. May be > 1.
-$5: String | nil
+$5: String?
 
 # The Nth group of the last successful match. May be > 1.
-$6: String | nil
+$6: String?
 
 # The Nth group of the last successful match. May be > 1.
-$7: String | nil
+$7: String?
 
 # The Nth group of the last successful match. May be > 1.
-$8: String | nil
+$8: String?
 
 # The Nth group of the last successful match. May be > 1.
-$9: String | nil
+$9: String?
 
 # Load path for searching Ruby scripts and extension libraries used
 # by Kernel#load and Kernel#require.
@@ -124,17 +124,17 @@ $=: bool
 $>: IO
 
 # The status of the last executed child process (thread-local).
-$?: Process::Status | nil
+$?: Process::Status?
 
 # The same as <code>$!.backtrace</code>.
-$@: Array[String] | nil
+$@: Array[String]?
 
 # The debug flag, which is set by the <tt>-d</tt> switch.  Enabling debug
 # output prints each exception raised to $stderr (but not its
 # backtrace).  Setting this to a true value enables debug output as
 # if <tt>-d</tt> were given on the command line.  Setting this to a false
 # value disables debug output. Aliased to $-d.
-$DEBUG: bool
+$DEBUG: boolish
 
 # Current input filename from ARGF. Same as ARGF.filename.
 $FILENAME: String
@@ -160,16 +160,16 @@ $PROGRAM_NAME: String
 # Setting this to a true value enables warnings as if <tt>-w</tt> or <tt>-v</tt> were given
 # on the command line.  Setting this to +nil+ disables warnings,
 # including from Kernel#warn. Aliased to $-v and $-w.
-$VERBOSE: bool | nil
+$VERBOSE: bool?
 
 # The output record separator for Kernel#print and IO#write. Default is +nil+.
-$\: String | nil
+$\: String?
 
 # The last input line of string by gets or readline.
-$_: String | nil
+$_: String?
 
 # The string to the left of the last successful match.
-$`: String | nil
+$`: String?
 
 # The current standard error output.
 $stderr: IO
@@ -181,4 +181,4 @@ $stdin: IO
 $stdout: IO
 
 # The information about the last match in the current scope (thread-local and frame-local).
-$~: MatchData | nil
+$~: MatchData?


### PR DESCRIPTION
Nearly all of the old-style `| nil` annotations have been replaced with `?`. Only `$-F` and `$;` have been left as-is, as they're `Regex | String | nil`.