### PR TITLE
Remove TRUE, FALSE, and NIL constants

### DIFF
--- a/core/constants.rbs
+++ b/core/constants.rbs
@@ -29,10 +29,6 @@
 #
 ::DATA: File
 
-::FALSE: FalseClass
-
-::NIL: NilClass
-
 # <!-- rdoc-file=version.c -->
 # The copyright string for ruby
 #
@@ -98,5 +94,3 @@
 # The Binding of the top level scope
 #
 ::TOPLEVEL_BINDING: Binding
-
-::TRUE: TrueClass


### PR DESCRIPTION
These constants were removed in Ruby 3.0; Ruby 2.7 is now 4 months EOL, and nobody was using these constants in 2.7 anyways.