### PR TITLE
Corrected Kernel#Array's signature

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -403,13 +403,11 @@ module Kernel : BasicObject
   #
   #     Array(:foo)             # => [:foo]
   #
-  def self?.Array: (NilClass x) -> [ ]
-                 | [T] (::Array[T] x) -> ::Array[T]
-                 | [T] (::Range[T] x) -> ::Array[T]
-                 | [T] (_Each[T] x) -> ::Array[T]
-                 | [K, V] (::Hash[K, V] x) -> ::Array[[ K, V ]]
-                 | [T] (T x) -> ::Array[T]
-
+  def self?.Array: (nil) -> [ ]
+                 | [T] (Array[T] x) -> Array[T]
+                 | [T] (_ToAry[T] x) -> Array[T]
+                 | [T] (_ToA[T] x) -> Array[T]
+                 | [T] (T x) -> Array[T]
   # <!--
   #   rdoc-file=complex.c
   #   - Complex(x[, y], exception: true)  ->  numeric or nil


### PR DESCRIPTION
This updates `Kernel#Array` to the correct signature.

The `Array()` function works as follows:
1. If the argument is an array, it's returned immediately
2. If the argument defines `to_ary`, then the return value of that is returned
3. If the argument defines `to_a`, then the return value of that is returned.
4. Otherwise, the argument is boxed up in an array and returned.