### PR TITLE
Corrected Kernel#Complex's signature

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -446,7 +446,11 @@ module Kernel : BasicObject
   #
   # See String#to_c.
   #
-  def self?.Complex: (Numeric | String x, ?Numeric | String y, ?exception: bool exception) -> Complex
+  def self?.Complex: (_ToC x, exception: false) -> Complex?
+                   | (_ToC x, ?exception: bool) -> Complex
+                   | (Numeric | String real, ?Numeric | String imag, exception: false) -> Complex?
+                   | (Numeric | String real, ?Numeric | String imag, ?exception: bool) -> Complex
+                   | (untyped, ?untyped, exception: false) -> nil
 
   # <!--
   #   rdoc-file=kernel.rb


### PR DESCRIPTION
This updates `Kernel#Complex`'s signature.

In particular, if the first argument defines `.to_c`, and no second argument is supplied, it calls and returns that. (In the case where `exception: false` is given, _all_ exceptions (even `Exception` itself) that would be thrown by `.to_c` are swallowed, and `nil` is returned.)

Two additional variants, for when `exception: false` is explicitly given, were added. In these cases, the return value is `Complex?`.