### PR TITLE
Updated the signature for Kernel#Float

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -464,7 +464,9 @@ module Kernel : BasicObject
   #     Float(nil)               #=> TypeError: can't convert nil into Float
   #     Float("123.0_badstring", exception: false)  #=> nil
   #
-  def self?.Float: (Numeric | String x, ?exception: bool exception) -> Float
+  def self?.Float: (_ToF arg, exception: false) -> Float?
+                 | (_ToF arg, ?exception: bool) -> Float
+                 | (untyped, exception: false) -> nil
 
   # <!--
   #   rdoc-file=object.c


### PR DESCRIPTION
This updates the signature for `Kernel#Float`.

The way the code checks for `Float` is pretty interesting:
- If it's an `Integer`, `Float`, or `Rational`, then it's immediately converted to a float and returned.
- If it's a `String`, then it calls `rb_str_to_dbl()`, passing along whether an exception should occur
- Otherwise, the `.to_f` method is called on the argument.

Note that if `exception: false` is given, the return value may be `nil`. In addition, when `exception: false` is supplied, _any_ type can be given for the first argument, but the return value is always `nil`.
