### PR TITLE
Updated Kernel#Hash

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -488,7 +488,7 @@ module Kernel : BasicObject
   #     Hash(nil)              # => {}
   #     Hash([])               # => {}
   #
-  def self?.Hash: [K, V] (Object x) -> ::Hash[K, V]
+  def self?.Hash: [K, V] (nil | [] | _ToHash[K, V])  -> Hash[K, V]
 
   # <!--
   #   rdoc-file=object.c


### PR DESCRIPTION
This updates `Kernel#Hash`'s signature.

This is probably the second-simplest of the kernel conversion methods, after `Kernel#String`: 
- If the argument is `nil` or an empty array, an empty hash is returned.
- Otherwise, `.to_hash` is called on the object.

I was debating on whether I should make a separate `(nil | []) -> {}` case, but I decided against it. (Using `[]` / `{}` literals in practice is pretty difficult, as it's a `Hash[bot, bot]`.)