### PR TITLE
Updated Kernel#Integer

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -574,9 +574,11 @@ module Kernel : BasicObject
   # With `exception` given as `false`, an exception of any kind is suppressed and
   # `nil` is returned.
   #
-  def self?.Integer: (Numeric | String arg, ?exception: bool exception) -> Integer
-                   | (String arg, ?Integer base, ?exception: bool exception) -> Integer
-
+  def self?.Integer: (string | int | _ToI arg, exception: false) -> Integer?
+                   | (string | int | _ToI arg, ?exception: bool) -> Integer
+                   | (string str, int base, exception: false) -> Integer?
+                   | (string str, int base, ?exception: bool) -> Integer
+                   | (untyped, ?untyped, exception: false) -> nil
   # <!--
   #   rdoc-file=rational.c
   #   - Rational(x, y, exception: true)  ->  rational or nil


### PR DESCRIPTION
This updates `Kernel#Integer` to be more correct.

Notably, in the one-argument form, the first argument needs to either define `to_int`, `to_i`, or `to_str` to be convertible. Additionally, int he two-argument form, the first argument just needs to define `to_str`, and the second `to_int`.

Like the other conversion `fuctions,` if `exception: false` is explicitly given, the return value is an `Integer?`. Additionally, `(untyped, ?untyped, exception: false) -> nil` was added, as any types are accepted when `exception: false` is supplied.

One thing to note, however, is that this definition isn't technically complete: The one-argument form can technically take a second argument. However, this argument needs to either:
1. Define `to_int`, which when called returns `0`, or
2. _Not define `to_int`_!

(For example, `Integer 123, :a` is valid.) Neither of these things is really possible to do in RBS, and attempting to force it in wouldn't work well, so I've leftit out.