### PR TITLE
Updated Kernel#Rational

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -622,7 +622,6 @@ module Kernel : BasicObject
   interface _RationalDiv[T]
     def /: (Numeric) -> T
   end
-  #: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
 
   # <!--
   #   rdoc-file=object.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -614,7 +614,15 @@ module Kernel : BasicObject
   #
   # See also String#to_r.
   #
-  def self?.Rational: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
+  def self?.Rational: (_ToInt | _ToR numer, ?_ToInt | _ToR denom, exception: false) -> Rational?
+                    | (_ToInt | _ToR numer, ?_ToInt | _ToR denom, ?exception: bool) -> Rational
+                    | [T] (Numeric&_RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
+                    | [T < Numeric] (T value, 1, ?exception: bool) -> T
+                    | (untyped, ?untyped, exception: false) -> nil
+  interface _RationalDiv[T]
+    def /: (Numeric) -> T
+  end
+  #: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
 
   # <!--
   #   rdoc-file=object.c


### PR DESCRIPTION
Updated `Kernel#Rational` to be more accurate.

Phew, this one is a mess. In "normal operation," the signature would look like this:

```rbs
type num = Complex|Float|int|_ToR|String
def self?.Rational: (num numer, num denom, exception: false) -> Rational?
                  | (num numer, num denom, ?exception: bool) -> Rational
```

However, `Kernel#Rational` _also_ tries to be a "division operator" for some reason: If the first argument is `Numeric`, but defines neither `to_int` nor `to_i` nor even `to_r`, `Kernel#Rational` will return `arg1 / arg2`. That is, it'll actually call the `/` operator on the first argument, with the second.

But it gets worse. If the second argument is exactly `1`, then `/` won't even be called. 

In neither case does `exception: false` actually work—unlike the other conversion methods, exceptions are _not_ caught when `Kernel#Rational` is trying to act like a division operator.
