### PR TITLE
Updated Kernel#srand

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -358,7 +358,7 @@ module Kernel : BasicObject
   #     srand 1234               # => 1234
   #     [ rand, rand ]           # => [0.1915194503788923, 0.6221087710398319]
   #
-  def self?.srand: (?Numeric number) -> Numeric
+  def self?.srand: (?int number) -> Integer
 
   # <!--
   #   rdoc-file=process.c


### PR DESCRIPTION
Updated `Kernel#srand` to be more correct.

Technically its first argument must respond to `to_int`, not be `Numeric`. (`srand Class.new(Numeric)` fails.) It also always returns an `Integer`.