### PR TITLE
Updated Kernel#fork

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -383,7 +383,7 @@ module Kernel : BasicObject
   # 4. Therefore you should use spawn() instead of fork().
   #
   def self?.fork: () -> Integer?
-                | () { () -> untyped } -> Integer?
+                | () { () -> void } -> Integer
 
   def initialize_copy: (self object) -> self
 


### PR DESCRIPTION
Minor update to `fork`: In the block form, `fork` always returns an `Integer` for the process id. The return value of the block is also unused