### PR TITLE
Updated Kernel write methods

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -54,6 +54,10 @@ interface _ToPath
   def to_path: () -> String
 end
 
+interface _Inspect
+  def inspect: () -> String
+end
+
 interface _Each[out A]
   def each: () { (A) -> void } -> void
 end

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1137,7 +1137,7 @@ module Kernel : BasicObject
   #     gets  # Sets $_ to the most recent user input.
   #     print # Prints $_.
   #
-  def self?.print: (*Kernel args) -> nil
+  def self?.print: (*_ToS args) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1171,9 +1171,9 @@ module Kernel : BasicObject
   #
   # With no arguments, does nothing.
   #
-  def self?.printf: (IO arg0, String arg1, *untyped args) -> nil
-                  | (String arg1, *untyped args) -> nil
-                  | () -> nil
+  def self?.printf: () -> nil
+                  | (String fmt, *untyped args) -> nil
+                  | (_Writer io, string fmt, *untyped args) -> nil
 
   # <!--
   #   rdoc-file=proc.c
@@ -1202,8 +1202,8 @@ module Kernel : BasicObject
   #
   # See IO#putc for important information regarding multi-byte characters.
   #
-  def self?.putc: (Integer arg0) -> Integer
-                | (String arg0) -> String
+  def self?.putc: [T < _ToInt] (T chr) -> T
+                | (String chr) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -1213,7 +1213,7 @@ module Kernel : BasicObject
   #
   #     $stdout.puts(objects)
   #
-  def self?.puts: (*untyped arg0) -> NilClass
+  def self?.puts: (*_ToS objects) -> nil
 
   # <!--
   #   rdoc-file=io.c
@@ -1240,8 +1240,8 @@ module Kernel : BasicObject
   #     0..4
   #     [0..4, 0..4, 0..4]
   #
-  def self?.p: [T] (T arg0) -> T
-             | (untyped, untyped, *untyped) -> Array[untyped]
+  def self?.p: [T < _Inspect] (T arg0) -> T
+             | (_Inspect arg0, _Inspect arg1, *_Inspect rest) -> Array[_Inspect]
              | () -> nil
 
   # <!--
@@ -1697,7 +1697,7 @@ module Kernel : BasicObject
   # :experimental
   # :   Used for experimental features that may change in future releases.
   #
-  def self?.warn: (*untyped msg, ?uplevel: Integer | nil, ?category: :deprecated | :experimental | nil) -> NilClass
+  def self?.warn: (*_ToS msg, ?uplevel: int?, ?category: Warning::category?) -> nil
 
   # <!--
   #   rdoc-file=process.c

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -223,7 +223,7 @@ class Object < BasicObject
   #
   #     1cat[4, 5, 6]
   #
-  def display: (?_Writeable port) -> void
+  def display: (?_Writer port) -> void
 
   # <!--
   #   rdoc-file=object.c
@@ -1072,10 +1072,6 @@ class Object < BasicObject
   #     2.yield_self.detect(&:odd?)            # => nil
   #
   alias then yield_self
-end
-
-interface _Writeable
-  def write: (untyped) -> void
 end
 
 type Object::name = Symbol | string

--- a/core/warning.rbs
+++ b/core/warning.rbs
@@ -29,6 +29,8 @@
 # The `warning` gem provides convenient ways to customize Warning.warn.
 #
 module Warning
+  type category = :deprecated | :experimental
+
   # <!--
   #   rdoc-file=error.c
   #   - warn(msg, category: nil)  -> nil
@@ -38,5 +40,5 @@ module Warning
   #
   # See the documentation of the Warning module for how to customize this.
   #
-  def self?.warn: (String message, ?category: :deprecated | :experimental | nil) -> nil
+  def self?.warn: (String message, ?category: category?) -> nil
 end

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -492,8 +492,10 @@ class KernelTest < StdlibTest
   end
 
   def test_print
+    print
     print 1
     print 'a', 2
+    print ToS.new
   end
 
   def test_printf
@@ -501,11 +503,13 @@ class KernelTest < StdlibTest
       printf io, 'a'
       printf io, '%d', 2
     end
-    # TODO
-    #   printf 's'
-    #   printf '%d', 2
-    #   printf '%d%s', 2, 1
-    #   printf
+
+    printf
+    printf "123"
+    printf "%s%d%f", "A", 2, 3.0
+
+    def (writer = Object.new).write(*) end
+    printf writer, ToStr.new("%s%d"), '1', 2
   end
 
   def test_proc
@@ -519,16 +523,32 @@ class KernelTest < StdlibTest
   def test_putc
     putc 1
     putc 'a'
+    putc ToInt.new
   end
 
   def test_puts
-    puts 1
-    puts Object.new
+    puts
+    puts 1, nil, false, "yes!", ToS.new
   end
 
   def test_p
+    p
     p 1
     p 'a', 2
+
+    def (obj = BasicObject.new).inspect
+      "foo"
+    end
+
+    p obj
+  end
+
+  def test_pp
+    pp
+    pp 1
+    pp 'a', 2 
+
+    pp Object.new
   end
 
   def test_rand
@@ -590,10 +610,13 @@ class KernelTest < StdlibTest
     warn 'foo'
     warn 'foo', 'bar'
     warn 'foo', uplevel: 1
+    warn ToS.new, uplevel: ToInt.new
+    warn ToS.new, uplevel: nil
 
     omit_if(RUBY_VERSION < "3.0")
 
     warn 'foo', uplevel: 1, category: :deprecated
+    warn 'foo', uplevel: 1, category: nil
   end
 
   def test_exec


### PR DESCRIPTION
This updates the signatures for all of the `Kernel` output methods (`print`, `printf`, `putc`, `puts`, `p`, and `warn`—`pp` was fine as-is), and `Object#display`.

Additionally, a `Warnings::category` type alias was added.