### PR TITLE
Updated control flow type definitions

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -383,7 +383,7 @@ module Kernel : BasicObject
   # 4. Therefore you should use spawn() instead of fork().
   #
   def self?.fork: () -> Integer?
-                | () { () -> untyped } -> Integer?
+                | () { () -> void } -> Integer
 
   def initialize_copy: (self object) -> self
 
@@ -691,7 +691,7 @@ module Kernel : BasicObject
   # Terminate execution immediately, effectively by calling `Kernel.exit(false)`.
   # If *msg* is given, it is written to STDERR prior to terminating.
   #
-  def self?.abort: (?String msg) -> bot
+  def self?.abort: (?string msg) -> bot
 
   # <!--
   #   rdoc-file=eval_jump.c
@@ -712,7 +712,7 @@ module Kernel : BasicObject
   #
   #     goodbye cruel world
   #
-  def self?.at_exit: () { () -> untyped } -> Proc
+  def self?.at_exit: () { () -> void } -> Proc
 
   # <!--
   #   rdoc-file=load.c
@@ -795,8 +795,7 @@ module Kernel : BasicObject
   #     at_exit function
   #     in finalizer
   #
-  def self?.exit: () -> bot
-                | (?Integer | TrueClass | FalseClass status) -> bot
+  def self?.exit: (?int | bool status) -> bot
 
   # <!--
   #   rdoc-file=process.c
@@ -807,7 +806,7 @@ module Kernel : BasicObject
   #
   #     Process.exit!(true)
   #
-  def self?.exit!: (?Integer | TrueClass | FalseClass status) -> bot
+  def self?.exit!: (?int | bool status) -> bot
 
   # <!-- rdoc-file=eval.c -->
   # With no arguments, raises the exception in `$!` or raises a RuntimeError if
@@ -828,8 +827,8 @@ module Kernel : BasicObject
   #     raise ArgumentError, "No parameters", caller
   #
   def self?.fail: () -> bot
-                | (String message, ?cause: Exception?) -> bot
-                | (_Exception exception, ?untyped message, ?::Array[String] backtrace, ?cause: Exception?) -> bot
+                | (string message, ?cause: Exception?) -> bot
+                | (_Exception exception, ?_ToS? message, ?nil | String | Array[String] backtrace, ?cause: Exception?) -> bot
 
   # <!--
   #   rdoc-file=eval.c
@@ -988,7 +987,7 @@ module Kernel : BasicObject
   #       puts enum.next
   #     } #=> :ok
   #
-  def self?.loop: () { (nil) -> untyped } -> bot
+  def self?.loop: () { () -> void } -> bot
                 | () -> ::Enumerator[nil, bot]
 
   # <!--
@@ -1550,7 +1549,7 @@ module Kernel : BasicObject
   #     sleep 1.9   #=> 2
   #     Time.new    #=> 2008-03-08 19:56:22 +0900
   #
-  def self?.sleep: () -> bot
+  def self?.sleep: (?nil) -> bot
                  | ((Integer | Float | _Divmod) duration) -> Integer
 
   interface _Divmod
@@ -1650,7 +1649,7 @@ module Kernel : BasicObject
   # optional second parameter supplies a return value for the `catch` block, which
   # otherwise defaults to `nil`. For examples, see Kernel::catch.
   #
-  def self?.throw: (Object tag, ?untyped obj) -> bot
+  def self?.throw: (untyped tag, ?untyped obj) -> bot
 
   # <!--
   #   rdoc-file=warning.rb

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -356,6 +356,11 @@ class KernelTest < StdlibTest
       abort 'foo'
     rescue SystemExit
     end
+
+    begin
+      abort ToStr.new
+    rescue SystemExit
+    end
   end
 
   def test_at_exit
@@ -388,6 +393,11 @@ class KernelTest < StdlibTest
     end
 
     begin
+      exit ToInt.new
+    rescue SystemExit
+    end
+
+    begin
       exit true
     rescue SystemExit
     end
@@ -413,6 +423,16 @@ class KernelTest < StdlibTest
     rescue RuntimeError
     end
 
+    begin
+      fail 'error', cause: nil
+    rescue RuntimeError
+    end
+
+    begin
+      fail 'error', cause: RuntimeError.new("oops!")
+    rescue RuntimeError
+    end
+
     test_error = Class.new(StandardError)
     begin
       fail test_error
@@ -425,7 +445,27 @@ class KernelTest < StdlibTest
     end
 
     begin
-      fail test_error, 'a', ['1.rb, 2.rb']
+      fail test_error, ToS.new, ['1.rb, 2.rb']
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'b', '1.rb'
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'b', nil
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'b', cause: RuntimeError.new("?")
+    rescue test_error
+    end
+
+    begin
+      fail test_error, 'b', cause: nil
     rescue test_error
     end
 
@@ -568,6 +608,9 @@ class KernelTest < StdlibTest
       [0.001, 0.001]
     end
     sleep o
+
+    omit_if(RUBY_VERSION < "3.3.0")
+    sleep nil
   end
 
   def test_syscall


### PR DESCRIPTION
Update `Kernel` "control flow" method definitions:
- `catch`: (nothing to do)
- `throw`: make the tag `untyped`
- `at_exit`: block return type is `void`
- `exit` and `exit!`: use `bool` instead of `TrueClass | FalseClass`; Also, use `int` instead of `Integer` for status
- `fork`: block return type is `void`, return type in block form is no longer `Integer?` but just `Integer`
- `loop`: block return type is `void`
- `sleep`: Add in support for Ruby-3.3.0 preview's `sleep(nil)`
- `raise` / `fail`: Add support for `raise has_a_to_str_method`, Made the `message` in the long-form `_ToS`, and allow for `nil` and `String` backtraces.

Technically, the `message` in the long form can be any type, as long as the first argument's `exception` function allows for it. So, we could do `[T] (_Exception[T], ?T?, ...`, but that seems like overkill. (Especially since `_Exception` is used in `Thread` and `Fiber`. Maybe when I get around to I could change the signature?)