### PR TITLE
Updated Kernel conversion methods

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -403,12 +403,10 @@ module Kernel : BasicObject
   #
   #     Array(:foo)             # => [:foo]
   #
-  def self?.Array: (NilClass x) -> [ ]
-                 | [T] (::Array[T] x) -> ::Array[T]
-                 | [T] (::Range[T] x) -> ::Array[T]
-                 | [T] (_Each[T] x) -> ::Array[T]
-                 | [K, V] (::Hash[K, V] x) -> ::Array[[ K, V ]]
-                 | [T] (T x) -> ::Array[T]
+  def self?.Array: (nil) -> []
+                 | [T] (Array[T] ary) -> Array[T]
+                 | [T] (_ToAry[T] | _ToA[T] array_like) -> Array[T]
+                 | [T] (T ele) -> [T]
 
   # <!--
   #   rdoc-file=complex.c
@@ -446,8 +444,11 @@ module Kernel : BasicObject
   #
   # See String#to_c.
   #
-  def self?.Complex: (Numeric | String x, ?Numeric | String y, ?exception: bool exception) -> Complex
-
+  def self?.Complex: (_ToC complex_like, ?exception: true) -> Complex
+                   | (_ToC complex_like, exception: bool) -> Complex?
+                   | (Numeric | String real, ?Numeric | String imag, ?exception: true) -> Complex
+                   | (Numeric | String real, ?Numeric | String imag, exception: bool) -> Complex?
+                   | (untyped, ?untyped, exception: false) -> nil
   # <!--
   #   rdoc-file=kernel.rb
   #   - Float(arg, exception: true)    -> float or nil
@@ -464,8 +465,9 @@ module Kernel : BasicObject
   #     Float(nil)               #=> TypeError: can't convert nil into Float
   #     Float("123.0_badstring", exception: false)  #=> nil
   #
-  def self?.Float: (Numeric | String x, ?exception: bool exception) -> Float
-
+  def self?.Float: (_ToF float_like, ?exception: true) -> Float
+                 | (_ToF float_like, exception: bool) -> Float?
+                 | (untyped, exception: false) -> nil
   # <!--
   #   rdoc-file=object.c
   #   - Hash(object) -> object or new_hash
@@ -488,7 +490,8 @@ module Kernel : BasicObject
   #     Hash(nil)              # => {}
   #     Hash([])               # => {}
   #
-  def self?.Hash: [K, V] (Object x) -> ::Hash[K, V]
+  def self?.Hash: [K, V] (nil | [] _empty) -> Hash[K, V]
+                | [K, V] (_ToHash[K, V] hash_like) -> Hash[K, V]
 
   # <!--
   #   rdoc-file=object.c
@@ -574,9 +577,11 @@ module Kernel : BasicObject
   # With `exception` given as `false`, an exception of any kind is suppressed and
   # `nil` is returned.
   #
-  def self?.Integer: (Numeric | String arg, ?exception: bool exception) -> Integer
-                   | (String arg, ?Integer base, ?exception: bool exception) -> Integer
-
+  def self?.Integer: (_ToInt | _ToI int_like, ?exception: true) -> Integer
+                   | (_ToInt | _ToI int_like, exception: bool) -> Integer?
+                   | (string str, ?int base, ?exception: true) -> Integer
+                   | (string str, ?int base, exception: bool) -> Integer?
+                   | (untyped, ?untyped, exception: false) -> nil
   # <!--
   #   rdoc-file=rational.c
   #   - Rational(x, y, exception: true)  ->  rational or nil
@@ -614,7 +619,17 @@ module Kernel : BasicObject
   #
   # See also String#to_r.
   #
-  def self?.Rational: (Numeric | String | Object x, ?Numeric | String y, ?exception: bool exception) -> Rational
+  def self?.Rational: (_ToInt | _ToR rational_like, ?exception: true) -> Rational
+                    | (_ToInt | _ToR rational_like, exception: bool) -> Rational?
+                    | (_ToInt | _ToR numer, ?_ToInt | _ToR denom, ?exception: true) -> Rational
+                    | (_ToInt | _ToR numer, ?_ToInt | _ToR denom, exception: bool) -> Rational?
+                    | [T] (Numeric&_RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
+                    | [T < Numeric] (T value, 1, ?exception: bool) -> T
+                    | (untyped, ?untyped, exception: false) -> nil
+
+  interface _RationalDiv[T]
+    def /: (Numeric) -> T
+  end
 
   # <!--
   #   rdoc-file=object.c
@@ -630,7 +645,7 @@ module Kernel : BasicObject
   #
   # Raises `TypeError` if `object` cannot be converted to a string.
   #
-  def self?.String: (_ToStr | _ToS x) -> String
+  def self?.String: (string | _ToS string_like) -> String
 
   # <!--
   #   rdoc-file=eval.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -449,6 +449,7 @@ module Kernel : BasicObject
                    | (Numeric | String real, ?Numeric | String imag, ?exception: true) -> Complex
                    | (Numeric | String real, ?Numeric | String imag, exception: bool) -> Complex?
                    | (untyped, ?untyped, exception: false) -> nil
+
   # <!--
   #   rdoc-file=kernel.rb
   #   - Float(arg, exception: true)    -> float or nil
@@ -468,6 +469,7 @@ module Kernel : BasicObject
   def self?.Float: (_ToF float_like, ?exception: true) -> Float
                  | (_ToF float_like, exception: bool) -> Float?
                  | (untyped, exception: false) -> nil
+
   # <!--
   #   rdoc-file=object.c
   #   - Hash(object) -> object or new_hash
@@ -582,6 +584,7 @@ module Kernel : BasicObject
                    | (string str, ?int base, ?exception: true) -> Integer
                    | (string str, ?int base, exception: bool) -> Integer?
                    | (untyped, ?untyped, exception: false) -> nil
+
   # <!--
   #   rdoc-file=rational.c
   #   - Rational(x, y, exception: true)  ->  rational or nil

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -392,6 +392,16 @@ module TypeAssertions
   include VersionHelper
 end
 
+class ToI
+  def initialize(value = 3)
+    @value = value
+  end
+
+  def to_i
+    @value
+  end
+end
+
 class ToInt
   def initialize(value = 3)
     @value = value
@@ -432,6 +442,16 @@ class ToS
   end
 end
 
+class ToA
+  def initialize(*args)
+    @args = args
+  end
+
+  def to_a
+    @args
+  end
+end
+
 class ToArray
   def initialize(*args)
     @args = args
@@ -439,6 +459,16 @@ class ToArray
 
   def to_ary
     @args
+  end
+end 
+
+class ToHash
+  def initialize(hash = { 'hello' => 'world' })
+    @hash = hash
+  end
+
+  def to_hash
+    @hash
   end
 end
 


### PR DESCRIPTION
This is a merging of the previous individual PRs for conversion methods into one, larger PR. (#1433 , #1434, #1435, #1436, #1437, #1438, #1439). Look at them for a little more in-depth details, adn some discussion topics. Summary of changes is below:

- `Kernel#Array`: Updated to represent the true definition: Only `.to_ary` and `.to_a` are used for conversions, and everything else is boxed up in an array.
- `Kernel#Complex`: Added the `.to_c` variant.
- `Kernel#Float`: Changed from `Numeric | String` to just be `_ToF`, which is what's used `internally.
- `Kernel#Hash`: The argument is no longer an `Object`: Instead, `.to_hash` is required for its argument, with the special case of `nil` and empty arrays (and _only_ empty arrays) returning empty hashes.
- `Kernel#Integer`: Updated to reflect the ability to pass implicit `.to_str` and `.to_int` to all variants, and only `.to_i` (not being a subclass of `Numeric`) for the one-argument case
- `Kernel#Rational`: Oh boy, this method is a mess. Check out the [original issue](https://github.com/ruby/rbs/pull/1438) for more details. tl;dr: If the first argument isn't `_ToInt | _ToR`, but is `Numeric`, it attempts to do division with it, which allows for returning arbitrary types.
- `Kernel#String`: Simply cleaned up naming; it was semantically correct beforehand.

For all conversion methods with an `exception: bool` field, two variants have been added: `(..., ?exception: true) -> type` and `(..., exception: bool) -> type?`. This reflects the fact that with `exception: false` (or an unknown boolean value, which may be false), the return type is `nil`.

Additionally, all the `exception: bool` variants, when given invalid types but with `exception: false`, will return `nil`. That's also been accounted for.