### PR TITLE
Updated stdlib defns for Binding

### DIFF
--- a/core/binding.rbs
+++ b/core/binding.rbs
@@ -30,9 +30,9 @@
 # Binding objects have no class-specific methods.
 #
 class Binding
-  public
-
   def clone: () -> self
+
+  def dup: () -> self
 
   # <!--
   #   rdoc-file=proc.c
@@ -48,69 +48,7 @@ class Binding
   #     b = get_binding("hello")
   #     b.eval("param")   #=> "hello"
   #
-  def eval: (String arg0, ?String filename, ?Integer lineno) -> untyped
-
-  # <!--
-  #   rdoc-file=lib/irb.rb
-  #   - irb(show_code: true)
-  # -->
-  # Opens an IRB session where `binding.irb` is called which allows for
-  # interactive debugging. You can call any methods or variables available in the
-  # current scope, and mutate state if you need to.
-  #
-  # Given a Ruby file called `potato.rb` containing the following code:
-  #
-  #     class Potato
-  #       def initialize
-  #         @cooked = false
-  #         binding.irb
-  #         puts "Cooked potato: #{@cooked}"
-  #       end
-  #     end
-  #
-  #     Potato.new
-  #
-  # Running `ruby potato.rb` will open an IRB session where `binding.irb` is
-  # called, and you will see the following:
-  #
-  #     $ ruby potato.rb
-  #
-  #     From: potato.rb @ line 4 :
-  #
-  #         1: class Potato
-  #         2:   def initialize
-  #         3:     @cooked = false
-  #      => 4:     binding.irb
-  #         5:     puts "Cooked potato: #{@cooked}"
-  #         6:   end
-  #         7: end
-  #         8:
-  #         9: Potato.new
-  #
-  #     irb(#<Potato:0x00007feea1916670>):001:0>
-  #
-  # You can type any valid Ruby code and it will be evaluated in the current
-  # context. This allows you to debug without having to run your code repeatedly:
-  #
-  #     irb(#<Potato:0x00007feea1916670>):001:0> @cooked
-  #     => false
-  #     irb(#<Potato:0x00007feea1916670>):002:0> self.class
-  #     => Potato
-  #     irb(#<Potato:0x00007feea1916670>):003:0> caller.first
-  #     => ".../2.5.1/lib/ruby/2.5.0/irb/workspace.rb:85:in `eval'"
-  #     irb(#<Potato:0x00007feea1916670>):004:0> @cooked = true
-  #     => true
-  #
-  # You can exit the IRB session with the `exit` command. Note that exiting will
-  # resume execution where `binding.irb` had paused it, as you can see from the
-  # output printed to standard output in this example:
-  #
-  #     irb(#<Potato:0x00007feea1916670>):005:0> exit
-  #     Cooked potato: true
-  #
-  # See IRB@IRB+Usage for more information.
-  #
-  def irb: () -> void
+  def eval: (string src, ?string filename, ?int lineno) -> untyped
 
   # <!--
   #   rdoc-file=proc.c
@@ -128,7 +66,7 @@ class Binding
   #
   #     binding.eval("defined?(#{symbol}) == 'local-variable'")
   #
-  def local_variable_defined?: (String | Symbol symbol) -> bool
+  def local_variable_defined?: (Symbol | string varname) -> bool
 
   # <!--
   #   rdoc-file=proc.c
@@ -146,7 +84,7 @@ class Binding
   #
   #     binding.eval("#{symbol}")
   #
-  def local_variable_get: (String | Symbol symbol) -> untyped
+  def local_variable_get: (Symbol | string varname) -> untyped
 
   # <!--
   #   rdoc-file=proc.c
@@ -173,7 +111,7 @@ class Binding
   #
   # if `obj` can be dumped in Ruby code.
   #
-  def local_variable_set: [U] (String | Symbol symbol, U obj) -> U
+  def local_variable_set: [U] (Symbol | string varname, U obj) -> U
 
   # <!--
   #   rdoc-file=proc.c
@@ -208,5 +146,5 @@ class Binding
   # -->
   # Returns the Ruby source filename and line number of the binding object.
   #
-  def source_location: () -> [ String, Integer ]
+  def source_location: () -> [String, Integer]
 end

--- a/test/stdlib/Binding_test.rb
+++ b/test/stdlib/Binding_test.rb
@@ -3,30 +3,48 @@ require_relative "test_helper"
 class BindingTest < StdlibTest
   target Binding
 
+  def test_clone
+    binding.clone
+  end
+
+  def test_dup
+    binding.dup
+  end
+
   def test_eval
     binding.eval('1', '(eval)', 1)
+    binding.eval(ToStr.new)
+    binding.eval(ToStr.new, ToStr.new)
+    binding.eval(ToStr.new, ToStr.new, ToInt.new)
   end
 
   def test_local_variable_defined?
     binding.local_variable_defined?(:yes)
     yes = true
     binding.local_variable_defined?('yes')
+    binding.local_variable_defined?(ToStr.new('yes'))
   end
 
   def test_local_variable_get
     foo = 1
     binding.local_variable_get(:foo)
     binding.local_variable_get('foo')
+    binding.local_variable_get(ToStr.new('foo'))
   end
 
   def test_local_variable_set
     binding.local_variable_set(:foo, 1)
     binding.local_variable_set('foo', 1)
+    binding.local_variable_set(ToStr.new('foo'), 1)
   end
 
   def test_local_variables
     foo = 1
     binding.local_variables
+  end
+
+  def test_receiver
+    binding.receiver
   end
 
   def test_source_location


### PR DESCRIPTION
This updates `Binding`, including associated tests:

- `Binding#dup` was added
- `Binding#eval` was updated to act like `Kernel#eval` (ie accepting `_ToStr` and `_ToInt` args)
- `Binding#irb` was removed
- `Binding#local_variable_defined?` now accepts `_ToStr`
- `Binding#local_variable_set` now accepts `_ToStr`
- `Binding#local_variable_get` now accepts `_ToStr`