### PR TITLE
doc: Add annotations notation to syntax.md

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -764,3 +764,19 @@ interface _Foo
   def new: () -> Foo
 end
 ```
+
+### Annotations
+
+Annotations are placed before declarations, members, and method types to mark up a metadata for the declaration, the member, or method types.
+The meaning of annotations are defined by the toolchain (ex. steep).
+
+```markdown
+_annotations_ ::= _annotation_ ...
+_annotation_ ::= `%a{` _annotation-text_ `}`  # Annotation using {}
+               | `%a(` _annotation-text_ `)`  # Annotation using ()
+               | `%a[` _annotation-text_ `]`  # Annotation using []
+               | `%a|` _annotation-text_ `|`  # Annotation using ||
+               | `%a<` _annotation-text_ `>`  # Annotation using <>
+
+_annotation-text_ ::= /[^\x00]*/              # Any characters except NUL (and parenthesis)
+```


### PR DESCRIPTION
I found some `parse_annotations()` calls in the [parser.c](https://github.com/ruby/rbs/blob/master/ext/rbs_extension/parser.c).

* parser_member_def()
* parse_module_members()
* parse_module_members()
* parse_decl()

Additionally, [signature_parsing_test.rb](https://github.com/ruby/rbs/blob/master/test/rbs/signature_parsing_test.rb) also tells us where we can insert annotations.
