### PR TITLE
Add type annotations for Struct

### DIFF
--- a/core/global_variables.rbs
+++ b/core/global_variables.rbs
@@ -33,7 +33,7 @@ $-F: Regexp | String | nil
 # Has a singleton method <code>$LOAD_PATH.resolve_feature_path(feature)</code>
 # that returns [+:rb+ or +:so+, path], which resolves the feature to
 # the path the original Kernel#require method would load.
-$-I: Array[String]
+$-I: Array[String] & _LoadPathAPI
 
 $-W: 0 | 1 | 2
 
@@ -109,7 +109,7 @@ $9: String?
 # Has a singleton method <code>$LOAD_PATH.resolve_feature_path(feature)</code>
 # that returns [+:rb+ or +:so+, path], which resolves the feature to
 # the path the original Kernel#require method would load.
-$:: Array[String]
+$:: Array[String] & _LoadPathAPI
 
 # The default separator for String#split. Non-nil $; will be deprecated. Aliased to $-F.
 $;: Regexp | String | nil
@@ -118,7 +118,7 @@ $;: Regexp | String | nil
 $<: RBS::Unnamed::ARGFClass
 
 # This variable is no longer effective. Deprecated.
-$=: bool
+$=: false
 
 # The default output stream for Kernel#print and Kernel#printf. $stdout by default.
 $>: IO

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -499,6 +499,12 @@
 class Hash[unchecked out K, unchecked out V] < Object
   include Enumerable[[ K, V ]]
 
+  interface _Key
+    def hash: () -> Integer
+
+    def eql?: (untyped rhs) -> boolish
+  end
+
   # <!--
   #   rdoc-file=hash.c
   #   - Hash[] -> new_empty_hash

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -46,12 +46,10 @@
 # *   Includes [module Enumerable](rdoc-ref:Enumerable@What-27s+Here), which
 #     provides dozens of additional methods.
 #
-#
 # See also Data, which is a somewhat similar, but stricter concept for defining
 # immutable value objects.
 #
 # Here, class Struct provides methods that are useful for:
-#
 # *   [Creating a Struct
 #     Subclass](rdoc-ref:Struct@Methods+for+Creating+a+Struct+Subclass)
 # *   [Querying](rdoc-ref:Struct@Methods+for+Querying)
@@ -61,25 +59,23 @@
 # *   [Iterating](rdoc-ref:Struct@Methods+for+Iterating)
 # *   [Converting](rdoc-ref:Struct@Methods+for+Converting)
 #
-#
 # ### Methods for Creating a Struct Subclass
 #
-# *   ::new: Returns a new subclass of Struct.
-#
+# *   ::new: Returns a new subclass of Struct.#
 #
 # ### Methods for Querying
 #
 # *   #hash: Returns the integer hash code.
-# *   #length, #size: Returns the number of members.
-#
+# *   #length, #size: Returns the number of members.#
 #
 # ### Methods for Comparing
 #
-# *   #==: Returns whether a given object is equal to `self`, using `==` to
-#     compare member values.
-# *   #eql?: Returns whether a given object is equal to `self`, using `eql?` to
-#     compare member values.
-#
+# [#==](#method-i-3D-3D)
+# :   Returns whether a given object is equal to `self`, using `==` to compare
+#     member values.
+# #eql?
+# :   Returns whether a given object is equal to `self`, using `eql?` to compare
+#     member values.#
 #
 # ### Methods for Fetching
 #
@@ -103,19 +99,24 @@
 #
 # ### Methods for Iterating
 #
-# *   #each: Calls a given block with each member name.
-# *   #each_pair: Calls a given block with each member name/value pair.
+# *   #inspect, #to_s: Returns a string representation of `self`.
+# *   #to_h: Returns a hash of the member name/value pairs in `self`.
 #
 #
 # ### Methods for Converting
 #
-# *   #inspect, #to_s: Returns a string representation of `self`.
-# *   #to_h: Returns a hash of the member name/value pairs in `self`.
+# #inspect, #to_s
+# :   Returns a string representation of `self`.
+# #to_h
+# :   Returns a hash of the member name/value pairs in `self`.
 #
-class Struct[Elem] < Object
-  include Enumerable[Elem?]
+class Struct[Elem]
+  include Enumerable[Elem]
 
-  type attribute_name = interned
+  # The types that can be used when "indexing" into a `Struct` via `[]`, `[]=`, `dig`, and
+  # `deconstruct_keys`.
+  #
+  type index = String | Symbol | int
 
   # <!--
   #   rdoc-file=struct.c
@@ -128,6 +129,8 @@ class Struct[Elem] < Object
   #
   # *   May be anonymous, or may have the name given by `class_name`.
   # *   May have members as given by `member_names`.
+  # *   May have initialization via ordinary arguments (the default) or via
+  #     keyword arguments (if `keyword_init: true` is given).
   # *   May have initialization via ordinary arguments, or via keyword arguments
   #
   #
@@ -203,6 +206,7 @@ class Struct[Elem] < Object
   #         Foo.new(foo: 0, bar: 1, baz: 2)
   #         # Raises ArgumentError: unknown keywords: baz
   #
+  #
   #     Method `::[]` is an alias for method `::new`.
   #
   # *   Method `:inspect` returns a string representation of the subclass:
@@ -219,7 +223,6 @@ class Struct[Elem] < Object
   #
   # By default, the arguments for initializing an instance of the new subclass can
   # be both positional and keyword arguments.
-  #
   # Optional keyword argument `keyword_init:` allows to force only one type of
   # arguments to be accepted:
   #
@@ -243,7 +246,208 @@ class Struct[Elem] < Object
   #     Any.new(1, 2)
   #     # => #<struct Any foo=1, bar=2>
   #
-  def initialize: (attribute_name, *attribute_name, ?keyword_init: boolish) ?{ () -> void } -> void
+  def self.new: [K < _StructClass[Elem]] (string? classname, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
+              | [K < _StructClass[Elem]] (Symbol field1, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
+
+  interface _StructClass[Elem]
+    def new: (*Elem fields, **Elem keyword_fields) -> instance
+  end
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - StructClass::members -> array_of_symbols
+  # -->
+  # Returns the member names of the Struct descendant as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     Customer.members # => [:name, :address, :zip]
+  #
+  def self.members: () -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - StructClass::keyword_init? -> true or falsy value
+  # -->
+  # Returns `true` if the class was initialized with `keyword_init: true`.
+  # Otherwise returns `nil` or `false`.
+  #
+  # Examples:
+  #     Foo = Struct.new(:a)
+  #     Foo.keyword_init? # => nil
+  #     Bar = Struct.new(:a, keyword_init: true)
+  #     Bar.keyword_init? # => true
+  #     Baz = Struct.new(:a, keyword_init: false)
+  #     Baz.keyword_init? # => false
+  #
+  def self.keyword_init?: () -> bool?
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - self == other -> true or false
+  # -->
+  # Returns  `true` if and only if the following are true; otherwise returns
+  # `false`:
+  #
+  # *   `other.class == self.class`.
+  # *   For each member name `name`, `other.name == self.name`.
+  #
+  #
+  # Examples:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr == joe # => true
+  #     joe_jr[:name] = 'Joe Smith, Jr.'
+  #     # => "Joe Smith, Jr."
+  #     joe_jr == joe # => false
+  #
+  def ==: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - eql?(other) -> true or false
+  # -->
+  # Returns `true` if and only if the following are true; otherwise returns
+  # `false`:
+  #
+  # *   `other.class == self.class`.
+  # *   For each member name `name`, `other.name.eql?(self.name)`.
+  #
+  #         Customer = Struct.new(:name, :address, :zip)
+  #         joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #         joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #         joe_jr.eql?(joe) # => true
+  #         joe_jr[:name] = 'Joe Smith, Jr.'
+  #         joe_jr.eql?(joe) # => false
+  #
+  #
+  # Related: Object#==.
+  #
+  def eql?: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - hash -> integer
+  # -->
+  # Returns the integer hash value for `self`.
+  #
+  # Two structs of the same class and with the same content will have the same
+  # hash code (and will compare using Struct#eql?):
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.hash == joe_jr.hash # => true
+  #     joe_jr[:name] = 'Joe Smith, Jr.'
+  #     joe.hash == joe_jr.hash # => false
+  #
+  # Related: Object#hash.
+  #
+  def hash: () -> Integer
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - inspect -> string
+  # -->
+  # Returns a string representation of `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.inspect # => "#<struct Customer name=\"Joe Smith\", address=\"123 Maple, Anytown NC\", zip=12345>"
+  #
+  # Struct#to_s is an alias for Struct#inspect.
+  #
+  def inspect: () -> String
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns a string representation of `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.inspect # => "#<struct Customer name=\"Joe Smith\", address=\"123 Maple, Anytown NC\", zip=12345>"
+  #
+  # Struct#to_s is an alias for Struct#inspect.
+  #
+  alias to_s inspect
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - to_a     -> array
+  # -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  def to_a: () -> Array[Elem]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - to_h -> hash
+  #   - to_h {|name, value| ... } -> hash
+  # -->
+  # Returns a hash containing the name and value for each member:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     h = joe.to_h
+  #     h # => {:name=>"Joe Smith", :address=>"123 Maple, Anytown NC", :zip=>12345}
+  #
+  # If a block is given, it is called with each name/value pair; the block should
+  # return a 2-element array whose elements will become a key/value pair in the
+  # returned hash:
+  #
+  #     h = joe.to_h{|name, value| [name.upcase, value.to_s.upcase]}
+  #     h # => {:NAME=>"JOE SMITH", :ADDRESS=>"123 MAPLE, ANYTOWN NC", :ZIP=>"12345"}
+  #
+  # Raises ArgumentError if the block returns an inappropriate value.
+  #
+  def to_h: () -> Hash[Symbol, Elem]
+          | [K, V] () { (Symbol key, Elem value) -> [K, V] } -> Hash[K, V]
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  alias values to_a
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - size -> integer
+  # -->
+  # Returns the number of members.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.size #=> 3
+  #
+  # Struct#length is an alias for Struct#size.
+  #
+  def size: () -> Integer
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the number of members.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.size #=> 3
+  #
+  # Struct#length is an alias for Struct#size.
+  #
+  alias length size
 
   # <!--
   #   rdoc-file=struct.c
@@ -266,34 +470,234 @@ class Struct[Elem] < Object
   #
   # Related: #each_pair.
   #
-  def each: () -> ::Enumerator[Elem?, self]
-          | () { (Elem? item) -> void } -> self
+  def each: () -> Enumerator[Elem, self]
+          | () { (Elem value) -> void } -> self
 
   # <!--
   #   rdoc-file=struct.c
-  #   - StructClass::members -> array_of_symbols
+  #   - each_pair {|(name, value)| ... } -> self
+  #   - each_pair -> enumerator
   # -->
-  # Returns the member names of the Struct descendant as an array:
+  # Calls the given block with each member name/value pair; returns `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.each_pair {|(name, value)| p "#{name} => #{value}" }
+  #
+  # Output:
+  #
+  #     "name => Joe Smith"
+  #     "address => 123 Maple, Anytown NC"
+  #     "zip => 12345"
+  #
+  # Returns an Enumerator if no block is given.
+  #
+  # Related: #each.
+  #
+  def each_pair: () -> Enumerator[[Symbol, Elem], self]
+               | () { ([Symbol, Elem] key_value) -> void } -> self
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - struct[name] -> object
+  #   - struct[n] -> object
+  # -->
+  # Returns a value from `self`.
+  #
+  # With symbol or string argument `name` given, returns the value for the named
+  # member:
   #
   #     Customer = Struct.new(:name, :address, :zip)
-  #     Customer.members # => [:name, :address, :zip]
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[:zip] # => 12345
   #
-  def self.members: () -> ::Array[Symbol]
+  # Raises NameError if `name` is not the name of a member.
+  #
+  # With integer argument `n` given, returns `self.values[n]` if `n` is in range;
+  # see Array@Array+Indexes:
+  #
+  #     joe[2]  # => 12345
+  #     joe[-2] # => "123 Maple, Anytown NC"
+  #
+  # Raises IndexError if `n` is out of range.
+  #
+  def []: (index name_or_position) -> Elem
 
   # <!--
   #   rdoc-file=struct.c
-  #   - StructClass::keyword_init? -> true or falsy value
+  #   - struct[name] = value -> value
+  #   - struct[n] = value -> value
   # -->
-  # Returns `true` if the class was initialized with `keyword_init: true`.
-  # Otherwise returns `nil` or `false`.
+  # Assigns a value to a member.
   #
-  # Examples:
+  # With symbol or string argument `name` given, assigns the given `value` to the
+  # named member; returns `value`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[:zip] = 54321 # => 54321
+  #     joe # => #<struct Customer name="Joe Smith", address="123 Maple, Anytown NC", zip=54321>
+  #
+  # Raises NameError if `name` is not the name of a member.
+  #
+  # With integer argument `n` given, assigns the given `value` to the `n`-th
+  # member if `n` is in range; see Array@Array+Indexes:
+  #
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[2] = 54321           # => 54321
+  #     joe[-3] = 'Joseph Smith' # => "Joseph Smith"
+  #     joe # => #<struct Customer name="Joseph Smith", address="123 Maple, Anytown NC", zip=54321>
+  #
+  # Raises IndexError if `n` is out of range.
+  #
+  def []=: (index name_or_position, Elem value) -> Elem
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - select {|value| ... } -> array
+  #   - select -> enumerator
+  # -->
+  # With a block given, returns an array of values from `self` for which the block
+  # returns a truthy value:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     a = joe.select {|value| value.is_a?(String) }
+  #     a # => ["Joe Smith", "123 Maple, Anytown NC"]
+  #     a = joe.select {|value| value.is_a?(Integer) }
+  #     a # => [12345]
+  #
+  # With no block given, returns an Enumerator.
+  #
+  # Struct#filter is an alias for Struct#select.
+  #
+  def select: () -> Enumerator[Elem, Array[Elem]]
+            | () { (Elem value) -> boolish } -> Array[Elem]
+
+  # <!-- rdoc-file=struct.c -->
+  # With a block given, returns an array of values from `self` for which the block
+  # returns a truthy value:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     a = joe.select {|value| value.is_a?(String) }
+  #     a # => ["Joe Smith", "123 Maple, Anytown NC"]
+  #     a = joe.select {|value| value.is_a?(Integer) }
+  #     a # => [12345]
+  #
+  # With no block given, returns an Enumerator.
+  #
+  # Struct#filter is an alias for Struct#select.
+  #
+  alias filter select
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - values_at(*integers) -> array
+  #   - values_at(integer_range) -> array
+  # -->
+  # Returns an array of values from `self`.
+  #
+  # With integer arguments `integers` given, returns an array containing each
+  # value given by one of `integers`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.values_at(0, 2)    # => ["Joe Smith", 12345]
+  #     joe.values_at(2, 0)    # => [12345, "Joe Smith"]
+  #     joe.values_at(2, 1, 0) # => [12345, "123 Maple, Anytown NC", "Joe Smith"]
+  #     joe.values_at(0, -3)   # => ["Joe Smith", "Joe Smith"]
+  #
+  # Raises IndexError if any of `integers` is out of range; see
+  # Array@Array+Indexes.
+  #
+  # With integer range argument `integer_range` given, returns an array containing
+  # each value given by the elements of the range; fills with `nil` values for
+  # range elements larger than the structure:
+  #
+  #     joe.values_at(0..2)
+  #     # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #     joe.values_at(-3..-1)
+  #     # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #     joe.values_at(1..4) # => ["123 Maple, Anytown NC", 12345, nil, nil]
+  #
+  # Raises RangeError if any element of the range is negative and out of range;
+  # see Array@Array+Indexes.
+  #
+  def values_at: (*int | range[int?] positions) -> Array[Elem]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - members -> array_of_symbols
+  # -->
+  # Returns the member names from `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     Customer.new.members # => [:name, :address, :zip]
+  #
+  # Related: #to_a.
+  #
+  def members: () -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - dig(name, *identifiers) -> object
+  #   - dig(n, *identifiers) -> object
+  # -->
+  # Finds and returns an object among nested objects. The nested objects may be
+  # instances of various classes. See [Dig Methods](rdoc-ref:dig_methods.rdoc).
+  #
+  # Given symbol or string argument `name`, returns the object that is specified
+  # by `name` and `identifiers`:
+  #
   #     Foo = Struct.new(:a)
-  #     Foo.keyword_init? # => nil
-  #     Bar = Struct.new(:a, keyword_init: true)
-  #     Bar.keyword_init? # => true
-  #     Baz = Struct.new(:a, keyword_init: false)
-  #     Baz.keyword_init? # => false
+  #     f = Foo.new(Foo.new({b: [1, 2, 3]}))
+  #     f.dig(:a) # => #<struct Foo a={:b=>[1, 2, 3]}>
+  #     f.dig(:a, :a) # => {:b=>[1, 2, 3]}
+  #     f.dig(:a, :a, :b) # => [1, 2, 3]
+  #     f.dig(:a, :a, :b, 0) # => 1
+  #     f.dig(:b, 0) # => nil
   #
-  def self.keyword_init?: () -> (true | false | nil)
+  # Given integer argument `n`, returns the object that is specified by `n` and
+  # `identifiers`:
+  #
+  #     f.dig(0) # => #<struct Foo a={:b=>[1, 2, 3]}>
+  #     f.dig(0, 0) # => {:b=>[1, 2, 3]}
+  #     f.dig(0, 0, :b) # => [1, 2, 3]
+  #     f.dig(0, 0, :b, 0) # => 1
+  #     f.dig(:b, 0) # => nil
+  #
+  def dig: (index name_or_position) -> Elem
+         | (index name_or_position, untyped, *untyped) -> untyped
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  alias deconstruct to_a
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - deconstruct_keys(array_of_names) -> hash
+  # -->
+  # Returns a hash of the name/value pairs for the given member names.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     h = joe.deconstruct_keys([:zip, :address])
+  #     h # => {:zip=>12345, :address=>"123 Maple, Anytown NC"}
+  #
+  # Returns all names and values if `array_of_names` is `nil`:
+  #
+  #     h = joe.deconstruct_keys(nil)
+  #     h # => {:name=>"Joseph Smith, Jr.", :address=>"123 Maple, Anytown NC", :zip=>12345}
+  #
+  def deconstruct_keys: (Array[index & Hash::_Key]? indices) -> Hash[index & Hash::_Key, Elem]
 end

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -97,7 +97,7 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_exist?
-    with_path.chain(with_io).each do |path|
+    with_path.and(with_io) do |path|
       assert_send_type "(::path | ::io) -> bool",
                        Dir, :exist?, path
     end

--- a/test/stdlib/Exception_test.rb
+++ b/test/stdlib/Exception_test.rb
@@ -16,7 +16,7 @@ class ExceptionSingletonTest < Test::Unit::TestCase
     assert_send_type  '() -> ExceptionSingletonTest::MyException',
                       MyException, :exception
 
-    with_string.chain([1r]).each do |message|
+    with_string.and(1r) do |message|
       assert_send_type  '(string | _ToS) -> ExceptionSingletonTest::MyException',
                         MyException, :exception, message
     end
@@ -83,7 +83,7 @@ class ExceptionInstanceTest < Test::Unit::TestCase
     assert_send_type  '() -> String',
                       INSTANCE, :detailed_message
 
-    [true, false, nil].each do |highlight|
+    with_bool.and_nil do |highlight|
       assert_send_type  '(highlight: bool?) -> String',
                         INSTANCE, :detailed_message, highlight: highlight
       assert_send_type  '(highlight: bool?, **untyped) -> String',
@@ -99,14 +99,14 @@ class ExceptionInstanceTest < Test::Unit::TestCase
     assert_send_type  '(self) -> self',
                       INSTANCE, :exception, INSTANCE
 
-    with_string.chain([Object.new, 1r]).each do |message|
+    with_string.and(Object.new, 1r) do |message|
       assert_send_type  '(string | _ToS) -> ExceptionInstanceTest::MyException',
                         MyException.new, :exception, message
     end
   end
 
   def test_initialize
-    with_string.chain([Object.new, 1r]).each do |message|
+    with_string.and(Object.new, 1r) do |message|
       assert_send_type  '(string | _ToS) -> self',
                         Exception.allocate, :initialize, message
     end
@@ -144,11 +144,11 @@ class ExceptionInstanceTest < Test::Unit::TestCase
     assert_send_type  '() -> String',
                       INSTANCE, :full_message
 
-    [true, false, nil].each do |highlight|
+    with_bool.and_nil do |highlight|
       assert_send_type  '(highlight: bool?) -> String',
                         INSTANCE, :full_message, highlight: highlight
       
-      with_string('top').chain(with_string('bottom'), [:top, :bottom, nil]).each do |order|
+      with_string('top').and(nil, with_string('bottom'), :top, :bottom) do |order|
         assert_send_type  '(highlight: bool?, order: (:top | :bottom | string)?) -> String',
                           INSTANCE, :full_message, highlight: highlight, order: order
       end

--- a/test/stdlib/Marshal_test.rb
+++ b/test/stdlib/Marshal_test.rb
@@ -26,7 +26,7 @@ class MarshalSingletonTest < Test::Unit::TestCase
     assert_send_type  '(untyped, Writer) -> Writer',
                       Marshal, :dump, obj, writer
 
-    with_int.chain([nil]).each do |limit|
+    with_int.and_nil do |limit|
       assert_send_type  '(untyped, Writer, int?) -> Writer',
                         Marshal, :dump, obj, writer, limit
     end
@@ -69,7 +69,7 @@ class MarshalSingletonTest < Test::Unit::TestCase
                         Marshal, meth, source, result_proc
       source.reset!
 
-      [nil, :yep, true, "hello"].each do |freeze|
+      with_boolish do |freeze|
         assert_send_type  '(string | Marshal::_Source, freeze: boolish) -> untyped',
                           Marshal, meth, source, freeze: freeze
         source.reset!
@@ -102,7 +102,7 @@ class MarshalIncludeTest < Test::Unit::TestCase
     assert_send_type  '(untyped, Writer) -> Writer',
                       Marshal, :dump, obj, writer
 
-    with_int.chain([nil]).each do |limit|
+    with_int.and_nil do |limit|
       assert_send_type  '(untyped, Writer, int?) -> Writer',
                         Marshal, :dump, obj, writer, limit
     end

--- a/test/stdlib/Signal_test.rb
+++ b/test/stdlib/Signal_test.rb
@@ -25,11 +25,11 @@ class SignalSingletonTest < Test::Unit::TestCase
   def test_trap
     old_usr2 = trap(:USR2, nil)
 
-    with_interned(:USR2).chain([Signal.list['USR2']]).each do |signal|
+    with_interned(:USR2).and(Signal.list['USR2']) do |signal|
       assert_send_type  '(Integer | ::interned) { (Integer) -> void } -> Signal::trap_command',
                         Signal, :trap, signal do |n| end
 
-      with_string('').chain([true, false, nil, Class.new{def call(x)end}.new]).each do |command|
+      with_string('').and(with_bool, nil, Class.new { def call(x) end }.new) do |command|
         assert_send_type  '(Integer | ::interned, Signal::trap_command) -> Signal::trap_command',
                           Signal, :trap, signal, command
       end

--- a/test/stdlib/Struct_test.rb
+++ b/test/stdlib/Struct_test.rb
@@ -1,16 +1,219 @@
-require_relative 'test_helper'
+require_relative "test_helper"
 
-class StructTest < Test::Unit::TestCase
+class StructSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
-  testing '::Struct[::Integer]'
+  testing "singleton(::Struct)"
+
+  def test_new
+    # Since we're redefining `TestNewStruct` constantly, we need to set `$VERBOSE` to nil to suppress
+    # the redeclaration warnings.
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
+
+    with_string 'TestNewStruct' do |classname|
+      with_interned :field1 do |field1|
+        with_interned :field2 do |field2|
+          assert_send_type  "(::string?, *::interned) -> singleton(Struct)",
+                            Struct, :new, classname, field1, field2
+          assert_send_type  "(::string?, *::interned) { (self) -> void } -> singleton(Struct)",
+                            Struct, :new, classname, field1, field2 do end
+
+          if Symbol === field1 # can't use `.is_a?` since `ToStr` doesn't define it.
+            assert_send_type  "(Symbol, *::interned) -> singleton(Struct)",
+                              Struct, :new, field1, field2
+            assert_send_type  "(Symbol, *::interned) { (self) -> void } -> singleton(Struct)",
+                              Struct, :new, field1, field2 do end
+          end
+
+          ['yes', false, nil].each do |kwinit|
+            assert_send_type  "(::string?, *::interned, keyword_init: ::boolish?) ?{ (self) -> void } -> singleton(Struct)",
+                              Struct, :new, classname, field1, field2, keyword_init: kwinit
+            assert_send_type  "(::string?, *::interned, keyword_init: ::boolish?) ?{ (self) -> void } -> singleton(Struct)",
+                              Struct, :new, classname, field1, field2, keyword_init: kwinit do end
+            
+            if Symbol === field1 # can't use `.is_a?` since `ToStr` doesn't define it.
+              assert_send_type  "(Symbol, *::interned, keyword_init: ::boolish?) -> singleton(Struct)",
+                                Struct, :new, field1, field2, keyword_init: kwinit
+              assert_send_type  "(Symbol, *::interned, keyword_init: ::boolish?) { (self) -> void } -> singleton(Struct)",
+                                Struct, :new, field1, field2, keyword_init: kwinit do end
+            end
+          end
+        end
+      end
+    end
+  ensure
+    $VERBOSE = old_verbose
+  end
+
+  def test_members
+    assert_send_type  "() -> Array[Symbol]",
+                      Struct.new(:foo, :bar), :members
+  end
+
+  def test_keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: true), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: false), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: nil), :keyword_init?
+  end
+end
+
+class StructInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Struct[Rational]"
 
   MyStruct = Struct.new(:foo, :bar)
+  Instance = MyStruct.new(1r, 2r)
+
+
+  def with_index(int=1, str=:bar, &block)
+    block.call str.to_s
+    block.call str.to_sym
+    with_int(int, &block)
+  end
+
+  def test_equal
+    assert_send_type  "(untyped) -> bool",
+                      Instance, :==, 3
+  end
+
+  def test_eql?
+    assert_send_type  "(untyped) -> bool",
+                      Instance, :eql?, 3
+  end
+
+  def test_hash
+    assert_send_type  "() -> Integer",
+                      Instance, :hash
+  end
+
+  def test_inspect
+    assert_send_type  "() -> String",
+                      Instance, :inspect
+  end
+
+  def test_to_s
+    assert_send_type  "() -> String",
+                      Instance, :to_s
+  end
+
+  def test_to_a
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :to_a
+  end
+
+  def test_to_h
+    assert_send_type  "() -> Hash[Symbol, Rational]",
+                      Instance, :to_h
+    assert_send_type  "[K, V] () { (Symbol, Rational) -> [K, V] } -> Hash[K, V]",
+                      Instance, :to_h do [1, 2] end
+  end
+
+  def test_values
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :values
+  end
+
+  def test_size
+    assert_send_type  "() -> Integer",
+                      Instance, :size
+  end
+
+  def test_length
+    assert_send_type  "() -> Integer",
+                      Instance, :length
+  end
 
   def test_each
-    assert_send_type '() { (::Integer?) -> void } -> self',
-                      MyStruct.new(42), :each do end
-    assert_send_type '() -> ::Enumerator[::Integer?, self]',
-                      MyStruct.new(42), :each
+    assert_send_type  "() -> Enumerator[Rational, self]",
+                      Instance, :each
+    assert_send_type  "() { (Rational) -> void } -> self",
+                      Instance, :each do end
+  end
+
+  def test_each_pair
+    assert_send_type  "() -> Enumerator[[Symbol, Rational], self]",
+                      Instance, :each_pair
+    assert_send_type  "() { ([Symbol, Rational]) -> void } -> self",
+                      Instance, :each_pair do end
+  end
+
+  def test_aref
+    with_index do |idx|
+      assert_send_type  "(Struct::index) -> Rational",
+                        Instance, :[], idx
+    end
+  end
+
+  def test_aset
+    with_index do |idx|
+      assert_send_type  "(Struct::index, Rational) -> Rational",
+                        Instance, :[]=, idx, 1r
+    end
+  end
+
+  def test_select
+    assert_send_type  "() -> Enumerator[Rational, Array[Rational]]",
+                      Instance, :select
+    assert_send_type  "() { (Rational) -> ::boolish } -> Array[Rational]",
+                      Instance, :select do end
+  end
+
+
+  def test_filter
+    assert_send_type  "() -> Enumerator[Rational, Array[Rational]]",
+                      Instance, :filter
+    assert_send_type  "() { (Rational) -> ::boolish } -> Array[Rational]",
+                      Instance, :filter do end
+  end
+
+  def test_values_at
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :values_at
+  
+    with_int 1 do |idx|
+      assert_send_type  "(*::int | ::range[::int?]) -> Array[Rational]",
+                        Instance, :values_at, idx, idx..nil
+    end
+  end
+
+  def test_members
+    assert_send_type  "() -> Array[Symbol]",
+                      Instance, :members
+  end
+
+  def test_dig
+    array_instance = MyStruct.new([1])
+    with_index do |idx|
+      assert_send_type  "(Struct::index) -> Rational",
+                        Instance, :dig, idx
+      assert_send_type  "(Struct::index, untyped, *untyped) -> untyped",
+                        array_instance, :dig, idx, 1
+    end
+  end
+
+  def test_deconstruct
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :deconstruct
+  end
+
+  def test_deconstruct_keys
+    assert_send_type  "(nil) -> Hash[Symbol, Rational]",
+                      Instance, :deconstruct_keys, nil
+
+    with_index do |idx|
+      # Ensure that the `ToInt` variants have `hash` and `eql?` defined.
+      def idx.hash = 0 unless defined? idx.hash
+      def idx.eql?(r) = false unless defined? idx.eql? 
+
+      assert_send_type  "(Array[Struct::index & Hash::_Key]) -> Hash[Struct::index & Hash::_Key, Rational]",
+                        Instance, :deconstruct_keys, [idx]
+    end
   end
 end

--- a/test/stdlib/UnboundMethod_test.rb
+++ b/test/stdlib/UnboundMethod_test.rb
@@ -17,14 +17,14 @@ class UnboundMethodInstanceTest < Test::Unit::TestCase
   end
 
   def test_eq
-    [UMETH, proc{}, Object.new, nil].each do |other|
+    with_untyped.and(UMETH) do |other|
       assert_send_type  '(untyped) -> bool',
                         UMETH, :==, other
     end
   end
 
   def test_eql?
-    [UMETH, proc{}, Object.new, nil].each do |other|
+    with_untyped.and(UMETH) do |other|
       assert_send_type  '(untyped) -> bool',
                         UMETH, :eql?, other
     end

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -168,66 +168,103 @@ module VersionHelper
 end
 
 module WithAliases
+  class WithEnum
+    include Enumerable
+
+    def initialize(enum) = @enum = enum
+
+    def each(&block) = @enum.each(&block)
+
+    def and_nil(&block)
+      self.and(nil, &block)
+    end
+
+    def and(*args, &block)
+      return WithEnum.new to_enum(__method__, args) unless block_given?
+      each(&block)
+      args.each do |arg|
+        if WithEnum === arg
+          arg.each(&block)
+        else
+          block.call(arg)
+        end
+      end
+    end
+  end
+
   def with_int(value = 3)
-    return to_enum(__method__, value) unless block_given?
+    return WithEnum.new to_enum(__method__, value) unless block_given?
     yield value
     yield ToInt.new(value)
   end
 
   def with_float(value = 0.1)
-    return to_enum(__method__, value) unless block_given?
+    return WithEnum.new to_enum(__method__, value) unless block_given?
     yield value
     yield ToF.new(value)
   end
 
-  def with_string(value = "")
-    return to_enum(__method__, value) unless block_given?
+  def with_string(value = '')
+    return WithEnum.new to_enum(__method__, value) unless block_given?
     yield value
     yield ToStr.new(value)
   end
 
   def with_array(*elements)
-    return to_enum(__method__, *elements) unless block_given?
+    return WithEnum.new to_enum(__method__, *elements) unless block_given?
 
     yield elements
     yield ToArray.new(*elements)
   end
 
   def with_hash(hash = {})
-    return to_enum(__method__, hash) unless block_given?
+    return WithEnum.new to_enum(__method__, hash) unless block_given?
 
     yield hash
     yield ToHash.new(hash)
   end
 
   def with_io(io = $stdout)
-    return to_enum(__method__, io) unless block_given?
+    return WithEnum.new to_enum(__method__, io) unless block_given?
     yield io
     yield ToIO.new(io)
   end
 
   def with_path(path = "/tmp/foo.txt", &block)
-    return to_enum(__method__, path) unless block_given?
+    return WithEnum.new to_enum(__method__, path) unless block_given?
 
     with_string(path, &block)
     block.call ToPath.new(path)
   end
 
   def with_encoding(encoding = Encoding::UTF_8, &block)
-    return to_enum(__method__, encoding) unless block_given?
+    return WithEnum.new to_enum(__method__, encoding) unless block_given?
 
     block.call encoding
     with_string(encoding.to_s, &block)
   end
 
   def with_interned(value = :&, &block)
-    return to_enum(__method__, value) unless block_given?
+    return WithEnum.new to_enum(__method__, value) unless block_given?
 
     with_string(value.to_s, &block)
     block.call value.to_sym
   end
-end
 
+  def with_bool
+    return WithEnum.new to_enum(__method__) unless block_given?
+    yield true
+    yield false
+  end
+
+  def with_boolish(&block)
+    return WithEnum.new to_enum(__method__) unless block_given?
+    with_bool(&block)
+    [nil, 1, Object.new, BlankSlate.new, "hello, world!"].each(&block)
+  end
+
+  alias with_untyped with_boolish
+end
 module TypeAssertions
   module ClassMethods
     attr_reader :target


### PR DESCRIPTION
This rewrites the entirety of `Struct`'s annotations.

It relies on #1492 to be merged so that it can use the `with_xxx` methods.

The type annotation on `Struct` is a bit unfortunate: It requires all instance variables to be of the same type (or union type), such as `Struct[Integer | String | bool]`. Note that `Struct.new(...).new` can take fewer arguments than fields, and the remaining fields are just filled in. To accommodate for this behaviour, I originally had things like `[]` return `Elem?`. However, I realized that you can just do something like `Struct[Integer?]` to allow for this.

There's still some weirdness with how `Struct.new` and `Struct.new(...).new` play out with type interfaces, so an extra branch `| (*Elem fields, **Elem keyword_fields) -> instance` was added to `Struct.new`'s definition. Unit testing this proved to be annoying, and I didn't end up being able to test the "Struct subclass" `new`.


More concretely, the changes are:
- Added tests for all of `Struct`'s methods
- Imported documentation for all of `Struct`
- Removed redundant `< Object` from `Struct`
- Struct includes `Enumerable[Elem]` not `Enumerable[Elem?]` now. (See above for how optional arguments to `new` works)
- Removed `attribute_name` as it was only used (a bit incorrectly) in `initialize`
- Added `type index = String | Symbol | int` which is used in `[]`, `[]=`, `dig`, and `deconstruct_keys`
- Updated `Struct.new` to more correctly reflect how creation works, and also added the optional struct name. (See above for weirdness with `Struct.new`.)
- `Struct.members`: removed leading `::` from `Array[Symbol]`
- `Struct.keyword_init?`: returns `bool?` now, instead of `true | false | nil`
- Added in definitions for `Struct` instance methods: `==`, `eql?`, `hash`, `inspect`, `to_a`, `to_h`, `size`, `each`, `each_pair`, `[]`, `[]`, `select`, `values_at`, `members`, `dig`, `deconstruct_keys`, `to_s`, `values`, `length`, `filter`, and `deconstruct`.
