### PR TITLE
[prototype runtime] Avoid alias for methods defined in another module

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -532,4 +532,42 @@ end
       end
     end
   end
+
+  module AliasTargetModule
+    def foo; end
+  end
+
+  class DefineMethodAlias
+    define_singleton_method(:qux, AliasTargetModule.instance_method(:foo))
+
+    define_method(:bar, AliasTargetModule.instance_method(:foo))
+
+    define_method(:baz, AliasTargetModule.instance_method(:foo))
+    private :baz
+  end
+
+  def test_define_method_alias
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DefineMethodAlias"], env: env, merge: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class DefineMethodAlias
+                def self.qux: () -> untyped
+
+                public
+
+                def bar: () -> untyped
+
+                private
+
+                def baz: () -> untyped
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
`define_method` and `define_singleton_method` can take UnboundMethod in second argument.
In addition, it can be specified even for methods of a completely different module.

For example, erubi uses this technique.

https://github.com/jeremyevans/erubi/blob/4d24561e79e291208996892800a5cb9d11b8d2af/lib/erubi.rb#L23

`rbs prototype runtime` produces the following output for the current erubi.

```rbs
$ rbs prototype runtime -r erubi Erubi
module Erubi
  alias self.h self.html_escape 

  ...snip...
```

However, the specified method does not exist.

```
Unknown method alias name: html_escape => h (::Erubi) (RBS::UnknownMethodAliasError)

    alias self.h self.html_escape
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

To avoid this problem, I suggest that in this case the output be as a method definition, not an alias.