### PR TITLE
Fix CI failure

### DIFF
--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -662,7 +662,7 @@ class KernelTest < StdlibTest
   def test_pp
     pp
     pp 1
-    pp 'a', 2 
+    pp 'a', 2
 
     pp Object.new
   end
@@ -704,9 +704,6 @@ class KernelTest < StdlibTest
       [0.001, 0.001]
     end
     sleep o
-
-    omit_if(RUBY_VERSION < "3.3.0")
-    sleep nil
   end
 
   def test_syscall

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -10,6 +10,17 @@ class Test::Unit::TestCase
   prepend TestSkip
 end
 
+class Test::Unit::TestCase
+  module Printer
+    def setup
+      STDERR.puts name
+      super
+    end
+  end
+
+  prepend Printer
+end
+
 module Spy
   def self.wrap(object, method_name)
     spy = WrapSpy.new(object: object, method_name: method_name)
@@ -460,7 +471,7 @@ class ToArray
   def to_ary
     @args
   end
-end 
+end
 
 class ToHash
   def initialize(hash = { 'hello' => 'world' })
@@ -578,6 +589,11 @@ class StdlibTest < Test::Unit::TestCase
               end
   end
 
+  # def setup
+  #   STDERR.puts name
+  #   super
+  # end
+
   def hook
     self.class.hook
   end
@@ -591,9 +607,11 @@ class StdlibTest < Test::Unit::TestCase
       null = StringIO.new
       @stdout, @stderr = $stdout, $stderr
       $stderr = $stdout = null
+      super
     end
 
     def teardown
+      super
       $stderr, $stdout = @stderr, @stdout
     end
   end

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -18,7 +18,7 @@ class Test::Unit::TestCase
     end
   end
 
-  prepend Printer
+  # prepend Printer
 end
 
 module Spy


### PR DESCRIPTION
`Kernel_test.rb` includes `sleep nil` that stops the thread forever.
This PR removes it.