### PR TITLE
Fix error when undefined interface or alias

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -276,9 +276,9 @@ module RBS
     end
 
     def normalize_type_name?(name)
-      if name.class?
-        normalize_module_name?(name)
-      else
+      return normalize_module_name?(name) if name.class?
+
+      type_name =
         unless name.namespace.empty?
           parent = name.namespace.to_type_name
           parent = normalize_module_name?(parent)
@@ -288,7 +288,8 @@ module RBS
         else
           name
         end
-      end
+
+      type_name?(type_name) ? type_name : false
     end
 
     def normalize_type_name!(name)

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -289,7 +289,9 @@ module RBS
           name
         end
 
-      type_name?(type_name) ? type_name : false
+      if type_name?(type_name)
+        type_name
+      end
     end
 
     def normalize_type_name!(name)

--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -132,7 +132,8 @@ module RBS
           end
         end
       when Types::ClassInstance, Types::Interface, Types::Alias
-        if type_name = env.normalize_type_name?(type.name)
+        type_name = env.normalize_type_name?(type.name)
+        if type_name && env.normalized_type_name?(type_name)
           type_params = case type
                         when Types::ClassInstance
                           env.class_decls[type_name].type_params

--- a/lib/rbs/variance_calculator.rb
+++ b/lib/rbs/variance_calculator.rb
@@ -132,8 +132,7 @@ module RBS
           end
         end
       when Types::ClassInstance, Types::Interface, Types::Alias
-        type_name = env.normalize_type_name?(type.name)
-        if type_name && env.normalized_type_name?(type_name)
+        if type_name = env.normalize_type_name?(type.name)
           type_params = case type
                         when Types::ClassInstance
                           env.class_decls[type_name].type_params

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -400,6 +400,40 @@ singleton(::BasicObject)
     end
   end
 
+  def test_undefined_interface
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        class Foo
+          def void: () -> _Void
+        end
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+        assert_equal "_Void", error.type_name.to_s
+      end
+    end
+  end
+
+  def test_undefined_alias
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+        class Foo
+          def void: () -> voida
+        end
+        RBS
+
+        error = assert_raises RBS::NoTypeFoundError do
+          cli.run(["-I", dir, "validate"])
+        end
+        assert_equal "voida", error.type_name.to_s
+      end
+    end
+  end
+
   def test_constant
     with_cli do |cli|
       cli.run(%w(constant Pathname))


### PR DESCRIPTION
If a non-existent interface or alias is specified as shown below, an unexpected error will occur during validation.

```rbs
# t.rbs
class Foo
  def void: () -> _Void
end
```

```
$ rbs -I t.rbs validate --silent
/lib/rbs/variance_calculator.rb:140:in `type': undefined method `decl' for nil:NilClass (NoMethodError)

                          env.interface_decls[type_name].decl.type_params
                                                        ^^^^^
```

I expect the following to work.
This behavior is the same as specifying a non-existent class name.

```
$ rbs -I t.rbs validate --silent
/lib/rbs/variance_calculator.rb:159:in `type': t.rbs:2:18...2:23: Could not find _Void (RBS::NoTypeFoundError)

    def void: () -> _Void
                    ^^^^^
```

Type alias also.

```
$ rbs -I t.rbs validate --silent
/lib/rbs/variance_calculator.rb:159:in `type': t.rbs:2:18...2:23: Could not find voida (RBS::NoTypeFoundError)

    def void: () -> voida
                    ^^^^^
```

I have validated RBS of some size for this change and found no significant degradation in performance.