### PR TITLE
Use class alias

### DIFF
--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -1741,10 +1741,10 @@ class Thread::SizedQueue < Thread::Queue
   def push: (untyped obj, ?boolish non_block, timeout: _ToF?) -> void
 end
 
-ConditionVariable: singleton(Thread::ConditionVariable)
+class ConditionVariable = Thread::ConditionVariable
 
-Mutex: singleton(Thread::Mutex)
+class Mutex = Thread::Mutex
 
-Queue: singleton(Thread::Queue)
+class Queue = Thread::Queue
 
-SizedQueue: singleton(Thread::SizedQueue)
+class SizedQueue = Thread::SizedQueue

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -144,7 +144,7 @@ end
       env = Environment.new
       loaded = loader.load(env: env)
 
-      assert_equal 1, loaded.count {|decl, _, _| decl.name == TypeName("Person") }
+      assert_equal 1, loaded.count {|decl, _, _| decl.respond_to?(:name) && decl.name == TypeName("Person") }
     end
   end
 


### PR DESCRIPTION
```rb
$ ruby -e 'pp Object.constants.map { [_1, Object.const_get(_1)] }.select { _2.kind_of?(Module) }.select {
 _1 != _2.name.to_sym }'
[[:Mutex, Thread::Mutex],
 [:Queue, Thread::Queue],
 [:SizedQueue, Thread::SizedQueue],
 [:ConditionVariable, Thread::ConditionVariable]]
```