### PR TITLE
Implement todo option

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -673,6 +673,7 @@ EOU
             merge = true
           end
           opts.on("--todo", "Generates only undefined methods compared to objects") do
+            Warning.warn("Geneating prototypes with `--todo` option is experimental\n", category: :experimental)
             todo = true
           end
           opts.on("--method-owner CLASS", "Generate method prototypes if the owner of the method is [CLASS]") do |klass|

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -644,6 +644,7 @@ EOU
         require_libs = []
         relative_libs = []
         merge = false
+        todo = false
         owners_included = []
         outline = false
 
@@ -671,6 +672,9 @@ EOU
           opts.on("--merge", "Merge generated prototype RBS with existing RBS") do
             merge = true
           end
+          opts.on("--todo", "Generates only undefined methods compared to objects") do
+            todo = true
+          end
           opts.on("--method-owner CLASS", "Generate method prototypes if the owner of the method is [CLASS]") do |klass|
             owners_included << klass
           end
@@ -690,7 +694,7 @@ EOU
           eval("require_relative(lib)", binding, "rbs")
         end
 
-        runtime = Prototype::Runtime.new(patterns: args, env: env, merge: merge, owners_included: owners_included)
+        runtime = Prototype::Runtime.new(patterns: args, env: env, merge: merge, todo: todo, owners_included: owners_included)
         runtime.outline = outline
 
         decls = runtime.decls

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -377,11 +377,13 @@ module RBS
 
         private_instance_methods = mod.private_instance_methods.select {|name| target_method?(mod, instance: name) }
         unless private_instance_methods.empty?
+          added = false
           members << AST::Members::Private.new(location: nil)
 
           private_instance_methods.sort.each do |name|
             next if todo_object&.skip_instance_method?(module_name: module_name_absolute, name: name)
 
+            added = true
             method = mod.instance_method(name)
 
             if can_alias?(mod, method)
@@ -412,6 +414,8 @@ module RBS
               end
             end
           end
+
+          members.pop unless added
         end
       end
 

--- a/sig/prototype/runtime.rbs
+++ b/sig/prototype/runtime.rbs
@@ -1,6 +1,26 @@
 module RBS
   module Prototype
     class Runtime
+      class Todo
+        @builder: DefinitionBuilder
+
+        @mixin_decls_cache: Hash[TypeName, Array[untyped]]
+
+        def initialize: (builder: DefinitionBuilder) -> void
+
+        def skip_mixin?: (type_name: TypeName, module_name: TypeName, mixin_class: mixin_class) -> bool
+
+        def skip_singleton_method?: (module_name: TypeName, name: Symbol) -> bool
+
+        def skip_instance_method?: (module_name: TypeName, name: Symbol) -> bool
+
+        def skip_constant?: (module_name: String, name: Symbol) -> bool
+
+        private def mixin_decls: (TypeName type_name) -> Array[AST::Members::Include | AST::Members::Extend | AST::Members::Prepend]
+      end
+
+      type mixin_class = singleton(AST::Members::Include) | singleton(AST::Members::Prepend) | singleton(AST::Members::Extend)
+
       @decls: Array[AST::Declarations::t]?
 
       @modules: Hash[String, Module]
@@ -10,6 +30,8 @@ module RBS
       @module_name_method: UnboundMethod
       @object_class: UnboundMethod
 
+      @todo_object: Todo?
+
       include Helpers
 
       attr_reader patterns: Array[String]
@@ -18,13 +40,17 @@ module RBS
 
       attr_reader merge: bool
 
+      attr_reader todo: bool
+
       attr_accessor outline: bool
 
       attr_reader owners_included: Array[Module]
 
-      def initialize: (patterns: Array[String], env: Environment, merge: bool, ?owners_included: Array[Symbol]) -> void
+      def initialize: (patterns: Array[String], env: Environment, merge: bool, ?todo: bool, ?owners_included: Array[Symbol]) -> void
 
       def target?: (Module const) -> bool
+
+      def todo_object: () -> Todo?
 
       def builder: () -> DefinitionBuilder
 
@@ -34,17 +60,7 @@ module RBS
 
       def to_type_name: (String name, ?full_name: bool) -> TypeName
 
-      interface _MixinFactory
-        def new: (
-          name: TypeName,
-          args: Array[Types::t],
-          location: Location[untyped, untyped]?,
-          comment: AST::Comment?,
-          annotations: Array[AST::Annotation]
-        ) -> (AST::Members::Include | AST::Members::Prepend | AST::Members::Extend)
-      end
-
-      def each_mixined_module: (TypeName type_name, Module mod) { (TypeName, TypeName, _MixinFactory) -> void } -> void
+      def each_mixined_module: (TypeName type_name, Module mod) { (TypeName, TypeName, mixin_class) -> void } -> void
 
       def each_mixined_module_one: (TypeName type_name, Module mod) { (TypeName, TypeName, bool) -> void } -> void
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -681,6 +681,28 @@ Processing `test/a_test.rb`...
     end
   end
 
+  def test_prototype__runtime__todo
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          begin
+            old = $stderr
+            $stderr = cli.stderr
+            cli.run(%w(prototype runtime --todo ::Object))
+          ensure
+            $stderr = old
+          end
+
+          assert_equal <<~EOM, cli.stdout.string
+          EOM
+
+          assert_match Regexp.new(Regexp.escape "Geneating prototypes with `--todo` option is experimental"), cli.stderr.string
+        end
+      end
+    end
+  end
+
+
   def test_test
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -670,7 +670,7 @@ end
 
                 def private_todo: () -> untyped
 
-                CONST_TODO: Integer
+                CONST_TODO: ::Integer
               end
             end
           end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -606,4 +606,89 @@ end
       end
     end
   end
+
+  class TodoClass
+    module MixinDefined
+    end
+    include MixinDefined
+    module MixinTodo
+    end
+    extend MixinTodo
+
+    def public_defined; end
+    def public_todo; end
+    private def private_defined; end
+    private def private_todo; end
+    def self.singleton_defined; end
+    def self.singleton_todo; end
+
+    CONST_DEFINED = 1
+    CONST_TODO = 1
+  end
+
+  module TodoModule
+    def public_defined; end
+    def public_todo; end
+  end
+
+  def test_todo
+    SignatureManager.new do |manager|
+      manager.files[Pathname("foo.rbs")] = <<~RBS
+        module RBS
+          class RuntimePrototypeTest < ::Test::Unit::TestCase
+            class TodoClass
+              module MixinDefined
+              end
+              include MixinDefined
+              def public_defined: () -> void
+              private def private_defined: () -> void
+              def self.singleton_defined: () -> void
+              CONST_DEFINED: Integer
+            end
+            module TodoModule
+              def public_defined: () -> void
+            end
+          end
+        end
+      RBS
+
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TodoClass"], env: env, merge: false, todo: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class TodoClass
+                extend RBS::RuntimePrototypeTest::TodoClass::MixinTodo
+
+                def self.singleton_todo: () -> untyped
+
+                public
+
+                def public_todo: () -> untyped
+
+                private
+
+                def private_todo: () -> untyped
+
+                CONST_TODO: Integer
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::TodoModule"], env: env, merge: false, todo: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              module TodoModule
+                public
+
+                def public_todo: () -> untyped
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
The todo option excludes predefined output from prototype runtime.

## Issue

https://github.com/ruby/rbs/issues/1449

## Supported features

This PR is implemented to exclude the following.

- Instance method
- Singleton method
- Constant
- Mixin

## Demo

```rbs
$ bundle exec rbs prototype runtime --todo IO
class IO
  public

  def external_encoding: () -> untyped

  def pread: (*untyped) -> untyped

  def pwrite: (untyped, untyped) -> untyped

  def to_path: () -> untyped

  def wait_priority: (*untyped) -> untyped
end
```