### PR TITLE
[prototype runtime] Fix error when output Object constants

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -388,6 +388,10 @@ module RBS
                      type: Types::Bases::Any.new(location: nil),
                      location: nil
                    )
+                 when ARGF
+                   Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ARGFClass"), args: [], location: nil)
+                 when ENV
+                   Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ENVClass"), args: [], location: nil)
                  else
                    value_type_name = to_type_name(const_name!(value.class))
                    args = type_args(value_type_name)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -533,6 +533,30 @@ end
     end
   end
 
+  class Unnamed
+    A = ARGF
+    B = ENV
+  end
+
+  def test_unnamed
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::Unnamed"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class Unnamed
+                A: ::RBS::Unnamed::ARGFClass
+
+                B: ::RBS::Unnamed::ENVClass
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
+
   module AliasTargetModule
     def foo; end
   end


### PR DESCRIPTION
Parsing for `Object` raises a RuntimeError.

```
$ bundle exec rbs prototype runtime Object
bundler: failed to load command: rbs (/Users/yuki.kurihara/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs)
/Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:574:in `const_name!': unhandled exception
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:396:in `block in generate_constants'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:369:in `each'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:369:in `generate_constants'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:461:in `generate_class'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:54:in `block in decls'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:51:in `each'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/prototype/runtime.rb:51:in `decls'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:696:in `run_prototype'
	from /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/cli.rb:137:in `run'
```

The cause is that `ARGF` is a special object and the class name is not correctly obtained.

This is a rare case, but the same problem can occur for all classes/modules with `ARGF` as a constant.

The correct type of `ARGF` in RBS is `RBS::Unnamed::ARGFClass`.

As a fix, I suggest that if the value of the constant is `ARGF`, the type should be `RBS::Unnamed::ARGFClass`.
I have also modified it so that the correct type, `RBS::Unnamed::ENVClass`, is applied for `ENV` as well.