### PR TITLE
Improve skip test message

### DIFF
--- a/test/test_skip.rb
+++ b/test/test_skip.rb
@@ -50,7 +50,10 @@ module TestSkip
     end
 
     def teardown
-      unless current_result.passed?
+      case
+      when passed?
+        # nop
+      else
         puts "💡You can skip this test `#{name}` by adding the name to `#{SKIP_TESTS_FILE}`"
       end
 


### PR DESCRIPTION
The `You can skip this test ...` message displays on every test case after one test case failed. Test with `self#passed?` to check if the current test case is failed or not.