### PR TITLE
Cleanup `Warning`

### DIFF
--- a/core/warning.rbs
+++ b/core/warning.rbs
@@ -29,7 +29,40 @@
 # The `warning` gem provides convenient ways to customize Warning.warn.
 #
 module Warning
+  # The types of categories the `Warning` module understands.
+  #
   type category = :deprecated | :experimental
+
+  # <!--
+  #   rdoc-file=error.c
+  #   - Warning[category]  -> true or false
+  # -->
+  # Returns the flag to show the warning messages for `category`. Supported
+  # categories are:
+  #
+  # `:deprecated`
+  # :   deprecation warnings
+  #
+  # *   assignment of non-nil value to `$,` and `$;`
+  # *   keyword arguments
+  # *   proc/lambda without block
+  #
+  # etc.
+  #
+  # `:experimental`
+  # :   experimental features
+  #
+  # *   Pattern matching
+  #
+  def self.[]: (category) -> bool
+
+  # <!--
+  #   rdoc-file=error.c
+  #   - Warning[category] = flag -> flag
+  # -->
+  # Sets the warning flags for `category`. See Warning.[] for the categories.
+  #
+  def self.[]=: [T] (category, T flag) -> T
 
   # <!--
   #   rdoc-file=error.c

--- a/test/stdlib/Warning_test.rb
+++ b/test/stdlib/Warning_test.rb
@@ -1,5 +1,39 @@
 require_relative "test_helper"
 
+WARNING_CATEGORIES = %i[deprecated experimental]
+
+class WarningSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "singleton(::Warning)"
+
+  def test_aref
+    WARNING_CATEGORIES.each do |category|
+      assert_send_type "(#{category.inspect}) -> bool",
+          Warning, :[], category
+    end
+
+    refute_send_type "(Symbol) -> bool",
+        Warning, :[], :unknown_category
+
+    refute_send_type "(ToSym) -> bool",
+        Warning, :[], ToSym.new(WARNING_CATEGORIES.first)
+  end
+
+  def test_aset
+    WARNING_CATEGORIES.each do |category|
+      assert_send_type "(#{category.inspect}, Rational) -> Rational",
+          Warning, :[]=, category, 1r
+    end
+
+    refute_send_type "(Symbol, Rational) -> Rational",
+        Warning, :[]=, :unknown_category, 1r
+
+    refute_send_type "(ToSym, Rational) -> Rational",
+        Warning, :[]=, ToSym.new(WARNING_CATEGORIES.first), 1r
+  end
+end
+
 class WarningTest < Test::Unit::TestCase
   include TypeAssertions
 
@@ -10,6 +44,7 @@ class WarningTest < Test::Unit::TestCase
   end
 
   def test_warn
+    old_stderr = $stderr
     $stderr = StringIO.new
 
     assert_send_type "(::String) -> nil",
@@ -23,18 +58,20 @@ class WarningTest < Test::Unit::TestCase
 
     omit_if(RUBY_VERSION < "3.0")
 
-    assert_send_type "(::String, category: :deprecated) -> nil",
-        Warning, :warn, 'message', category: :deprecated
-
-    assert_send_type "(::String, category: :experimental) -> nil",
-        Warning, :warn, 'message', category: :experimental
+    WARNING_CATEGORIES.each do |category|
+      assert_send_type "(::String, category: #{category.inspect}) -> nil",
+          Warning, :warn, 'message', category: category
+    end
 
     assert_send_type "(::String, category: nil) -> nil",
         Warning, :warn, 'message', category: nil
 
+    refute_send_type "(::String, category: ToSym) -> nil",
+        Warning, :warn, 'message', category: ToSym.new(WARNING_CATEGORIES.first)
+
     refute_send_type "(::String, category: ::Symbol) -> nil",
         Warning, :warn, 'message', category: :unknown_category
   ensure
-    $stderr = STDERR
+    $stderr = old_stderr
   end
 end

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -453,6 +453,17 @@ class ToS
   end
 end
 
+
+class ToSym
+  def initialize(value = :&)
+    @value = value
+  end
+
+  def to_sym
+    @value
+  end
+end
+
 class ToA
   def initialize(*args)
     @args = args


### PR DESCRIPTION
This adds mainly adds support for `Warning[:deprecated]` and `Warning[:deprecated] = foo`, but also:
- Adds the `ToSym` test helper type
- Added documentation for `Warning::category`
- Abstracted out the list of catagories within the unit tests (in preparation for when `performance` is added in the future.)