### PR TITLE
Updated FalseClass, NilClass, and TrueClass

### DIFF
--- a/core/false_class.rbs
+++ b/core/false_class.rbs
@@ -4,8 +4,6 @@
 # operators allowing `false` to participate correctly in logical expressions.
 #
 class FalseClass
-  public
-
   def !: () -> true
 
   # <!--
@@ -37,8 +35,7 @@ class FalseClass
   # Exclusive Or---If *obj* is `nil` or `false`, returns `false`; otherwise,
   # returns `true`.
   #
-  def ^: (nil) -> false
-       | (false) -> false
+  def ^: (false | nil) -> false
        | (untyped obj) -> true
 
   # <!-- rdoc-file=object.c -->
@@ -61,9 +58,6 @@ class FalseClass
   # -->
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
   #
-  def |: (nil) -> false
-       | (false) -> false
+  def |: (nil | false) -> false
        | (untyped obj) -> true
-
-  def clone: (?freeze: true?) -> self
 end

--- a/core/nil_class.rbs
+++ b/core/nil_class.rbs
@@ -2,8 +2,6 @@
 # The class of the singleton object `nil`.
 #
 class NilClass
-  public
-
   def !: () -> true
 
   # <!--
@@ -45,8 +43,7 @@ class NilClass
   # Exclusive Or---If *obj* is `nil` or `false`, returns `false`; otherwise,
   # returns `true`.
   #
-  def ^: (nil) -> false
-       | (false) -> false
+  def ^: (false | nil) -> false
        | (untyped obj) -> true
 
   # <!--
@@ -81,7 +78,7 @@ class NilClass
   #
   #     nil.to_a   #=> []
   #
-  def to_a: () -> [ ]
+  def to_a: () -> []
 
   # <!--
   #   rdoc-file=complex.c
@@ -109,7 +106,7 @@ class NilClass
   #
   #     nil.to_h   #=> {}
   #
-  def to_h: () -> ::Hash[untyped, untyped]
+  def to_h: () -> {}
 
   # <!--
   #   rdoc-file=nilclass.rb
@@ -144,9 +141,6 @@ class NilClass
   # -->
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
   #
-  def |: (nil) -> false
-       | (false) -> false
+  def |: (nil | false) -> false
        | (untyped obj) -> true
-
-  def clone: (?freeze: true?) -> self
 end

--- a/core/true_class.rbs
+++ b/core/true_class.rbs
@@ -4,8 +4,6 @@
 # allowing `true` to be used in logical expressions.
 #
 class TrueClass
-  public
-
   def !: () -> false
 
   # <!--
@@ -14,8 +12,7 @@ class TrueClass
   # -->
   # And---Returns `false` if *obj* is `nil` or `false`, `true` otherwise.
   #
-  def &: (nil) -> false
-       | (false) -> false
+  def &: (false | nil) -> false
        | (untyped obj) -> true
 
   # <!--
@@ -35,8 +32,7 @@ class TrueClass
   # -->
   # Exclusive Or---Returns `true` if *obj* is `nil` or `false`, `false` otherwise.
   #
-  def ^: (nil) -> true
-       | (false) -> true
+  def ^: (false | nil) -> true
        | (untyped obj) -> false
 
   # <!-- rdoc-file=object.c -->
@@ -67,6 +63,4 @@ class TrueClass
   #     or
   #
   def |: (untyped obj) -> true
-
-  def clone: (?freeze: true?) -> self
 end

--- a/test/stdlib/FalseClass_test.rb
+++ b/test/stdlib/FalseClass_test.rb
@@ -1,38 +1,66 @@
 require_relative "test_helper"
 
-class FalseClassTest < StdlibTest
-  target FalseClass
+class FalseClassInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing '::FalseClass'
 
   def test_not
-    !false
+    assert_send_type "() -> true",
+                     false, :!
   end
 
   def test_and
-    false & true
+    assert_send_type "(false) -> false",
+                     false, :&, false
+    assert_send_type "(true) -> false",
+                     false, :&, true
+    assert_send_type "(nil) -> false",
+                     false, :&, nil
+    assert_send_type "(untyped) -> false",
+                     false, :&, Object.new
   end
 
   def test_eqq
-    false === false
-    false === true
+    assert_send_type "(false) -> true",
+                     false, :===, false
+    assert_send_type "(true) -> false",
+                     false, :===, true
+    assert_send_type "(nil) -> false",
+                     false, :===, nil
+    assert_send_type "(untyped) -> false",
+                     false, :===, Object.new
   end
 
   def test_xor
-    false ^ false
-    false ^ nil
-    false ^ 42
+    assert_send_type "(false) -> false",
+                     false, :^, false
+    assert_send_type "(true) -> true",
+                     false, :^, true
+    assert_send_type "(nil) -> false",
+                     false, :^, nil
+    assert_send_type "(untyped) -> true",
+                     false, :^, Object.new
   end
 
   def test_inspect
-    false.inspect
+    assert_send_type "() -> 'false'",
+                     false, :inspect
   end
 
   def test_to_s
-    false.to_s
+    assert_send_type "() -> 'false'",
+                     false, :to_s
   end
 
   def test_or
-    false | false
-    false | nil
-    false | 42
+    assert_send_type "(false) -> false",
+                     false, :|, false
+    assert_send_type "(true) -> true",
+                     false, :|, true
+    assert_send_type "(nil) -> false",
+                     false, :|, nil
+    assert_send_type "(untyped) -> true",
+                     false, :|, Object.new
   end
 end

--- a/test/stdlib/NilClass_test.rb
+++ b/test/stdlib/NilClass_test.rb
@@ -1,71 +1,113 @@
 require_relative "test_helper"
 
-class NilClassTest < StdlibTest
-  target NilClass
+class NilClassInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing '::NilClass'
+
+  def test_not
+    assert_send_type "() -> true",
+                     nil, :!
+  end
 
   def test_and
-    nil & true
+    assert_send_type "(nil) -> false",
+                     nil, :&, nil
+    assert_send_type "(false) -> false",
+                     nil, :&, false
+    assert_send_type "(true) -> false",
+                     nil, :&, true
+    assert_send_type "(untyped) -> false",
+                     nil, :&, Object.new
   end
 
   def test_eqq
-    nil === nil
-    nil === false
+    assert_send_type "(nil) -> true",
+                     nil, :===, nil
+    assert_send_type "(false) -> false",
+                     nil, :===, false
+    assert_send_type "(true) -> false",
+                     nil, :===, true
+    assert_send_type "(untyped) -> false",
+                     nil, :===, Object.new
   end
 
   def test_match
-    nil =~ 42
+    assert_send_type "(untyped) -> nil",
+                     nil, :=~, Object.new
   end
 
   def test_xor
-    nil ^ nil
-    nil ^ false
-    nil ^ 42
+    assert_send_type "(nil) -> false",
+                     nil, :^, nil
+    assert_send_type "(false) -> false",
+                     nil, :^, false
+    assert_send_type "(true) -> true",
+                     nil, :^, true
+    assert_send_type "(untyped) -> true",
+                     nil, :^, Object.new
   end
 
   def test_inspect
-    nil.inspect
+    assert_send_type "() -> 'nil'",
+                     nil, :inspect
   end
 
   def test_nil?
-    nil.nil?
+    assert_send_type "() -> true",
+                     nil, :nil?
   end
 
   def test_rationalize
-    nil.rationalize
-    nil.rationalize(0.01)
+    assert_send_type "() -> Rational",
+                     nil, :rationalize
+    assert_send_type "(untyped) -> Rational",
+                     nil, :rationalize, Object.new
   end
 
   def test_to_a
-    nil.to_a
+    assert_send_type "() -> []",
+                     nil, :to_a
   end
 
   def test_to_c
-    nil.to_c
+    assert_send_type "() -> Complex",
+                     nil, :to_c
   end
 
   def test_to_f
-    nil.to_f
+    assert_send_type "() -> Float",
+                     nil, :to_f
   end
 
   def test_to_h
-    nil.to_h
+    assert_send_type "() -> Hash[untyped, untyped]",
+                     nil, :to_h
   end
 
   def test_to_i
-    nil.to_i
+    assert_send_type "() -> 0",
+                     nil, :to_i
   end
 
   def test_to_r
-    nil.to_r
+    assert_send_type "() -> Rational",
+                     nil, :to_r
   end
 
   def test_to_s
-    nil.to_s
+    assert_send_type "() -> ''",
+                     nil, :to_s
   end
 
   def test_or
-    nil | nil
-    nil | false
-    nil | 42
+    assert_send_type "(nil) -> false",
+                     nil, :|, nil
+    assert_send_type "(false) -> false",
+                     nil, :|, false
+    assert_send_type "(true) -> true",
+                     nil, :|, true
+    assert_send_type "(untyped) -> true",
+                     nil, :|, Object.new
   end
 end

--- a/test/stdlib/TrueClass_test.rb
+++ b/test/stdlib/TrueClass_test.rb
@@ -1,38 +1,66 @@
 require_relative "test_helper"
 
-class TrueClassTest < StdlibTest
-  target TrueClass
+class TrueClassInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing '::TrueClass'
 
   def test_not
-    !true
+    assert_send_type "() -> false",
+                     true, :!
   end
 
   def test_and
-    true.&(nil)
-    true.&(false)
-    true.&(42)
+    assert_send_type "(true) -> true",
+                     true, :&, true
+    assert_send_type "(nil) -> false",
+                     true, :&, nil
+    assert_send_type "(false) -> false",
+                     true, :&, false
+    assert_send_type "(untyped) -> true",
+                     true, :&, Object.new
   end
 
   def test_eqq
-    true === true
-    true === false
+    assert_send_type "(true) -> true",
+                     true, :===, true
+    assert_send_type "(nil) -> false",
+                     true, :===, nil
+    assert_send_type "(false) -> false",
+                     true, :===, false
+    assert_send_type "(untyped) -> false",
+                     true, :===, Object.new
   end
 
   def test_xor
-    true.^(nil)
-    true.^(false)
-    true.^(42)
+    assert_send_type "(true) -> false",
+                     true, :^, true
+    assert_send_type "(nil) -> true",
+                     true, :^, nil
+    assert_send_type "(false) -> true",
+                     true, :^, false
+    assert_send_type "(untyped) -> false",
+                     true, :^, Object.new
   end
 
   def test_inspect
-    true.inspect
+    assert_send_type "() -> 'true'",
+                     true, :inspect
   end
 
   def test_to_s
-    true.to_s
+    assert_send_type "() -> 'true'",
+                     true, :to_s
   end
 
   def test_or
-    true.|(nil)
+    assert_send_type "(true) -> true",
+                     true, :|, true
+    assert_send_type "(nil) -> true",
+                     true, :|, nil
+    assert_send_type "(false) -> true",
+                     true, :|, false
+    assert_send_type "(untyped) -> true",
+                     true, :|, Object.new
   end
 end


### PR DESCRIPTION
This primarily updates the unit tests for `FalseClass`, `NilClass`, and `TrueClass` to the newer system. It also:
- Removed `public` from the beginning of definitions (it's redundant)
- Removed `def clone: (?freeze: true?) -> self`, as that's defined on `Kernel`
- Collapsed redundant branches (`(nil) -> false | (false) -> false` is now just `(nil | false) -> false`. I decided not to do `(false?) -> false`, as the nil variant's important for the method definition, and doesn't just indicate an absence of a value)
- For `NilClass`, `to_h` now returns `{}`, not `::Hash[untyped, untyped]`. It maintains parity with the other methods (eg `def to_a: () -> []`)