### PR TITLE
[prototype runtime] Fix error when constant is a BasicObject instance.

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -377,8 +377,10 @@ module RBS
             next
           end
 
-          next if value.is_a?(Class) || value.is_a?(Module)
-          unless value.class.name
+          next if object_class(value).equal?(Class)
+          next if object_class(value).equal?(Module)
+
+          unless object_class(value).name
             RBS.logger.warn("Skipping constant #{name} #{value} of #{mod} as an instance of anonymous class")
             next
           end
@@ -396,7 +398,7 @@ module RBS
                  when ENV
                    Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ENVClass"), args: [], location: nil)
                  else
-                   value_type_name = to_type_name(const_name!(value.class), full_name: true).absolute!
+                   value_type_name = to_type_name(const_name!(object_class(value)), full_name: true).absolute!
                    args = type_args(value_type_name)
                    Types::ClassInstance.new(name: value_type_name, args: args, location: nil)
                  end
@@ -590,6 +592,11 @@ module RBS
         else
           name
         end
+      end
+
+      def object_class(value)
+        @object_class ||= Object.instance_method(:class)
+        @object_class.bind_call(value)
       end
 
       def type_args(type_name)

--- a/sig/prototype/runtime.rbs
+++ b/sig/prototype/runtime.rbs
@@ -8,6 +8,7 @@ module RBS
       @builder: DefinitionBuilder
 
       @module_name_method: UnboundMethod
+      @object_class: UnboundMethod
 
       include Helpers
 
@@ -76,6 +77,8 @@ module RBS
       def const_name: (Module const) -> String?
 
       def const_name!: (Module const) -> String
+
+      def object_class: (untyped) -> untyped
 
       def type_args: (TypeName type_name) -> Array[Types::t]
 

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -533,29 +533,34 @@ end
     end
   end
 
-  class Unnamed
+  class Constants
     module Name
       class Space
       end
     end
     A = ARGF
     B = ENV
+    C = BasicObject.new
     D = Name::Space.new
+    E = Class.new # skip
+    F = Module.new # skip
   end
 
-  def test_unnamed
+  def test_constants
     SignatureManager.new do |manager|
       manager.build do |env|
-        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::Unnamed"], env: env, merge: false)
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::Constants"], env: env, merge: false)
         assert_write p.decls, <<~RBS
           module RBS
             class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class Unnamed
+              class Constants
                 A: ::RBS::Unnamed::ARGFClass
 
                 B: ::RBS::Unnamed::ENVClass
 
-                D: ::RBS::RuntimePrototypeTest::Unnamed::Name::Space
+                C: ::BasicObject
+
+                D: ::RBS::RuntimePrototypeTest::Constants::Name::Space
               end
             end
           end


### PR DESCRIPTION
BasicObject instances are difficult to determine because the methods that can be called are very limited.

There are actual examples, and I think it should be fixed.

https://github.com/Shopify/bootsnap/blob/b75c683feb8c9b4b1da72fe19c788ad112c7fd96/lib/bootsnap/compile_cache.rb#L5