### PR TITLE
Should keep escape of alias and attr family

### DIFF
--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -107,7 +107,7 @@ module RBS
           "#{clause.namespace}*"
         end
       end
-      
+
       puts "use #{clauses.join(", ")}"
     end
 
@@ -264,8 +264,8 @@ module RBS
       when AST::Members::Alias
         write_comment member.comment
         write_annotation member.annotations
-        new_name = member.singleton? ? "self.#{member.new_name}" : member.new_name
-        old_name = member.singleton? ? "self.#{member.old_name}" : member.old_name
+        new_name = member.singleton? ? "self.#{method_name(member.new_name)}" : method_name(member.new_name)
+        old_name = member.singleton? ? "self.#{method_name(member.old_name)}" : method_name(member.old_name)
         puts "alias #{new_name} #{old_name}"
       when AST::Members::InstanceVariable
         write_comment member.comment
@@ -385,7 +385,7 @@ module RBS
                    ""
                  end
 
-      "#{visibility}attr_#{kind} #{receiver}#{attr.name}#{var}: #{attr.type}"
+      "#{visibility}attr_#{kind} #{receiver}#{method_name(attr.name)}#{var}: #{attr.type}"
     end
 
     def preserve_empty_line(prev, decl)

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -124,6 +124,22 @@ module XYZZY[X, Y]
   def `foo!=`: () -> Integer
 
   def `: (String) -> untyped
+
+  attr_accessor `a-b`: String
+
+  attr_reader `a-b`: String
+
+  attr_writer `a-b`: String
+
+  attr_accessor self.`a-b`: String
+
+  attr_reader self.`a-b`: String
+
+  attr_writer self.`a-b`: String
+
+  alias `b-a` `a-b`
+
+  alias self.`b-a` self.`a-b`
 end
     SIG
   end


### PR DESCRIPTION
Passing `RBS::Writer` for the aliases and attr family will cause the backquote to be off and output an RBS that results in a syntax error.

I fixed `RBS::Writer` so that backquotes are kept.