### PR TITLE
Clean up the incorrect untyped errors

### DIFF
--- a/core/false_class.rbs
+++ b/core/false_class.rbs
@@ -25,7 +25,7 @@ class FalseClass
   # statements.
   #
   def ===: (false) -> true
-         | (untyped obj) -> false
+         | (untyped obj) -> bool
 
   # <!--
   #   rdoc-file=object.c
@@ -36,7 +36,7 @@ class FalseClass
   # returns `true`.
   #
   def ^: (false | nil) -> false
-       | (untyped obj) -> true
+       | (untyped obj) -> bool
 
   # <!-- rdoc-file=object.c -->
   # The string representation of `false` is "false".
@@ -59,5 +59,5 @@ class FalseClass
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
   #
   def |: (nil | false) -> false
-       | (untyped obj) -> true
+       | (untyped obj) -> bool
 end

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -448,7 +448,7 @@ module Kernel : BasicObject
                    | (_ToC complex_like, exception: bool) -> Complex?
                    | (Numeric | String real, ?Numeric | String imag, ?exception: true) -> Complex
                    | (Numeric | String real, ?Numeric | String imag, exception: bool) -> Complex?
-                   | (untyped, ?untyped, exception: false) -> nil
+                   | (untyped, ?untyped, ?exception: bool) -> Complex?
 
   # <!--
   #   rdoc-file=kernel.rb
@@ -468,7 +468,7 @@ module Kernel : BasicObject
   #
   def self?.Float: (_ToF float_like, ?exception: true) -> Float
                  | (_ToF float_like, exception: bool) -> Float?
-                 | (untyped, exception: false) -> nil
+                 | (untyped, ?exception: bool) -> Float?
 
   # <!--
   #   rdoc-file=object.c
@@ -579,11 +579,11 @@ module Kernel : BasicObject
   # With `exception` given as `false`, an exception of any kind is suppressed and
   # `nil` is returned.
   #
-  def self?.Integer: (_ToInt | _ToI int_like, ?exception: true) -> Integer
-                   | (_ToInt | _ToI int_like, exception: bool) -> Integer?
+  def self?.Integer: (int | _ToI int_like, ?exception: true) -> Integer
+                   | (int | _ToI int_like, exception: bool) -> Integer?
                    | (string str, ?int base, ?exception: true) -> Integer
                    | (string str, ?int base, exception: bool) -> Integer?
-                   | (untyped, ?untyped, exception: false) -> nil
+                   | (untyped, ?untyped, ?exception: bool) -> Integer?
 
   # <!--
   #   rdoc-file=rational.c
@@ -622,13 +622,13 @@ module Kernel : BasicObject
   #
   # See also String#to_r.
   #
-  def self?.Rational: (_ToInt | _ToR rational_like, ?exception: true) -> Rational
-                    | (_ToInt | _ToR rational_like, exception: bool) -> Rational?
-                    | (_ToInt | _ToR numer, ?_ToInt | _ToR denom, ?exception: true) -> Rational
-                    | (_ToInt | _ToR numer, ?_ToInt | _ToR denom, exception: bool) -> Rational?
+  def self?.Rational: (int | _ToR rational_like, ?exception: true) -> Rational
+                    | (int | _ToR rational_like, exception: bool) -> Rational?
+                    | (int | _ToR numer, ?int | _ToR denom, ?exception: true) -> Rational
+                    | (int | _ToR numer, ?int | _ToR denom, exception: bool) -> Rational?
                     | [T] (Numeric&_RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
                     | [T < Numeric] (T value, 1, ?exception: bool) -> T
-                    | (untyped, ?untyped, exception: false) -> nil
+                    | (untyped, ?untyped, ?exception: bool) -> Rational?
 
   interface _RationalDiv[T]
     def /: (Numeric) -> T

--- a/core/nil_class.rbs
+++ b/core/nil_class.rbs
@@ -23,7 +23,7 @@ class NilClass
   # statements.
   #
   def ===: (nil) -> true
-         | (untyped obj) -> false
+         | (untyped obj) -> bool
 
   # <!--
   #   rdoc-file=object.c
@@ -44,7 +44,7 @@ class NilClass
   # returns `true`.
   #
   def ^: (false | nil) -> false
-       | (untyped obj) -> true
+       | (untyped obj) -> bool
 
   # <!--
   #   rdoc-file=object.c
@@ -142,5 +142,5 @@ class NilClass
   # Or---Returns `false` if *obj* is `nil` or `false`; `true` otherwise.
   #
   def |: (nil | false) -> false
-       | (untyped obj) -> true
+       | (untyped obj) -> bool
 end

--- a/core/true_class.rbs
+++ b/core/true_class.rbs
@@ -13,7 +13,7 @@ class TrueClass
   # And---Returns `false` if *obj* is `nil` or `false`, `true` otherwise.
   #
   def &: (false | nil) -> false
-       | (untyped obj) -> true
+       | (untyped obj) -> bool
 
   # <!--
   #   rdoc-file=object.c
@@ -24,7 +24,7 @@ class TrueClass
   # statements.
   #
   def ===: (true) -> true
-         | (untyped obj) -> false
+         | (untyped obj) -> bool
 
   # <!--
   #   rdoc-file=object.c
@@ -33,7 +33,7 @@ class TrueClass
   # Exclusive Or---Returns `true` if *obj* is `nil` or `false`, `false` otherwise.
   #
   def ^: (false | nil) -> true
-       | (untyped obj) -> false
+       | (untyped obj) -> bool
 
   # <!-- rdoc-file=object.c -->
   # The string representation of `true` is "true".


### PR DESCRIPTION
I erroneously used `| (untyped) -> ...` previously as an "anything but the previous arguments" variant, but in reality it can be "anything, including the previous arguments"—so the new return values reflect the uncertainty of that