### PR TITLE
[prototype runtime] Const name should be absolute

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -393,7 +393,7 @@ module RBS
                  when ENV
                    Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ENVClass"), args: [], location: nil)
                  else
-                   value_type_name = to_type_name(const_name!(value.class))
+                   value_type_name = to_type_name(const_name!(value.class), full_name: true).absolute!
                    args = type_args(value_type_name)
                    Types::ClassInstance.new(name: value_type_name, args: args, location: nil)
                  end
@@ -531,7 +531,7 @@ module RBS
           # Insert AST::Declarations if declarations are not added previously
           unless outer_decl
             outer_module or raise
-            
+
             if outer_module.is_a?(Class)
               outer_decl = AST::Declarations::Class.new(
                 name: to_type_name(outer_module_name),

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -86,7 +86,7 @@ module RBS
 
         def a: () -> untyped
 
-        NAME: String
+        NAME: ::String
       end
     end
   end
@@ -155,7 +155,7 @@ module RBS
 
         def a: () -> untyped
 
-        NAME: String
+        NAME: ::String
       end
     end
   end
@@ -314,7 +314,7 @@ end
 
                   def self.to_s: () -> untyped
 
-                  INSTANCE: C
+                  INSTANCE: ::RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
                 end
 
                 class C2 < ::RBS::RuntimePrototypeTest::TestForOverrideModuleName::C
@@ -325,7 +325,7 @@ end
 
                   def self.to_s: () -> untyped
 
-                  X: Integer
+                  X: ::Integer
                 end
               end
             end
@@ -365,7 +365,7 @@ end
                 end
 
                 module M
-                  HASH: Hash[untyped, untyped]
+                  HASH: ::Hash[untyped, untyped]
                 end
               end
             end
@@ -534,8 +534,13 @@ end
   end
 
   class Unnamed
+    module Name
+      class Space
+      end
+    end
     A = ARGF
     B = ENV
+    D = Name::Space.new
   end
 
   def test_unnamed
@@ -549,6 +554,8 @@ end
                 A: ::RBS::Unnamed::ARGFClass
 
                 B: ::RBS::Unnamed::ENVClass
+
+                D: ::RBS::RuntimePrototypeTest::Unnamed::Name::Space
               end
             end
           end


### PR DESCRIPTION
For example, given the following class, the result of `rbs prototype runtime` will be invalid.

```rb
$ cat t.rb
require 'active_support/all'

class Foo
  T = 1.day
end

$ rbs prototype runtime -R t.rb Foo
class Foo
  T: Duration #=> Could not find ::Duration (RBS::NoTypeFoundError)
end
```

To fix this problem, I modified the constant type to be absolute path.
If we want to keep the expression minimal, we will need to consider context, etc.