### PR TITLE
Fix the issue where ::array[T] would be interpreted as ::array, and type mismatch

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -318,7 +318,7 @@ module RBS
         when Types::Optional
           Test.call(val, IS_AP, ::NilClass) || value(val, type.type)
         when Types::Alias
-          value(val, builder.expand_alias(type.name))
+          value(val, builder.expand_alias2(type.name, type.args))
         when Types::Tuple
           Test.call(val, IS_AP, ::Array) &&
             type.types.map.with_index {|ty, index| value(val[index], ty) }.all?


### PR DESCRIPTION
Currently, it's not possible to test signatures with type aliases that take parameters in them, as `RBS::Test::TypeCheck#value` doesn't pass them correctly to `builder.expand_alias`. This fixes that. 
