### PR TITLE
Add in with_XXX methods

### DIFF
--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -241,7 +241,7 @@ class Dir
   # -->
   # Returns `true` if the named file is a directory, `false` otherwise.
   #
-  def self.exist?: (path | _ToIO file_name) -> bool
+  def self.exist?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=dir.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -404,8 +404,7 @@ module Kernel : BasicObject
   #     Array(:foo)             # => [:foo]
   #
   def self?.Array: (nil) -> []
-                 | [T] (Array[T] ary) -> Array[T]
-                 | [T] (_ToAry[T] | _ToA[T] array_like) -> Array[T]
+                 | [T] (array[T] | _ToA[T] array_like) -> Array[T]
                  | [T] (T ele) -> [T]
 
   # <!--
@@ -581,8 +580,8 @@ module Kernel : BasicObject
   #
   def self?.Integer: (int | _ToI int_like, ?exception: true) -> Integer
                    | (int | _ToI int_like, exception: bool) -> Integer?
-                   | (string str, ?int base, ?exception: true) -> Integer
-                   | (string str, ?int base, exception: bool) -> Integer?
+                   | (string str, int base, ?exception: true) -> Integer
+                   | (string str, int base, exception: bool) -> Integer?
                    | (untyped, ?untyped, ?exception: bool) -> Integer?
 
   # <!--
@@ -756,7 +755,7 @@ module Kernel : BasicObject
   #     autoload(:B, "b")
   #     autoload?(:B)            #=> "b"
   #
-  def self?.autoload?: (Symbol | String name) -> String?
+  def self?.autoload?: (interned name) -> String?
 
   # <!--
   #   rdoc-file=proc.c

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -97,8 +97,10 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_exist?
-    assert_send_type "(::ToStr) -> bool",
-                     Dir, :exist?, ToStr.new(__dir__)
+    with_path.chain(with_io).each do |path|
+      assert_send_type "(::path | ::io) -> bool",
+                       Dir, :exist?, path
+    end
   end
 
   def test_foreach

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -652,6 +652,11 @@ class StringInstanceTest < Test::Unit::TestCase
   end
 
   def test_encode
+    with_encoding Encoding::UTF_8 do |encoding|
+      assert_send_type "(::encoding) -> String",
+                       "string", :encode, encoding
+    end
+
     assert_send_type "(String) -> String",
                      "string", :encode, "ascii"
     assert_send_type "(String, Encoding) -> String",

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -167,6 +167,67 @@ module VersionHelper
   end
 end
 
+module WithAliases
+  def with_int(value = 3)
+    return to_enum(__method__, value) unless block_given?
+    yield value
+    yield ToInt.new(value)
+  end
+
+  def with_float(value = 0.1)
+    return to_enum(__method__, value) unless block_given?
+    yield value
+    yield ToF.new(value)
+  end
+
+  def with_string(value = "")
+    return to_enum(__method__, value) unless block_given?
+    yield value
+    yield ToStr.new(value)
+  end
+
+  def with_array(*elements)
+    return to_enum(__method__, *elements) unless block_given?
+
+    yield elements
+    yield ToArray.new(*elements)
+  end
+
+  def with_hash(hash = {})
+    return to_enum(__method__, hash) unless block_given?
+
+    yield hash
+    yield ToHash.new(hash)
+  end
+
+  def with_io(io = $stdout)
+    return to_enum(__method__, io) unless block_given?
+    yield io
+    yield ToIO.new(io)
+  end
+
+  def with_path(path = "/tmp/foo.txt", &block)
+    return to_enum(__method__, path) unless block_given?
+
+    with_string(path, &block)
+    block.call ToPath.new(path)
+  end
+
+  def with_encoding(encoding = Encoding::UTF_8, &block)
+    return to_enum(__method__, encoding) unless block_given?
+
+    block.call encoding
+    with_string(encoding.to_s, &block)
+  end
+
+  def with_interned(value = :&, &block)
+    return to_enum(__method__, value) unless block_given?
+
+    with_string(value.to_s, &block)
+    block.call value.to_sym
+  end
+end
+
 module TypeAssertions
   module ClassMethods
     attr_reader :target
@@ -401,6 +462,17 @@ module TypeAssertions
   end
 
   include VersionHelper
+  include WithAliases
+end
+
+class ToIO
+  def initialize(io = $stdout)
+    @io = io
+  end
+
+  def to_io
+    @io
+  end
 end
 
 class ToI


### PR DESCRIPTION
This adds in the `with_XXX` test methods, as well as example usages of them: `with_int`, `with_float`, `with_string`, `with_array`, `with_hash`, `with_io`, `with_path`, `with_encoding`, and `with_interned`. (The `with_range` method will be in a separate PR as it has a few unresolved issues.) These allow for reasily testing the type variants (`int`, `array[T]`, `path`, etc.) without having to enumerate every possible variation.

Note, this requires #1491 to be merged, as it prevents some of the example functions from typechecking.

More concretely, this PR adds the following types in `test_helper`:
- `WithAliases`, which defines these types, and is `include`d in `TypeAssertions`
- `ToIO`, for use with `_ToIO` (and `with_io`).

It also updates the following signatures, which are used to test the `with_XXX` functions:
- `Dir.exist?`: Use `path | io` instead of `path | _ToIO`.
- `Kernel.Array`: Merge the `Array[T]` and `_ToArray[T] | _ToA[T]` branches into `array[T] | _ToA[T]`.
- `Kernel.autoload?`: Converted from `Symbol | String` into the correct `interned`

It also updates the following tests:
- Converts `Dir_test`'s `test_exist?` to use `with_path.chain(with_io)`
- Added `KernelSingletonTest`, with the following methods:
  - `test_Array`: tests `with_array`
  - `test_Float`: tests `with_float`
  - `test_Hash`: tests `with_Hash`
  - `test_Integer`: tests `with_int` and `with_string`
  - `test_String`: tests `with_string`
  - `test_autoload?`: tests `with_interned`
- Added an `with_encoding` variant to the beginning of `String_test`'s`test_encode`
