### PR TITLE
[prototype runtime] Optimize performance

### DIFF
--- a/sig/prototype/runtime.rbs
+++ b/sig/prototype/runtime.rbs
@@ -3,7 +3,7 @@ module RBS
     class Runtime
       @decls: Array[AST::Declarations::t]?
 
-      @modules: Array[Module]
+      @modules: Hash[String, Module]
 
       @builder: DefinitionBuilder
 


### PR DESCRIPTION
### Problem

When the number of modules/classes is large and the path is deep, there is a problem that the performance of `rbs prototype runtime` is extremely degraded.
This is due to the loop of calling `const_name` for all modules to find their names each time the paths are nested.
This situation can easily occur in Rails applications and is worth addressing.

### Solution

To suppress this loop, I modified `@modules` to be `Hash` to suppress the search cost.

### Comparison Code

```rb
$ cat t.rb
module Root
  10.times do |i|
    const_set("A_#{i}", Module.new{
      10.times do |j|
        const_set("B_#{i}_#{j}", Module.new{
          10.times do |k|
            const_set("C_#{i}_#{j}_#{k}", Module.new{
              10.times do |l|
                const_set("D_#{i}_#{j}_#{k}_#{l}", Class.new)
              end
            })
          end
        })
      end
    })
  end
end

$ time bundle exec rbs prototype runtime -R t.rb "Root*" > /dev/null

# before
101.24s user 1.69s system 99% cpu 1:43.11 total

# after
1.05s user 0.14s system 89% cpu 1.330 total
```