### PR TITLE
Update FileTest's definitions

### DIFF
--- a/core/file_test.rbs
+++ b/core/file_test.rbs
@@ -13,7 +13,7 @@ module FileTest
   #     File.blockdev?('/dev/sda1')       # => true
   #     File.blockdev?(File.new('t.tmp')) # => false
   #
-  def self?.blockdev?: (String | IO file_name) -> bool
+  def self?.blockdev?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -24,7 +24,7 @@ module FileTest
   #     File.chardev?($stdin)     # => true
   #     File.chardev?('t.txt')     # => false
   #
-  def self?.chardev?: (String | IO file_name) -> bool
+  def self?.chardev?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -42,14 +42,16 @@ module FileTest
   #
   # Argument `path` can be an IO object.
   #
-  def self?.directory?: (String | IO file_name) -> bool
+  def self?.directory?: (path | io file_name) -> bool
 
   # <!-- rdoc-file=file.c -->
   # Returns `true` if the named file exists and has a zero size.
   #
   # *file_name* can be an IO object.
   #
-  def self?.empty?: (String | IO file_name) -> bool
+  alias empty? zero?
+
+  alias self.empty? self.zero?
 
   # <!--
   #   rdoc-file=file.c
@@ -65,7 +67,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not executable by the effective user/group.
   #
-  def self?.executable?: (String file_name) -> bool
+  def self?.executable?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -81,7 +83,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not executable by the real user/group.
   #
-  def self?.executable_real?: (String file_name) -> bool
+  def self?.executable_real?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -93,7 +95,7 @@ module FileTest
   #
   # "file exists" means that stat() or fstat() system call is successful.
   #
-  def self?.exist?: (String | IO file_name) -> bool
+  def self?.exist?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -106,7 +108,7 @@ module FileTest
   # If the `file` argument is a symbolic link, it will resolve the symbolic link
   # and use the file referenced by the link.
   #
-  def self?.file?: (String | IO file) -> bool
+  def self?.file?: (path | io file) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -117,7 +119,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.grpowned?: (String | IO file_name) -> bool
+  def self?.grpowned?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -137,7 +139,7 @@ module FileTest
   #     open("d", "w") {}
   #     p File.identical?("a", "d")      #=> false
   #
-  def self?.identical?: (String | IO file_1, String | IO file_2) -> bool
+  def self?.identical?: (path | io file_1, path | io file_2) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -148,7 +150,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.owned?: (String | IO file_name) -> bool
+  def self?.owned?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -160,7 +162,7 @@ module FileTest
   #     File.pipe?('tmp/fifo') # => true
   #     File.pipe?('t.txt')    # => false
   #
-  def self?.pipe?: (String | IO file_name) -> bool
+  def self?.pipe?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -172,7 +174,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not readable by the effective user/group.
   #
-  def self?.readable?: (String file_name) -> bool
+  def self?.readable?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -184,7 +186,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not readable by the real user/group.
   #
-  def self?.readable_real?: (String file_name) -> bool
+  def self?.readable_real?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -194,7 +196,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.setgid?: (String | IO file_name) -> bool
+  def self?.setgid?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -204,7 +206,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.setuid?: (String | IO file_name) -> bool
+  def self?.setuid?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -214,7 +216,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.size: (String | IO file_name) -> Integer
+  def self?.size: (path | io file_name) -> Integer
 
   # <!--
   #   rdoc-file=file.c
@@ -225,7 +227,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.size?: (String | IO file_name) -> Integer?
+  def self?.size?: (path | io file_name) -> Integer?
 
   # <!--
   #   rdoc-file=file.c
@@ -237,7 +239,7 @@ module FileTest
   #     File.socket?(Socket.new(:INET, :STREAM)) # => true
   #     File.socket?(File.new('t.txt'))          # => false
   #
-  def self?.socket?: (String | IO file_name) -> bool
+  def self?.socket?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -247,7 +249,7 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.sticky?: (String | IO file_name) -> bool
+  def self?.sticky?: (path | io file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -259,7 +261,7 @@ module FileTest
   #     File.symlink?('symlink') # => true
   #     File.symlink?('t.txt')   # => false
   #
-  def self?.symlink?: (String file_name) -> bool
+  def self?.symlink?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -275,7 +277,7 @@ module FileTest
   #     m = File.world_readable?("/etc/passwd")
   #     sprintf("%o", m)                              #=> "644"
   #
-  def self?.world_readable?: (String | IO file_name) -> Integer?
+  def self?.world_readable?: (path | io file_name) -> Integer?
 
   # <!--
   #   rdoc-file=file.c
@@ -291,7 +293,7 @@ module FileTest
   #     m = File.world_writable?("/tmp")
   #     sprintf("%o", m)                              #=> "777"
   #
-  def self?.world_writable?: (String | IO file_name) -> Integer?
+  def self?.world_writable?: (path | io file_name) -> Integer?
 
   # <!--
   #   rdoc-file=file.c
@@ -303,7 +305,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not writable by the effective user/group.
   #
-  def self?.writable?: (String file_name) -> bool
+  def self?.writable?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -315,7 +317,7 @@ module FileTest
   # Note that some OS-level security features may cause this to return true even
   # though the file is not writable by the real user/group.
   #
-  def self?.writable_real?: (String file_name) -> bool
+  def self?.writable_real?: (path file_name) -> bool
 
   # <!--
   #   rdoc-file=file.c
@@ -325,5 +327,5 @@ module FileTest
   #
   # *file_name* can be an IO object.
   #
-  def self?.zero?: (String | IO file_name) -> bool
+  def self?.zero?: (path | io file_name) -> bool
 end

--- a/test/stdlib/FileTest_test.rb
+++ b/test/stdlib/FileTest_test.rb
@@ -5,177 +5,195 @@ class FileTestSingletonTest < Test::Unit::TestCase
 
   testing "singleton(::FileTest)"
 
+
+  def with_path_io(path: __FILE__, io: default=IO.open(IO.sysopen(File.expand_path(__FILE__))), &block)
+    with_path(path, &block)
+    with_io(io, &block)
+  ensure
+    io.close if default
+  end
+
   def test_blockdev?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :blockdev?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :blockdev?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :blockdev?, path_or_io
+    end
   end
 
   def test_chardev?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :chardev?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :chardev?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :chardev?, path_or_io
+    end
   end
 
   def test_directory?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :directory?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :directory?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :directory?, path_or_io
+    end
   end
 
   def test_empty?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :empty?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :empty?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :empty?, path_or_io
+    end
   end
 
   def test_executable?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :executable?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :executable?, path
+    end
   end
 
   def test_executable_real?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :executable_real?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :executable_real?, path
+    end
   end
 
   def test_exist?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :exist?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :exist?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :exist?, path_or_io
+    end
   end
 
   def test_file?
-    assert_send_type  "(::String file) -> bool",
-                      FileTest, :file?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file) -> bool",
-                      FileTest, :file?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :file?, path_or_io
+    end
   end
 
   def test_grpowned?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :grpowned?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :grpowned?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :grpowned?, path_or_io
+    end
   end
 
   def test_identical?
-    assert_send_type  "(::String file_1, ::String file_2) -> bool",
-                      FileTest, :identical?, File.expand_path(__FILE__), File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_1, ::IO file_2) -> bool",
-                      FileTest, :identical?, io_open, io_open
+    with_path_io do |path_or_io1|
+      with_path_io do |path_or_io2|
+        assert_send_type  "(::path | ::io, ::path | ::io) -> bool",
+                          FileTest, :identical?, path_or_io1, path_or_io2
+      end
+    end
   end
 
   def test_owned?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :owned?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :owned?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :owned?, path_or_io
+    end
   end
 
   def test_pipe?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :pipe?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :pipe?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :pipe?, path_or_io
+    end
   end
 
   def test_readable?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :readable?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :readable?, path
+    end
   end
 
   def test_readable_real?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :readable_real?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :readable_real?, path
+    end
   end
 
   def test_setgid?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :setgid?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :setgid?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :setgid?, path_or_io
+    end
   end
 
   def test_setuid?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :setuid?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :setuid?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :setuid?, path_or_io
+    end
   end
 
   def test_size
-    assert_send_type  "(::String file_name) -> ::Integer",
-                      FileTest, :size, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> ::Integer",
-                      FileTest, :size, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> Integer",
+                        FileTest, :size, path_or_io
+    end
   end
 
   def test_size?
-    assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :size?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> ::Integer?",
-                      FileTest, :size?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> Integer?",
+                        FileTest, :size?, path_or_io
+    end
   end
 
   def test_socket?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :socket?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :socket?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :socket?, path_or_io
+    end
   end
 
   def test_sticky?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :sticky?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :sticky?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :sticky?, path_or_io
+    end
   end
 
   def test_symlink?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :symlink?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :symlink?, path
+    end
   end
 
   def test_world_readable?
-    assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :world_readable?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> ::Integer?",
-                      FileTest, :world_readable?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> Integer?",
+                        FileTest, :world_readable?, path_or_io
+    end
   end
 
   def test_world_writable?
-    assert_send_type  "(::String file_name) -> ::Integer?",
-                      FileTest, :world_writable?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> ::Integer?",
-                      FileTest, :world_writable?, io_open
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> Integer?",
+                        FileTest, :world_writable?, path_or_io
+    end
   end
 
   def test_writable?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :writable?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :writable?, path
+    end
   end
 
   def test_writable_real?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :writable_real?, File.expand_path(__FILE__)
+    with_path do |path|
+      assert_send_type  "(::path) -> bool",
+                        FileTest, :writable_real?, path
+    end
   end
 
   def test_zero?
-    assert_send_type  "(::String file_name) -> bool",
-                      FileTest, :zero?, File.expand_path(__FILE__)
-    assert_send_type  "(::IO file_name) -> bool",
-                      FileTest, :zero?, io_open
-  end
-
-  private
-
-  def io_open
-    IO.open(IO.sysopen(File.expand_path(__FILE__)))
+    with_path_io do |path_or_io|
+      assert_send_type  "(::path | ::io) -> bool",
+                        FileTest, :zero?, path_or_io
+    end
   end
 end


### PR DESCRIPTION
This updates the signatures for `FileTest`, and updates the unit tests accordingly.

The current signatures are actually pretty accurate, they are just missing the implicit conversions.

More concretely the following changes were made to `FileTest`'s signatures:
- `blockdev?`, `chardev?`, `directory?`, `exist?`, `file?`, `grpowned?`, `owned?`, `pipe?`, `setgid?`, `setuid?`, `size?`, `size?`, `socket?`, `sticky?`, `world_readable?`, `world_writable?`, and `zero?`: Converted from `(String | IO) -> ...` to `(path | io) -> ...`.
- `empty?`: Changed to be an alias of `zero?`.
- `executable?`, `executable_real?`, `readable?`, `readable_real?`, `symlink?`, `writable?`, and `writable_real?`: Converted from `(String) -> ...` to `(path) -> ...`.
- `identical?`: Changed from `(String | IO, String | IO) -> ...` to `(path | io, path | io) -> ...`.
