### PR TITLE
Updated binding to use modern kernel tests

### DIFF
--- a/core/binding.rbs
+++ b/core/binding.rbs
@@ -30,9 +30,9 @@
 # Binding objects have no class-specific methods.
 #
 class Binding
-  def clone: () -> instance
+  def clone: () -> self
 
-  def dup: () -> instance
+  def dup: () -> self
 
   # <!--
   #   rdoc-file=proc.c

--- a/core/binding.rbs
+++ b/core/binding.rbs
@@ -30,9 +30,9 @@
 # Binding objects have no class-specific methods.
 #
 class Binding
-  def clone: () -> self
+  def clone: () -> instance
 
-  def dup: () -> self
+  def dup: () -> instance
 
   # <!--
   #   rdoc-file=proc.c

--- a/test/stdlib/Binding_test.rb
+++ b/test/stdlib/Binding_test.rb
@@ -6,12 +6,12 @@ class BindingInstanceTest < Test::Unit::TestCase
   testing 'Binding'
 
   def test_clone
-    assert_send_type  '() -> instance',
+    assert_send_type  '() -> Binding',
                       binding, :clone
   end
 
   def test_dup
-    assert_send_type  '() -> instance',
+    assert_send_type  '() -> Binding',
                       binding, :dup
   end
 
@@ -19,7 +19,7 @@ class BindingInstanceTest < Test::Unit::TestCase
     with_string '123' do |src|
       assert_send_type  '(string) -> untyped',
                         binding, :eval, src
-      
+
       with_string 'my file' do |filename|
         assert_send_type  '(string, string) -> untyped',
                           binding, :eval, src, filename

--- a/test/stdlib/Binding_test.rb
+++ b/test/stdlib/Binding_test.rb
@@ -1,53 +1,72 @@
 require_relative "test_helper"
 
-class BindingTest < StdlibTest
-  target Binding
+class BindingInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing 'Binding'
 
   def test_clone
-    binding.clone
+    assert_send_type  '() -> instance',
+                      binding, :clone
   end
 
   def test_dup
-    binding.dup
+    assert_send_type  '() -> instance',
+                      binding, :dup
   end
 
   def test_eval
-    binding.eval('1', '(eval)', 1)
-    binding.eval(ToStr.new)
-    binding.eval(ToStr.new, ToStr.new)
-    binding.eval(ToStr.new, ToStr.new, ToInt.new)
+    with_string '123' do |src|
+      assert_send_type  '(string) -> untyped',
+                        binding, :eval, src
+      
+      with_string 'my file' do |filename|
+        assert_send_type  '(string, string) -> untyped',
+                          binding, :eval, src, filename
+
+        with_int 3 do |lineno|
+          assert_send_type  '(string, string, int) -> untyped',
+                            binding, :eval, src, filename, lineno
+        end
+      end
+    end
   end
 
   def test_local_variable_defined?
-    binding.local_variable_defined?(:yes)
-    yes = true
-    binding.local_variable_defined?('yes')
-    binding.local_variable_defined?(ToStr.new('yes'))
+    with_interned :hello do |varname|
+      assert_send_type  '(interned) -> bool',
+                        binding, :local_variable_defined?, varname
+    end
   end
 
   def test_local_variable_get
-    foo = 1
-    binding.local_variable_get(:foo)
-    binding.local_variable_get('foo')
-    binding.local_variable_get(ToStr.new('foo'))
+    with_interned :varname do |varname|
+      assert_send_type  '(interned) -> untyped',
+                        binding, :local_variable_get, varname
+    end
   end
 
   def test_local_variable_set
-    binding.local_variable_set(:foo, 1)
-    binding.local_variable_set('foo', 1)
-    binding.local_variable_set(ToStr.new('foo'), 1)
+    with_interned :hello do |varname|
+      assert_send_type  '(interned, Rational) -> Rational',
+                        binding, :local_variable_set, varname, 1r
+    end
   end
 
   def test_local_variables
-    foo = 1
-    binding.local_variables
+    foo = bar = baz = 3 # make a few local variables
+
+    assert_send_type  '() -> Array[Symbol]',
+                      binding, :local_variables
   end
 
   def test_receiver
-    binding.receiver
+    assert_send_type  '() -> untyped',
+                      binding, :receiver
   end
 
   def test_source_location
-    binding.source_location
+    assert_send_type  '() -> [String, Integer]',
+                      binding, :source_location
   end
 end


### PR DESCRIPTION
This updates `Binding`'s tests to use the modern version of unit tests.

Also, it updates `Binding#clone` and `Binding#dup` to return `instance`, not `self`.