### PR TITLE
Updated ThreadGroup

### DIFF
--- a/core/thread_group.rbs
+++ b/core/thread_group.rbs
@@ -8,7 +8,13 @@
 # Newly created threads belong to the same group as the thread from which they
 # were created.
 #
-class ThreadGroup < Object
+class ThreadGroup
+  # <!-- rdoc-file=thread.c -->
+  # The default ThreadGroup created when Ruby starts; all Threads belong to it by
+  # default.
+  #
+  Default: ThreadGroup
+
   # <!--
   #   rdoc-file=thread.c
   #   - thgrp.add(thread)   -> thgrp
@@ -34,7 +40,7 @@ class ThreadGroup < Object
   #     Initial group now #<Thread:0x401b3c18>#<Thread:0x401bdf4c>
   #     tg group now #<Thread:0x401b3c90>
   #
-  def add: (Thread thread) -> ThreadGroup
+  def add: (Thread thread) -> self
 
   # <!--
   #   rdoc-file=thread.c
@@ -69,11 +75,5 @@ class ThreadGroup < Object
   #
   #     ThreadGroup::Default.list   #=> [#<Thread:0x401bdf4c run>]
   #
-  def list: () -> ::Array[Thread]
+  def list: () -> Array[Thread]
 end
-
-# <!-- rdoc-file=thread.c -->
-# The default ThreadGroup created when Ruby starts; all Threads belong to it by
-# default.
-#
-ThreadGroup::Default: ThreadGroup

--- a/test/stdlib/ThreadGroup_test.rb
+++ b/test/stdlib/ThreadGroup_test.rb
@@ -1,29 +1,51 @@
 require_relative "test_helper"
 
-class ThreadGroupTest < StdlibTest
-  target ThreadGroup
+class ThreadGroupInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::ThreadGroup"
+
+  def test_Default
+    assert_const_type 'ThreadGroup', 'ThreadGroup::Default'
+  end
 
   def test_add
-    tg = ThreadGroup.new
-    tg.add(Thread.new {})
+    thr = Thread.new{}
+    assert_send_type  '(Thread) -> self',
+                      ThreadGroup.new, :add, thr
+  ensure
+    thr.kill
   end
 
   def test_enclose
-    tg = ThreadGroup.new
-    tg.enclose
+    assert_send_type  '() -> self',
+                      ThreadGroup.new, :enclose
   end
 
   def test_enclosed?
     tg = ThreadGroup.new
-    tg.enclosed?
+
+    assert_send_type  '() -> bool',
+                      tg, :enclosed?
+
     tg.enclose
-    tg.enclosed?
+
+    assert_send_type  '() -> bool',
+                      tg, :enclosed?
   end
 
   def test_list
     tg = ThreadGroup.new
-    tg.list
-    tg.add(Thread.new {})
-    tg.list
+    thr = Thread.new{}
+
+    assert_send_type  '() -> Array[Thread]',
+                      tg, :list
+
+    tg.add(thr)
+
+    assert_send_type  '() -> Array[Thread]',
+                      tg, :list
+  ensure
+    thr.kill
   end
 end


### PR DESCRIPTION
This updates the signatures for `ThreadGroup`, and adds tests for it.

More specifically, the following changes were made.
- Removed redundant `< Object` from `ThreadGroup`
- Moved `Default` inside `ThreadGroup`
- `ThreadGroup#add` : return `self` instead of `ThreadGroup`
- `ThreadGroup#list`: removed `::` from `::Array[Thread]` 