### PR TITLE
Updated UnboundMethod, added Method::param_types

### DIFF
--- a/core/method.rbs
+++ b/core/method.rbs
@@ -23,6 +23,8 @@
 #     #=> [#<Date: 2017-03-01 ((2457814j,0s,0n),+0s,2299161j)>, #<Date: 2017-03-02 ((2457815j,0s,0n),+0s,2299161j)>]
 #
 class Method < Object
+  type param_types = Array[[:req | :opt | :rest | :keyreq | :key | :keyrest | :block, Symbol] | [:rest | :keyrest | :nokey]]
+
   # <!--
   #   rdoc-file=proc.c
   #   - meth.to_proc    -> proc
@@ -252,7 +254,7 @@ class Method < Object
   #     def foo(bar, baz, *args, &blk); end
   #     method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:rest, :args], [:block, :blk]]
   #
-  def parameters: () -> ::Array[[ :req | :opt | :rest | :keyreq | :key | :keyrest | :block, Symbol ] | [ :rest | :keyrest ]]
+  def parameters: () -> param_types
 
   # <!--
   #   rdoc-file=proc.c

--- a/core/unbound_method.rbs
+++ b/core/unbound_method.rbs
@@ -60,7 +60,29 @@ class UnboundMethod
   #     Array.instance_method(:sum) == Enumerable.instance_method(:sum)
   #     #=> false, Array redefines the method for efficiency
   #
-  def ==: (untyped) -> bool
+  def ==: (untyped other) -> bool
+
+  # <!-- rdoc-file=proc.c -->
+  # Two unbound method objects are equal if they refer to the same method
+  # definition.
+  #
+  #     Array.instance_method(:each_slice) == Enumerable.instance_method(:each_slice)
+  #     #=> true
+  #
+  #     Array.instance_method(:sum) == Enumerable.instance_method(:sum)
+  #     #=> false, Array redefines the method for efficiency
+  #
+  alias eql? ==
+
+  # <!--
+  #   rdoc-file=proc.c
+  #   - meth.hash   -> integer
+  # -->
+  # Returns a hash value corresponding to the method object.
+  #
+  # See also Object#hash.
+  #
+  def hash: () -> Integer
 
   # <!--
   #   rdoc-file=proc.c
@@ -78,7 +100,7 @@ class UnboundMethod
   #     m.call # => "bar"
   #     n = m.clone.call # => "bar"
   #
-  def clone: () -> self
+  def clone: () -> instance
 
   # <!--
   #   rdoc-file=proc.c
@@ -189,6 +211,34 @@ class UnboundMethod
   #
   def inspect: () -> String
 
+  # <!-- rdoc-file=proc.c -->
+  # Returns a human-readable description of the underlying method.
+  #
+  #     "cat".method(:count).inspect   #=> "#<Method: String#count(*)>"
+  #     (1..3).method(:map).inspect    #=> "#<Method: Range(Enumerable)#map()>"
+  #
+  # In the latter case, the method description includes the "owner" of the
+  # original method (`Enumerable` module, which is included into `Range`).
+  #
+  # `inspect` also provides, when possible, method argument names (call sequence)
+  # and source location.
+  #
+  #     require 'net/http'
+  #     Net::HTTP.method(:get).inspect
+  #     #=> "#<Method: Net::HTTP.get(uri_or_host, path=..., port=...) <skip>/lib/ruby/2.7.0/net/http.rb:457>"
+  #
+  # `...` in argument definition means argument is optional (has some default
+  # value).
+  #
+  # For methods defined in C (language core and extensions), location and argument
+  # names can't be extracted, and only generic information is provided in form of
+  # `*` (any number of arguments) or `_` (some positional argument).
+  #
+  #     "cat".method(:count).inspect   #=> "#<Method: String#count(*)>"
+  #     "cat".method(:+).inspect       #=> "#<Method: String#+(_)>""
+  #
+  alias to_s inspect
+
   # <!--
   #   rdoc-file=proc.c
   #   - meth.name    -> symbol
@@ -213,7 +263,7 @@ class UnboundMethod
   #
   #     (1..3).method(:map).owner #=> Enumerable
   #
-  def owner: () -> Module
+  def owner: () -> (Class | Module)
 
   # <!--
   #   rdoc-file=proc.c
@@ -233,8 +283,7 @@ class UnboundMethod
   #     def foo(bar, baz, *args, &blk); end
   #     method(:foo).parameters #=> [[:req, :bar], [:req, :baz], [:rest, :args], [:block, :blk]]
   #
-  def parameters: () -> ::Array[[ Symbol, Symbol ]]
-                | () -> ::Array[[ Symbol ]]
+  def parameters: () -> Method::param_types
 
   # <!--
   #   rdoc-file=proc.c
@@ -243,7 +292,7 @@ class UnboundMethod
   # Returns the Ruby source filename and line number containing this method or nil
   # if this method was not defined in Ruby (i.e. native).
   #
-  def source_location: () -> [ String, Integer ]?
+  def source_location: () -> [String, Integer]?
 
   # <!--
   #   rdoc-file=proc.c
@@ -276,5 +325,5 @@ class UnboundMethod
   # arguments. This is semantically equivalent to `umeth.bind(recv).call(args,
   # ...)`.
   #
-  def bind_call: (untyped recv, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  def bind_call: (untyped recv, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped
 end

--- a/test/stdlib/UnboundMethod_test.rb
+++ b/test/stdlib/UnboundMethod_test.rb
@@ -1,75 +1,118 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
-class UnboundMethodTest < Test::Unit::TestCase
+class UnboundMethodInstanceTest < Test::Unit::TestCase
   include TypeAssertions
-  testing "::UnboundMethod"
 
-  class TestClass
-    def m(a, m = 1, *rest, x, k: 1, **kwrest, &blk)
-    end
+  testing '::UnboundMethod'
 
-    # to_s has super method
-    def to_s
-      ''
+  UMETH = Rational.instance_method(:to_s)
+
+  module ParamMeths
+    def leading_optional(a=3, b=4, c, d: 3) end
+    def all_params(a, b=3, *c, d: 1, e:, **f, &g) end
+    def only_ddd(...) end
+    def tailing_ddd(a, ...) end
+    def no_kwargs(**nil) end
+    eval "def shorthand(*, **, &) end" unless RUBY_VERSION < '3.1'
+  end
+
+  def test_eq
+    [UMETH, proc{}, Object.new, nil].each do |other|
+      assert_send_type  '(untyped) -> bool',
+                        UMETH, :==, other
     end
+  end
+
+  def test_eql?
+    [UMETH, proc{}, Object.new, nil].each do |other|
+      assert_send_type  '(untyped) -> bool',
+                        UMETH, :eql?, other
+    end
+  end
+
+  def test_hash
+    assert_send_type  '() -> Integer',
+                      UMETH, :hash
+  end
+
+  def test_clone
+    assert_send_type  '() -> instance',
+                      UMETH, :clone
   end
 
   def test_arity
-    assert_send_type "() -> Integer",
-                     unbound_method, :arity
+    assert_send_type  '() -> Integer',
+                      UMETH, :arity
   end
 
   def test_bind
-    assert_send_type "(Object) -> Method",
-                     unbound_method, :bind, 42
+    assert_send_type  '(untyped) -> Method',
+                      UMETH, :bind, 1r
+  end
+
+  def test_inspect
+    assert_send_type  '() -> String',
+                      UMETH, :inspect
+  end
+
+  def test_to_s
+    assert_send_type  '() -> String',
+                      UMETH, :to_s
   end
 
   def test_name
-    assert_send_type "() -> Symbol",
-                     unbound_method, :name
+    assert_send_type  '() -> Symbol',
+                      UMETH, :name
   end
 
   def test_owner
-    assert_send_type "() -> Module",
-                     unbound_method, :owner
+    assert_send_type  '() -> (Class | Module)',
+                      UMETH, :owner
+    assert_send_type  '() -> (Class | Module)',
+                      Module.method(:private).unbind, :owner
   end
 
   def test_parameters
-    assert_send_type "() -> Array[[ Symbol ]]",
-                     unbound_method, :parameters
-    assert_send_type "() -> Array[[ Symbol, Symbol ]]",
-                     TestClass.instance_method(:m), :parameters
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:leading_optional), :parameters
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:all_params), :parameters
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:only_ddd), :parameters
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:tailing_ddd), :parameters
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:no_kwargs), :parameters
+    
+    omit_if(RUBY_VERSION < '3.1')
+
+    assert_send_type  '() -> ::Method::param_types',
+                      ParamMeths.instance_method(:shorthand), :parameters
   end
 
   def test_source_location
-    assert_send_type "() -> nil",
-                     unbound_method, :source_location
-    assert_send_type "() -> [ String, Integer ]",
-                     TestClass.instance_method(:m), :source_location
+    assert_send_type  '() -> [String, Integer]?',
+                      UMETH, :source_location
+    assert_send_type  '() -> [String, Integer]?',
+                      ParamMeths.instance_method(:leading_optional), :source_location
   end
 
   def test_super_method
-    assert_send_type "() -> nil",
-                     TestClass.instance_method(:m), :super_method
-    assert_send_type "() -> UnboundMethod",
-                     TestClass.instance_method(:to_s), :super_method
+    assert_send_type  '() -> UnboundMethod?',
+                      UMETH, :super_method
+    assert_send_type  '() -> UnboundMethod?',
+                      ParamMeths.instance_method(:leading_optional), :super_method
   end
 
   def test_original_name
-    assert_send_type "() -> Symbol",
-                     unbound_method, :original_name
+    assert_send_type  '() -> Symbol',
+                      UMETH, :original_name
   end
 
   def test_bind_call
-    assert_send_type "(Integer) -> String",
-                     unbound_method, :bind_call, 42
-    assert_send_type "(Integer, Integer) -> String",
-                     unbound_method, :bind_call, 42, 16
-    assert_send_type "(UnboundMethodTest::TestClass, Integer, Integer, foo: String) { () -> void } -> nil",
-                     TestClass.instance_method(:m), :bind_call, TestClass.new, 42, 43, foo: 'bar' do end
-  end
-
-  def unbound_method
-    Integer.instance_method(:to_s)
+    assert_send_type  '(untyped, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped',
+                      UMETH, :bind_call, 1r
+    assert_send_type  '(untyped, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped',
+                      ParamMeths.instance_method(:only_ddd), :bind_call, Object.new.extend(ParamMeths)
   end
 end


### PR DESCRIPTION
This updates the type definitions for `UnboundMethod`, as well as introduces the `Method::param_types` alias.

More specifically, this:
- Updates `UnboundMethod_test.rb` to use the new testing harness, and conform to new signatures.
- Adds in `Method::param_types`, and changes `Method#parameters` to return it
- `UnboundMethod#eql?`: added as an alias for `UnboundMethod#==` 
- `UnboundMethod#hash`: added in 
- `UnboundMethod#clone`: Now returns `instance` not `self`
- `UnboundMethod#to_s`: added as an alias for `UnboundMethod#inspect`
- `UnboundMethod#owner`: The return type is now `(Class | Module)` instead of `Module`. While it's technically redundant, it's not common knowledge (especially amount new rubyists) that `Class`es are `Module`s, so this is a bit clearer IMO.
- `UnboundMethod#parameters`: Now returns `Method::param_types`
- `UnboundMethod#bind_call`: Added in `**untyped`; while technically redundant, I like making it explicit that kwargs are also allowed.