### PR TITLE
Updated Signal

### DIFF
--- a/core/signal.rbs
+++ b/core/signal.rbs
@@ -45,7 +45,7 @@ module Signal
   #
   #     Signal.list   #=> {"EXIT"=>0, "HUP"=>1, "INT"=>2, "QUIT"=>3, "ILL"=>4, "TRAP"=>5, "IOT"=>6, "ABRT"=>6, "FPE"=>8, "KILL"=>9, "BUS"=>7, "SEGV"=>11, "SYS"=>31, "PIPE"=>13, "ALRM"=>14, "TERM"=>15, "URG"=>23, "STOP"=>19, "TSTP"=>20, "CONT"=>18, "CHLD"=>17, "CLD"=>17, "TTIN"=>21, "TTOU"=>22, "IO"=>29, "XCPU"=>24, "XFSZ"=>25, "VTALRM"=>26, "PROF"=>27, "WINCH"=>28, "USR1"=>10, "USR2"=>12, "PWR"=>30, "POLL"=>29}
   #
-  def self.list: () -> ::Hash[String, Integer]
+  def self?.list: () -> Hash[String, Integer]
 
   # <!--
   #   rdoc-file=signal.c
@@ -61,7 +61,7 @@ module Signal
   #
   #     INT
   #
-  def self.signame: (Integer arg0) -> String?
+  def self?.signame: (int signo) -> String?
 
   # <!--
   #   rdoc-file=signal.c
@@ -89,6 +89,12 @@ module Signal
   #     Child died
   #     Terminating: 27460
   #
-  def self.trap: (Integer | String | Symbol signal, ?untyped command) -> (String | Proc)
-               | (Integer | String | Symbol signal) { (Integer arg0) -> untyped } -> (String | Proc)
+  def self?.trap: (Integer | interned signal) { (Integer) -> void } -> trap_command
+                | (Integer | interned signal, trap_command command) -> trap_command
+
+  type trap_command = string | bool | nil | _TrapCommand
+
+  interface _TrapCommand
+    def call: (Integer signo) -> void
+  end
 end

--- a/test/stdlib/Signal_test.rb
+++ b/test/stdlib/Signal_test.rb
@@ -1,0 +1,41 @@
+require_relative 'test_helper'
+
+class SignalSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing 'singleton(::Signal)'
+
+  def test_list
+    assert_send_type  '() -> Hash[String, Integer]',
+                      Signal, :list
+  end
+
+  def test_signame
+    with_int 0 do |int|
+      assert_send_type  '(::int) -> String?',
+                        Signal, :signame, int
+    end
+
+    with_int -1 do |int|
+      assert_send_type  '(::int) -> Signal?',
+                        Signal, :signame, int
+    end
+  end
+
+  def test_trap
+    old_usr2 = trap(:USR2, nil)
+
+    with_interned(:USR2).chain([Signal.list['USR2']]).each do |signal|
+      assert_send_type  '(Integer | ::interned) { (Integer) -> void } -> Signal::trap_command',
+                        Signal, :trap, signal do |n| end
+
+      with_string('').chain([true, false, nil, Class.new{def call(x)end}.new]).each do |command|
+        assert_send_type  '(Integer | ::interned, Signal::trap_command) -> Signal::trap_command',
+                          Signal, :trap, signal, command
+      end
+    end
+
+  ensure
+    trap(:USR2, old_usr2)
+  end
+end


### PR DESCRIPTION
This updates signatures for `Signal` as well as added `Signal_test.rb`.

More specifically, this makes the following changes:
- All three methods in `Signal` are now `self?`, as they're `module_function`s.
- `Signal.list`: Removed leading `::` in `::Hash[String, Integer]`
- `Signal.signame`: Use `int` instead of `Integer`  for `signo`
- `Signal.trap`: The signal is now `Integer | interned`, and use `Signal::trap_command` for the `command` type and return type.
- Added `Signal::trap_command`, which is `string | bool | nil | _TrapCommand` (where `_TrapCommand` is an interface with just `def call: (Integer signal) -> void`
   - Technically, `trap` can accept `Integer`s and `Float`s as well, but that's just an implementation bug (And, in fact, can cause a segfault if ruby is compiled without optimizations.)
