### PR TITLE
add `Kernel#respond_to_missing?`

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2806,6 +2806,8 @@ module Kernel : BasicObject
   #
   def respond_to?: (interned name, ?boolish include_all) -> bool
 
+  private def respond_to_missing?: (Symbol, bool) -> bool
+
   # <!--
   #   rdoc-file=vm_eval.c
   #   - foo.send(symbol [, args...])       -> obj

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2806,6 +2806,21 @@ module Kernel : BasicObject
   #
   def respond_to?: (interned name, ?boolish include_all) -> bool
 
+  # <!--
+  #   rdoc-file=vm_method.c
+  #   - obj.respond_to_missing?(symbol, include_all) -> true or false
+  #   - obj.respond_to_missing?(string, include_all) -> true or false
+  # -->
+  # DO NOT USE THIS DIRECTLY.
+  #
+  # Hook method to return whether the *obj* can respond to *id* method or not.
+  #
+  # When the method name parameter is given as a string, the string is converted
+  # to a symbol.
+  #
+  # See #respond_to?, and the example of BasicObject.
+  #
+  %a{annotate:rdoc:copy:Object#respond_to_missing?}
   private def respond_to_missing?: (Symbol, bool) -> bool
 
   # <!--

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -941,4 +941,15 @@ class KernelInstanceTest < Test::Unit::TestCase
       Object.instance_method(:to_s)
     )
   end
+  
+  def test_respond_to_missing?
+    obj = Object.new
+    
+    # The default implementation always returns `false` regardless of the args,
+    # let alone their types; though overrides only have to support Symbol + bool
+    assert_send_type(
+      "(::Symbol, bool) -> bool",
+      obj, :respond_to_missing?, :to_s, true
+    )
+  end
 end


### PR DESCRIPTION
https://github.com/ruby/rbs/blob/fce99b9700f5b9c9749e7a8c65852dc4b6b40cc7/test/test_helper.rb#L112-L113

My current project overrides `respond_to_missing?` and fails Steep on the courtesy `super` calls.

This originally based on #1504 because they conflict (this’d be `Object#respond_to_missing?` otherwise). Since the prerequisite is now (forced-pushed and) merged, this PR now bases on `master` itself.