### PR TITLE
doc: Add description for implicitly-returns-nil annotation

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -780,3 +780,8 @@ _annotation_ ::= `%a{` _annotation-text_ `}`  # Annotation using {}
 
 _annotation-text_ ::= /[^\x00]*/              # Any characters except NUL (and parenthesis)
 ```
+
+Supported annotations are:
+
+* `implicitly-returns-nil`: This annotation tells the method may return nil (ex. `Array#[]` and `Hash#[]`).
+  RBS itself doesn't do anything for this annotation. The type checkers may give precise types of the methods with the annotations.


### PR DESCRIPTION
refs: https://github.com/ruby/rbs/pull/1226

I also find `annotate:rdoc:*' and `steep:deprecated` and `pure' annotations. I think the former two are not needed to be documented. But it might be better to document the last one. Once I posted a similar PR to the Steep project. But I think it would be better to move it to this project.