### PR TITLE
Updated constants

### DIFF
--- a/core/constants.rbs
+++ b/core/constants.rbs
@@ -4,16 +4,16 @@
 #
 # See ARGF (the class) for more details.
 #
-::ARGF: RBS::Unnamed::ARGFClass
+ARGF: RBS::Unnamed::ARGFClass
 
 # <!-- rdoc-file=ruby.c -->
 # ARGV contains the command line arguments used to run ruby.
 #
 # A library like OptionParser can be used to process command-line arguments.
 #
-::ARGV: Array[String]
+ARGV: Array[String]
 
-::CROSS_COMPILING: NilClass
+CROSS_COMPILING: true?
 
 # <!-- rdoc-file=ruby.c -->
 # DATA is a File that contains the data section of the executed file. To create
@@ -27,70 +27,70 @@
 #     $ ruby t.rb
 #     hello world!
 #
-::DATA: File
+DATA: File
 
 # <!-- rdoc-file=version.c -->
 # The copyright string for ruby
 #
-::RUBY_COPYRIGHT: String
+RUBY_COPYRIGHT: String
 
 # <!-- rdoc-file=version.c -->
 # The full ruby version string, like `ruby -v` prints
 #
-::RUBY_DESCRIPTION: String
+RUBY_DESCRIPTION: String
 
 # <!-- rdoc-file=version.c -->
 # The engine or interpreter this ruby uses.
 #
-::RUBY_ENGINE: String
+RUBY_ENGINE: String
 
 # <!-- rdoc-file=version.c -->
 # The version of the engine or interpreter this ruby uses.
 #
-::RUBY_ENGINE_VERSION: String
+RUBY_ENGINE_VERSION: String
 
 # <!-- rdoc-file=version.c -->
 # The patchlevel for this ruby.  If this is a development build of ruby the
 # patchlevel will be -1
 #
-::RUBY_PATCHLEVEL: Integer
+RUBY_PATCHLEVEL: Integer
 
 # <!-- rdoc-file=version.c -->
 # The platform for this ruby
 #
-::RUBY_PLATFORM: String
+RUBY_PLATFORM: String
 
 # <!-- rdoc-file=version.c -->
 # The date this ruby was released
 #
-::RUBY_RELEASE_DATE: String
+RUBY_RELEASE_DATE: String
 
 # <!-- rdoc-file=version.c -->
 # The GIT commit hash for this ruby.
 #
-::RUBY_REVISION: Integer
+RUBY_REVISION: String
 
 # <!-- rdoc-file=version.c -->
 # The running version of ruby
 #
-::RUBY_VERSION: String
+RUBY_VERSION: String
 
 # <!-- rdoc-file=io.c -->
 # Holds the original stderr
 #
-::STDERR: IO
+STDERR: IO
 
 # <!-- rdoc-file=io.c -->
 # Holds the original stdin
 #
-::STDIN: IO
+STDIN: IO
 
 # <!-- rdoc-file=io.c -->
 # Holds the original stdout
 #
-::STDOUT: IO
+STDOUT: IO
 
 # <!-- rdoc-file=vm.c -->
 # The Binding of the top level scope
 #
-::TOPLEVEL_BINDING: Binding
+TOPLEVEL_BINDING: Binding

--- a/test/stdlib/constants_test.rb
+++ b/test/stdlib/constants_test.rb
@@ -1,0 +1,104 @@
+require_relative 'test_helper'
+
+# initialize temporary class
+module RBS
+  module Unnamed
+    ARGFClass = ARGF.class
+  end
+end
+
+class ConstantsTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing 'singleton(Object)'
+
+  def test_ARGF
+    assert_const_type  'RBS::Unnamed::ARGFClass',
+                       'ARGF'
+  end
+
+  def test_ARGV
+    assert_const_type  'Array[String]',
+                       'ARGV'
+  end
+
+  def test_CROSS_COMPILING
+    # There's no way to test both variants of `CROSS_COMPILING`.
+    assert_const_type 'true?',
+                      'CROSS_COMPILING'
+  end
+
+  def test_DATA
+    omit_unless defined?(DATA) # If you run this file from rake `DATA` won't be visible.
+    assert_const_type 'File',
+                      'DATA'
+  end
+
+  def test_RUBY_COPYRIGHT
+    assert_const_type 'String',
+                      'RUBY_COPYRIGHT'
+  end
+
+  def test_RUBY_DESCRIPTION
+    assert_const_type 'String',
+                      'RUBY_DESCRIPTION'
+  end
+
+  def test_RUBY_ENGINE
+    assert_const_type 'String',
+                      'RUBY_ENGINE'
+  end
+
+  def test_RUBY_ENGINE_VERSION
+    assert_const_type 'String',
+                      'RUBY_ENGINE_VERSION'
+  end
+
+  def test_RUBY_PATCHLEVEL
+    assert_const_type 'Integer',
+                      'RUBY_PATCHLEVEL'
+  end
+
+  def test_RUBY_PLATFORM
+    assert_const_type 'String',
+                      'RUBY_PLATFORM'
+  end
+
+  def test_RUBY_RELEASE_DATE
+    assert_const_type 'String',
+                      'RUBY_RELEASE_DATE'
+  end
+
+  def test_RUBY_REVISION
+    assert_const_type 'String',
+                      'RUBY_REVISION'
+  end
+
+  def test_RUBY_VERSION
+    assert_const_type 'String',
+                      'RUBY_VERSION'
+  end
+
+  def test_STDERR
+    assert_const_type 'IO',
+                      'STDERR'
+  end
+
+  def test_STDIN
+    assert_const_type 'IO',
+                      'STDIN'
+  end
+
+  def test_STDOUT
+    assert_const_type 'IO',
+                      'STDOUT'
+  end
+
+  def test_TOPLEVEL_BINDING
+    assert_const_type 'Binding',
+                      'TOPLEVEL_BINDING'
+  end
+end
+
+__END__
+This `__END__` is here so `DATA` is visible in the `test_DATA` method.


### PR DESCRIPTION
This pr updates the toplevel constants type definitions, and introduces `constants_test.rbs` to add tests.

More specifically, the following changes were made:
- The leading `::` on all constant names was removed
- `CROSS_COMPILING` is now `true?`.
- `RUBY_REVISION` is now a `String`.

There were some difficulties with writing tests, though:
- There's no way to test for `DATA` when using `rake`, as `DATA` is only defined if the entrypoint file has an `__END__`.  I added `__END__` to the end of `constants_test.rbs` though, so if you manually run the file it should work.
- There's no way to test for `CROSS_COMPILING`'s variations: You'd have to recompile ruby and check.