### PR TITLE
Update RbConfig

### DIFF
--- a/core/rb_config.rbs
+++ b/core/rb_config.rbs
@@ -7,6 +7,49 @@
 # built.
 #
 module RbConfig
+  # <!-- rdoc-file=rbconfig.rb -->
+  # The hash configurations stored.
+  #
+  CONFIG: Hash[String, String]
+
+  # <!-- rdoc-file=rbconfig.rb -->
+  # DESTDIR on make install.
+  #
+  DESTDIR: String
+
+  # <!-- rdoc-file=rbconfig.rb -->
+  # Almost same with CONFIG. MAKEFILE_CONFIG has other variable reference like
+  # below.
+  #
+  #     MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
+  #
+  # The values of this constant is used for creating Makefile.
+  #
+  #     require 'rbconfig'
+  #
+  #     print <<-END_OF_MAKEFILE
+  #     prefix = #{RbConfig::MAKEFILE_CONFIG['prefix']}
+  #     exec_prefix = #{RbConfig::MAKEFILE_CONFIG['exec_prefix']}
+  #     bindir = #{RbConfig::MAKEFILE_CONFIG['bindir']}
+  #     END_OF_MAKEFILE
+  #
+  #     => prefix = /usr/local
+  #        exec_prefix = $(prefix)
+  #        bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
+  #
+  # RbConfig.expand is used for resolving references like above in rbconfig.
+  #
+  #     require 'rbconfig'
+  #     p RbConfig.expand(RbConfig::MAKEFILE_CONFIG["bindir"])
+  #     # => "/usr/local/bin"
+  #
+  MAKEFILE_CONFIG: Hash[String, String]
+
+  # <!-- rdoc-file=rbconfig.rb -->
+  # Ruby installed directory.
+  #
+  TOPDIR: String
+
   # <!--
   #   rdoc-file=rbconfig.rb
   #   - RbConfig.expand(val)         -> string
@@ -18,50 +61,28 @@ module RbConfig
   #
   def self.expand: (String val, ?Hash[String, String] config) -> String
 
+  # <!--
+  #   rdoc-file=rbconfig.rb
+  #   - RbConfig.fire_update!(key, val)               -> array
+  #   - RbConfig.fire_update!(key, val, mkconf, conf) -> array
+  # -->
+  # updates `key+ in `mkconf` with `val`, and all values depending on
+  # the `key` in `mkconf`.
+  #
+  #   RbConfig::MAKEFILE_CONFIG.values_at("CC", "LDSHARED") # => ["gcc", "$(CC) -shared"]
+  #   RbConfig::CONFIG.values_at("CC", "LDSHARED")          # => ["gcc", "gcc -shared"]
+  #   RbConfig.fire_update!("CC", "gcc-8")                  # => ["CC", "LDSHARED"]
+  #   RbConfig::MAKEFILE_CONFIG.values_at("CC", "LDSHARED") # => ["gcc-8", "$(CC) -shared"]
+  #   RbConfig::CONFIG.values_at("CC", "LDSHARED")          # => ["gcc-8", "gcc-8 -shared"]
+  #
+  # returns updated keys list, or `nil` if nothing changed.
   def self.fire_update!: (String key, String val, ?Hash[String, String] mkconf, ?Hash[String, String] conf) -> Array[String]?
 
+  # <!--
+  #   rdoc-file=rbconfig.rb
+  #   - RbConfig.ruby -> path
+  # -->
+  #
+  # returns the absolute pathname of the ruby command.
   def self.ruby: () -> String
 end
-
-# <!-- rdoc-file=rbconfig.rb -->
-# The hash configurations stored.
-#
-RbConfig::CONFIG: Hash[String, String]
-
-# <!-- rdoc-file=rbconfig.rb -->
-# DESTDIR on make install.
-#
-RbConfig::DESTDIR: String
-
-# <!-- rdoc-file=rbconfig.rb -->
-# Almost same with CONFIG. MAKEFILE_CONFIG has other variable reference like
-# below.
-#
-#     MAKEFILE_CONFIG["bindir"] = "$(exec_prefix)/bin"
-#
-# The values of this constant is used for creating Makefile.
-#
-#     require 'rbconfig'
-#
-#     print <<-END_OF_MAKEFILE
-#     prefix = #{RbConfig::MAKEFILE_CONFIG['prefix']}
-#     exec_prefix = #{RbConfig::MAKEFILE_CONFIG['exec_prefix']}
-#     bindir = #{RbConfig::MAKEFILE_CONFIG['bindir']}
-#     END_OF_MAKEFILE
-#
-#     => prefix = /usr/local
-#        exec_prefix = $(prefix)
-#        bindir = $(exec_prefix)/bin  MAKEFILE_CONFIG = {}
-#
-# RbConfig.expand is used for resolving references like above in rbconfig.
-#
-#     require 'rbconfig'
-#     p RbConfig.expand(RbConfig::MAKEFILE_CONFIG["bindir"])
-#     # => "/usr/local/bin"
-#
-RbConfig::MAKEFILE_CONFIG: Hash[String, String]
-
-# <!-- rdoc-file=rbconfig.rb -->
-# Ruby installed directory.
-#
-RbConfig::TOPDIR: String

--- a/test/stdlib/RbConfig_test.rb
+++ b/test/stdlib/RbConfig_test.rb
@@ -1,21 +1,68 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
-class RbConfigTest < StdlibTest
-  target RbConfig
+class RbConfigSingletonTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing 'singleton(::RbConfig)'
+
+  def test_CONFIG
+    assert_const_type 'Hash[String, String]',
+                      'RbConfig::CONFIG'
+  end
+
+  def test_DESTDIR
+    assert_const_type 'String',
+                      'RbConfig::DESTDIR'
+  end
+
+  def test_MAKEFILE_CONFIG
+    assert_const_type 'Hash[String, String]',
+                      'RbConfig::MAKEFILE_CONFIG'
+  end
+
+  def test_TOPDIR
+    assert_const_type 'String',
+                      'RbConfig::TOPDIR'
+  end
 
   def test_expand
-    RbConfig.expand("/home/userName/.rbenv/versions/2.7.0/bin")
-    RbConfig.expand("/home/userName/.rbenv/versions/2.7.0/bin", "UNICODE_VERSION"=>"12.1.0")
+    assert_send_type  '(String) -> String',
+                      RbConfig, :expand, 'hello/world'
+
+    assert_send_type  '(String, Hash[String, String]) -> String',
+                      RbConfig, :expand, 'hello/world', 'a' => 'b'
   end
 
   def test_fire_update!
-    # Add test on nothing changed
-    RbConfig.fire_update!("CC", "gcc-8")
-    RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0")
-    RbConfig.fire_update!("CC", "gcc-8", "UNICODE_VERSION"=>"12.1.0", "PATH_SEPARATOR"=>":")
+    orig_makefile_config = RbConfig::MAKEFILE_CONFIG.clone
+    orig_config = RbConfig::CONFIG.clone
+
+    key, val = RbConfig::MAKEFILE_CONFIG.to_a.first
+
+    # Note: we use `val += '1'` instead of `val.concat '1'`, as `val.concat` would leave the updated
+    # key in the config hash, and so you couldn't update it.
+
+    assert_send_type  '(String, String) -> nil',
+                      RbConfig, :fire_update!, key, val
+    assert_send_type  '(String, String) -> Array[String]',
+                      RbConfig, :fire_update!, key, (val += '1')
+
+    assert_send_type  '(String, String, Hash[String, String]) -> nil',
+                      RbConfig, :fire_update!, key, val, RbConfig::MAKEFILE_CONFIG
+    assert_send_type  '(String, String, Hash[String, String]) -> Array[String]',
+                      RbConfig, :fire_update!, key, (val += '1'), RbConfig::MAKEFILE_CONFIG
+
+    assert_send_type  '(String, String, Hash[String, String], Hash[String, String]) -> nil',
+                      RbConfig, :fire_update!, key, val, RbConfig::MAKEFILE_CONFIG, RbConfig::CONFIG
+    assert_send_type  '(String, String, Hash[String, String], Hash[String, String]) -> Array[String]',
+                      RbConfig, :fire_update!, key, (val += '1'), RbConfig::MAKEFILE_CONFIG, RbConfig::CONFIG
+  ensure
+    RbConfig::MAKEFILE_CONFIG.replace orig_makefile_config
+    RbConfig::CONFIG.replace orig_config
   end
 
   def test_ruby
-    RbConfig.ruby
+    assert_send_type  '() -> String',
+                      RbConfig, :ruby
   end
 end


### PR DESCRIPTION
This updates `RbConfig` (which I didn't even know existed until working on it...), and it's associated tests.

This source file is entirely written in `.rb`, so there aren't really any implicit conversions, so no method definitions needed updating.

More specifically, this:
- Adds unit tests
- Moves `RbConfig::{CONFIG,DESTDIR,MAKEFILE_CONFIG,TOPDIR}` inside `RbConfig`
- Adds documentation for `RbConfig#fire_update!` and `RbConfig#ruby`
