### PR TITLE
Show location of type by method command

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -433,8 +433,9 @@ EOU
       stdout.puts "  accessibility: #{method.accessibility}"
       stdout.puts "  types:"
       separator = " "
-      for type in method.method_types
-        stdout.puts "    #{separator} #{type}"
+      length_max = method.method_types.map { |type| type.to_s.length }.max or raise
+      method.method_types.each do |type|
+        stdout.puts format("    %s %-#{length_max}s   at %s", separator, type, type.location)
         separator = "|"
       end
     end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -204,15 +204,15 @@ singleton(::BasicObject)
   def test_method
     with_cli do |cli|
       cli.run(%w(method ::Object yield_self))
-      assert_equal <<-EOF, stdout.string
-::Object#yield_self
-  defined_in: ::Kernel
-  implementation: ::Kernel
-  accessibility: public
-  types:
-      [X] () { (self) -> X } -> X
-    | () -> ::Enumerator[self, untyped]
-      EOF
+      assert_includes stdout.string, '::Object#yield_self'
+      assert_includes stdout.string, 'defined_in: ::Kernel'
+      assert_includes stdout.string, 'implementation: ::Kernel'
+      assert_includes stdout.string, 'accessibility: public'
+      assert_includes stdout.string, 'types:'
+      assert_includes stdout.string, '  [X] () { (self) -> X } -> X'
+      assert_includes stdout.string, 'rbs/core/kernel.rbs'
+      assert_includes stdout.string, '| () -> ::Enumerator[self, untyped]'
+      assert_includes stdout.string, 'rbs/core/kernel.rbs'
     end
 
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
I propose not only displaying type definitions but also indicating the location where the definition is written. This would help users quickly locate the source of type definitions and save them time.

Example:

```
$ bundle exec rbs -r bigdecimal method Float -
::Float#-
  defined_in: ::Float
  implementation: ::Float
  accessibility: public
  types:
      (::BigDecimal) -> ::BigDecimal   at /Users/ksss/src/github.com/ksss/rbs/stdlib/bigdecimal/0/big_decimal.rbs:1562:9...1562:35
    | (::Complex) -> ::Complex         at /Users/ksss/src/github.com/ksss/rbs/core/float.rbs:179:9...179:29
    | (::Numeric) -> ::Float           at /Users/ksss/src/github.com/ksss/rbs/core/float.rbs:180:9...180:27
```