### PR TITLE
[prototype runtime --todo] Consider accessibility mismatch

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -17,16 +17,22 @@ module RBS
           end
         end
 
-        def skip_singleton_method?(module_name:, name:)
+        def skip_singleton_method?(module_name:, method:, accessibility:)
           return false unless @builder.env.module_class_entry(module_name.absolute!)
 
-          @builder.build_singleton(module_name.absolute!).methods.has_key?(name)
+          method_definition = @builder.build_singleton(module_name.absolute!).methods[method.name]
+          return false unless method_definition
+
+          method_definition.accessibility == accessibility
         end
 
-        def skip_instance_method?(module_name:, name:)
+        def skip_instance_method?(module_name:, method:, accessibility:)
           return false unless @builder.env.module_class_entry(module_name.absolute!)
 
-          @builder.build_instance(module_name.absolute!).methods.has_key?(name)
+          method_definition = @builder.build_instance(module_name.absolute!).methods[method.name]
+          return false unless method_definition
+
+          method_definition.accessibility == accessibility
         end
 
         def skip_constant?(module_name:, name:)
@@ -303,9 +309,8 @@ module RBS
       def generate_methods(mod, module_name, members)
         module_name_absolute = to_type_name(const_name!(mod), full_name: true).absolute!
         mod.singleton_methods.select {|name| target_method?(mod, singleton: name) }.sort.each do |name|
-          next if todo_object&.skip_singleton_method?(module_name: module_name_absolute, name: name)
-
           method = mod.singleton_class.instance_method(name)
+          next if todo_object&.skip_singleton_method?(module_name: module_name_absolute, method: method, accessibility: :public)
 
           if can_alias?(mod.singleton_class, method)
             members << AST::Members::Alias.new(
@@ -341,9 +346,8 @@ module RBS
           members << AST::Members::Public.new(location: nil)
 
           public_instance_methods.sort.each do |name|
-            next if todo_object&.skip_instance_method?(module_name: module_name_absolute, name: name)
-
             method = mod.instance_method(name)
+            next if todo_object&.skip_instance_method?(module_name: module_name_absolute, method: method, accessibility: :public)
 
             if can_alias?(mod, method)
               members << AST::Members::Alias.new(
@@ -381,11 +385,10 @@ module RBS
           members << AST::Members::Private.new(location: nil)
 
           private_instance_methods.sort.each do |name|
-            next if todo_object&.skip_instance_method?(module_name: module_name_absolute, name: name)
+            method = mod.instance_method(name)
+            next if todo_object&.skip_instance_method?(module_name: module_name_absolute, method: method, accessibility: :private)
 
             added = true
-            method = mod.instance_method(name)
-
             if can_alias?(mod, method)
               members << AST::Members::Alias.new(
                 new_name: method.name,

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -621,6 +621,7 @@ end
     private def private_todo; end
     def self.singleton_defined; end
     def self.singleton_todo; end
+    private def accessibility_mismatch; end
 
     CONST_DEFINED = 1
     CONST_TODO = 1
@@ -643,6 +644,7 @@ end
               def public_defined: () -> void
               private def private_defined: () -> void
               def self.singleton_defined: () -> void
+              def accessibility_mismatch: () -> void
               CONST_DEFINED: Integer
             end
             module TodoModule
@@ -667,6 +669,8 @@ end
                 def public_todo: () -> untyped
 
                 private
+
+                def accessibility_mismatch: () -> untyped
 
                 def private_todo: () -> untyped
 


### PR DESCRIPTION
For example, the current `Kernel#initialize_copy` is defined as a public method in RBS, but it's actually a private method. This fact was discovered through the implementation of this PR.
Such accessibility inconsistencies should also be detected as part of the "todo" items.