### PR TITLE
Add private instance methods of Kernel `#initialize_*`

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -385,8 +385,6 @@ module Kernel : BasicObject
   def self?.fork: () -> Integer?
                 | () { () -> void } -> Integer
 
-  def initialize_copy: (self object) -> self
-
   # <!--
   #   rdoc-file=object.c
   #   - Array(object) -> object or new_array
@@ -2971,6 +2969,8 @@ module Kernel : BasicObject
 
   %a{annotate:rdoc:skip}
   alias then yield_self
+
+  private def initialize_copy: (self object) -> self
 end
 
 Kernel::RUBYGEMS_ACTIVATION_MONITOR: untyped

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2971,6 +2971,10 @@ module Kernel : BasicObject
   alias then yield_self
 
   private def initialize_copy: (self object) -> self
+
+  private def initialize_clone: (self object, ?freeze: bool?) -> self
+
+  private def initialize_dup: (self object) -> self
 end
 
 Kernel::RUBYGEMS_ACTIVATION_MONITOR: untyped

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -941,10 +941,10 @@ class KernelInstanceTest < Test::Unit::TestCase
       Object.instance_method(:to_s)
     )
   end
-  
+
   def test_respond_to_missing?
     obj = Object.new
-    
+
     # The default implementation always returns `false` regardless of the args,
     # let alone their types; though overrides only have to support Symbol + bool
     assert_send_type(
@@ -957,6 +957,25 @@ class KernelInstanceTest < Test::Unit::TestCase
     assert_send_type(
       "(self) -> self",
       Object.new, :initialize_copy, Object.new
+    )
+  end
+
+  def test_initialize_clone
+    assert_send_type(
+      "(self) -> self",
+      Object.new, :initialize_clone, Object.new
+    )
+
+    assert_send_type(
+      "(self, freeze: bool) -> self",
+      Object.new, :initialize_clone, Object.new, freeze: true
+    )
+  end
+
+  def test_initialize_dup
+    assert_send_type(
+      "(self) -> self",
+      Object.new, :initialize_dup, Object.new
     )
   end
 end

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -952,4 +952,11 @@ class KernelInstanceTest < Test::Unit::TestCase
       obj, :respond_to_missing?, :to_s, true
     )
   end
+
+  def test_initialize_copy
+    assert_send_type(
+      "(self) -> self",
+      Object.new, :initialize_copy, Object.new
+    )
+  end
 end


### PR DESCRIPTION
- Fix visibility for `Kernel#initialize_copy`
- Add `Kernel#initialize_clone`
- Add `Kernel#initialize_dup`

All of these should be defined as private instance methods within `Kernel`.

Note: These methods were discovered by https://github.com/ruby/rbs/pull/1539