### PR TITLE
Delete `sources` section from lockfile

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -44,12 +44,6 @@ module RBS
             path: config.repo_path_data,
             gemfile_lock_path: definition.lockfile.relative_path_from(lockfile_dir)
           )
-          config.sources.each do |source|
-            case source
-            when Sources::Git
-              lockfile.sources[source.name] = source
-            end
-          end
 
           if with_lockfile && lockfile_path.file?
             @existing_lockfile = Lockfile.from_lockfile(lockfile_path: lockfile_path, data: YAML.load_file(lockfile_path.to_s))

--- a/sig/collection/config/lockfile.rbs
+++ b/sig/collection/config/lockfile.rbs
@@ -7,7 +7,6 @@ module RBS
         # Data structure stored in `rbs_collection.lock.yaml`
         #
         type lockfile_data = {
-          "sources" => Array[Sources::Git::source_entry]?,   # null if empty
           "path" => String,
           "gems" => Array[library_data]?,         # null if empty
           "gemfile_lock_path" => String?          # gemfile_lock_path is optional because older versions doesn't have it
@@ -43,8 +42,6 @@ module RBS
         #
         attr_reader gemfile_lock_path: Pathname?
 
-        attr_reader sources: Hash[String, Sources::Git]
-
         attr_reader gems: Hash[String, library]
 
         def initialize: (lockfile_path: Pathname, path: Pathname, gemfile_lock_path: Pathname?) -> void
@@ -58,9 +55,6 @@ module RBS
         %a{pure} def gemfile_lock_fullpath: () -> Pathname?
 
         def to_lockfile: () -> lockfile_data
-
-        def each_source: () { (Sources::t) -> void } -> void
-                       | () -> Enumerator[Sources::t, void]
 
         def self.from_lockfile: (lockfile_path: Pathname, data: lockfile_data) -> Lockfile
 

--- a/test/rbs/collection/config_test.rb
+++ b/test/rbs/collection/config_test.rb
@@ -58,12 +58,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -115,12 +109,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
         string = YAML.dump(lockfile.to_lockfile)
 
         assert_config <<~YAML, string
-          sources:
-            - type: git
-              name: ruby/gem_rbs_collection
-              remote: #{remote}
-              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
-              repo_dir: gems
           path: "/path/to/somewhere"
           gemfile_lock_path: 'Gemfile.lock'
           gems:
@@ -155,12 +143,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       gemfile_lock_path.write GEMFILE_LOCK
 
       lockfile_yaml = <<~YAML
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -212,12 +194,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -277,12 +253,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -359,12 +329,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -414,12 +378,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -461,12 +419,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
       YAML
@@ -564,12 +516,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: ".gem_rbs_collection"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -628,12 +574,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: ".gem_rbs_collection"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -690,12 +630,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: ".gem_rbs_collection"
         gemfile_lock_path: 'Gemfile.lock'
       YAML
@@ -740,12 +674,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: ".gem_rbs_collection"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -824,12 +752,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
       string = YAML.dump(lockfile.to_lockfile)
 
       assert_config <<~YAML, string
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: 9612e5e67697153dcc7464c01115db44d29b1e34
-            repo_dir: gems
         path: ".gem_rbs_collection"
         gemfile_lock_path: 'Gemfile.lock'
         gems:
@@ -896,12 +818,6 @@ class RBS::Collection::ConfigTest < Test::Unit::TestCase
 
       # Version mismatched rbs_collection.lock.yaml (Gemfile.lock expects rainbow-3.0.0, but this expects 2.0)
       lockfile_yaml = <<~YAML
-        sources:
-          - type: git
-            name: ruby/gem_rbs_collection
-            remote: https://github.com/ruby/gem_rbs_collection.git
-            revision: cde6057e7546843ace6420c5783dd945c6ccda54
-            repo_dir: gems
         path: "/path/to/somewhere"
         gemfile_lock_path: 'Gemfile.lock'
         gems:


### PR DESCRIPTION
The `sources` section in the `rbs_collection.lock.yaml` is not used at all, but generates unintended diffs on `rbs collection install`.

This PR deletes the section from newly generated lockfiles.

`rbs collection install` and `rbs collection update` deletes the section from the lockfile, but `rbs collection install --frozen` keeps the section.