### PR TITLE
Use valid syntax

### DIFF
--- a/test/rbs/node_usage_test.rb
+++ b/test/rbs/node_usage_test.rb
@@ -9,7 +9,7 @@ class RBS::NodeUsageTest < Test::Unit::TestCase
 
   def test_conditional
     NodeUsage.new(parse(<<~RB))
-      if block
+      def block
         yield
       end
 


### PR DESCRIPTION
`yield` cannot appear outside a method.
`RubyVM::AbstractSyntaxTree` currently does not check it, but that does not mean it will never do.