### PR TITLE
stdlib: Separate types for net-protocol from net-http module

### DIFF
--- a/stdlib/net-http/0/manifest.yaml
+++ b/stdlib/net-http/0/manifest.yaml
@@ -1,3 +1,3 @@
 dependencies:
+  - name: net-protocol
   - name: uri
-  - name: timeout

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -1,57 +1,8 @@
 module Net
-  class Protocol
-    VERSION: String
-  end
-
-  class ProtocolError < StandardError
-  end
-
-  class ProtoSyntaxError < ProtocolError
-  end
-
-  class ProtoFatalError < ProtocolError
-  end
-
-  class ProtoUnknownError < ProtocolError
-  end
-
-  class ProtoServerError < ProtocolError
-  end
-
-  class ProtoAuthError < ProtocolError
-  end
-
-  class ProtoCommandError < ProtocolError
-  end
-
-  class ProtoRetriableError < ProtocolError
-  end
-
   class HTTPBadResponse < StandardError
   end
 
   class HTTPHeaderSyntaxError < StandardError
-  end
-
-  # <!-- rdoc-file=lib/net/protocol.rb -->
-  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot be
-  # created within the open_timeout.
-  #
-  class OpenTimeout < Timeout::Error
-  end
-
-  # <!-- rdoc-file=lib/net/protocol.rb -->
-  # ReadTimeout, a subclass of Timeout::Error, is raised if a chunk of the
-  # response cannot be read within the read_timeout.
-  #
-  class ReadTimeout < Timeout::Error
-  end
-
-  # <!-- rdoc-file=lib/net/protocol.rb -->
-  # WriteTimeout, a subclass of Timeout::Error, is raised if a chunk of the
-  # response cannot be written within the write_timeout.  Not raised on Windows.
-  #
-  class WriteTimeout < Timeout::Error
   end
 
   # <!-- rdoc-file=lib/net/http.rb -->

--- a/stdlib/net-protocol/0/manifest.yaml
+++ b/stdlib/net-protocol/0/manifest.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - name: timeout

--- a/stdlib/net-protocol/0/net-protocol.rbs
+++ b/stdlib/net-protocol/0/net-protocol.rbs
@@ -1,0 +1,56 @@
+module Net
+  class Protocol
+    VERSION: String
+  end
+
+  class ProtocolError < StandardError
+  end
+
+  class ProtoSyntaxError < ProtocolError
+  end
+
+  class ProtoFatalError < ProtocolError
+  end
+
+  class ProtoUnknownError < ProtocolError
+  end
+
+  class ProtoServerError < ProtocolError
+  end
+
+  class ProtoAuthError < ProtocolError
+  end
+
+  class ProtoCommandError < ProtocolError
+  end
+
+  class ProtoRetriableError < ProtocolError
+  end
+
+  class HTTPBadResponse < StandardError
+  end
+
+  class HTTPHeaderSyntaxError < StandardError
+  end
+
+  # <!-- rdoc-file=lib/net/protocol.rb -->
+  # OpenTimeout, a subclass of Timeout::Error, is raised if a connection cannot be
+  # created within the open_timeout.
+  #
+  class OpenTimeout < Timeout::Error
+  end
+
+  # <!-- rdoc-file=lib/net/protocol.rb -->
+  # ReadTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be read within the read_timeout.
+  #
+  class ReadTimeout < Timeout::Error
+  end
+
+  # <!-- rdoc-file=lib/net/protocol.rb -->
+  # WriteTimeout, a subclass of Timeout::Error, is raised if a chunk of the
+  # response cannot be written within the write_timeout.  Not raised on Windows.
+  #
+  class WriteTimeout < Timeout::Error
+  end
+end


### PR DESCRIPTION
refs: https://github.com/ruby/net-protocol