### PR TITLE
[prototype runtime] Add --autoload option

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -701,13 +701,15 @@ EOU
               end
             end
             ::Module.prepend(hook)
+            ::Kernel.prepend(hook)
 
             arguments = []
             TracePoint.new(:call) do |tp|
-              base = tp.self
+              base = tp.self.kind_of?(Module) ? tp.self : Kernel
               name = (tp.binding or raise).local_variable_get(:name)
               arguments << [base, name]
             end.enable(target: hook.instance_method(:autoload), &block)
+
             arguments.each do |(base, name)|
               begin
                 base.const_get(name)

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -648,6 +648,7 @@ EOU
         todo = false
         owners_included = []
         outline = false
+        autoload = false
 
         OptionParser.new do |opts|
           opts.banner = <<EOU
@@ -683,17 +684,47 @@ EOU
           opts.on("--outline", "Generates only module/class/constant declaration (no method definition)") do
             outline = true
           end
+          opts.on("--autoload", "Load all autoload path") do
+            autoload = true
+          end
         end.parse!(args)
 
         loader = options.loader()
         env = Environment.from_loader(loader).resolve_type_names
 
-        require_libs.each do |lib|
-          require(lib)
-        end
+        # @type var autoloader: ^() { () -> void } -> void
+        autoloader = ->(&block) {
+          if autoload
+            hook = Module.new do
+              def autoload(name, path)
+                super
+              end
+            end
+            ::Module.prepend(hook)
 
-        relative_libs.each do |lib|
-          eval("require_relative(lib)", binding, "rbs")
+            arguments = []
+            TracePoint.new(:call) do |tp|
+              base = tp.self
+              name = (tp.binding or raise).local_variable_get(:name)
+              arguments << [base, name]
+            end.enable(target: hook.instance_method(:autoload), &block)
+            arguments.each do |(base, name)|
+              begin
+                base.const_get(name)
+              rescue LoadError, StandardError
+              end
+            end
+          else
+            block.call
+          end
+        }
+        autoloader.call do
+          require_libs.each do |lib|
+            require(lib)
+          end
+          relative_libs.each do |lib|
+            eval("require_relative(lib)", binding, "rbs")
+          end
         end
 
         runtime = Prototype::Runtime.new(patterns: args, env: env, merge: merge, todo: todo, owners_included: owners_included)


### PR DESCRIPTION
I've added the `--autoload` option to include objects from autoload destinations as analysis targets.

`rbs prototype runtime` has an issue where it cannot read from `autoload` destinations, unlike `rbs prototype rb`. To resolve this, I've added an option to forcibly load `Module#autoload`.

Using `TracePoint`, it target `Module#autoload` to hook and retrieve its arguments, which are then loaded later. There is an issue where nested `autoload` cannot be read, but in most cases, it resolves the problem.

Since it's using the `target` option of `TracePoint#enable`, there's hardly any performance degradation.

### Example

before

```
$ bundle exec rbs prototype runtime -r rack 'Rack::*' 2>/dev/null | wc
       4       6      36
```

after

```
$ bundle exec rbs prototype runtime -r rack --autoload 'Rack::*' 2>/dev/null | wc
    2076    5331   44641
```