### PR TITLE
prototype rb: Ignore ITER (method call with block)

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -361,13 +361,7 @@ module RBS
           end
 
         when :ITER
-          method_name = node.children.first.children.first
-          case method_name
-          when :refine
-            # ignore
-          else
-            process_children(node, decls: decls, comments: comments, context: context)
-          end
+          # ignore
 
         when :CDECL
           const_name = case

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -864,7 +864,7 @@ end
     EOF
   end
 
-  def test_refinements
+  def test_ITER
     parser = RB.new
 
     rb = <<~'RUBY'
@@ -874,6 +874,11 @@ module M
 
   refine Array do
     def by_refinements
+    end
+  end
+
+  included do
+    def in_included
     end
   end
 end


### PR DESCRIPTION
Not to extract incorrect definitions from DSL blocks, `rbs prototype rb` ignores all ITER nodes (method call with block).