### PR TITLE
core: Kernel.fail is able to accept keyword arguments

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -844,6 +844,7 @@ module Kernel : BasicObject
   def self?.fail: () -> bot
                 | (string message, ?cause: Exception?) -> bot
                 | (_Exception exception, ?_ToS? message, ?String | Array[String] | nil backtrace, ?cause: Exception?) -> bot
+                | (_Exception exception, ?cause: Exception?, **untyped) -> bot
 
   # <!--
   #   rdoc-file=eval.c

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -656,6 +656,11 @@ class KernelTest < StdlibTest
     rescue test_error
     end
 
+    begin
+      fail test_error.new('a'), foo: 1, bar: 2, baz: 3, cause: RuntimeError.new("?")
+    rescue test_error
+    end
+
     exception_container = Class.new do
       define_method :exception do |arg = 'a'|
         test_error.new(arg)


### PR DESCRIPTION
For compatibility, Kernel.fail (as kwnon as raise) is able to accept keyword arguments.  It's not undocumented in the Ruby language documentation, but it's surely mentioned in the Ruby's spec.

refs: https://github.com/ruby/ruby/blob/v3_2_0/spec/ruby/shared/kernel/raise.rb#L38-L50