### PR TITLE
Update MatchData

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -229,7 +229,7 @@ type float = Float | _ToF
 
 # Represents a `Range[T]`, or a type that acts like it (via `.begin`, `.end`, and `.exclude_end?`).
 #
-type range[T] = Range[T] | _Range[T]
+type range[T] = Range[T & Range::_Spaceship] | _Range[T]
 
 # Represents a `String`, or a type convertible to it (via `.to_str`).
 #

--- a/core/match_data.rbs
+++ b/core/match_data.rbs
@@ -300,13 +300,14 @@ class MatchData
   #     # => #<MatchData "01" a:"0" a:"1">
   #     m.named_captures #=> {"a" => "1"}
   #
-  %a{ruby:version:>=3.3.0 }
-  def named_captures: (symbolize_names: true) -> Hash[Symbol, String?]
-                    | (?symbolize_names: false) -> Hash[String, String?]
-                    | (symbolize_names: boolish) -> Hash[Symbol | String, String?]
-
   %a{ruby:version:<3.3}
   def named_captures: () -> Hash[String, String?]
+
+  # %a{ruby:version:>=3.3.0}
+  # def named_captures: (symbolize_names: true) -> Hash[Symbol, String?]
+  #                   | (?symbolize_names: false) -> Hash[String, String?]
+  #                   | (symbolize_names: boolish) -> Hash[Symbol | String, String?]
+
 
   # <!--
   #   rdoc-file=re.c

--- a/core/match_data.rbs
+++ b/core/match_data.rbs
@@ -45,7 +45,7 @@
 # See also "Special global variables" section in Regexp documentation.
 #
 class MatchData
-  public
+  type backref = String | Symbol | int
 
   # <!-- rdoc-file=re.c -->
   # Returns `true` if `object` is another MatchData object whose target string,
@@ -80,10 +80,9 @@ class MatchData
   #     m['foo'] # => "h"
   #     m[:bar]  # => "ge"
   #
-  def []: (Integer idx) -> String?
-        | (Integer start, Integer length) -> ::Array[String?]
-        | (::Range[Integer] range) -> ::Array[String?]
-        | (interned name) -> String?
+  def []: (backref idx, ?nil) -> String?
+        | (range[int?] range, ?nil) -> Array[String?]?
+        | (int start, int length) -> Array[String?]?
 
   # <!--
   #   rdoc-file=re.c
@@ -121,7 +120,7 @@ class MatchData
   #
   # Related: MatchData#end, MatchData#offset, MatchData#byteoffset.
   #
-  def begin: (Integer | interned n_or_name) -> Integer?
+  def begin: (backref index) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -139,7 +138,7 @@ class MatchData
   #     p m.byteoffset(:foo) #=> [0, 1]
   #     p m.byteoffset(:bar) #=> [2, 3]
   #
-  def byteoffset: (Integer | interned n_or_name) -> ([ Integer, Integer ] | [ nil, nil ])
+  def byteoffset: (backref index) -> ([Integer, Integer] | [nil, nil])
 
   # <!--
   #   rdoc-file=re.c
@@ -154,7 +153,7 @@ class MatchData
   #
   # Related: MatchData.to_a.
   #
-  def captures: () -> ::Array[String?]
+  def captures: () -> Array[String?]
 
   # <!-- rdoc-file=re.c -->
   # Returns the array of captures, which are all matches except `m[0]`:
@@ -183,7 +182,7 @@ class MatchData
   #     m = /(\d{2}):(\d{2}):(\d{2})/.match("18:37:22")
   #     m.deconstruct_keys(nil) # => {}
   #
-  def deconstruct_keys: (Array[Symbol]?) -> Hash[Symbol, String?]
+  def deconstruct_keys: (Array[Symbol]? keys) -> Hash[Symbol, String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -221,7 +220,7 @@ class MatchData
   #
   # Related: MatchData#begin, MatchData#offset, MatchData#byteoffset.
   #
-  def end: (Integer | interned n_or_name) -> Integer?
+  def end: (backref index) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -232,7 +231,7 @@ class MatchData
   #
   # MatchData#eql? is an alias for MatchData#==.
   #
-  def eql?: (untyped other) -> bool
+  alias eql? ==
 
   # <!--
   #   rdoc-file=re.c
@@ -276,7 +275,7 @@ class MatchData
   #
   # MatchData#length is an alias for MatchData.size.
   #
-  def length: () -> Integer
+  alias length size
 
   # <!--
   #   rdoc-file=re.c
@@ -301,7 +300,13 @@ class MatchData
   #     # => #<MatchData "01" a:"0" a:"1">
   #     m.named_captures #=> {"a" => "1"}
   #
-  def named_captures: () -> ::Hash[String, String?]
+  %a{ruby:version:>=3.3.0 }
+  def named_captures: (symbolize_names: true) -> Hash[Symbol, String?]
+                    | (?symbolize_names: false) -> Hash[String, String?]
+                    | (symbolize_names: boolish) -> Hash[Symbol | String, String?]
+
+  %a{ruby:version:<3.3}
+  def named_captures: () -> Hash[String, String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -322,7 +327,7 @@ class MatchData
   #     m = /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge")
   #     m.regexp.names # => ["foo", "bar", "baz"]
   #
-  def names: () -> ::Array[String]
+  def names: () -> Array[String]
 
   # <!--
   #   rdoc-file=re.c
@@ -348,7 +353,7 @@ class MatchData
   #     m.match('foo') # => "h"
   #     m.match(:bar)  # => "ge"
   #
-  def match: (int | interned) -> String?
+  def match: (backref index) -> String?
 
   # <!--
   #   rdoc-file=re.c
@@ -375,7 +380,7 @@ class MatchData
   #     m.match_length('foo') # => 1
   #     m.match_length(:bar)  # => 2
   #
-  def match_length: (int | interned) -> Integer?
+  def match_length: (backref index) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -414,7 +419,7 @@ class MatchData
   #
   # Related: MatchData#byteoffset, MatchData#begin, MatchData#end.
   #
-  def offset: (Integer | interned n_or_name) -> ([ Integer, Integer ] | [ nil, nil ])
+  def offset: (backref index) -> ([Integer, Integer] | [nil, nil])
 
   # <!--
   #   rdoc-file=re.c
@@ -500,7 +505,7 @@ class MatchData
   #
   # Related: MatchData#captures.
   #
-  def to_a: () -> ::Array[String?]
+  def to_a: () -> Array[String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -544,9 +549,9 @@ class MatchData
   #     m.values_at(0, 1..2, :a, :b, :op)
   #     # => ["1 + 2", "1", "+", "1", "2", "+"]
   #
-  def values_at: (*Integer | interned n_or_name) -> ::Array[String?]
+  def values_at: (*backref | range[int?] indices) -> Array[String?]
 
   private
 
-  def initialize_copy: (self object) -> void
+  def initialize_copy: (instance object) -> self
 end

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -225,7 +225,12 @@
 # *   #to_a (aliased as #entries): Returns elements of `self` in an array.
 # *   #to_s: Returns a string representation of `self` (uses #to_s).
 #
-class Range[out Elem] < Object
+class Range[out Elem < _Spaceship] < Object
+  interface _Spaceship
+    def <=>: (instance rhs) -> Integer
+           | (untyped rhs) -> Integer?
+  end
+
   include Enumerable[Elem]
 
   # <!--

--- a/core/string.rbs
+++ b/core/string.rbs
@@ -820,6 +820,10 @@ class String
   #
   def =~: (untyped obj) -> Integer?
 
+  interface _Match[O]
+    def =~: (String) -> O
+  end
+
   # <!--
   #   rdoc-file=string.c
   #   - string[index] -> new_string or nil

--- a/test/stdlib/MatchData_test.rb
+++ b/test/stdlib/MatchData_test.rb
@@ -24,7 +24,7 @@ class MatchDataInstanceTest < Test::Unit::TestCase
   end
 
   def test_eq(meth: :==)
-    with_instance do |isntance|
+    with_instance do |instance|
       [KW_INSTANCE, INSTANCE, true, BasicObject.new, nil, :hello].each do |obj|
         assert_send_type '(untyped) -> bool',
                          instance, meth, obj
@@ -32,30 +32,53 @@ class MatchDataInstanceTest < Test::Unit::TestCase
     end
   end
 
-=begin
   def test_aref
-    with_backref 'greet', 1 do |bref|
-      assert_send_type  '(backref) -> String',
-                        INSTANCE, :[], bref
-      assert_send_type  '(backref, nil) -> String',
-                        INSTANCE, :[], bref, nil
+    # []: (backref, ?nil) -> String
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> String',
+                       KW_INSTANCE, :[], bref
+      assert_send_type '(MatchData::backref, nil) -> String',
+                       KW_INSTANCE, :[], bref, nil
+    end
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> String',
+                       INSTANCE, :[], bref
+      assert_send_type '(MatchData::backref, nil) -> String',
+                       INSTANCE, :[], bref, nil
     end
 
-    with_backref 'invalid', 999 do |bref|
-      assert_send_type  '(backref) -> nil',
-                        INSTANCE, :[], bref
-      assert_send_type  '(backref, nil) -> nil',
-                        INSTANCE, :[], bref, nil
+    # []: (backref, ?nil) -> nil
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       KW_INSTANCE, :[], bref
+      assert_send_type '(MatchData::backref, nil) -> nil',
+                       KW_INSTANCE, :[], bref, nil
+    end
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       INSTANCE, :[], bref
+      assert_send_type '(MatchData::backref, nil) -> nil',
+                       INSTANCE, :[], bref, nil
     end
 
-    with_int()
+    # []: (range[int?] range, ?nil) -> Array[String?]
+    [true,false].each do |exclude_end|
+      with_range with_int(1).chain([nil]), with_int(3).chain([nil]), exclude_end, iter: true do |rng|
+        with_instance do |instance|
+          assert_send_type '(range[int?]) -> Array[String?]',
+            INSTANCE, :[], rng
+          assert_send_type '(range[int?], nil) -> Array[String?]',
+            INSTANCE, :[], rng, nil
+        end
+      end
+    end
 
-    with_range
-
-  def []: (backref idx, ?nil) -> String?
-        | (range[int?] range, ?nil) -> Array[String?]?
-        | (int start, int length) -> Array[String?]?
-=end
+    # []: (int, int) -> Array[String?]?
+  end
+#   def []: (backref idx, ?nil) -> String?
+#         | (range[int?] range, ?nil) -> Array[String?]?
+#         | (int start, int length) -> Array[String?]?
+# =end
 
   def test_begin
     with_backref :whom, 2 do |bref|

--- a/test/stdlib/MatchData_test.rb
+++ b/test/stdlib/MatchData_test.rb
@@ -1,146 +1,298 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
-class MatchDataTest < StdlibTest
-  target MatchData
+class MatchDataInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
 
-  # test_==
-  def test_equal
-    foo = 'foo'
-    foo.match('f') == foo.match('f')
+  testing '::MatchData'
+
+  KW_INSTANCE  = "hello, friend; how are you?".match(/(?<greet>hello).*?(?<whom>friend)(?<punct>[!?])?.*/)
+  INSTANCE = "hello, friend; how are you?".match(/(hello).*?(friend)([!?])?/)
+  $~ = nil
+
+  def with_backref(str, int, &block)
+    with_int(int, &block) if int
+
+    if str
+      yield str.to_s
+      yield str.to_sym
+    end
   end
 
-  # test_[]
-  def test_square_bracket
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~[0]
-    $~[3]
-    $~[0..3]
-    $~[0, 4]
-    $~['first']
-    $~['third']
-    $~[:first]
-    $~[:third]
+  def with_instance
+    yield KW_INSTANCE
+    yield INSTANCE
   end
 
-  # test_begin
+  def test_eq(meth: :==)
+    with_instance do |isntance|
+      [KW_INSTANCE, INSTANCE, true, BasicObject.new, nil, :hello].each do |obj|
+        assert_send_type '(untyped) -> bool',
+                         instance, meth, obj
+      end
+    end
+  end
+
+=begin
+  def test_aref
+    with_backref 'greet', 1 do |bref|
+      assert_send_type  '(backref) -> String',
+                        INSTANCE, :[], bref
+      assert_send_type  '(backref, nil) -> String',
+                        INSTANCE, :[], bref, nil
+    end
+
+    with_backref 'invalid', 999 do |bref|
+      assert_send_type  '(backref) -> nil',
+                        INSTANCE, :[], bref
+      assert_send_type  '(backref, nil) -> nil',
+                        INSTANCE, :[], bref, nil
+    end
+
+    with_int()
+
+    with_range
+
+  def []: (backref idx, ?nil) -> String?
+        | (range[int?] range, ?nil) -> Array[String?]?
+        | (int start, int length) -> Array[String?]?
+=end
+
   def test_begin
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.begin 0
-    $~.begin 3
-    $~.begin 'first'
-    $~.begin 'third'
-    $~.begin :first
-    $~.begin :third
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       KW_INSTANCE, :begin, bref
+    end
+
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       KW_INSTANCE, :begin, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       INSTANCE, :begin, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       INSTANCE, :begin, bref
+    end
   end
 
-  def test_caputres
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.captures
+  def test_byteoffset
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> [Integer, Integer]',
+                       KW_INSTANCE, :byteoffset, bref
+    end
+
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> [nil, nil]',
+                       KW_INSTANCE, :byteoffset, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> [Integer, Integer]',
+                       INSTANCE, :byteoffset, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> [nil, nil]',
+                       INSTANCE, :byteoffset, bref
+    end
+  end
+
+  def test_captures(meth: :captures)
+    with_instance do |instance|
+      assert_send_type '() -> Array[String?]',
+                       instance, meth
+    end
+  end
+
+  def test_deconstruct
+    test_captures meth: :deconstruct
+  end
+
+  def test_deconstruct_keys
+    with_instance do |instance|
+      assert_send_type '(nil) -> Hash[Symbol, String?]',
+                       instance, :deconstruct_keys, nil
+      assert_send_type '(Array[Symbol]) -> Hash[Symbol, String?]',
+                       instance, :deconstruct_keys, [:greet, :punct, :invalid]
+    end
   end
 
   def test_end
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.end 0
-    $~.end 3
-    $~.end 'first'
-    $~.end 'third'
-    $~.end :first
-    $~.end :third
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       KW_INSTANCE, :end, bref
+    end
+
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       KW_INSTANCE, :end, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       INSTANCE, :end, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       INSTANCE, :end, bref
+    end
   end
 
   def test_eql?
-    foo = 'foo'
-    foo.match('f').eql? foo.match('f')
+    test_eq meth: :eql?
   end
 
   def test_hash
-    'foo'.match('f').hash
+    assert_send_type '() -> Integer',
+                     INSTANCE, :hash
   end
 
   def test_inspect
-    'foo'.match('f').inspect
+    assert_send_type '() -> String',
+                     INSTANCE, :inspect
   end
 
   def test_length
-    'foo'.match('f').length
+    test_size meth: :length
   end
 
   def test_named_captures
-    'foo'.match('(?<a>foo)').named_captures
+    with_instance do |instance|
+      assert_send_type '() -> Hash[String, String?]',
+                       instance, :named_captures
+
+      next if RUBY_VERSION < '3.3'
+
+      assert_send_type '(symbolize_names: true) -> Hash[Symbol, String?]',
+                       instance, :named_captures, symbolize_names: true
+      assert_send_type '(symbolize_names: false) -> Hash[String, String?]',
+                       instance, :named_captures, symbolize_names: false
+
+      [123, nil].each do |symbolize_names|
+        assert_send_type '(symbolize_names: boolish) -> Hash[String | Symbol, String?]',
+                         instance, :named_captures, symbolize_names: symbolize_names
+      end
+    end
   end
 
   def test_names
-    'foo'.match('(?<a>foo)').names
+    with_instance do |instance|
+      assert_send_type '() -> Array[String]',
+                       instance, :names
+    end
   end
 
   def test_match
-    m = /(.)(.)(\d+)(\d)(\w)?/.match("THX1138.")
-    m.match(0)
-    m.match(4.0)
-    m.match(ToInt.new(5))
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> String',
+                       KW_INSTANCE, :match, bref
+    end
 
-    m = /(?<foo>.)(.)(?<bar>.+)/.match("hoge")
-    m.match(:foo)
-    m.match("bar")
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       KW_INSTANCE, :match, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> String',
+                       INSTANCE, :match, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       INSTANCE, :match, bref
+    end
   end
 
   def test_match_length
-    m = /(.)(.)(\d+)(\d)(\w)?/.match("THX1138.")
-    m.match_length(0)
-    m.match_length(4.0)
-    m.match_length(ToInt.new(5))
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       KW_INSTANCE, :match_length, bref
+    end
 
-    m = /(?<foo>.)(.)(?<bar>.+)/.match("hoge")
-    m.match_length(:foo)
-    m.match_length("bar")
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       KW_INSTANCE, :match_length, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> Integer',
+                       INSTANCE, :match_length, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> nil',
+                       INSTANCE, :match_length, bref
+    end
   end
 
   def test_offset
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.offset 0
-    $~.offset 3
-    $~.offset 'first'
-    $~.offset 'third'
-    $~.offset :first
-    $~.offset :third
+    with_backref :whom, 2 do |bref|
+      assert_send_type '(MatchData::backref) -> [Integer, Integer]',
+                       KW_INSTANCE, :offset, bref
+    end
+
+    with_backref :punct, 3 do |bref|
+      assert_send_type '(MatchData::backref) -> [nil, nil]',
+                       KW_INSTANCE, :offset, bref
+    end
+
+    with_int 2 do |bref|
+      assert_send_type '(MatchData::backref) -> [Integer, Integer]',
+                       INSTANCE, :offset, bref
+    end
+
+    with_int 3 do |bref|
+      assert_send_type '(MatchData::backref) -> [nil, nil]',
+                       INSTANCE, :offset, bref
+    end
   end
 
   def test_post_match
-    'foo'.match('f').post_match
+    assert_send_type '() -> String',
+                     INSTANCE, :post_match
   end
 
   def test_pre_match
-    'foo'.match('o').pre_match
+    assert_send_type '() -> String',
+                     INSTANCE, :pre_match
   end
 
   def test_regexp
-    'foo'.match('f').regexp
+    assert_send_type '() -> Regexp',
+                     INSTANCE, :regexp
   end
 
-  def test_size
-    'foo'.match('f').size
+  def test_size(meth: :size)
+    assert_send_type '() -> Integer',
+                     INSTANCE, meth
   end
 
   def test_string
-    'foo'.match('f').string
+    assert_send_type '() -> String',
+                     INSTANCE, :string
   end
 
   def test_to_a
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.to_a
+    assert_send_type '() -> Array[String?]',
+                     INSTANCE, :to_a
   end
 
   def test_to_s
-    'foo'.match('f').to_s
+    assert_send_type '() -> String',
+                     INSTANCE, :to_s
   end
 
+=begin
   def test_values_at
-    /(?<first>foo)(?<second>bar)(?<third>Baz)?/ =~ "foobarbaz"
-    $~.values_at 0
-    $~.values_at 3
-    $~.values_at 'first'
-    $~.values_at 'third'
-    $~.values_at :first
-    $~.values_at :third
+  def values_at: (*backref | range[int?] indices) -> Array[String?]
+    assert_send_type '() -> String',
+                     INSTANCE, :to_s
   end
+=end
 end

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -200,6 +200,11 @@ module WithAliases
     yield ToHash.new(hash)
   end
 
+  def with_range(*args)
+    yield Range.new(*args)
+    yield CustomRange.new(*args)
+  end
+
   def with_io(io = $stdout)
     return to_enum(__method__, io) unless block_given?
     yield io
@@ -671,6 +676,20 @@ class Writer
 
   def write(*vals)
     @buffer.concat vals.join
+  end
+end
+
+class CustomRange < BlankSlate
+  attr_reader :begin, :end
+
+  def initialize(begin_, end_, exclude_end=false)
+    @begin = begin_
+    @end = end_
+    @exclude_end = exclude_end_
+  end
+
+  def exclude_end?
+    @exclude_end
   end
 end
 


### PR DESCRIPTION
This PR updates `MatchData` and its associated tests, as well as adds `String::_Match`.

More specifically, this makes the following semantic updates:
- `MatchData::backref`: Added, equal to `String | Symbol | int`
- `MatchData#[]`: Updated to use `backref`, implicit `int`s, and `range[int?]`
- `MatchData#{begin,end,match,match_length,offset}`: Updated to use `backref`
- `MatchData#deconstruct_keys`: Named argument `keys`
- `MatchData#eql?`: Now an alias for `==`
- `MatchData#length`: Now an alias for `size`
- `MatchData#named_captures`: Added `symbolize_names` and annotation for >= 3.3.0
- `MatchData#values_at`: Now uses `backref` and `range[int?]`
- `MatchData#initialize_copy`: Takes an `instance` and returns `void`.

TODO: Add tests for `[]`, `values_at`, and `initialize_copy`.