### PR TITLE
Better support for inherited class of `Struct` or `Data` by prototype runtime

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -492,7 +492,7 @@ module RBS
         unless decl
           if mod < Struct
             decl = StructGenerator.new(mod).build_decl
-          elsif mod < Data
+          elsif RUBY_VERSION >= '3.2' && mod < Data
             decl = DataGenerator.new(mod).build_decl
           else
             decl = AST::Declarations::Class.new(
@@ -511,7 +511,7 @@ module RBS
 
         generate_mixin(mod, decl, type_name, type_name_absolute)
 
-        unless mod < Struct || mod < Data
+        unless mod < Struct || (RUBY_VERSION >= '3.2' && mod < Data)
           generate_methods(mod, type_name, decl.members) unless outline
         end
 

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'runtime/helpers'
+require_relative 'runtime/value_object_generator'
+
 module RBS
   module Prototype
     class Runtime
@@ -47,7 +50,8 @@ module RBS
       end
       private_constant :Todo
 
-      include Helpers
+      include Prototype::Helpers
+      include Runtime::Helpers
 
       attr_reader :patterns
       attr_reader :env
@@ -112,22 +116,6 @@ module RBS
         end
 
         @decls or raise
-      end
-
-      def to_type_name(name, full_name: false)
-        *prefix, last = name.split(/::/)
-
-        last or raise
-
-        if full_name
-          if prefix.empty?
-            TypeName.new(name: last.to_sym, namespace: Namespace.empty)
-          else
-            TypeName.new(name: last.to_sym, namespace: Namespace.parse(prefix.join("::")))
-          end
-        else
-          TypeName.new(name: last.to_sym, namespace: Namespace.empty)
-        end
       end
 
       private def each_mixined_module(type_name, mod)
@@ -502,33 +490,30 @@ module RBS
         end #: AST::Declarations::Class?
 
         unless decl
-          decl = AST::Declarations::Class.new(
-            name: to_type_name(only_name(mod)),
-            type_params: type_params(mod),
-            super_class: generate_super_class(mod),
-            members: [],
-            annotations: [],
-            location: nil,
-            comment: nil
-          )
+          if mod < Struct
+            decl = StructGenerator.new(mod).build_decl
+          elsif mod < Data
+            decl = DataGenerator.new(mod).build_decl
+          else
+            decl = AST::Declarations::Class.new(
+              name: to_type_name(only_name(mod)),
+              type_params: type_params(mod),
+              super_class: generate_super_class(mod),
+              members: [],
+              annotations: [],
+              location: nil,
+              comment: nil
+            )
+          end
 
           outer_decls << decl
         end
 
-        each_mixined_module(type_name, mod) do |module_name, module_full_name, mixin_class|
-          next if todo_object&.skip_mixin?(type_name: type_name_absolute, module_name: module_full_name, mixin_class: mixin_class)
+        generate_mixin(mod, decl, type_name, type_name_absolute)
 
-          args = type_args(module_full_name)
-          decl.members << mixin_class.new(
-            name: module_name,
-            args: args,
-            location: nil,
-            comment: nil,
-            annotations: []
-          )
+        unless mod < Struct || mod < Data
+          generate_methods(mod, type_name, decl.members) unless outline
         end
-
-        generate_methods(mod, type_name, decl.members) unless outline
 
         generate_constants mod, decl.members
       end
@@ -564,6 +549,14 @@ module RBS
           outer_decls << decl
         end
 
+        generate_mixin(mod, decl, type_name, type_name_absolute)
+
+        generate_methods(mod, type_name, decl.members) unless outline
+
+        generate_constants mod, decl.members
+      end
+
+      def generate_mixin(mod, decl, type_name, type_name_absolute)
         each_mixined_module(type_name, mod) do |module_name, module_full_name, mixin_class|
           next if todo_object&.skip_mixin?(type_name: type_name_absolute, module_name: module_full_name, mixin_class: mixin_class)
 
@@ -576,10 +569,6 @@ module RBS
             annotations: []
           )
         end
-
-        generate_methods(mod, type_name, decl.members) unless outline
-
-        generate_constants mod, decl.members
       end
 
       # Generate/find outer module declarations
@@ -637,34 +626,6 @@ module RBS
 
         # Return the array of declarations checked out at the end
         destination
-      end
-
-      # Returns the exact name & not compactly declared name
-      def only_name(mod)
-        # No nil check because this method is invoked after checking if the module exists
-        const_name!(mod).split(/::/).last or raise # (A::B::C) => C
-      end
-
-      def const_name!(const)
-        const_name(const) or raise
-      end
-
-      def const_name(const)
-        @module_name_method ||= Module.instance_method(:name)
-        name = @module_name_method.bind(const).call
-        return nil unless name
-
-        begin
-          deprecated, Warning[:deprecated] = Warning[:deprecated], false
-          Object.const_get(name)
-        rescue NameError
-          # Should generate const name if anonymous or internal module (e.g. NameError::message)
-          nil
-        else
-          name
-        ensure
-          Warning[:deprecated] = deprecated
-        end
       end
 
       def object_class(value)

--- a/lib/rbs/prototype/runtime/helpers.rb
+++ b/lib/rbs/prototype/runtime/helpers.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module RBS
+  module Prototype
+    class Runtime
+      module Helpers
+        private
+
+        # Returns the exact name & not compactly declared name
+        def only_name(mod)
+          # No nil check because this method is invoked after checking if the module exists
+          const_name!(mod).split(/::/).last or raise # (A::B::C) => C
+        end
+
+        def const_name!(const)
+          const_name(const) or raise
+        end
+
+        def const_name(const)
+          @module_name_method ||= Module.instance_method(:name)
+          name = @module_name_method.bind(const).call
+          return nil unless name
+
+          begin
+            deprecated, Warning[:deprecated] = Warning[:deprecated], false
+            Object.const_get(name)
+          rescue NameError
+            # Should generate const name if anonymous or internal module (e.g. NameError::message)
+            nil
+          else
+            name
+          ensure
+            Warning[:deprecated] = deprecated
+          end
+        end
+
+        def to_type_name(name, full_name: false)
+          *prefix, last = name.split(/::/)
+
+          last or raise
+
+          if full_name
+            if prefix.empty?
+              TypeName.new(name: last.to_sym, namespace: Namespace.empty)
+            else
+              TypeName.new(name: last.to_sym, namespace: Namespace.parse(prefix.join("::")))
+            end
+          else
+            TypeName.new(name: last.to_sym, namespace: Namespace.empty)
+          end
+        end
+
+        def untyped
+          @untyped ||= Types::Bases::Any.new(location: nil)
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs/prototype/runtime/value_object_generator.rb
+++ b/lib/rbs/prototype/runtime/value_object_generator.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module RBS
+  module Prototype
+    class Runtime
+      class ValueObjectBase
+        include Helpers
+
+        def initialize(target_class)
+          @target_class = target_class
+        end
+
+        def build_decl
+          decl = AST::Declarations::Class.new(
+            name: to_type_name(only_name(@target_class)),
+            type_params: [],
+            super_class: build_super_class,
+            members: [],
+            annotations: [],
+            location: nil,
+            comment: nil
+          )
+
+          add_decl_members(decl)
+
+          decl
+        end
+
+        private
+
+        # def self.members: () -> [ :foo, :bar ]
+        # def members: () -> [ :foo, :bar ]
+        def build_s_members
+          [:singleton, :instance].map do |kind|
+            AST::Members::MethodDefinition.new(
+              name: :members,
+              overloads: [
+                AST::Members::MethodDefinition::Overload.new(
+                  annotations: [],
+                  method_type: MethodType.new(
+                    type: Types::Function.empty(
+                      Types::Tuple.new(
+                        types: @target_class.members.map do |member|
+                          if member.to_s.ascii_only?
+                            Types::Literal.new(literal: member, location: nil)
+                          else
+                            BuiltinNames::Symbol.instance_type
+                          end
+                        end,
+                        location: nil
+                      )
+                    ),
+                    type_params: [],
+                    block: nil,
+                    location: nil,
+                  )
+                )
+              ],
+              kind: kind,
+              location: nil,
+              comment: nil,
+              annotations: [],
+              overloading: false,
+              visibility: nil
+            )
+          end
+        end
+
+        # attr_accessor foo: untyped
+        def build_member_accessors(ast_members_class)
+          @target_class.members.map do |member|
+            ast_members_class.new(
+              name: member,
+              ivar_name: nil,
+              type: untyped,
+              kind: :instance,
+              location: nil,
+              comment: nil,
+              annotations: []
+            )
+          end
+        end
+      end
+
+      class StructGenerator < ValueObjectBase
+        def build_super_class
+          AST::Declarations::Class::Super.new(name: TypeName("::Struct"), args: [untyped], location: nil)
+        end
+
+        def add_decl_members(decl)
+          decl.members.concat build_s_new
+          decl.members.concat build_s_keyword_init_p
+          decl.members.concat build_s_members
+          decl.members.concat build_member_accessors(AST::Members::AttrAccessor)
+        end
+
+        # def self.new: (?untyped foo, ?untyped bar) -> instance
+        #             | (?foo: untyped, ?bar: untyped) -> instance
+        def build_s_new
+          [:new, :[]].map do |name|
+            new_overloads = []
+
+            if @target_class.keyword_init? == false || @target_class.keyword_init? == nil
+              new_overloads << AST::Members::MethodDefinition::Overload.new(
+                annotations: [],
+                method_type: MethodType.new(
+                  type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
+                    optional_positionals: @target_class.members.map { |m| Types::Function::Param.new(name: m, type: untyped) },
+                  ),
+                  type_params: [],
+                  block: nil,
+                  location: nil,
+                )
+              )
+            end
+            if @target_class.keyword_init? == true || @target_class.keyword_init? == nil
+              new_overloads << AST::Members::MethodDefinition::Overload.new(
+                annotations: [],
+                method_type: MethodType.new(
+                  type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
+                    optional_keywords: @target_class.members.to_h { |m| [m, Types::Function::Param.new(name: nil, type: untyped)] },
+                  ),
+                  type_params: [],
+                  block: nil,
+                  location: nil,
+                )
+              )
+            end
+
+            AST::Members::MethodDefinition.new(
+              name: name,
+              overloads: new_overloads,
+              kind: :singleton,
+              location: nil,
+              comment: nil,
+              annotations: [],
+              overloading: false,
+              visibility: nil
+            )
+          end
+        end
+
+        # def self.keyword_init?: () -> bool?
+        def build_s_keyword_init_p
+          return_type = @target_class.keyword_init?.nil? \
+                      ? Types::Bases::Nil.new(location: nil)
+                      : Types::Literal.new(literal: @target_class.keyword_init?, location: nil)
+          type = Types::Function.empty(return_type)
+
+          [
+            AST::Members::MethodDefinition.new(
+              name: :keyword_init?,
+              overloads: [
+                AST::Members::MethodDefinition::Overload.new(
+                  annotations: [],
+                  method_type: MethodType.new(
+                    type: type,
+                    type_params: [],
+                    block: nil,
+                    location: nil,
+                  )
+                )
+              ],
+              kind: :singleton,
+              location: nil,
+              comment: nil,
+              annotations: [],
+              overloading: false,
+              visibility: nil
+            )
+          ]
+        end
+      end
+
+      class DataGenerator < ValueObjectBase
+        def build_super_class
+          AST::Declarations::Class::Super.new(name: TypeName("::Data"), args: [], location: nil)
+        end
+
+        def add_decl_members(decl)
+          decl.members.concat build_s_new
+          decl.members.concat build_s_members
+          decl.members.concat build_member_accessors(AST::Members::AttrReader)
+        end
+
+        # def self.new: (untyped foo, untyped bar) -> instance
+        #             | (foo: untyped, bar: untyped) -> instance
+        def build_s_new
+          [:new, :[]].map do |name|
+            new_overloads = []
+
+            new_overloads << AST::Members::MethodDefinition::Overload.new(
+              annotations: [],
+              method_type: MethodType.new(
+                type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
+                  required_positionals: @target_class.members.map { |m| Types::Function::Param.new(name: m, type: untyped) },
+                ),
+                type_params: [],
+                block: nil,
+                location: nil,
+              )
+            )
+            new_overloads << AST::Members::MethodDefinition::Overload.new(
+              annotations: [],
+              method_type: MethodType.new(
+                type: Types::Function.empty(Types::Bases::Instance.new(location: nil)).update(
+                  required_keywords: @target_class.members.to_h { |m| [m, Types::Function::Param.new(name: nil, type: untyped)] },
+                ),
+                type_params: [],
+                block: nil,
+                location: nil,
+              )
+            )
+
+            AST::Members::MethodDefinition.new(
+              name: name,
+              overloads: new_overloads,
+              kind: :singleton,
+              location: nil,
+              comment: nil,
+              annotations: [],
+              overloading: false,
+              visibility: nil
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rbs/prototype/runtime/value_object_generator.rb
+++ b/lib/rbs/prototype/runtime/value_object_generator.rb
@@ -85,6 +85,8 @@ module RBS
       end
 
       class StructGenerator < ValueObjectBase
+        CAN_CALL_KEYWORD_INIT_P = Struct.new(:tmp).respond_to?(:keyword_init?)
+
         def build_super_class
           AST::Declarations::Class::Super.new(name: TypeName("::Struct"), args: [untyped], location: nil)
         end
@@ -102,7 +104,7 @@ module RBS
           [:new, :[]].map do |name|
             new_overloads = []
 
-            if @target_class.keyword_init? == false || @target_class.keyword_init? == nil
+            if CAN_CALL_KEYWORD_INIT_P ? (@target_class.keyword_init? == false || @target_class.keyword_init? == nil) : true
               new_overloads << AST::Members::MethodDefinition::Overload.new(
                 annotations: [],
                 method_type: MethodType.new(
@@ -115,7 +117,7 @@ module RBS
                 )
               )
             end
-            if @target_class.keyword_init? == true || @target_class.keyword_init? == nil
+            if CAN_CALL_KEYWORD_INIT_P ? (@target_class.keyword_init? == true || @target_class.keyword_init? == nil) : true
               new_overloads << AST::Members::MethodDefinition::Overload.new(
                 annotations: [],
                 method_type: MethodType.new(
@@ -144,6 +146,8 @@ module RBS
 
         # def self.keyword_init?: () -> bool?
         def build_s_keyword_init_p
+          return [] unless CAN_CALL_KEYWORD_INIT_P
+
           return_type = @target_class.keyword_init?.nil? \
                       ? Types::Bases::Nil.new(location: nil)
                       : Types::Literal.new(literal: @target_class.keyword_init?, location: nil)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -701,131 +701,205 @@ end
     SignatureManager.new do |manager|
       manager.build do |env|
         p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructInheritWithNil"], env: env, merge: false)
-        assert_write p.decls, <<~RBS
-          module RBS
-            class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class StructInheritWithNil < ::Struct[untyped]
-                def self.new: (?untyped foo, ?untyped bar) -> instance
-                            | (?foo: untyped foo, ?bar: untyped bar) -> instance
+        if Runtime::StructGenerator::CAN_CALL_KEYWORD_INIT_P
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructInheritWithNil < ::Struct[untyped]
+                  def self.new: (?untyped foo, ?untyped bar) -> instance
+                              | (?foo: untyped, ?bar: untyped) -> instance
 
-                def self.[]: (?untyped foo, ?untyped bar) -> instance
-                           | (?foo: untyped foo, ?bar: untyped bar) -> instance
+                  def self.[]: (?untyped foo, ?untyped bar) -> instance
+                             | (?foo: untyped, ?bar: untyped) -> instance
 
-                def self.keyword_init?: () -> nil
+                  def self.keyword_init?: () -> nil
 
-                def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar ]
 
-                def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar ]
 
-                attr_accessor foo: untyped
+                  attr_accessor foo: untyped
 
-                attr_accessor bar: untyped
+                  attr_accessor bar: untyped
+                end
               end
             end
-          end
-        RBS
+          RBS
+        else
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructInheritWithNil < ::Struct[untyped]
+                  def self.new: (?untyped foo, ?untyped bar) -> instance
+                              | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.[]: (?untyped foo, ?untyped bar) -> instance
+                             | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.members: () -> [ :foo, :bar ]
+
+                  def members: () -> [ :foo, :bar ]
+
+                  attr_accessor foo: untyped
+
+                  attr_accessor bar: untyped
+                end
+              end
+            end
+          RBS
+        end
 
         p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructKeywordInitTrue"], env: env, merge: false)
-        assert_write p.decls, <<~RBS
-          module RBS
-            class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class StructKeywordInitTrue < ::Struct[untyped]
-                def self.new: (?foo: untyped foo, ?bar: untyped bar) -> instance
+        if Runtime::StructGenerator::CAN_CALL_KEYWORD_INIT_P
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructKeywordInitTrue < ::Struct[untyped]
+                  def self.new: (?foo: untyped, ?bar: untyped) -> instance
 
-                def self.[]: (?foo: untyped foo, ?bar: untyped bar) -> instance
+                  def self.[]: (?foo: untyped, ?bar: untyped) -> instance
 
-                def self.keyword_init?: () -> true
+                  def self.keyword_init?: () -> true
 
-                def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar ]
 
-                def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar ]
 
-                attr_accessor foo: untyped
+                  attr_accessor foo: untyped
 
-                attr_accessor bar: untyped
+                  attr_accessor bar: untyped
+                end
               end
             end
-          end
-        RBS
+          RBS
+        else
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructKeywordInitTrue < ::Struct[untyped]
+                  def self.new: (?untyped foo, ?untyped bar) -> instance
+                              | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.[]: (?untyped foo, ?untyped bar) -> instance
+                             | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.members: () -> [ :foo, :bar ]
+
+                  def members: () -> [ :foo, :bar ]
+
+                  attr_accessor foo: untyped
+
+                  attr_accessor bar: untyped
+                end
+              end
+            end
+          RBS
+        end
 
         p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructKeywordInitFalse"], env: env, merge: false)
-        assert_write p.decls, <<~RBS
-          module RBS
-            class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class StructKeywordInitFalse < ::Struct[untyped]
-                def self.new: (?untyped foo, ?untyped bar) -> instance
+        if Runtime::StructGenerator::CAN_CALL_KEYWORD_INIT_P
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructKeywordInitFalse < ::Struct[untyped]
+                  def self.new: (?untyped foo, ?untyped bar) -> instance
 
-                def self.[]: (?untyped foo, ?untyped bar) -> instance
+                  def self.[]: (?untyped foo, ?untyped bar) -> instance
 
-                def self.keyword_init?: () -> false
+                  def self.keyword_init?: () -> false
 
-                def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar ]
 
-                def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar ]
 
-                attr_accessor foo: untyped
+                  attr_accessor foo: untyped
 
-                attr_accessor bar: untyped
+                  attr_accessor bar: untyped
+                end
               end
             end
-          end
-        RBS
+          RBS
+        else
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class StructKeywordInitFalse < ::Struct[untyped]
+                  def self.new: (?untyped foo, ?untyped bar) -> instance
+                              | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.[]: (?untyped foo, ?untyped bar) -> instance
+                             | (?foo: untyped, ?bar: untyped) -> instance
+
+                  def self.members: () -> [ :foo, :bar ]
+
+                  def members: () -> [ :foo, :bar ]
+
+                  attr_accessor foo: untyped
+
+                  attr_accessor bar: untyped
+                end
+              end
+            end
+          RBS
+        end
       end
     end
   end
 
-  class DataInherit < Data.define(:foo, :bar)
-  end
-  DataConst = Data.define(:foo, :bar)
+  if RUBY_VERSION >= '3.2'
+    class DataInherit < Data.define(:foo, :bar)
+    end
+    DataConst = Data.define(:foo, :bar)
 
-  def test_data
-    SignatureManager.new do |manager|
-      manager.build do |env|
-        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataInherit"], env: env, merge: false)
-        assert_write p.decls, <<~RBS
-          module RBS
-            class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class DataInherit < ::Data
-                def self.new: (untyped foo, untyped bar) -> instance
-                            | (foo: untyped, bar: untyped) -> instance
+    def test_data
+      SignatureManager.new do |manager|
+        manager.build do |env|
+          p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataInherit"], env: env, merge: false)
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class DataInherit < ::Data
+                  def self.new: (untyped foo, untyped bar) -> instance
+                              | (foo: untyped, bar: untyped) -> instance
 
-                def self.[]: (untyped foo, untyped bar) -> instance
-                           | (foo: untyped, bar: untyped) -> instance
+                  def self.[]: (untyped foo, untyped bar) -> instance
+                             | (foo: untyped, bar: untyped) -> instance
 
-                def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar ]
 
-                def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar ]
 
-                attr_reader foo: untyped
+                  attr_reader foo: untyped
 
-                attr_reader bar: untyped
+                  attr_reader bar: untyped
+                end
               end
             end
-          end
-        RBS
+          RBS
 
-        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataConst"], env: env, merge: false)
-        assert_write p.decls, <<~RBS
-          module RBS
-            class RuntimePrototypeTest < ::Test::Unit::TestCase
-              class DataConst < ::Data
-                def self.new: (untyped foo, untyped bar) -> instance
-                            | (foo: untyped, bar: untyped) -> instance
+          p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataConst"], env: env, merge: false)
+          assert_write p.decls, <<~RBS
+            module RBS
+              class RuntimePrototypeTest < ::Test::Unit::TestCase
+                class DataConst < ::Data
+                  def self.new: (untyped foo, untyped bar) -> instance
+                              | (foo: untyped, bar: untyped) -> instance
 
-                def self.[]: (untyped foo, untyped bar) -> instance
-                           | (foo: untyped, bar: untyped) -> instance
+                  def self.[]: (untyped foo, untyped bar) -> instance
+                             | (foo: untyped, bar: untyped) -> instance
 
-                def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar ]
 
-                def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar ]
 
-                attr_reader foo: untyped
+                  attr_reader foo: untyped
 
-                attr_reader bar: untyped
+                  attr_reader bar: untyped
+                end
               end
             end
-          end
-        RBS
+          RBS
+        end
       end
     end
   end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -691,4 +691,142 @@ end
       end
     end
   end
+
+  class StructInheritWithNil < Struct.new(:foo, :bar, keyword_init: nil)
+  end
+  StructKeywordInitTrue = Struct.new(:foo, :bar, keyword_init: true)
+  StructKeywordInitFalse = Struct.new(:foo, :bar, keyword_init: false)
+
+  def test_struct
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructInheritWithNil"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class StructInheritWithNil < ::Struct[untyped]
+                def self.new: (?untyped foo, ?untyped bar) -> instance
+                            | (?foo: untyped foo, ?bar: untyped bar) -> instance
+
+                def self.[]: (?untyped foo, ?untyped bar) -> instance
+                           | (?foo: untyped foo, ?bar: untyped bar) -> instance
+
+                def self.keyword_init?: () -> nil
+
+                def self.members: () -> [ :foo, :bar ]
+
+                def members: () -> [ :foo, :bar ]
+
+                attr_accessor foo: untyped
+
+                attr_accessor bar: untyped
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructKeywordInitTrue"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class StructKeywordInitTrue < ::Struct[untyped]
+                def self.new: (?foo: untyped foo, ?bar: untyped bar) -> instance
+
+                def self.[]: (?foo: untyped foo, ?bar: untyped bar) -> instance
+
+                def self.keyword_init?: () -> true
+
+                def self.members: () -> [ :foo, :bar ]
+
+                def members: () -> [ :foo, :bar ]
+
+                attr_accessor foo: untyped
+
+                attr_accessor bar: untyped
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::StructKeywordInitFalse"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class StructKeywordInitFalse < ::Struct[untyped]
+                def self.new: (?untyped foo, ?untyped bar) -> instance
+
+                def self.[]: (?untyped foo, ?untyped bar) -> instance
+
+                def self.keyword_init?: () -> false
+
+                def self.members: () -> [ :foo, :bar ]
+
+                def members: () -> [ :foo, :bar ]
+
+                attr_accessor foo: untyped
+
+                attr_accessor bar: untyped
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
+
+  class DataInherit < Data.define(:foo, :bar)
+  end
+  DataConst = Data.define(:foo, :bar)
+
+  def test_data
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataInherit"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class DataInherit < ::Data
+                def self.new: (untyped foo, untyped bar) -> instance
+                            | (foo: untyped, bar: untyped) -> instance
+
+                def self.[]: (untyped foo, untyped bar) -> instance
+                           | (foo: untyped, bar: untyped) -> instance
+
+                def self.members: () -> [ :foo, :bar ]
+
+                def members: () -> [ :foo, :bar ]
+
+                attr_reader foo: untyped
+
+                attr_reader bar: untyped
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::DataConst"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class DataConst < ::Data
+                def self.new: (untyped foo, untyped bar) -> instance
+                            | (foo: untyped, bar: untyped) -> instance
+
+                def self.[]: (untyped foo, untyped bar) -> instance
+                           | (foo: untyped, bar: untyped) -> instance
+
+                def self.members: () -> [ :foo, :bar ]
+
+                def members: () -> [ :foo, :bar ]
+
+                attr_reader foo: untyped
+
+                attr_reader bar: untyped
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
When running `rbs prototype runtime`, I've made special branches for classes that inherit from `Struct` and `Data`, allowing for the generation of more user-friendly RBS as prototypes.

## Demo

```rb
# t.rb
class Foo < Struct.new(:foo, :bar, keyword_init: true)
end

Bar = Struct.new(:foo, :bar, keyword_init: true)

class Baz < Data.define(:foo, :bar)
end

Qux = Data.define(:foo, :bar)
```

```
$ bundle exec rbs prototype runtime -R t.rb Foo Bar Baz Qux
```

before

```rbs
class Bar < ::Struct[untyped]
  def self.[]: (*untyped) -> untyped

  def self.inspect: () -> untyped

  def self.keyword_init?: () -> untyped

  def self.members: () -> untyped

  def self.new: (*untyped) -> untyped

  public

  def bar: () -> untyped

  def bar=: (untyped _) -> untyped

  def foo: () -> untyped

  def foo=: (untyped _) -> untyped
end

class Baz
end

class Foo
end

class Qux < ::Data
  def self.[]: (*untyped) -> untyped

  def self.inspect: () -> untyped

  def self.members: () -> untyped

  def self.new: (*untyped) -> untyped

  public

  def bar: () -> untyped

  def foo: () -> untyped
end
```

after

```rbs
class Bar < ::Struct[untyped]
  def self.new: (?foo: untyped, ?bar: untyped) -> instance

  def self.[]: (?foo: untyped, ?bar: untyped) -> instance

  def self.keyword_init?: () -> true

  def self.members: () -> [ :foo, :bar ]

  def members: () -> [ :foo, :bar ]

  attr_accessor foo: untyped

  attr_accessor bar: untyped
end

class Baz < ::Data
  def self.new: (untyped foo, untyped bar) -> instance
              | (foo: untyped, bar: untyped) -> instance

  def self.[]: (untyped foo, untyped bar) -> instance
             | (foo: untyped, bar: untyped) -> instance

  def self.members: () -> [ :foo, :bar ]

  def members: () -> [ :foo, :bar ]

  attr_reader foo: untyped

  attr_reader bar: untyped
end

class Foo < ::Struct[untyped]
  def self.new: (?foo: untyped, ?bar: untyped) -> instance

  def self.[]: (?foo: untyped, ?bar: untyped) -> instance

  def self.keyword_init?: () -> true

  def self.members: () -> [ :foo, :bar ]

  def members: () -> [ :foo, :bar ]

  attr_accessor foo: untyped

  attr_accessor bar: untyped
end

class Qux < ::Data
  def self.new: (untyped foo, untyped bar) -> instance
              | (foo: untyped, bar: untyped) -> instance

  def self.[]: (untyped foo, untyped bar) -> instance
             | (foo: untyped, bar: untyped) -> instance

  def self.members: () -> [ :foo, :bar ]

  def members: () -> [ :foo, :bar ]

  attr_reader foo: untyped

  attr_reader bar: untyped
end
```