### PR TITLE
Add `Abbrev` to runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rbs (3.2.0)
+      abbrev
 
 PATH
   remote: test/assets/test-gem
@@ -11,6 +12,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    abbrev (0.1.1)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0"
+  spec.add_dependency "abbrev"
 end


### PR DESCRIPTION
This PR adds `Abbrev` to runtime dependency to suppress the following Ruby 3.3's warning:

```console
$ ruby -ve 'require "rbs/cli"'
ruby 3.3.0preview2 (2023-09-14 master e50fcca9a7) [x86_64-darwin21]
/Users/mi/.asdf/installs/ruby/3.3.0-preview2/lib/ruby/gems/3.3.0+0/gems/rbs-3.2.2/lib/rbs/cli.rb:6: warning: abbrev which will be not part of the default gems since Ruby 3.4.0
```

ref: https://bugs.ruby-lang.org/issues/19351