### PR TITLE
Avoid an error when parsing files including SyntaxError

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -951,7 +951,12 @@ EOU
             output_path = (output_dir + relative_path).sub_ext(".rbs")
 
             parser = new_parser[]
-            parser.parse file_path.read()
+            begin
+              parser.parse file_path.read()
+            rescue SyntaxError
+              stdout.puts "  ⚠️  Unable to parse due to SyntaxError: `#{file_path}`"
+              next
+            end
 
             if output_path.file?
               if force

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -736,6 +736,32 @@ Processing `test/a_test.rb`...
     end
   end
 
+  def test_prototype_batch_syntax_error
+    Dir.mktmpdir do |dir|
+      dir = Pathname(dir)
+
+      (dir + "lib").mkdir
+      (dir + "lib/a.rb").write(<<-RUBY)
+class A < <%= @superclass %>
+end
+      RUBY
+
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          cli.run(%w(prototype rb --out_dir=sig lib))
+
+          assert_equal <<-EOM, cli.stdout.string
+Processing `lib`...
+  Generating RBS for `lib/a.rb`...
+  ⚠️  Unable to parse due to SyntaxError: `lib/a.rb`
+          EOM
+        end
+      end
+
+      refute_predicate dir + "sig", :directory?
+    end
+  end
+
   def test_prototype__runtime__todo
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do


### PR DESCRIPTION
There are cases where ERB templates are saved as `*.rb`.
For example, `devise`.
refs: https://github.com/heartcombo/devise/blob/v4.9.3/lib/generators/active_record/templates/migration.rb

Running `rbs prototype rb` in a directory containing these files will crash due to a SyntaxError.
This commit fixes that to avoid the error and continue processing.

fixes #1414
