### PR TITLE
Add new category to Warning

### DIFF
--- a/core/warning.rbs
+++ b/core/warning.rbs
@@ -31,7 +31,7 @@
 module Warning
   # The types of categories the `Warning` module understands.
   #
-  type category = :deprecated | :experimental
+  type category = :deprecated | :experimental | :performance
 
   # <!--
   #   rdoc-file=error.c

--- a/test/stdlib/Warning_test.rb
+++ b/test/stdlib/Warning_test.rb
@@ -1,6 +1,7 @@
 require_relative "test_helper"
 
-WARNING_CATEGORIES = %i[deprecated experimental performance]
+WARNING_CATEGORIES = %i[deprecated experimental]
+WARNING_CATEGORIES << :performance if RUBY_VERSION >= '3.3'
 
 class WarningSingletonTest < Test::Unit::TestCase
   include TypeAssertions

--- a/test/stdlib/Warning_test.rb
+++ b/test/stdlib/Warning_test.rb
@@ -1,6 +1,6 @@
 require_relative "test_helper"
 
-WARNING_CATEGORIES = %i[deprecated experimental]
+WARNING_CATEGORIES = %i[deprecated experimental performance]
 
 class WarningSingletonTest < Test::Unit::TestCase
   include TypeAssertions


### PR DESCRIPTION
It seems that a new category will be added from Ruby v3.3.

https://bugs.ruby-lang.org/issues/19538
https://github.com/ruby/ruby/pull/7708