### PR TITLE
version.rb - update from 3.2.0 to 3.2.2

### DIFF
--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "3.2.0"
+  VERSION = "3.2.2"
 end


### PR DESCRIPTION
This is causing the RBS gem to not be installed in Ruby master.  I believe [gems/bundled_gems](https://github.com/ruby/ruby/blob/f717faac632dd8664d0967f8e639b84d5d032854/gems/bundled_gems) in ruby/ruby will also need an update...