### PR TITLE
stdlib: Update type for URI.join

### DIFF
--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -278,7 +278,7 @@ module URI
   #     URI.join('http://example.com', '/foo/', 'bar')
   #     # => #<URI::HTTP http://example.com/foo/bar>
   #
-  def self.join: (String str, *String strs) -> URI::Generic
+  def self.join: (_ToStr | URI::Generic str, *_ToStr | URI::Generic strs) -> URI::Generic
 
   # <!--
   #   rdoc-file=lib/uri/common.rb

--- a/test/stdlib/URI_test.rb
+++ b/test/stdlib/URI_test.rb
@@ -84,6 +84,8 @@ class URISingletonTest < Test::Unit::TestCase
                      URI, :join, "http://example.com"
     assert_send_type "(String, String) -> URI::Generic",
                      URI, :join, "http://example.com", "foo"
+    assert_send_type "(URI::Generic, URI::Generic) -> URI::Generic",
+                     URI, :join, URI("http://example.com"), URI("foo")
   end
 
   def test_parse


### PR DESCRIPTION
URI.join takes not only strings, but also URI objects.  Therefore it would be better to update its signature.

Internally, arguments will be converted to URI objects before concatenating.
https://github.com/ruby/ruby/blob/v3_2_2/lib/uri/rfc3986_parser.rb#L107-L116