### PR TITLE
core: Add _Top interface to support inverting boolish

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -275,3 +275,9 @@ type interned = Symbol | string
 # Any Ruby object can have `boolish` type.
 #
 type boolish = top
+
+# `_Top` is an internal type for the `top` type.
+# It provides `!` operator to support inverting `top` and `boolish` objects.
+interface _Top
+  def !: () -> bool
+end


### PR DESCRIPTION
To support inverting boolish values, adds a new interface `_Top` that provides `!` operator.

refs: https://github.com/soutaro/steep/issues/939