### PR TITLE
Support cases where `Module#constants` has been redefined

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 require: rubocop-rubycw
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   DisabledByDefault: true
   Exclude:
     - 'vendor/bundle/**/*'

--- a/lib/rbs/prototype/runtime/reflection.rb
+++ b/lib/rbs/prototype/runtime/reflection.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RBS
+  module Prototype
+    class Runtime
+      module Reflection
+        def self.object_class(value)
+          @object_class ||= Object.instance_method(:class)
+          @object_class.bind_call(value)
+        end
+
+        def self.constants_of(mod, inherit = true)
+          @constants_of ||= Module.instance_method(:constants)
+          @constants_of.bind_call(mod, inherit)
+        end
+      end
+    end
+  end
+end

--- a/sig/prototype/runtime.rbs
+++ b/sig/prototype/runtime.rbs
@@ -1,6 +1,12 @@
 module RBS
   module Prototype
     class Runtime
+      module Reflection
+        def self.object_class: (Module value) -> Class
+
+        def self.constants_of: (Module mod, ?bool inherit) -> Array[Symbol]
+      end
+
       class Todo
         @builder: DefinitionBuilder
 

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -907,4 +907,30 @@ end
       end
     end
   end
+
+  class Redefined
+    def self.constants = raise
+    def class = raise
+  end
+
+  def test_reflection
+    SignatureManager.new do |manager|
+      manager.build do |env|
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::Redefined"], env: env, merge: false)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class Redefined
+                def self.constants: () -> untyped
+
+                public
+
+                def class: () -> untyped
+              end
+            end
+          end
+        RBS
+      end
+    end
+  end
 end


### PR DESCRIPTION
rbs 3.3.0.pre.1

When analyzing the gem `rouge` with `prototype runtime`, an error occurs.
The cause is that the `.constants` method is overridden in `rouge`.

I fixed the issue by using the method of calling the `Module#constants` UnboundMethod.

repro

```
$ bundle exec rbs prototype runtime -r rouge Rouge::Lexers::Actionscript
```

before

```
/ruby/3.2.0/gems/rouge-4.1.1/lib/rouge/lexers/actionscript.rb:96:in `constants': wrong number of arguments (given 1, expected 0) (ArgumentError)
```

after

```
module Rouge
  module Lexers
    class Actionscript < ::Rouge::RegexLexer
      def self.builtins: () -> untyped

      def self.constants: () -> untyped

      def self.declarations: () -> untyped

      def self.keywords: () -> untyped

      def self.reserved: () -> untyped
    end
  end
end
```