### PR TITLE
Print type syntax errors instead of raising error

### DIFF
--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -432,10 +432,10 @@ singleton(::BasicObject)
       with_cli do |cli|
         Dir.mktmpdir do |dir|
           (Pathname(dir) + 'a.rbs').write(rbs)
-          error = assert_raises RuntimeError do
-            cli.run(["-I", dir, "validate"])
-          end
-          assert_match(/void|self|instance|class/, error.message)
+          cli.run(["-I", dir, "validate"])
+
+          last_lines = stdout.string.lines.last(3)
+          assert_match(/void|self|instance|class/, last_lines.join("\n"))
         end
       end
     end


### PR DESCRIPTION
Raising on syntax error will block using `rbs validate` command when one of the dependencies has the problem.

```
$ rbs validate
(Many lines showing the progress...)
sig/rbs.rbs:22:13...22:21: `instance` or `class` type is not allowed in this context
```