### PR TITLE
[rbs diff] Resolve constants name

### DIFF
--- a/lib/rbs/resolver/constant_resolver.rb
+++ b/lib/rbs/resolver/constant_resolver.rb
@@ -22,7 +22,7 @@ module RBS
 
             unless name.namespace.empty?
               parent = name.namespace.to_type_name
-              table = children_table[parent] or raise
+              table = children_table[parent] or raise "#{parent} not found by #{name}"
             else
               table = toplevel
             end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1185,7 +1185,7 @@ Processing `lib`...
         | `def qux: (untyped) -> untyped` | `-` |
         | `def quux: () -> void` | `alias quux bar` |
         | `def self.baz: () -> (::Integer \\| ::String)` | `def self.baz: (::Integer) -> ::Integer?` |
-        | `::Foo::CONST: Array[Integer]` | `::Foo::CONST: Array[String]` |
+        | `CONST: ::Array[::Integer]` | `CONST: ::Array[::String]` |
       MARKDOWN
     end
   end
@@ -1204,8 +1204,8 @@ Processing `lib`...
         - def self.baz: () -> (::Integer | ::String)
         + def self.baz: (::Integer) -> ::Integer?
 
-        - ::Foo::CONST: Array[Integer]
-        + ::Foo::CONST: Array[String]
+        - CONST: ::Array[::Integer]
+        + CONST: ::Array[::String]
       DIFF
     end
   end

--- a/test/rbs/diff_test.rb
+++ b/test/rbs/diff_test.rb
@@ -67,11 +67,10 @@ class RBS::DiffTest < Test::Unit::TestCase
         ["def qux: (untyped) -> untyped", "-"],
         ["def quux: () -> void", "alias quux bar"],
         ["def self.baz: () -> (::Integer | ::String)", "def self.baz: (::Integer) -> ::Integer?"],
-        ["::Foo::SAME_MOD_OTHER_VALUE: 2", "::Foo::SAME_MOD_OTHER_VALUE: String"],
-        ["::Foo::SAME_MOD_BEFORE_ONLY: 3", "-"],
-        ["::Foo::OTHER_MOD_SAME_VALUE: 4", "-"],
-        ["::Foo::OTHER_MOD_OTHER_VALUE: 5", "-"],
-        ["-", "::Foo::SAME_MOD_AFTER_ONLY: 3"]
+        ["SAME_MOD_OTHER_VALUE: 2", "SAME_MOD_OTHER_VALUE: ::String"],
+        ["SAME_MOD_BEFORE_ONLY: 3", "-"],
+        ["OTHER_MOD_OTHER_VALUE: 5", "OTHER_MOD_OTHER_VALUE: ::Array[::Integer]"],
+        ["-", "SAME_MOD_AFTER_ONLY: 3"]
       ], results
     end
   end


### PR DESCRIPTION
`rbs diff` command compares methods with their definitions resolved, but for constants, the comparison is a simple decl.

In this PR, constants are now compared as references from the specified type name by name resolution.