### PR TITLE
[rbs diff] Load dependencies from manifest.yaml

### DIFF
--- a/lib/rbs/diff.rb
+++ b/lib/rbs/diff.rb
@@ -70,7 +70,18 @@ module RBS
     def build_env(path)
       loader = @library_options.loader()
       path&.each do |dir|
-        loader.add(path: Pathname(dir))
+        dir_pathname = Pathname(dir)
+        loader.add(path: dir_pathname)
+
+        manifest_pathname = dir_pathname / 'manifest.yaml'
+        if manifest_pathname.exist?
+          manifest = YAML.safe_load(manifest_pathname.read)
+          if manifest['dependencies']
+            manifest['dependencies'].each do |dependency|
+              loader.add(library: dependency['name'], version: nil)
+            end
+          end
+        end
       end
       Environment.from_loader(loader)
     end


### PR DESCRIPTION
The `rbs diff` command selects the environment to compare, but since manifest.yml is not read, there are cases where name resolution is not possible.

Fixed to read manifest.yml.