### PR TITLE
Stop exiting with error when syntax error detected during validation

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -445,6 +445,7 @@ EOU
 
     def run_validate(args, options)
       stdout = stdout()
+      exit_error = false
 
       OptionParser.new do |opts|
         opts.banner = <<EOU
@@ -460,6 +461,9 @@ EOU
         opts.on("--silent") do
           stdout = StringIO.new
         end
+        opts.on("--[no-]exit-error-on-syntax-error", "exit(1) if syntax error is detected") {|bool|
+          exit_error = bool
+        }
       end.parse!(args)
 
       loader = options.loader()
@@ -632,7 +636,7 @@ EOU
         syntax_errors.each do |message|
           self.stdout.puts message
         end
-        exit(1)
+        exit 1 if exit_error
       end
     end
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -432,12 +432,16 @@ singleton(::BasicObject)
       with_cli do |cli|
         Dir.mktmpdir do |dir|
           (Pathname(dir) + 'a.rbs').write(rbs)
-          assert_raises SystemExit do
-            cli.run(["-I", dir, "validate"])
-          end
+
+          cli.run(["-I", dir, "validate"])
 
           last_lines = stdout.string.lines.last(3)
           assert_match(/void|self|instance|class/, last_lines.join("\n"))
+
+          cli.run(["-I", dir, "validate", "--no-exit-error-on-syntax-error"])
+          assert_raises SystemExit do
+            cli.run(["-I", dir, "validate", "--exit-error-on-syntax-error"])
+          end
         end
       end
     end


### PR DESCRIPTION
This PR stops exiting with error when syntax error is detected.

When the new syntax validation detects an error:

1. It prints the errors the end of validation command
2. It exits with `0` to avoid `rbs validate` command failing
3. Pass `--exit-error-on-syntax-error` to `exit(1)`

Related to: #1566 