### PR TITLE
Load Bundler lazily

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1246,6 +1246,8 @@ EOB
     end
 
     def run_collection(args, options)
+      require 'bundler'
+
       opts = collection_options(args)
       params = {}
       opts.order args.drop(1), into: params

--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'yaml'
-require 'bundler'
 
 require_relative './collection/sources'
 require_relative './collection/config'


### PR DESCRIPTION
Loading Bundler at the top-level causes a problem on testing for ruby/ruby. So this PR makes it lazy.

It will also improve the performance of launching `rbs` command (except `rbs collection`). 


cc/ @hsbt 