### PR TITLE
[rbs validate] Use RBS.logger instead of stdout

### DIFF
--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -39,6 +39,7 @@ class RBS::CliTest < Test::Unit::TestCase
   end
 
   def with_cli
+    RBS.logger_output = stdout
     yield CLI.new(stdout: stdout, stderr: stderr)
   ensure
     @stdout = nil
@@ -240,13 +241,13 @@ singleton(::BasicObject)
 
   def test_validate
     with_cli do |cli|
-      cli.run(%w(validate))
+      cli.run(%w(--log-level=info validate))
       assert_match(/Validating/, stdout.string)
     end
 
     with_cli do |cli|
       cli.run(%w(validate --silent))
-      assert_equal "", stdout.string
+      assert_match /`--silent` option is deprecated. Please use --log-level=error instead.$/, stdout.string
     end
 
     with_cli do |cli|


### PR DESCRIPTION
Using a logger for messages like "Validating class/module definition" seems more appropriate. By using a logger, the following benefits can be achieved:

- Behavior can be unified with the `--log-level` option, which makes the `--silent` option unnecessary.
- Timestamps can be recorded.
- Log levels can be divided into equivalents of info and warn.
    - The process of eliminating duplicate `syntax_errors` also seems like a workaround for the problem of info-equivalent and warn-equivalent information getting mixed up. By dividing the log levels, information can be appropriately divided, making the elimination of duplicates unnecessary.