### PR TITLE
Fix flaky test

### DIFF
--- a/lib/rbs/collection.rb
+++ b/lib/rbs/collection.rb
@@ -2,6 +2,7 @@
 
 require 'yaml'
 
+require_relative './cli/colored_io'
 require_relative './collection/sources'
 require_relative './collection/config'
 require_relative './collection/config/lockfile'


### PR DESCRIPTION
The order in which tests are run could lead to test failures.
This is happening because `RBS::CLI::ColoredIO` is used within `RBS::Collection` but has not been loaded.

ref: https://github.com/ruby/rbs/actions/runs/6833184489?pr=1615