### PR TITLE
Should escape if param name include not simple-word

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -883,7 +883,11 @@ module RBS
 
         def to_s
           if name
-            "#{type} #{name}"
+            if name.match?(/\A[a-zA-Z0-9_]+\z/)
+              "#{type} #{name}"
+            else
+              "#{type} `#{name}`"
+            end
           else
             "#{type}"
           end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -696,7 +696,7 @@ end
     end
   end
 
-  class StructInheritWithNil < Struct.new(:foo, :bar, keyword_init: nil)
+  class StructInheritWithNil < Struct.new(:foo, :bar, :baz?, keyword_init: nil)
   end
   StructKeywordInitTrue = Struct.new(:foo, :bar, keyword_init: true)
   StructKeywordInitFalse = Struct.new(:foo, :bar, keyword_init: false)
@@ -712,21 +712,23 @@ end
             module RBS
               class RuntimePrototypeTest < ::Test::Unit::TestCase
                 class StructInheritWithNil < ::Struct[untyped]
-                  def self.new: (?untyped foo, ?untyped bar) -> instance
-                              | (?foo: untyped, ?bar: untyped) -> instance
+                  def self.new: (?untyped foo, ?untyped bar, ?untyped `baz?`) -> instance
+                              | (?foo: untyped, ?bar: untyped, ?baz?: untyped) -> instance
 
-                  def self.[]: (?untyped foo, ?untyped bar) -> instance
-                             | (?foo: untyped, ?bar: untyped) -> instance
+                  def self.[]: (?untyped foo, ?untyped bar, ?untyped `baz?`) -> instance
+                             | (?foo: untyped, ?bar: untyped, ?baz?: untyped) -> instance
 
                   def self.keyword_init?: () -> nil
 
-                  def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar, :baz? ]
 
-                  def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar, :baz? ]
 
                   attr_accessor foo: untyped
 
                   attr_accessor bar: untyped
+
+                  attr_accessor baz?: untyped
                 end
               end
             end
@@ -863,7 +865,7 @@ end
   end
 
   if RUBY_VERSION >= '3.2'
-    class DataInherit < Data.define(:foo, :bar)
+    class DataInherit < Data.define(:foo, :bar, :baz?)
     end
     DataConst = Data.define(:foo, :bar)
     class DataDirectInherit < Data
@@ -877,19 +879,21 @@ end
             module RBS
               class RuntimePrototypeTest < ::Test::Unit::TestCase
                 class DataInherit < ::Data
-                  def self.new: (untyped foo, untyped bar) -> instance
-                              | (foo: untyped, bar: untyped) -> instance
+                  def self.new: (untyped foo, untyped bar, untyped `baz?`) -> instance
+                              | (foo: untyped, bar: untyped, baz?: untyped) -> instance
 
-                  def self.[]: (untyped foo, untyped bar) -> instance
-                             | (foo: untyped, bar: untyped) -> instance
+                  def self.[]: (untyped foo, untyped bar, untyped `baz?`) -> instance
+                             | (foo: untyped, bar: untyped, baz?: untyped) -> instance
 
-                  def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar, :baz? ]
 
-                  def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar, :baz? ]
 
                   attr_reader foo: untyped
 
                   attr_reader bar: untyped
+
+                  attr_reader baz?: untyped
                 end
               end
             end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -738,19 +738,21 @@ end
             module RBS
               class RuntimePrototypeTest < ::Test::Unit::TestCase
                 class StructInheritWithNil < ::Struct[untyped]
-                  def self.new: (?untyped foo, ?untyped bar) -> instance
-                              | (?foo: untyped, ?bar: untyped) -> instance
+                  def self.new: (?untyped foo, ?untyped bar, ?untyped `baz?`) -> instance
+                              | (?foo: untyped, ?bar: untyped, ?baz?: untyped) -> instance
 
-                  def self.[]: (?untyped foo, ?untyped bar) -> instance
-                             | (?foo: untyped, ?bar: untyped) -> instance
+                  def self.[]: (?untyped foo, ?untyped bar, ?untyped `baz?`) -> instance
+                             | (?foo: untyped, ?bar: untyped, ?baz?: untyped) -> instance
 
-                  def self.members: () -> [ :foo, :bar ]
+                  def self.members: () -> [ :foo, :bar, :baz? ]
 
-                  def members: () -> [ :foo, :bar ]
+                  def members: () -> [ :foo, :bar, :baz? ]
 
                   attr_accessor foo: untyped
 
                   attr_accessor bar: untyped
+
+                  attr_accessor baz?: untyped
                 end
               end
             end

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -115,6 +115,8 @@ module XYZZY[X, Y]
 
   def def: () -> Symbol
 
+  def foo: (untyped `include?`) -> void
+
   def self: () -> void
 
   def self?: () -> void


### PR DESCRIPTION
Fixes a syntax error in RBS output by `rbs prototype runtime` when names that cannot be used as variable names are used as members of Struct/Data, so that they are escaped.
The root cause of this problem is that parameter names are not escaped in `Writer`, or are missed even if escaped.

Real example:
https://github.com/rails/rails/blob/5b45a58cc8ad1809ee2732aa994fdb421a09cd94/activerecord/lib/active_record/relation/predicate_builder/range_handler.rb#L6