### PR TITLE
Update Struct

### DIFF
--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -499,6 +499,12 @@
 class Hash[unchecked out K, unchecked out V] < Object
   include Enumerable[[ K, V ]]
 
+  interface _Key
+    def hash: () -> Integer
+
+    def eql?: (untyped rhs) -> boolish
+  end
+
   # <!--
   #   rdoc-file=hash.c
   #   - Hash[] -> new_empty_hash

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -46,12 +46,10 @@
 # *   Includes [module Enumerable](rdoc-ref:Enumerable@What-27s+Here), which
 #     provides dozens of additional methods.
 #
-#
 # See also Data, which is a somewhat similar, but stricter concept for defining
 # immutable value objects.
 #
 # Here, class Struct provides methods that are useful for:
-#
 # *   [Creating a Struct
 #     Subclass](rdoc-ref:Struct@Methods+for+Creating+a+Struct+Subclass)
 # *   [Querying](rdoc-ref:Struct@Methods+for+Querying)
@@ -61,25 +59,23 @@
 # *   [Iterating](rdoc-ref:Struct@Methods+for+Iterating)
 # *   [Converting](rdoc-ref:Struct@Methods+for+Converting)
 #
-#
 # ### Methods for Creating a Struct Subclass
 #
-# *   ::new: Returns a new subclass of Struct.
-#
+# *   ::new: Returns a new subclass of Struct.#
 #
 # ### Methods for Querying
 #
 # *   #hash: Returns the integer hash code.
-# *   #length, #size: Returns the number of members.
-#
+# *   #length, #size: Returns the number of members.#
 #
 # ### Methods for Comparing
 #
-# *   #==: Returns whether a given object is equal to `self`, using `==` to
-#     compare member values.
-# *   #eql?: Returns whether a given object is equal to `self`, using `eql?` to
-#     compare member values.
-#
+# [#==](#method-i-3D-3D)
+# :   Returns whether a given object is equal to `self`, using `==` to compare
+#     member values.
+# #eql?
+# :   Returns whether a given object is equal to `self`, using `eql?` to compare
+#     member values.#
 #
 # ### Methods for Fetching
 #
@@ -103,19 +99,24 @@
 #
 # ### Methods for Iterating
 #
-# *   #each: Calls a given block with each member name.
-# *   #each_pair: Calls a given block with each member name/value pair.
+# *   #inspect, #to_s: Returns a string representation of `self`.
+# *   #to_h: Returns a hash of the member name/value pairs in `self`.
 #
 #
 # ### Methods for Converting
 #
-# *   #inspect, #to_s: Returns a string representation of `self`.
-# *   #to_h: Returns a hash of the member name/value pairs in `self`.
+# #inspect, #to_s
+# :   Returns a string representation of `self`.
+# #to_h
+# :   Returns a hash of the member name/value pairs in `self`.
 #
-class Struct[Elem] < Object
-  include Enumerable[Elem?]
+class Struct[Elem]
+  include Enumerable[Elem]
 
-  type attribute_name = interned
+  # The types that can be used when "indexing" into a `Struct` via `[]`, `[]=`, `dig`, and
+  # `deconstruct_keys`.
+  #
+  type index = String | Symbol | int
 
   # <!--
   #   rdoc-file=struct.c
@@ -128,6 +129,8 @@ class Struct[Elem] < Object
   #
   # *   May be anonymous, or may have the name given by `class_name`.
   # *   May have members as given by `member_names`.
+  # *   May have initialization via ordinary arguments (the default) or via
+  #     keyword arguments (if `keyword_init: true` is given).
   # *   May have initialization via ordinary arguments, or via keyword arguments
   #
   #
@@ -203,6 +206,7 @@ class Struct[Elem] < Object
   #         Foo.new(foo: 0, bar: 1, baz: 2)
   #         # Raises ArgumentError: unknown keywords: baz
   #
+  #
   #     Method `::[]` is an alias for method `::new`.
   #
   # *   Method `:inspect` returns a string representation of the subclass:
@@ -219,7 +223,6 @@ class Struct[Elem] < Object
   #
   # By default, the arguments for initializing an instance of the new subclass can
   # be both positional and keyword arguments.
-  #
   # Optional keyword argument `keyword_init:` allows to force only one type of
   # arguments to be accepted:
   #
@@ -243,7 +246,208 @@ class Struct[Elem] < Object
   #     Any.new(1, 2)
   #     # => #<struct Any foo=1, bar=2>
   #
-  def initialize: (attribute_name, *attribute_name, ?keyword_init: boolish) ?{ () -> void } -> void
+  def self.new: [K < _StructClass[Elem]] (string? classname, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
+              | [K < _StructClass[Elem]] (Symbol field1, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
+
+  interface _StructClass[Elem]
+    def new: (*Elem fields, **Elem keyword_fields) -> instance
+  end
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - StructClass::members -> array_of_symbols
+  # -->
+  # Returns the member names of the Struct descendant as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     Customer.members # => [:name, :address, :zip]
+  #
+  def self.members: () -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - StructClass::keyword_init? -> true or falsy value
+  # -->
+  # Returns `true` if the class was initialized with `keyword_init: true`.
+  # Otherwise returns `nil` or `false`.
+  #
+  # Examples:
+  #     Foo = Struct.new(:a)
+  #     Foo.keyword_init? # => nil
+  #     Bar = Struct.new(:a, keyword_init: true)
+  #     Bar.keyword_init? # => true
+  #     Baz = Struct.new(:a, keyword_init: false)
+  #     Baz.keyword_init? # => false
+  #
+  def self.keyword_init?: () -> bool?
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - self == other -> true or false
+  # -->
+  # Returns  `true` if and only if the following are true; otherwise returns
+  # `false`:
+  #
+  # *   `other.class == self.class`.
+  # *   For each member name `name`, `other.name == self.name`.
+  #
+  #
+  # Examples:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr == joe # => true
+  #     joe_jr[:name] = 'Joe Smith, Jr.'
+  #     # => "Joe Smith, Jr."
+  #     joe_jr == joe # => false
+  #
+  def ==: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - eql?(other) -> true or false
+  # -->
+  # Returns `true` if and only if the following are true; otherwise returns
+  # `false`:
+  #
+  # *   `other.class == self.class`.
+  # *   For each member name `name`, `other.name.eql?(self.name)`.
+  #
+  #         Customer = Struct.new(:name, :address, :zip)
+  #         joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #         joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #         joe_jr.eql?(joe) # => true
+  #         joe_jr[:name] = 'Joe Smith, Jr.'
+  #         joe_jr.eql?(joe) # => false
+  #
+  #
+  # Related: Object#==.
+  #
+  def eql?: (untyped other) -> bool
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - hash -> integer
+  # -->
+  # Returns the integer hash value for `self`.
+  #
+  # Two structs of the same class and with the same content will have the same
+  # hash code (and will compare using Struct#eql?):
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe    = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe_jr = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.hash == joe_jr.hash # => true
+  #     joe_jr[:name] = 'Joe Smith, Jr.'
+  #     joe.hash == joe_jr.hash # => false
+  #
+  # Related: Object#hash.
+  #
+  def hash: () -> Integer
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - inspect -> string
+  # -->
+  # Returns a string representation of `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.inspect # => "#<struct Customer name=\"Joe Smith\", address=\"123 Maple, Anytown NC\", zip=12345>"
+  #
+  # Struct#to_s is an alias for Struct#inspect.
+  #
+  def inspect: () -> String
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns a string representation of `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.inspect # => "#<struct Customer name=\"Joe Smith\", address=\"123 Maple, Anytown NC\", zip=12345>"
+  #
+  # Struct#to_s is an alias for Struct#inspect.
+  #
+  alias to_s inspect
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - to_a     -> array
+  # -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  def to_a: () -> Array[Elem]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - to_h -> hash
+  #   - to_h {|name, value| ... } -> hash
+  # -->
+  # Returns a hash containing the name and value for each member:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     h = joe.to_h
+  #     h # => {:name=>"Joe Smith", :address=>"123 Maple, Anytown NC", :zip=>12345}
+  #
+  # If a block is given, it is called with each name/value pair; the block should
+  # return a 2-element array whose elements will become a key/value pair in the
+  # returned hash:
+  #
+  #     h = joe.to_h{|name, value| [name.upcase, value.to_s.upcase]}
+  #     h # => {:NAME=>"JOE SMITH", :ADDRESS=>"123 MAPLE, ANYTOWN NC", :ZIP=>"12345"}
+  #
+  # Raises ArgumentError if the block returns an inappropriate value.
+  #
+  def to_h: () -> Hash[Symbol, Elem]
+          | [K, V] () { (Symbol key, Elem value) -> [K, V] } -> Hash[K, V]
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  alias values to_a
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - size -> integer
+  # -->
+  # Returns the number of members.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.size #=> 3
+  #
+  # Struct#length is an alias for Struct#size.
+  #
+  def size: () -> Integer
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the number of members.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.size #=> 3
+  #
+  # Struct#length is an alias for Struct#size.
+  #
+  alias length size
 
   # <!--
   #   rdoc-file=struct.c
@@ -266,34 +470,234 @@ class Struct[Elem] < Object
   #
   # Related: #each_pair.
   #
-  def each: () -> ::Enumerator[Elem?, self]
-          | () { (Elem? item) -> void } -> self
+  def each: () -> Enumerator[Elem, self]
+          | () { (Elem value) -> void } -> self
 
   # <!--
   #   rdoc-file=struct.c
-  #   - StructClass::members -> array_of_symbols
+  #   - each_pair {|(name, value)| ... } -> self
+  #   - each_pair -> enumerator
   # -->
-  # Returns the member names of the Struct descendant as an array:
+  # Calls the given block with each member name/value pair; returns `self`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip) # => Customer
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.each_pair {|(name, value)| p "#{name} => #{value}" }
+  #
+  # Output:
+  #
+  #     "name => Joe Smith"
+  #     "address => 123 Maple, Anytown NC"
+  #     "zip => 12345"
+  #
+  # Returns an Enumerator if no block is given.
+  #
+  # Related: #each.
+  #
+  def each_pair: () -> Enumerator[[Symbol, Elem], self]
+               | () { ([Symbol, Elem] key_value) -> void } -> self
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - struct[name] -> object
+  #   - struct[n] -> object
+  # -->
+  # Returns a value from `self`.
+  #
+  # With symbol or string argument `name` given, returns the value for the named
+  # member:
   #
   #     Customer = Struct.new(:name, :address, :zip)
-  #     Customer.members # => [:name, :address, :zip]
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[:zip] # => 12345
   #
-  def self.members: () -> ::Array[Symbol]
+  # Raises NameError if `name` is not the name of a member.
+  #
+  # With integer argument `n` given, returns `self.values[n]` if `n` is in range;
+  # see Array@Array+Indexes:
+  #
+  #     joe[2]  # => 12345
+  #     joe[-2] # => "123 Maple, Anytown NC"
+  #
+  # Raises IndexError if `n` is out of range.
+  #
+  def []: (index name_or_position) -> Elem
 
   # <!--
   #   rdoc-file=struct.c
-  #   - StructClass::keyword_init? -> true or falsy value
+  #   - struct[name] = value -> value
+  #   - struct[n] = value -> value
   # -->
-  # Returns `true` if the class was initialized with `keyword_init: true`.
-  # Otherwise returns `nil` or `false`.
+  # Assigns a value to a member.
   #
-  # Examples:
+  # With symbol or string argument `name` given, assigns the given `value` to the
+  # named member; returns `value`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[:zip] = 54321 # => 54321
+  #     joe # => #<struct Customer name="Joe Smith", address="123 Maple, Anytown NC", zip=54321>
+  #
+  # Raises NameError if `name` is not the name of a member.
+  #
+  # With integer argument `n` given, assigns the given `value` to the `n`-th
+  # member if `n` is in range; see Array@Array+Indexes:
+  #
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe[2] = 54321           # => 54321
+  #     joe[-3] = 'Joseph Smith' # => "Joseph Smith"
+  #     joe # => #<struct Customer name="Joseph Smith", address="123 Maple, Anytown NC", zip=54321>
+  #
+  # Raises IndexError if `n` is out of range.
+  #
+  def []=: (index name_or_position, Elem value) -> Elem
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - select {|value| ... } -> array
+  #   - select -> enumerator
+  # -->
+  # With a block given, returns an array of values from `self` for which the block
+  # returns a truthy value:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     a = joe.select {|value| value.is_a?(String) }
+  #     a # => ["Joe Smith", "123 Maple, Anytown NC"]
+  #     a = joe.select {|value| value.is_a?(Integer) }
+  #     a # => [12345]
+  #
+  # With no block given, returns an Enumerator.
+  #
+  # Struct#filter is an alias for Struct#select.
+  #
+  def select: () -> Enumerator[Elem, Array[Elem]]
+            | () { (Elem value) -> boolish } -> Array[Elem]
+
+  # <!-- rdoc-file=struct.c -->
+  # With a block given, returns an array of values from `self` for which the block
+  # returns a truthy value:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     a = joe.select {|value| value.is_a?(String) }
+  #     a # => ["Joe Smith", "123 Maple, Anytown NC"]
+  #     a = joe.select {|value| value.is_a?(Integer) }
+  #     a # => [12345]
+  #
+  # With no block given, returns an Enumerator.
+  #
+  # Struct#filter is an alias for Struct#select.
+  #
+  alias filter select
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - values_at(*integers) -> array
+  #   - values_at(integer_range) -> array
+  # -->
+  # Returns an array of values from `self`.
+  #
+  # With integer arguments `integers` given, returns an array containing each
+  # value given by one of `integers`:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.values_at(0, 2)    # => ["Joe Smith", 12345]
+  #     joe.values_at(2, 0)    # => [12345, "Joe Smith"]
+  #     joe.values_at(2, 1, 0) # => [12345, "123 Maple, Anytown NC", "Joe Smith"]
+  #     joe.values_at(0, -3)   # => ["Joe Smith", "Joe Smith"]
+  #
+  # Raises IndexError if any of `integers` is out of range; see
+  # Array@Array+Indexes.
+  #
+  # With integer range argument `integer_range` given, returns an array containing
+  # each value given by the elements of the range; fills with `nil` values for
+  # range elements larger than the structure:
+  #
+  #     joe.values_at(0..2)
+  #     # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #     joe.values_at(-3..-1)
+  #     # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #     joe.values_at(1..4) # => ["123 Maple, Anytown NC", 12345, nil, nil]
+  #
+  # Raises RangeError if any element of the range is negative and out of range;
+  # see Array@Array+Indexes.
+  #
+  def values_at: (*int | range[int?] positions) -> Array[Elem]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - members -> array_of_symbols
+  # -->
+  # Returns the member names from `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     Customer.new.members # => [:name, :address, :zip]
+  #
+  # Related: #to_a.
+  #
+  def members: () -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - dig(name, *identifiers) -> object
+  #   - dig(n, *identifiers) -> object
+  # -->
+  # Finds and returns an object among nested objects. The nested objects may be
+  # instances of various classes. See [Dig Methods](rdoc-ref:dig_methods.rdoc).
+  #
+  # Given symbol or string argument `name`, returns the object that is specified
+  # by `name` and `identifiers`:
+  #
   #     Foo = Struct.new(:a)
-  #     Foo.keyword_init? # => nil
-  #     Bar = Struct.new(:a, keyword_init: true)
-  #     Bar.keyword_init? # => true
-  #     Baz = Struct.new(:a, keyword_init: false)
-  #     Baz.keyword_init? # => false
+  #     f = Foo.new(Foo.new({b: [1, 2, 3]}))
+  #     f.dig(:a) # => #<struct Foo a={:b=>[1, 2, 3]}>
+  #     f.dig(:a, :a) # => {:b=>[1, 2, 3]}
+  #     f.dig(:a, :a, :b) # => [1, 2, 3]
+  #     f.dig(:a, :a, :b, 0) # => 1
+  #     f.dig(:b, 0) # => nil
   #
-  def self.keyword_init?: () -> (true | false | nil)
+  # Given integer argument `n`, returns the object that is specified by `n` and
+  # `identifiers`:
+  #
+  #     f.dig(0) # => #<struct Foo a={:b=>[1, 2, 3]}>
+  #     f.dig(0, 0) # => {:b=>[1, 2, 3]}
+  #     f.dig(0, 0, :b) # => [1, 2, 3]
+  #     f.dig(0, 0, :b, 0) # => 1
+  #     f.dig(:b, 0) # => nil
+  #
+  def dig: (index name_or_position) -> Elem
+         | (index name_or_position, untyped, *untyped) -> untyped
+
+  # <!-- rdoc-file=struct.c -->
+  # Returns the values in `self` as an array:
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     joe.to_a # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+  #
+  # Struct#values and Struct#deconstruct are aliases for Struct#to_a.
+  #
+  # Related: #members.
+  #
+  alias deconstruct to_a
+
+  # <!--
+  #   rdoc-file=struct.c
+  #   - deconstruct_keys(array_of_names) -> hash
+  # -->
+  # Returns a hash of the name/value pairs for the given member names.
+  #
+  #     Customer = Struct.new(:name, :address, :zip)
+  #     joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
+  #     h = joe.deconstruct_keys([:zip, :address])
+  #     h # => {:zip=>12345, :address=>"123 Maple, Anytown NC"}
+  #
+  # Returns all names and values if `array_of_names` is `nil`:
+  #
+  #     h = joe.deconstruct_keys(nil)
+  #     h # => {:name=>"Joseph Smith, Jr.", :address=>"123 Maple, Anytown NC", :zip=>12345}
+  #
+  def deconstruct_keys: (Array[index & Hash::_Key]? indices) -> Hash[index & Hash::_Key, Elem]
 end

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -246,12 +246,8 @@ class Struct[Elem]
   #     Any.new(1, 2)
   #     # => #<struct Any foo=1, bar=2>
   #
-  def self.new: [K < _StructClass[Elem]] (string? classname, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
-              | [K < _StructClass[Elem]] (Symbol field1, *interned fields, ?keyword_init: boolish?) ?{ (K) -> void } -> K
-
-  interface _StructClass[Elem]
-    def new: (*Elem fields, **Elem keyword_fields) -> instance
-  end
+  def self.new: (string? classname, *interned fields, ?keyword_init: boolish?) ?{ (singleton(Struct)) [self: singleton(Struct)] -> void } -> untyped
+              | (Symbol field1, *interned fields, ?keyword_init: boolish?) ?{ (singleton(Struct)) [self: singleton(Struct)] -> void } -> untyped
 
   # <!--
   #   rdoc-file=struct.c

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -46,10 +46,12 @@
 # *   Includes [module Enumerable](rdoc-ref:Enumerable@What-27s+Here), which
 #     provides dozens of additional methods.
 #
+#
 # See also Data, which is a somewhat similar, but stricter concept for defining
 # immutable value objects.
 #
 # Here, class Struct provides methods that are useful for:
+#
 # *   [Creating a Struct
 #     Subclass](rdoc-ref:Struct@Methods+for+Creating+a+Struct+Subclass)
 # *   [Querying](rdoc-ref:Struct@Methods+for+Querying)
@@ -59,23 +61,25 @@
 # *   [Iterating](rdoc-ref:Struct@Methods+for+Iterating)
 # *   [Converting](rdoc-ref:Struct@Methods+for+Converting)
 #
+#
 # ### Methods for Creating a Struct Subclass
 #
-# *   ::new: Returns a new subclass of Struct.#
+# *   ::new: Returns a new subclass of Struct.
+#
 #
 # ### Methods for Querying
 #
 # *   #hash: Returns the integer hash code.
-# *   #length, #size: Returns the number of members.#
+# *   #length, #size: Returns the number of members.
+#
 #
 # ### Methods for Comparing
 #
-# [#==](#method-i-3D-3D)
-# :   Returns whether a given object is equal to `self`, using `==` to compare
-#     member values.
-# #eql?
-# :   Returns whether a given object is equal to `self`, using `eql?` to compare
-#     member values.#
+# *   #==: Returns whether a given object is equal to `self`, using `==` to
+#     compare member values.
+# *   #eql?: Returns whether a given object is equal to `self`, using `eql?` to
+#     compare member values.
+#
 #
 # ### Methods for Fetching
 #
@@ -99,16 +103,14 @@
 #
 # ### Methods for Iterating
 #
-# *   #inspect, #to_s: Returns a string representation of `self`.
-# *   #to_h: Returns a hash of the member name/value pairs in `self`.
+# *   #each: Calls a given block with each member name.
+# *   #each_pair: Calls a given block with each member name/value pair.
 #
 #
 # ### Methods for Converting
 #
-# #inspect, #to_s
-# :   Returns a string representation of `self`.
-# #to_h
-# :   Returns a hash of the member name/value pairs in `self`.
+# *   #inspect, #to_s: Returns a string representation of `self`.
+# *   #to_h: Returns a hash of the member name/value pairs in `self`.
 #
 class Struct[Elem]
   include Enumerable[Elem]
@@ -129,8 +131,6 @@ class Struct[Elem]
   #
   # *   May be anonymous, or may have the name given by `class_name`.
   # *   May have members as given by `member_names`.
-  # *   May have initialization via ordinary arguments (the default) or via
-  #     keyword arguments (if `keyword_init: true` is given).
   # *   May have initialization via ordinary arguments, or via keyword arguments
   #
   #
@@ -206,7 +206,6 @@ class Struct[Elem]
   #         Foo.new(foo: 0, bar: 1, baz: 2)
   #         # Raises ArgumentError: unknown keywords: baz
   #
-  #
   #     Method `::[]` is an alias for method `::new`.
   #
   # *   Method `:inspect` returns a string representation of the subclass:
@@ -223,6 +222,7 @@ class Struct[Elem]
   #
   # By default, the arguments for initializing an instance of the new subclass can
   # be both positional and keyword arguments.
+  #
   # Optional keyword argument `keyword_init:` allows to force only one type of
   # arguments to be accepted:
   #

--- a/test/stdlib/Struct_test.rb
+++ b/test/stdlib/Struct_test.rb
@@ -1,16 +1,219 @@
-require_relative 'test_helper'
+require_relative "test_helper"
 
-class StructTest < Test::Unit::TestCase
+class StructSingletonTest < Test::Unit::TestCase
   include TypeAssertions
 
-  testing '::Struct[::Integer]'
+  testing "singleton(::Struct)"
+
+  def test_new
+    # Since we're redefining `TestNewStruct` constantly, we need to set `$VERBOSE` to nil to suppress
+    # the redeclaration warnings.
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
+
+    with_string 'TestNewStruct' do |classname|
+      with_interned :field1 do |field1|
+        with_interned :field2 do |field2|
+          assert_send_type  "(::string?, *::interned) -> singleton(Struct)",
+                            Struct, :new, classname, field1, field2
+          assert_send_type  "(::string?, *::interned) { (self) -> void } -> singleton(Struct)",
+                            Struct, :new, classname, field1, field2 do end
+
+          if Symbol === field1 # can't use `.is_a?` since `ToStr` doesn't define it.
+            assert_send_type  "(Symbol, *::interned) -> singleton(Struct)",
+                              Struct, :new, field1, field2
+            assert_send_type  "(Symbol, *::interned) { (self) -> void } -> singleton(Struct)",
+                              Struct, :new, field1, field2 do end
+          end
+
+          ['yes', false, nil].each do |kwinit|
+            assert_send_type  "(::string?, *::interned, keyword_init: ::boolish?) ?{ (self) -> void } -> singleton(Struct)",
+                              Struct, :new, classname, field1, field2, keyword_init: kwinit
+            assert_send_type  "(::string?, *::interned, keyword_init: ::boolish?) ?{ (self) -> void } -> singleton(Struct)",
+                              Struct, :new, classname, field1, field2, keyword_init: kwinit do end
+            
+            if Symbol === field1 # can't use `.is_a?` since `ToStr` doesn't define it.
+              assert_send_type  "(Symbol, *::interned, keyword_init: ::boolish?) -> singleton(Struct)",
+                                Struct, :new, field1, field2, keyword_init: kwinit
+              assert_send_type  "(Symbol, *::interned, keyword_init: ::boolish?) { (self) -> void } -> singleton(Struct)",
+                                Struct, :new, field1, field2, keyword_init: kwinit do end
+            end
+          end
+        end
+      end
+    end
+  ensure
+    $VERBOSE = old_verbose
+  end
+
+  def test_members
+    assert_send_type  "() -> Array[Symbol]",
+                      Struct.new(:foo, :bar), :members
+  end
+
+  def test_keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: true), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: false), :keyword_init?
+    assert_send_type  "() -> bool?",
+                      Struct.new(:foo, keyword_init: nil), :keyword_init?
+  end
+end
+
+class StructInstanceTest < Test::Unit::TestCase
+  include TypeAssertions
+
+  testing "::Struct[Rational]"
 
   MyStruct = Struct.new(:foo, :bar)
+  Instance = MyStruct.new(1r, 2r)
+
+
+  def with_index(int=1, str=:bar, &block)
+    block.call str.to_s
+    block.call str.to_sym
+    with_int(int, &block)
+  end
+
+  def test_equal
+    assert_send_type  "(untyped) -> bool",
+                      Instance, :==, 3
+  end
+
+  def test_eql?
+    assert_send_type  "(untyped) -> bool",
+                      Instance, :eql?, 3
+  end
+
+  def test_hash
+    assert_send_type  "() -> Integer",
+                      Instance, :hash
+  end
+
+  def test_inspect
+    assert_send_type  "() -> String",
+                      Instance, :inspect
+  end
+
+  def test_to_s
+    assert_send_type  "() -> String",
+                      Instance, :to_s
+  end
+
+  def test_to_a
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :to_a
+  end
+
+  def test_to_h
+    assert_send_type  "() -> Hash[Symbol, Rational]",
+                      Instance, :to_h
+    assert_send_type  "[K, V] () { (Symbol, Rational) -> [K, V] } -> Hash[K, V]",
+                      Instance, :to_h do [1, 2] end
+  end
+
+  def test_values
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :values
+  end
+
+  def test_size
+    assert_send_type  "() -> Integer",
+                      Instance, :size
+  end
+
+  def test_length
+    assert_send_type  "() -> Integer",
+                      Instance, :length
+  end
 
   def test_each
-    assert_send_type '() { (::Integer?) -> void } -> self',
-                      MyStruct.new(42), :each do end
-    assert_send_type '() -> ::Enumerator[::Integer?, self]',
-                      MyStruct.new(42), :each
+    assert_send_type  "() -> Enumerator[Rational, self]",
+                      Instance, :each
+    assert_send_type  "() { (Rational) -> void } -> self",
+                      Instance, :each do end
+  end
+
+  def test_each_pair
+    assert_send_type  "() -> Enumerator[[Symbol, Rational], self]",
+                      Instance, :each_pair
+    assert_send_type  "() { ([Symbol, Rational]) -> void } -> self",
+                      Instance, :each_pair do end
+  end
+
+  def test_aref
+    with_index do |idx|
+      assert_send_type  "(Struct::index) -> Rational",
+                        Instance, :[], idx
+    end
+  end
+
+  def test_aset
+    with_index do |idx|
+      assert_send_type  "(Struct::index, Rational) -> Rational",
+                        Instance, :[]=, idx, 1r
+    end
+  end
+
+  def test_select
+    assert_send_type  "() -> Enumerator[Rational, Array[Rational]]",
+                      Instance, :select
+    assert_send_type  "() { (Rational) -> ::boolish } -> Array[Rational]",
+                      Instance, :select do end
+  end
+
+
+  def test_filter
+    assert_send_type  "() -> Enumerator[Rational, Array[Rational]]",
+                      Instance, :filter
+    assert_send_type  "() { (Rational) -> ::boolish } -> Array[Rational]",
+                      Instance, :filter do end
+  end
+
+  def test_values_at
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :values_at
+  
+    with_int 1 do |idx|
+      assert_send_type  "(*::int | ::range[::int?]) -> Array[Rational]",
+                        Instance, :values_at, idx, idx..nil
+    end
+  end
+
+  def test_members
+    assert_send_type  "() -> Array[Symbol]",
+                      Instance, :members
+  end
+
+  def test_dig
+    array_instance = MyStruct.new([1])
+    with_index do |idx|
+      assert_send_type  "(Struct::index) -> Rational",
+                        Instance, :dig, idx
+      assert_send_type  "(Struct::index, untyped, *untyped) -> untyped",
+                        array_instance, :dig, idx, 1
+    end
+  end
+
+  def test_deconstruct
+    assert_send_type  "() -> Array[Rational]",
+                      Instance, :deconstruct
+  end
+
+  def test_deconstruct_keys
+    assert_send_type  "(nil) -> Hash[Symbol, Rational]",
+                      Instance, :deconstruct_keys, nil
+
+    with_index do |idx|
+      # Ensure that the `ToInt` variants have `hash` and `eql?` defined.
+      def idx.hash = 0 unless defined? idx.hash
+      def idx.eql?(r) = false unless defined? idx.eql? 
+
+      assert_send_type  "(Array[Struct::index & Hash::_Key]) -> Hash[Struct::index & Hash::_Key, Rational]",
+                        Instance, :deconstruct_keys, [idx]
+    end
   end
 end


### PR DESCRIPTION
This PR updates `Struct`'s definitions, as well as adds in the `Hash::_Key` interface (needed for `Struct#deconstruct_keys`), which will be used when I work on `Hash`.

There's one small caveat: There's no real way to annotate `<subclass of Struct>.new`. After talking it over with @soutaro, we've decided it's fine and users can just add their own `new`s type definitions if needed. e.g.:
```ruby
Point = Struct.new(:x, :y) do def to_s = "(#{x}, #{y})" end
```
would become
```rbs
class Point < Struct[Numeric]
  attr_reader x: Numeric

  attr_reader y: Numeric
  
  def initialize: (Numeric x, Numeric y) -> void
  
  def to_s: () ->  String
end
```

