### PR TITLE
Allow to use RBS in symlinked tree

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -83,7 +83,7 @@ module RBS
         private def validate_gemfile_lock_path!(lock:, gemfile_lock_path:)
           return unless lock
           return unless lock.gemfile_lock_fullpath
-          unless lock.gemfile_lock_fullpath == gemfile_lock_path
+          unless File.realpath(lock.gemfile_lock_fullpath) == File.realpath(gemfile_lock_path)
             raise GemfileLockMismatchError.new(expected: lock.gemfile_lock_fullpath, actual: gemfile_lock_path)
           end
         end


### PR DESCRIPTION
Currently RBS cannot be used from Bazel or any other tool that builds a forest of symlinks because Gemfile.lock has different path:

```
$ rbs collection install
RBS Collection loads a different Gemfile.lock from before. (RBS::Collection::Config::LockfileGenerator::GemfileLockMismatchError)
The Gemfile.lock must be the same as that is recorded in rbs_collection.lock.yaml.
Expected Gemfile.lock: /private/var/tmp/_bazel_p0deje/d9f7ca256f773f0ccaaf86cfc9fd2df8/execroot/selenium/bazel-out/darwin_arm64-fastbuild/bin/rb/rbs-install.rb.sh.runfiles/selenium/rb/Gemfile.lock
Actual Gemfile.lock: /Users/p0deje/Development/SeleniumHQ/selenium/rb/Gemfile.lock
```

This commit would allow to resolve the symlink before attempting to paths.