### PR TITLE
Add description about rbs prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,48 @@ $ rbs methods ::Object
 $ rbs method Object then
 ```
 
+An end user of `rbs` will probably find `rbs prototype` the most useful. This command generates boilerplate signature declarations for ruby files. For example, say you have written the below ruby script.
+```ruby
+# person.rb
+class Person
+  attr_reader :name
+  attr_reader :contacts
+
+  def initialize(name:)
+    @name = name
+    @contacts = []
+  end
+
+  def speak
+    "I'm #{@name} and I love Ruby!"
+  end
+end
+```
+Running prototype on the above will automatically generate
+```
+$ rbs prototype rb person.rb
+class Person
+  @name: untyped
+
+  @contacts: untyped
+
+  attr_reader name: untyped
+
+  attr_reader contacts: untyped
+
+  def initialize: (name: untyped) -> void
+
+  def speak: () -> ::String
+end
+```
+It prints signatures for all methods, classes, instance variables, and constants.
+This is only a starting point, and you should edit the output to match your signature more accurately.
+
+`rbs prototpe` offers three options. 
+- `rb` generates from just the available Ruby code
+- `rbi` generates from Sorbet RBI
+- `runtime` generates from runtime API
+
 ## Library
 
 There are two important concepts, _environment_ and _definition_.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ $ rbs method Object then
 ```
 
 An end user of `rbs` will probably find `rbs prototype` the most useful. This command generates boilerplate signature declarations for ruby files. For example, say you have written the below ruby script.
+
 ```ruby
 # person.rb
 class Person
@@ -94,7 +95,9 @@ class Person
   end
 end
 ```
+
 Running prototype on the above will automatically generate
+
 ```
 $ rbs prototype rb person.rb
 class Person
@@ -111,10 +114,12 @@ class Person
   def speak: () -> ::String
 end
 ```
+
 It prints signatures for all methods, classes, instance variables, and constants.
 This is only a starting point, and you should edit the output to match your signature more accurately.
 
-`rbs prototpe` offers three options. 
+`rbs prototpe` offers three options.
+
 - `rb` generates from just the available Ruby code
 - `rbi` generates from Sorbet RBI
 - `runtime` generates from runtime API


### PR DESCRIPTION
I mostly used what is already in the [Steep README](https://github.com/soutaro/steep/blob/f68f477d6050cd0d2bd80f38c4645f72b7b04a11/README.md?plain=1#L163). Some differences besides change in wording are
- Shorter example script `person.rb`
- Additional explanation of `rb` option in `rbs prototype`

This closes #1614 