### PR TITLE
Bugfix; `.respond_to` is no longer used in `Rbs::Test::Errors#inspect_`

### DIFF
--- a/lib/rbs/test/errors.rb
+++ b/lib/rbs/test/errors.rb
@@ -29,8 +29,11 @@ module RBS
         end
       end
 
+      RESPOND_TO = ::Kernel.instance_method :respond_to?
+      private_constant :RESPOND_TO
+
       def self.inspect_(obj)
-        if obj.respond_to?(:inspect)
+        if RESPOND_TO.bind_call(obj, :inspect)
           obj.inspect
         else
           Test::INSPECT.bind(obj).call     # For the case inspect is not defined (like BasicObject)


### PR DESCRIPTION
This fixes a bug in the testing suite where `.respond_to?` is being used on `BlankSlate` subclass instances.