### PR TITLE
Update MatchData

### DIFF
--- a/core/match_data.rbs
+++ b/core/match_data.rbs
@@ -45,7 +45,9 @@
 # See also "Special global variables" section in Regexp documentation.
 #
 class MatchData
-  public
+  type capture = String | Symbol | int
+
+  def initialize_copy: (MatchData instance) -> self
 
   # <!-- rdoc-file=re.c -->
   # Returns `true` if `object` is another MatchData object whose target string,
@@ -53,7 +55,8 @@ class MatchData
   #
   # MatchData#eql? is an alias for MatchData#==.
   #
-  def ==: (untyped other) -> bool
+  def ==: (MatchData other) -> bool
+        | (untyped) -> false
 
   # <!--
   #   rdoc-file=re.c
@@ -80,10 +83,9 @@ class MatchData
   #     m['foo'] # => "h"
   #     m[:bar]  # => "ge"
   #
-  def []: (Integer idx) -> String?
-        | (Integer start, Integer length) -> ::Array[String?]
-        | (::Range[Integer] range) -> ::Array[String?]
-        | (interned name) -> String?
+  def []: (capture backref, ?nil) -> String?
+        | (int start, int length) -> Array[String?]
+        | (range[int?] range) -> Array[String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -121,7 +123,7 @@ class MatchData
   #
   # Related: MatchData#end, MatchData#offset, MatchData#byteoffset.
   #
-  def begin: (Integer | interned n_or_name) -> Integer?
+  def begin: (capture backref) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -139,7 +141,7 @@ class MatchData
   #     p m.byteoffset(:foo) #=> [0, 1]
   #     p m.byteoffset(:bar) #=> [2, 3]
   #
-  def byteoffset: (Integer | interned n_or_name) -> ([ Integer, Integer ] | [ nil, nil ])
+  def byteoffset: (capture backref) -> ([Integer, Integer] | [nil, nil])
 
   # <!--
   #   rdoc-file=re.c
@@ -154,7 +156,7 @@ class MatchData
   #
   # Related: MatchData.to_a.
   #
-  def captures: () -> ::Array[String?]
+  def captures: () -> Array[String?]
 
   # <!-- rdoc-file=re.c -->
   # Returns the array of captures, which are all matches except `m[0]`:
@@ -183,7 +185,7 @@ class MatchData
   #     m = /(\d{2}):(\d{2}):(\d{2})/.match("18:37:22")
   #     m.deconstruct_keys(nil) # => {}
   #
-  def deconstruct_keys: (Array[Symbol]?) -> Hash[Symbol, String?]
+  def deconstruct_keys: (Array[Symbol]? array_of_names) -> Hash[Symbol, String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -221,7 +223,7 @@ class MatchData
   #
   # Related: MatchData#begin, MatchData#offset, MatchData#byteoffset.
   #
-  def end: (Integer | interned n_or_name) -> Integer?
+  def end: (capture backref) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -232,7 +234,7 @@ class MatchData
   #
   # MatchData#eql? is an alias for MatchData#==.
   #
-  def eql?: (untyped other) -> bool
+  alias eql? ==
 
   # <!--
   #   rdoc-file=re.c
@@ -276,7 +278,7 @@ class MatchData
   #
   # MatchData#length is an alias for MatchData.size.
   #
-  def length: () -> Integer
+  alias length size
 
   # <!--
   #   rdoc-file=re.c
@@ -301,7 +303,7 @@ class MatchData
   #     # => #<MatchData "01" a:"0" a:"1">
   #     m.named_captures #=> {"a" => "1"}
   #
-  def named_captures: () -> ::Hash[String, String?]
+  def named_captures: () -> Hash[String, String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -322,7 +324,7 @@ class MatchData
   #     m = /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge")
   #     m.regexp.names # => ["foo", "bar", "baz"]
   #
-  def names: () -> ::Array[String]
+  def names: () -> Array[String]
 
   # <!--
   #   rdoc-file=re.c
@@ -348,7 +350,7 @@ class MatchData
   #     m.match('foo') # => "h"
   #     m.match(:bar)  # => "ge"
   #
-  def match: (int | interned) -> String?
+  def match: (capture backref) -> String?
 
   # <!--
   #   rdoc-file=re.c
@@ -375,7 +377,7 @@ class MatchData
   #     m.match_length('foo') # => 1
   #     m.match_length(:bar)  # => 2
   #
-  def match_length: (int | interned) -> Integer?
+  def match_length: (capture backref) -> Integer?
 
   # <!--
   #   rdoc-file=re.c
@@ -414,7 +416,7 @@ class MatchData
   #
   # Related: MatchData#byteoffset, MatchData#begin, MatchData#end.
   #
-  def offset: (Integer | interned n_or_name) -> ([ Integer, Integer ] | [ nil, nil ])
+  def offset: (capture backref) -> ([Integer, Integer] | [nil, nil])
 
   # <!--
   #   rdoc-file=re.c
@@ -500,7 +502,7 @@ class MatchData
   #
   # Related: MatchData#captures.
   #
-  def to_a: () -> ::Array[String?]
+  def to_a: () -> Array[String?]
 
   # <!--
   #   rdoc-file=re.c
@@ -544,9 +546,5 @@ class MatchData
   #     m.values_at(0, 1..2, :a, :b, :op)
   #     # => ["1 + 2", "1", "+", "1", "2", "+"]
   #
-  def values_at: (*Integer | interned n_or_name) -> ::Array[String?]
-
-  private
-
-  def initialize_copy: (self object) -> void
+  def values_at: (*capture | range[int?] backrefs) -> Array[String?]
 end


### PR DESCRIPTION
NOTE: This PR needs #1649 to be merged

This PR updates the type definitions and completely overhauls the tests for `MatchData`.

More specifically,
- `MatchData::capture`: Added, type alias for `String | Symbol | int`. (Not `interned`, as that's `string | Symbol`.)
- `MatchData#initialize_copy`: Moved to the top of the definition list
- `MatchData#==`: Returns `bool` for `MatchData`s, and `false` for `untyped`
- `MatchData#[]`: Now uses `capture`, implicit ints, and implicit ranges
- `MatchData#{begin,{byte,}offset,match{,_length},end}`: Now uses `capture`, updated variable names
- `MatchData#deconstruct_keys`: Updated variable names
- `MatchData#eql?`: Now an alias for `MatchData#==`
- `MatchData#length`: Now an alias for `MatchData#size`
- `MatchData#values_at`: Now uses `capture | range[int?]`