### PR TITLE
Should raise ParsingError instead of ArgumentError

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -276,6 +276,14 @@ static VALUE parse_function_param(parserstate *state) {
     param_range.start = type_range.start;
     param_range.end = name_range.end;
 
+    if (!is_keyword_token(state->current_token.type)) {
+      raise_syntax_error(
+        state,
+        state->current_token,
+        "unexpected token for function parameter name"
+      );
+    }
+
     VALUE name = rb_to_symbol(rbs_unquote_string(state, state->current_token.range, 0));
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -641,13 +641,25 @@ RBS
     assert_raises RBS::ParsingError do
       RBS::Parser.parse_method_type(buffer("(foo + 1) -> void"))
     end.tap do |exn|
-      assert_equal "test.rbs:1:7...1:8: Syntax error: unexpected token for method type parameters, token=`1` (tINTEGER)", exn.message
+      assert_equal "test.rbs:1:5...1:6: Syntax error: unexpected token for function parameter name, token=`+` (tOPERATOR)", exn.message
     end
 
     assert_raises RBS::ParsingError do
       RBS::Parser.parse_method_type(buffer("(foo: untyped, Bar) -> void"))
     end.tap do |exn|
       assert_equal "test.rbs:1:15...1:18: Syntax error: required keyword argument type is expected, token=`Bar` (tUIDENT)", exn.message
+    end
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_method_type(buffer("(foo`: untyped) -> void"))
+    end.tap do |exn|
+      assert_equal "test.rbs:1:4...1:5: Syntax error: unexpected token for function parameter name, token=``` (tOPERATOR)", exn.message
+    end
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_method_type(buffer("(?foo\": untyped) -> void"))
+    end.tap do |exn|
+      assert_equal "test.rbs:1:5...1:6: Syntax error: unexpected token for function parameter name, token=`\"` (ErrorToken)", exn.message
     end
 
     assert_raises RBS::ParsingError do


### PR DESCRIPTION
I noticed that there are cases where obvious syntax errors are being reported as ArgumentError, so I have corrected this issue.


actual

```
$ bundle exec rbs parse --method-type -e '(foo` untyped) -> void'
bundler: failed to load command: rbs (/Users/ksss/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/bin/rbs)
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:12:in `_parse_method_type': negative string size (or size too big) (ArgumentError)
```

expect

```
$ bundle exec rbs parse --method-type -e '(foo` untyped) -> void'
-e:1:4...1:5: Syntax error: unexpected token for function parameter name, token=``` (tOPERATOR) (RBS::ParsingError)

  (foo` untyped) -> void
      ^
```