### PR TITLE
change Date.parse signature to match behavior

### DIFF
--- a/stdlib/date/0/date.rbs
+++ b/stdlib/date/0/date.rbs
@@ -533,7 +533,7 @@ class Date
   #
   # Related: Date._parse (returns a hash).
   #
-  def self.parse: (String str, ?boolish complete, ?Integer start) -> Date
+  def self.parse: (?String str, ?boolish complete, ?Integer start) -> Date
 
   # <!--
   #   rdoc-file=ext/date/date_core.c

--- a/test/stdlib/Date_test.rb
+++ b/test/stdlib/Date_test.rb
@@ -158,6 +158,8 @@ class DateSingletonTest < Test::Unit::TestCase
                       Date, :parse, "2020-08-15", :true
     assert_send_type  "(::String str, bool complete, ::Integer start) -> ::Date",
                       Date, :parse, "2020-08-15", true, Date::ITALY
+    assert_send_type  "() -> ::Date",
+                      Date, :parse
   end
 
   def test_rfc2822


### PR DESCRIPTION
Date.parse returns a a value when called with no argument.  
When called with too many arguments the ArgumentError also states the expected number is (0..3)