### PR TITLE
stdlib/resolv: Resolv::DNS::Resource::Generic.create returns a class

### DIFF
--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -921,7 +921,7 @@ end
 # A generic resource abstract class.
 #
 class Resolv::DNS::Resource::Generic < Resolv::DNS::Resource
-  def self.create: (Integer type_value, Integer class_value) -> instance
+  def self.create: (Integer type_value, Integer class_value) -> Class  # actually, a subclass of Generic
 
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 

--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -921,7 +921,7 @@ end
 # A generic resource abstract class.
 #
 class Resolv::DNS::Resource::Generic < Resolv::DNS::Resource
-  def self.create: (Integer type_value, Integer class_value) -> Class  # actually, a subclass of Generic
+  def self.create: (Integer type_value, Integer class_value) -> Class
 
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 

--- a/test/stdlib/resolv/DNS_test.rb
+++ b/test/stdlib/resolv/DNS_test.rb
@@ -490,3 +490,16 @@ class ResolvDNSRequesterInstanceTest < Test::Unit::TestCase
       requester, :close
   end
 end
+
+class ResolvDNSResourceGenericSigletonTest < Test::Unit::TestCase
+  include TypeAssertions
+  library 'resolv'
+  testing 'singleton(::Resolv::DNS::Resource::Generic)'
+
+  def test_create
+    rrtype = assert_send_type "(Integer, Integer) -> Class",
+      Resolv::DNS::Resource::Generic, :create, Resolv::DNS::Resource::IN::ClassValue, 65280
+    assert_send_type "(String) -> ::Resolv::DNS::Resource::Generic",
+      rrtype, :new, ''
+  end
+end


### PR DESCRIPTION
`Resolv::DNS::Resource::Generic.create` is not a data constructor but defines a new subclass of `Resolv::DNS::Resource::Generic` and returns it.

```
% irb -rresolv
irb(main):001> rrtype = Resolv::DNS::Resource::Generic.create(65280, Resolv::DNS::Resource::IN::ClassValue)
=> Resolv::DNS::Resource::Generic::Type65280_Class1
irb(main):002> rrtype.class
=> Class
irb(main):003> rrtype.superclass
=> Resolv::DNS::Resource::Generic
```

The result type is some subclass of `Generic`, but, IIUC, RBS currently has no way to express the upper bound for a `Class` (ref. https://github.com/ruby/rbs/issues/1542).