### PR TITLE
[collection] Ignore directory starting with `_` as version from git source

### DIFF
--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -248,7 +248,7 @@ module RBS
               if gem_name
                 versions[gem_name.to_s] ||= Set[]
 
-                if version
+                if version && !version.basename.to_s.start_with?('_')
                   versions[gem_name.to_s] << version.basename.to_s
                 end
               end


### PR DESCRIPTION
The git source should allow for putting a directory starting with `_` in a gem directory.


# Background

I'm planning to introduce a new reviewing system to https://github.com/ruby/gem_rbs_collection.
In the new system, I'll add a new file to describe who is responsible for the gem. For example: (The file name is tentative)

```
.
└── gems
    └── rails
        ├── 7.0
        └── _reviewers.yaml
```


But `rbs collection` interprets `_reviewers.yaml` as a version. It is unexpected behavior.


# Solution

Ignore files/directories starting with `_` as a version.

Ignoring files starting with `_` is an existing convention in RBS. So I think this behavior is natural for the users.


This solution has another advantage. We can use a directory starting with `_` for another purpose. For example, we can put an RBS generator for the gem in the directory.

