### PR TITLE
Fix order for collection sources

### DIFF
--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -64,12 +64,11 @@ module RBS
       end
 
       def sources
-        @sources ||= (
-          @data['sources']
-            .map { |c| Sources.from_config_entry(c, base_directory: @config_path.dirname) }
-            .push(Sources::Stdlib.instance)
-            .push(Sources::Rubygems.instance)
-        )
+        @sources ||= [
+          Sources::Stdlib.instance,
+          Sources::Rubygems.instance,
+          *@data['sources'].map { |c| Sources.from_config_entry(c, base_directory: @config_path.dirname) }
+        ]
       end
 
       def gems


### PR DESCRIPTION
When a gem registered in the gem_rbs_collection includes its own RBS in the `sig` directory, the one from gem_rbs_collection is used by default. Although it's possible to specify a different `source`, the gem itself requires the user to set this.

Specifically, I am attempting to include a `sig` directory within the gem itself for `aws-sdk-core`.
https://github.com/aws/aws-sdk-ruby/issues/2950

I believe it's more practical to prioritize the gem's own RBS by default, and allow the use of gem_rbs_collection's RBS optionally. In this PR, I've changed the priority as follows:

- stdlib
- rubygems
- sources(gem_rbs_collection)

I'm finding it difficult to write tests.