### PR TITLE
A tiny followup for #1641’s oopsies

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -1349,7 +1349,7 @@ class String
   # modification made, `self` otherwise.
   #
   def chomp!: (nil) -> nil
-            | (?string separator) -> self?
+            | (?string? separator) -> self? # https://github.com/ruby/rbs/pull/1672#discussion_r1423324796
 
   # <!--
   #   rdoc-file=string.c

--- a/core/string.rbs
+++ b/core/string.rbs
@@ -1349,7 +1349,8 @@ class String
   # modification made, `self` otherwise.
   #
   def chomp!: (nil) -> nil
-            | (?string? separator) -> self? # https://github.com/ruby/rbs/pull/1672#discussion_r1423324796
+          # | (?string separator) -> self? # https://github.com/ruby/rbs/pull/1672#discussion_r1423324796
+            | (?string? separator) -> self?
 
   # <!--
   #   rdoc-file=string.c

--- a/core/string.rbs
+++ b/core/string.rbs
@@ -1349,7 +1349,7 @@ class String
   # modification made, `self` otherwise.
   #
   def chomp!: (nil) -> nil
-            | (?string? separator) -> self?
+            | (?string separator) -> self?
 
   # <!--
   #   rdoc-file=string.c
@@ -2741,7 +2741,7 @@ class String
   #     "\x81"
   #     "\x81"
   #
-  def scrub: (?string replacement) -> String
+  def scrub: (?string? replacement) -> String
            | (?nil) { (String bytes) -> string } -> String
 
   # <!--

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -1281,6 +1281,11 @@ class StringInstanceTest < Test::Unit::TestCase
     assert_send_type  '() -> String',
                       invalid, :scrub
 
+    assert_send_type  '(nil) -> String',
+                      valid, :scrub, nil
+    assert_send_type  '(nil) -> String',
+                      invalid, :scrub, nil
+
     with_string '&' do |replacement|
       assert_send_type  '(string) -> String',
                         valid, :scrub, replacement
@@ -1309,6 +1314,11 @@ class StringInstanceTest < Test::Unit::TestCase
                       valid.dup, :scrub!
     assert_send_type  '() -> String',
                       invalid.dup, :scrub!
+
+    assert_send_type  '(nil) -> String',
+                      valid.dup, :scrub!, nil
+    assert_send_type  '(nil) -> String',
+                      invalid.dup, :scrub!, nil
 
     with_string '&' do |replacement|
       assert_send_type  '(string) -> String',


### PR DESCRIPTION
* ~~`chomp!`: The `?` suffix in `(?string? separator)` is already covered by `(nil)`.~~
* **`scrub`: Just like `scrub!`, `scrub(nil, &nil)` is a thing.**

---

Question: What shall the convension around `?Regexp | string | nil` vs. `?Regexp | string?` be?