### PR TITLE
Update methods for Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,9 +31,8 @@ jobs:
             job: stdlib_test
           - container_tag: 3.1-dev-focal
             job: stdlib_test
-        include:
-          - container_tag: master-nightly-focal
-            allow_failures: "true"
+          - container_tag: 3.2-dev-focal
+            job: stdlib_test
     container:
       image: rubylang/ruby:${{ matrix.container_tag }}
     steps:

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -366,6 +366,61 @@ class Dir
 
   # <!--
   #   rdoc-file=dir.c
+  #   - Dir.fchdir(fd) -> 0
+  #   - Dir.fchdir(fd) { ... } -> object
+  # -->
+  # Changes the current working directory to the directory specified by the
+  # integer file descriptor `fd`.
+  #
+  # When passing a file descriptor over a UNIX socket or to a child process, using
+  # `fchdir` instead of `chdir` avoids the [time-of-check to time-of-use
+  # vulnerability](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use)
+  #
+  # With no block, changes to the directory given by `fd`:
+  #
+  #     Dir.chdir('/var/spool/mail')
+  #     Dir.pwd # => "/var/spool/mail"
+  #     dir  = Dir.new('/usr')
+  #     fd = dir.fileno
+  #     Dir.fchdir(fd) do
+  #       Dir.pwd # => "/usr"
+  #     end
+  #     Dir.pwd # => "/var/spool/mail"
+  #
+  # With a block, temporarily changes the working directory:
+  #
+  # *   Calls the block with the argument.
+  # *   Changes to the given directory.
+  # *   Executes the block
+  # *   Restores the previous working directory.
+  # *   Returns the block's return value.
+  #
+  #
+  # Example:
+  #
+  #     Dir.chdir('/var/spool/mail')
+  #     Dir.pwd # => "/var/spool/mail"
+  #     Dir.chdir('/tmp') do
+  #       Dir.pwd # => "/tmp"
+  #     end
+  #     Dir.pwd # => "/var/spool/mail"
+  #
+  # This method uses the
+  # [fchdir()](https://www.man7.org/linux/man-pages/man3/fchdir.3p.html) function
+  # defined by POSIX 2008; the method is not implemented on non-POSIX platforms
+  # (raises NotImplementedError).
+  #
+  # Raises an exception if the file descriptor is not valid.
+  #
+  # In a multi-threaded program an error is raised if a thread attempts to open a
+  # `chdir` block while another thread has one open, or a call to `chdir` without
+  # a block occurs inside a block passed to `chdir` (even in the same thread).
+  #
+  def self.fchdir: (int) -> Integer
+                 | [T] (int) { () -> T } -> T
+
+  # <!--
+  #   rdoc-file=dir.c
   #   - Dir.foreach(dirpath, encoding: 'UTF-8') {|entry_name| ... }  -> nil
   # -->
   # Calls the block with each entry name in the directory at `dirpath`; sets the

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -757,6 +757,20 @@ class Dir
 
   # <!--
   #   rdoc-file=dir.c
+  #   - chdir -> nil
+  # -->
+  # Changes the current working directory to the path of `self`:
+  #
+  #     Dir.pwd # => "/"
+  #     dir = Dir.new('example')
+  #     dir.chdir
+  #     dir.pwd # => "/example"
+  #
+  def chdir: () -> Integer
+           | [T] { () -> T } -> T
+
+  # <!--
+  #   rdoc-file=dir.c
   #   - children -> array
   # -->
   # Returns an array of the entry names in `self` except for `'.'` and `'..'`:

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -454,6 +454,28 @@ class Dir
 
   # <!--
   #   rdoc-file=dir.c
+  #   - Dir.for_fd(fd) -> dir
+  # -->
+  # Returns a new Dir object representing the directory specified by the given
+  # integer directory file descriptor `fd`:
+  #
+  #     d0 = Dir.new('..')
+  #     d1 = Dir.for_fd(d0.fileno)
+  #
+  # Note that the returned `d1` does not have an associated path:
+  #
+  #     d0.path # => '..'
+  #     d1.path # => nil
+  #
+  # This method uses the
+  # [fdopendir()](https://www.man7.org/linux/man-pages/man3/fdopendir.3p.html)
+  # function defined by POSIX 2008; the method is not implemented on non-POSIX
+  # platforms (raises NotImplementedError).
+  #
+  def self.for_fd: (int) -> Dir
+
+  # <!--
+  #   rdoc-file=dir.c
   #   - Dir.pwd -> string
   # -->
   # Returns the path to the current working directory:

--- a/core/fiber.rbs
+++ b/core/fiber.rbs
@@ -371,6 +371,20 @@ class Fiber < Object
 
   # <!--
   #   rdoc-file=cont.c
+  #   - fiber.kill -> nil
+  # -->
+  # Terminates `fiber` by raising an uncatchable exception, returning the
+  # terminated Fiber.
+  #
+  # If the fiber has not been started, transition directly to the terminated
+  # state.
+  #
+  # If the fiber is already terminated, does nothing.
+  #
+  def kill: () -> nil
+
+  # <!--
+  #   rdoc-file=cont.c
   #   - fiber.raise                                 -> obj
   #   - fiber.raise(string)                         -> obj
   #   - fiber.raise(exception [, string [, array]]) -> obj

--- a/core/io/buffer.rbs
+++ b/core/io/buffer.rbs
@@ -165,6 +165,21 @@ class IO
     #
     def self.map: (File file, ?Integer? size, ?Integer offset, ?Integer flags) -> Buffer
 
+    # <!--
+    #   rdoc-file=io_buffer.c
+    #   - IO::Buffer.string(length) {|io_buffer| ... read/write io_buffer ...} -> string
+    # -->
+    # Creates a new string of the given length and yields a IO::Buffer instance to
+    # the block which uses the string as a source. The block is expected to write to
+    # the buffer and the string will be returned.
+    #
+    #     IO::Buffer.string(4) do |buffer|
+    #       buffer.set_string("Ruby")
+    #     end
+    #     # => "Ruby"
+    #
+    def self.string: (int) { (Buffer) -> void } -> String
+
     public
 
     # <!--

--- a/core/match_data.rbs
+++ b/core/match_data.rbs
@@ -305,6 +305,8 @@ class MatchData
   #     m.named_captures(symbolize_names: true) #=> {:a => "1"}
   #
   def named_captures: () -> Hash[String, String?]
+                    | (symbolize_names: true) -> Hash[Symbol, String?]
+                    | (symbolize_names: boolish) -> Hash[String | Symbol, String?]
 
   # <!--
   #   rdoc-file=re.c

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -1529,6 +1529,50 @@ class Module < Object
 
   # <!--
   #   rdoc-file=object.c
+  #   - mod.set_temporary_name(string) -> self
+  #   - mod.set_temporary_name(nil) -> self
+  # -->
+  # Sets the temporary name of the module `mod`. This name is used as a prefix for
+  # the names of constants declared in `mod`. If the module is assigned a
+  # permanent name, the temporary name is discarded.
+  #
+  # After a permanent name is assigned, a temporary name can no longer be set, and
+  # this method raises a RuntimeError.
+  #
+  # If the name given is not a string or is a zero length string, this method
+  # raises an ArgumentError.
+  #
+  # The temporary name must not be a valid constant name, to avoid confusion with
+  # actual constants. If you attempt to set a temporary name that is a a valid
+  # constant name, this method raises an ArgumentError.
+  #
+  # If the given name is `nil`, the module becomes anonymous.
+  #
+  # Example:
+  #
+  #     m = Module.new # => #<Module:0x0000000102c68f38>
+  #     m.name #=> nil
+  #
+  #     m.set_temporary_name("fake_name") # => fake_name
+  #     m.name #=> "fake_name"
+  #
+  #     m.set_temporary_name(nil) # => #<Module:0x0000000102c68f38>
+  #     m.name #=> nil
+  #
+  #     n = Module.new
+  #     n.set_temporary_name("fake_name")
+  #
+  #     n::M = m
+  #     n::M.name #=> "fake_name::M"
+  #     N = n
+  #
+  #     N.name #=> "nested_fake_name"
+  #     N::M.name #=> "N::M"
+  #
+  def set_temporary_name: (string?) -> self
+
+  # <!--
+  #   rdoc-file=object.c
   #   - mod.singleton_class?    -> true or false
   # -->
   # Returns `true` if *mod* is a singleton class or `false` if it is an ordinary

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -1463,7 +1463,7 @@ class Module < Object
   #
   # Returns a module, where refined methods are defined.
   #
-  def refine: (Module mod) { () -> void } -> Refinement
+  def refine: (Module mod) { () [self: Refinement] -> void } -> Refinement
 
   # <!--
   #   rdoc-file=eval.c

--- a/core/object_space/weak_key_map.rbs
+++ b/core/object_space/weak_key_map.rbs
@@ -1,0 +1,102 @@
+%a{annotate:rdoc:skip}
+module ObjectSpace
+  # <!-- rdoc-file=weakmap.c -->
+  # An ObjectSpace::WeakKeyMap object holds references to any objects, but objects
+  # uses as keys can be garbage collected.
+  #
+  # Objects used as values can't be garbage collected until the key is.
+  #
+  class WeakKeyMap[Key, Value]
+    public
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map[key] -> value
+    # -->
+    # Returns the value associated with the given `key` if found.
+    #
+    # If `key` is not found, returns `nil`.
+    #
+    def []: (Key) -> Value?
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map[key] = value -> value
+    # -->
+    # Associates the given `value` with the given `key`; returns `value`.
+    #
+    # The reference to `key` is weak, so when there is no other reference to `key`
+    # it may be garbage collected.
+    #
+    # If the given `key` exists, replaces its value with the given `value`; the
+    # ordering is not affected
+    #
+    def []=: (Key, Value?) -> Value?
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map.clear -> self
+    # -->
+    # Removes all map entries; returns `self`.
+    #
+    def clear: () -> self
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map.delete(key) -> value or nil
+    #   - map.delete(key) {|key| ... } -> object
+    # -->
+    # Deletes the entry for the given `key` and returns its associated value.
+    #
+    # If no block is given and `key` is found, deletes the entry and returns the
+    # associated value:
+    #     m = ObjectSpace::WeakKeyMap.new
+    #     m["foo"] = 1
+    #     m.delete("foo") # => 1
+    #     m["foo"] # => nil
+    #
+    # If no block given and `key` is not found, returns `nil`.
+    #
+    # If a block is given and `key` is found, ignores the block, deletes the entry,
+    # and returns the associated value:
+    #     m = ObjectSpace::WeakKeyMap.new
+    #     m["foo"] = 2
+    #     h.delete("foo") { |key| raise 'Will never happen'} # => 2
+    #
+    # If a block is given and `key` is not found, calls the block and returns the
+    # block's return value:
+    #     m = ObjectSpace::WeakKeyMap.new
+    #     h.delete("nosuch") { |key| "Key #{key} not found" } # => "Key nosuch not found"
+    #
+    def delete: (Key) -> Value?
+              | [T] (Key) { (Key) -> T } -> (Value | T)
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map.getkey(key) -> existing_key or nil
+    # -->
+    # Returns the existing equal key if it exists, otherwise returns `nil`.
+    #
+    def getkey: (untyped) -> Key?
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - map.inspect -> new_string
+    # -->
+    # Returns a new String containing informations about the map:
+    #
+    #     m = ObjectSpace::WeakKeyMap.new
+    #     m[key] = value
+    #     m.inspect # => "#<ObjectSpace::WeakKeyMap:0x00000001028dcba8 size=1>"
+    #
+    def inspect: () -> String
+
+    # <!--
+    #   rdoc-file=weakmap.c
+    #   - hash.key?(key) -> true or false
+    # -->
+    # Returns `true` if `key` is a key in `self`, otherwise `false`.
+    #
+    def key?: (Key) -> bool
+  end
+end

--- a/core/process.rbs
+++ b/core/process.rbs
@@ -1421,6 +1421,33 @@ module Process
   # Process.waitpid2 is an alias for Process.waitpid.
   #
   def self.waitpid2: (?Integer pid, ?Integer flags) -> [ Integer, Process::Status ]
+
+  # <!--
+  #   rdoc-file=process.c
+  #   - Process.warmup    -> true
+  # -->
+  # Notify the Ruby virtual machine that the boot sequence is finished, and that
+  # now is a good time to optimize the application. This is useful for long
+  # running applications.
+  #
+  # This method is expected to be called at the end of the application boot. If
+  # the application is deployed using a pre-forking model, `Process.warmup` should
+  # be called in the original process before the first fork.
+  #
+  # The actual optimizations performed are entirely implementation specific and
+  # may change in the future without notice.
+  #
+  # On CRuby, `Process.warmup`:
+  #
+  # *   Performs a major GC.
+  # *   Compacts the heap.
+  # *   Promotes all surviving objects to the old generation.
+  # *   Precomputes the coderange of all strings.
+  # *   Frees all empty heap pages and increments the allocatable pages counter by
+  #     the number of pages freed.
+  # *   Invoke `malloc_trim` if available to free empty malloc pages.
+  #
+  def self.warmup: () -> bool
 end
 
 # <!-- rdoc-file=process.c -->

--- a/core/ractor.rbs
+++ b/core/ractor.rbs
@@ -1014,4 +1014,8 @@ class Ractor
 
   class UnsafeError < Ractor::Error
   end
+
+  %a{annotate:rdoc:skip}
+  class Selector
+  end
 end

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -872,6 +872,27 @@ class Range[out Elem] < Object
 
   # <!--
   #   rdoc-file=range.c
+  #   - reverse_each {|element| ... } -> self
+  #   - reverse_each                  -> an_enumerator
+  # -->
+  # With a block given, passes each element of `self` to the block in reverse
+  # order:
+  #
+  #     a = []
+  #     (1..4).reverse_each {|element| a.push(element) } # => 1..4
+  #     a # => [4, 3, 2, 1]
+  #
+  #     a = []
+  #     (1...4).reverse_each {|element| a.push(element) } # => 1...4
+  #     a # => [3, 2, 1]
+  #
+  # With no block given, returns an enumerator.
+  #
+  def reverse_each: () { (Elem) -> void } -> self
+                  | () -> ::Enumerator[Elem, self]
+
+  # <!--
+  #   rdoc-file=range.c
   #   - size -> non_negative_integer or Infinity or nil
   # -->
   # Returns the count of elements in `self` if both begin and end values are

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -808,6 +808,70 @@ class Range[out Elem] < Object
 
   # <!--
   #   rdoc-file=range.c
+  #   - overlap?(range) -> true or false
+  # -->
+  # Returns `true` if `range` overlaps with `self`, `false` otherwise:
+  #
+  #     (0..2).overlap?(1..3) #=> true
+  #     (0..2).overlap?(3..4) #=> false
+  #     (0..).overlap?(..0)   #=> true
+  #
+  # With non-range argument, raises TypeError.
+  #
+  #     (1..3).overlap?(1)         # TypeError
+  #
+  # Returns `false` if an internal call to `<=>` returns `nil`; that is, the
+  # operands are not comparable.
+  #
+  #     (1..3).overlap?('a'..'d')  # => false
+  #
+  # Returns `false` if `self` or `range` is empty. "Empty range" means that its
+  # begin value is larger than, or equal for an exclusive range, its end value.
+  #
+  #     (4..1).overlap?(2..3)      # => false
+  #     (4..1).overlap?(..3)       # => false
+  #     (4..1).overlap?(2..)       # => false
+  #     (2...2).overlap?(1..2)     # => false
+  #
+  #     (1..4).overlap?(3..2)      # => false
+  #     (..4).overlap?(3..2)       # => false
+  #     (1..).overlap?(3..2)       # => false
+  #     (1..2).overlap?(2...2)     # => false
+  #
+  # Returns `false` if the begin value one of `self` and `range` is larger than,
+  # or equal if the other is an exclusive range, the end value of the other:
+  #
+  #     (4..5).overlap?(2..3)      # => false
+  #     (4..5).overlap?(2...4)     # => false
+  #
+  #     (1..2).overlap?(3..4)      # => false
+  #     (1...3).overlap?(3..4)     # => false
+  #
+  # Returns `false` if the end value one of `self` and `range` is larger than, or
+  # equal for an exclusive range, the end value of the other:
+  #
+  #     (4..5).overlap?(2..3)      # => false
+  #     (4..5).overlap?(2...4)     # => false
+  #
+  #     (1..2).overlap?(3..4)      # => false
+  #     (1...3).overlap?(3..4)     # => false
+  #
+  # This method assumes that there is no minimum value because Ruby lacks a
+  # standard method for determining minimum values. This assumption is invalid.
+  # For example, there is no value smaller than `-Float::INFINITY`, making
+  # +(...-Float::INFINITY)+ an empty set. Consequently, +(...-Float::INFINITY)+
+  # has no elements in common with itself, yet
+  # +(...-Float::INFINITY).overlap?((...-Float::INFINITY))+ returns true due to
+  # this assumption. In general, if +r = (...minimum); r.overlap?(r)+ returns
+  # `true`, where `minimum` is a value that no value is smaller than. Such values
+  # include `-Float::INFINITY`, `[]`, +""+, and classes without subclasses.
+  #
+  # Related: Range#cover?.
+  #
+  def overlap?: (Range[untyped]) -> bool
+
+  # <!--
+  #   rdoc-file=range.c
   #   - size -> non_negative_integer or Infinity or nil
   # -->
   # Returns the count of elements in `self` if both begin and end values are

--- a/core/refinement.rbs
+++ b/core/refinement.rbs
@@ -49,4 +49,12 @@ class Refinement < Module
   # Return the class refined by the receiver.
   #
   def refined_class: () -> Module
+
+  # <!--
+  #   rdoc-file=eval.c
+  #   - target    -> class
+  # -->
+  # Return the class or module refined by the receiver.
+  #
+  def target: () -> Module
 end

--- a/core/ruby_vm.rbs
+++ b/core/ruby_vm.rbs
@@ -260,4 +260,115 @@ module RubyVM::AbstractSyntaxTree
     #
     def children: () -> Array[untyped]
   end
+
+  # <!-- rdoc-file=yjit.rb -->
+  # This module allows for introspection of YJIT, CRuby's just-in-time compiler.
+  # Everything in the module is highly implementation specific and the API might
+  # be less stable compared to the standard library.
+  # This module may not exist if YJIT does not support the particular platform
+  # for which CRuby is built.
+  #
+  module YJIT
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - code_gc()
+    # -->
+    # Discard existing compiled code to reclaim memory
+    # and allow for recompilations in the future.
+    #
+    def self.code_gc: () -> void
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - dump_exit_locations(filename)
+    # -->
+    # Marshal dumps exit locations to the given filename.
+    # Usage:
+    # If `--yjit-exit-locations` is passed, a file named
+    # "yjit_exit_locations.dump" will automatically be generated.
+    # If you want to collect traces manually, call `dump_exit_locations`
+    # directly.
+    # Note that calling this in a script will generate stats after the
+    # dump is created, so the stats data may include exits from the
+    # dump itself.
+    # In a script call:
+    #     at_exit do
+    #       RubyVM::YJIT.dump_exit_locations("my_file.dump")
+    #     end
+    #
+    # Then run the file with the following options:
+    #     ruby --yjit --yjit-trace-exits test.rb
+    #
+    # Once the code is done running, use Stackprof to read the dump file.
+    # See Stackprof documentation for options.
+    #
+    def self.dump_exit_locations: (untyped filename) -> void
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - enable()
+    # -->
+    # Enable YJIT compilation.
+    #
+    def self.enable: () -> void
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - enabled?()
+    # -->
+    # Check if YJIT is enabled.
+    #
+    def self.enabled?: () -> bool
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - format_number(pad, number)
+    # -->
+    # Format large numbers with comma separators for readability
+    #
+    def self.format_number: (untyped pad, untyped number) -> untyped
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - format_number_pct(pad, number, total)
+    # -->
+    # Format a number along with a percentage over a total value
+    #
+    def self.format_number_pct: (untyped pad, untyped number, untyped total) -> untyped
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - reset_stats!()
+    # -->
+    # Discard statistics collected for `--yjit-stats`.
+    #
+    def self.reset_stats!: () -> void
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - runtime_stats(context: false)
+    # -->
+    # Return a hash for statistics generated for the `--yjit-stats` command line
+    # option.
+    # Return `nil` when option is not passed or unavailable.
+    #
+    def self.runtime_stats: (?context: bool) -> Hash[untyped, untyped]?
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - stats_enabled?()
+    # -->
+    # Check if `--yjit-stats` is used.
+    #
+    def self.stats_enabled?: () -> bool
+
+    # <!--
+    #   rdoc-file=yjit.rb
+    #   - stats_string()
+    # -->
+    # Format and print out counters as a String. This returns a non-empty
+    # content only when `--yjit-stats` is enabled.
+    #
+    def self.stats_string: () -> String
+  end
 end

--- a/core/ruby_vm.rbs
+++ b/core/ruby_vm.rbs
@@ -371,4 +371,7 @@ module RubyVM::AbstractSyntaxTree
     #
     def self.stats_string: () -> String
   end
+
+  module RJIT
+  end
 end

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -1624,6 +1624,15 @@ class Thread::Queue < Object
 
   # <!--
   #   rdoc-file=thread_sync.c
+  #   - freeze
+  # -->
+  # Raises an exception:
+  #     Queue.new.freeze # Raises TypeError (cannot freeze #<Thread::Queue:0x...>)
+  #
+  def freeze: () -> bot
+
+  # <!--
+  #   rdoc-file=thread_sync.c
   #   - length
   #   - size
   # -->

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -1709,6 +1709,15 @@ class Thread::SizedQueue < Thread::Queue
 
   # <!--
   #   rdoc-file=thread_sync.c
+  #   - freeze
+  # -->
+  # Raises an exception:
+  #     Queue.new.freeze # Raises TypeError (cannot freeze #<Thread::Queue:0x...>)
+  #
+  def freeze: () -> bot
+
+  # <!--
+  #   rdoc-file=thread_sync.c
   #   - new(max)
   # -->
   # Creates a fixed-length queue with a maximum size of `max`.

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -129,6 +129,17 @@ class DirSingletonTest < Test::Unit::TestCase
                      Dir, :foreach, "."
   end
 
+  def test_for_fd
+    fd = Dir.new(Dir.pwd).fileno
+
+    with_int(fd) do |int|
+      assert_send_type(
+        "(::int) -> ::Dir",
+        Dir, :for_fd, int
+      )
+    end
+  end
+
   def test_getwd
     assert_send_type "() -> ::String",
                      Dir, :getwd

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -103,6 +103,22 @@ class DirSingletonTest < Test::Unit::TestCase
     end
   end
 
+  def test_fchdir
+    fd = Dir.new(Dir.pwd).fileno
+
+    with_int(fd) do |int|
+      assert_send_type(
+        "(::int) -> ::Integer",
+        Dir, :fchdir, int
+      )
+
+      assert_send_type(
+        "(::int) { () -> ::String } -> ::String",
+        Dir, :fchdir, int, &proc { "string" }
+      )
+    end
+  end
+
   def test_foreach
     assert_send_type "(::String) { (::String) -> 3 } -> nil",
                      Dir, :foreach, "." do 3 end

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -194,6 +194,20 @@ class DirInstanceTest < Test::Unit::TestCase
 
   testing "::Dir"
 
+  def test_chdir
+    dir = Dir.new(Dir.pwd)
+
+    assert_send_type(
+      "() -> Integer",
+      dir, :chdir
+    )
+
+    assert_send_type(
+      "() { () -> String } -> String",
+      dir, :chdir, &proc { "hello" }
+    )
+  end
+
   def test_children
     assert_send_type "() -> ::Array[::String]",
                      Dir.new("."), :children

--- a/test/stdlib/MatchData_test.rb
+++ b/test/stdlib/MatchData_test.rb
@@ -136,10 +136,20 @@ class MatchDataInstanceTest < Test::Unit::TestCase
   end
 
   def test_named_captures
-    assert_send_type  '() -> Hash[String, String]',
-                      INSTANCE, :named_captures
-    assert_send_type  '() -> Hash[String, nil]',
-                      INSTANCE2, :named_captures
+    assert_send_type '() -> Hash[String, String]',
+                     INSTANCE, :named_captures
+    assert_send_type '() -> Hash[String, nil]',
+                     INSTANCE2, :named_captures
+    assert_send_type(
+      '(symbolize_names: true) -> Hash[Symbol, String]',
+      INSTANCE, :named_captures, symbolize_names: true
+    )
+    with_boolish do
+      assert_send_type(
+        '(symbolize_names: boolish) -> Hash[Symbol | String, String]',
+        INSTANCE, :named_captures, symbolize_names: _1
+      )
+    end
   end
 
   def test_names

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -261,4 +261,20 @@ class ModuleInstanceTest < Test::Unit::TestCase
       )
     end
   end
+
+  def test_set_temporary_name
+    mod = Module.new
+
+    with_string "fake_name" do |name|
+      assert_send_type(
+        "(::string) -> ::Module",
+        mod, :set_temporary_name, name
+      )
+    end
+
+    assert_send_type(
+      "(nil) -> Module",
+      mod, :set_temporary_name, nil
+    )
+  end
 end

--- a/test/stdlib/ObjectSpace_WeakKeyMap_test.rb
+++ b/test/stdlib/ObjectSpace_WeakKeyMap_test.rb
@@ -1,0 +1,109 @@
+require_relative "test_helper"
+require 'objspace'
+
+class ObjectSpace_WeakKeyMapTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing "::ObjectSpace::WeakKeyMap[::String, ::Integer]"
+
+  def test_aref
+    map = ObjectSpace::WeakKeyMap.new()
+
+    map["foo"] = 123
+
+    assert_send_type(
+      "(::String) -> ::Integer",
+      map, :[], "foo"
+    )
+
+    assert_send_type(
+      "(::String) -> nil",
+      map, :[], "bar"
+    )
+  end
+
+  def test_aref_update
+    map = ObjectSpace::WeakKeyMap.new()
+
+    assert_send_type(
+      "(::String, ::Integer) -> ::Integer",
+      map, :[]=, "foo", 123
+    )
+
+    assert_send_type(
+      "(::String, nil) -> nil",
+      map, :[]=, "bar", nil
+    )
+  end
+
+  def test_clear
+    map = ObjectSpace::WeakKeyMap.new()
+
+    assert_send_type(
+      "() -> ::ObjectSpace::WeakKeyMap",
+      map, :clear
+    )
+  end
+
+  def test_delete
+    map = ObjectSpace::WeakKeyMap.new()
+
+    map["foo"] = 123
+    map["bar"] = 123
+
+    assert_send_type(
+      "(::String) -> ::Integer",
+      map, :delete, "foo"
+    )
+    assert_send_type(
+      "(::String) -> nil",
+      map, :delete, "foo"
+    )
+
+    assert_send_type(
+      "(::String) { (::String) -> nil } -> ::Integer",
+      map, :delete, "bar", &proc { nil }
+    )
+    assert_send_type(
+      "(::String) { (::String) -> ::String } -> ::String",
+      map, :delete, "bar", &proc { "Hello" }
+    )
+  end
+
+  def test_getkey
+    map = ObjectSpace::WeakKeyMap.new()
+
+    map["foo"] = 123
+
+    assert_send_type(
+      "(::Integer) -> ::String",
+      map, :getkey, 123
+    )
+    assert_send_type(
+      "(::String) -> nil",
+      map, :getkey, "abc"
+    )
+  end
+
+  def test_inspect
+    map = ObjectSpace::WeakKeyMap.new()
+
+    map["foo"] = 123
+
+    assert_send_type(
+      "() -> ::String",
+      map, :inspect
+    )
+  end
+
+  def test_key?
+    map = ObjectSpace::WeakKeyMap.new()
+
+    map["foo"] = 123
+
+    assert_send_type(
+      "(::String) -> bool",
+      map, :key?, "foo"
+    )
+  end
+end

--- a/test/stdlib/Range_test.rb
+++ b/test/stdlib/Range_test.rb
@@ -126,3 +126,16 @@ class RangeTest < StdlibTest
     (1..).member?(-2)
   end
 end
+
+class RangeInstanceTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing "::Range[::Integer]"
+
+  def test_overlap?
+    assert_send_type(
+      "(::Range[::Integer]) -> bool",
+      (2..5), :overlap?, (3..4)
+    )
+  end
+end

--- a/test/stdlib/io/Buffer_test.rb
+++ b/test/stdlib/io/Buffer_test.rb
@@ -33,6 +33,15 @@ class IO_Buffer_SingletonTest < Test::Unit::TestCase
       IO::Buffer, :new, 10, IO::Buffer::INTERNAL
     )
   end
+
+  def test_string
+    with_int 10 do |int|
+      assert_send_type(
+        "(int) { (IO::Buffer) -> nil } -> String",
+        IO::Buffer, :string, int, &proc { nil }
+      )
+    end
+  end
 end
 
 class IO_Buffer_InstanceTest < Test::Unit::TestCase


### PR DESCRIPTION
### Added methods

* [x] Dir.fchdir
* [x] Dir.for_fd
* [x] Dir#chdir
* [x] Process.warmup
* [x] YJIT.enable
* [x] YJIT.stats_string
* [x] Fiber#kill
* [x] ObjectSpace::WeakKeyMap#[]
* [x] ObjectSpace::WeakKeyMap#[]=
* [x] ObjectSpace::WeakKeyMap#clear
* [x] ObjectSpace::WeakKeyMap#delete
* [x] ObjectSpace::WeakKeyMap#getkey
* [x] ObjectSpace::WeakKeyMap#inspect
* [x] ObjectSpace::WeakKeyMap#key?
* [x] ObjectSpace::WeakMap#delete (skip)
* [x] Module#set_temporary_name
* [x] Ractor::Selector#add (skip)
* [x] Ractor::Selector#clear (skip)
* [x] Ractor::Selector#empty? (skip)
* [x] Ractor::Selector#remove (skip)
* [x] Ractor::Selector#wait (skip)
* [x] Range#overlap?
* [x] Range#reverse_each
* [x] Refinement#target
* [x] Queue#freeze
* [x] SizedQueue#freeze
* [x] IO::Buffer.string
* [x] String#dup (skip)

### Removed methods

* [x] Encoding#replicate
* [x] GC.using_rvargc?
* [x] GC.verify_transient_heap_internal_consistency

### Renamed class

* [x] RubyVM::RJIT -> RubyVM::MJIT (all methods are kept except RubyVM::MJIT.pause)

### Changed methods

* [x] `MatchData#named_captures` now accepts `symbolize_names: bool`
