### PR TITLE
Should raise ParsingError instead of NoMethodError

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -723,7 +723,7 @@ VALUE parse_record_attributes(parserstate *state) {
       case tINTEGER:
       case kTRUE:
       case kFALSE:
-        key = rb_funcall(parse_type(state), rb_intern("literal"), 0);
+        key = rb_funcall(parse_simple(state), rb_intern("literal"), 0);
         break;
       default:
         raise_syntax_error(

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -669,6 +669,33 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
     assert_equal "a.rbs:1:2...1:5: Syntax error: unexpected record key token, token=`foo` (tLIDENT)", error.message
   end
 
+  def test_record_with_optional_key
+    error = assert_raises(RBS::ParsingError) do
+      Parser.parse_type("{ 1?: untyped }")
+    end
+    assert_equal "pQUESTION", error.token_type
+    assert_equal "?", error.location.source
+    assert_equal "a.rbs:1:3...1:4: Syntax error: expected a token `pFATARROW`, token=`?` (pQUESTION)", error.message
+  end
+
+  def test_record_with_intersection_key
+    error = assert_raises(RBS::ParsingError) do
+      Parser.parse_type("{ 1&2: untyped }")
+    end
+    assert_equal "pAMP", error.token_type
+    assert_equal "&", error.location.source
+    assert_equal "a.rbs:1:3...1:4: Syntax error: expected a token `pFATARROW`, token=`&` (pAMP)", error.message
+  end
+
+  def test_record_with_union_key
+    error = assert_raises(RBS::ParsingError) do
+      Parser.parse_type("{ 1|2: untyped }")
+    end
+    assert_equal "pBAR", error.token_type
+    assert_equal "|", error.location.source
+    assert_equal "a.rbs:1:3...1:4: Syntax error: expected a token `pFATARROW`, token=`|` (pBAR)", error.message
+  end
+
   def test_type_var
     Parser.parse_type("Array[A]", variables: []).yield_self do |type|
       assert_instance_of Types::ClassInstance, type


### PR DESCRIPTION
I found a record type pattern that resulted in a `NoMethodError` instead of a `ParsingError`, so I fixed it.

```rb
RBS::Parser.parse_type("{1?: 1}")
#=> /Users/ksss/.rbenv/versions/3.3.0-rc1/lib/ruby/gems/3.3.0+0/gems/rbs-3.3.2/lib/rbs/parser_aux.rb:7:in `_parse_type': undefined method `literal' for an instance of RBS::Types::Optional (NoMethodError)

      _parse_type(buf, range.begin || 0, range.end || buf.last_position, variables, require_eof)
      ^^^^^^^^^^^
```

It seems that if the record key starts with Symbol, String, Integer, true, or false, and is not a literal type, the `literal` method cannot be called, resulting in a NoMethodError.

Although it is not impossible to optimize the code for each token in detail, I think that using `parse_simple` is a reasonable fix.