### PR TITLE
Add `delegate` library

### DIFF
--- a/stdlib/delegate/0/delegator.rbs
+++ b/stdlib/delegate/0/delegator.rbs
@@ -1,0 +1,186 @@
+# <!-- rdoc-file=lib/delegate.rb -->
+# This library provides three different ways to delegate method calls to an
+# object.  The easiest to use is SimpleDelegator.  Pass an object to the
+# constructor and all methods supported by the object will be delegated.  This
+# object can be changed later.
+#
+# Going a step further, the top level DelegateClass method allows you to easily
+# setup delegation through class inheritance.  This is considerably more
+# flexible and thus probably the most common use for this library.
+#
+# Finally, if you need full control over the delegation scheme, you can inherit
+# from the abstract class Delegator and customize as needed.  (If you find
+# yourself needing this control, have a look at Forwardable which is also in the
+# standard library.  It may suit your needs better.)
+#
+# SimpleDelegator's implementation serves as a nice example of the use of
+# Delegator:
+#
+#     require 'delegate'
+#
+#     class SimpleDelegator < Delegator
+#       def __getobj__
+#         @delegate_sd_obj # return object we are delegating to, required
+#       end
+#
+#       def __setobj__(obj)
+#         @delegate_sd_obj = obj # change delegation object,
+#                                # a feature we're providing
+#       end
+#     end
+#
+# ## Notes
+#
+# Be advised, RDoc will not detect delegated methods.
+#
+class Delegator < BasicObject
+  def self.const_missing: (Symbol n) -> untyped
+
+  def self.delegating_block: (Symbol mid) -> Proc
+
+  def self.public_api: () -> untyped
+
+  public
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - !()
+  # -->
+  # Delegates ! to the _*getobj*_
+  #
+  def !: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - !=(obj)
+  # -->
+  # Returns true if two objects are not considered of equal value.
+  #
+  def !=: (untyped obj) -> bool
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - ==(obj)
+  # -->
+  # Returns true if two objects are considered of equal value.
+  #
+  def ==: (untyped obj) -> bool
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - __getobj__()
+  # -->
+  # This method must be overridden by subclasses and should return the object
+  # method calls are being delegated to.
+  #
+  def __getobj__: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - __setobj__(obj)
+  # -->
+  # This method must be overridden by subclasses and change the object delegate to
+  # *obj*.
+  #
+  def __setobj__: (untyped obj) -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - eql?(obj)
+  # -->
+  # Returns true if two objects are considered of equal value.
+  #
+  def eql?: (untyped obj) -> bool
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - freeze()
+  # -->
+  # :method: freeze Freeze both the object returned by _*getobj*_ and self.
+  #
+  def freeze: () -> self
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - marshal_dump()
+  # -->
+  # Serialization support for the object returned by _*getobj*_.
+  #
+  def marshal_dump: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - marshal_load(data)
+  # -->
+  # Reinitializes delegation from a serialized object.
+  #
+  def marshal_load: (untyped data) -> void
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - method_missing(m, *args, &block)
+  # -->
+  #
+  def method_missing: (Symbol m, *untyped args, **untyped) { (*untyped, **untyped) -> untyped } -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - methods(all=true)
+  # -->
+  # Returns the methods available to this delegate object as the union of this
+  # object's and _*getobj*_ methods.
+  #
+  def methods: (?boolish all) -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - protected_methods(all=true)
+  # -->
+  # Returns the methods available to this delegate object as the union of this
+  # object's and _*getobj*_ protected methods.
+  #
+  def protected_methods: (?boolish all) -> Array[Symbol]
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - public_methods(all=true)
+  # -->
+  # Returns the methods available to this delegate object as the union of this
+  # object's and _*getobj*_ public methods.
+  #
+  def public_methods: (?untyped all) -> Array[Symbol]
+
+  private
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - new(obj)
+  # -->
+  # Pass in the *obj* to delegate method calls to.  All methods supported by *obj*
+  # will be delegated to.
+  #
+  def initialize: (untyped obj) -> void
+
+  def initialize_clone: (self obj, ?freeze: bool?) -> self
+
+  def initialize_dup: (self obj) -> self
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - respond_to_missing?(m, include_private)
+  # -->
+  # Checks for a method provided by this the delegate object by forwarding the
+  # call through _*getobj*_.
+  #
+  def respond_to_missing?: (Symbol m, bool include_private) -> bool
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - target_respond_to?(target, m, include_private)
+  # -->
+  # Handle BasicObject instances
+  #
+  def target_respond_to?: (untyped target, Symbol m, bool include_private) -> bool
+
+  VERSION: String
+end

--- a/stdlib/delegate/0/kernel.rbs
+++ b/stdlib/delegate/0/kernel.rbs
@@ -1,0 +1,47 @@
+%a{annotate:rdoc:skip}
+class Object
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - DelegateClass(superclass, &block)
+  # -->
+  # The primary interface to this library.  Use to setup delegation when defining
+  # your class.
+  #
+  #     class MyClass < DelegateClass(ClassToDelegateTo) # Step 1
+  #       def initialize
+  #         super(obj_of_ClassToDelegateTo)              # Step 2
+  #       end
+  #     end
+  #
+  # or:
+  #
+  #     MyClass = DelegateClass(ClassToDelegateTo) do    # Step 1
+  #       def initialize
+  #         super(obj_of_ClassToDelegateTo)              # Step 2
+  #       end
+  #     end
+  #
+  # Here's a sample of use from Tempfile which is really a File object with a few
+  # special rules about storage location and when the File should be deleted.
+  # That makes for an almost textbook perfect example of how to use delegation.
+  #
+  #     class Tempfile < DelegateClass(File)
+  #       # constant and class member data initialization...
+  #
+  #       def initialize(basename, tmpdir=Dir::tmpdir)
+  #         # build up file path/name in var tmpname...
+  #
+  #         @tmpfile = File.open(tmpname, File::RDWR|File::CREAT|File::EXCL, 0600)
+  #
+  #         # ...
+  #
+  #         super(@tmpfile)
+  #
+  #         # below this point, all methods of File are supported...
+  #       end
+  #
+  #       # ...
+  #     end
+  #
+  def DelegateClass: (Class) -> Class
+end

--- a/stdlib/delegate/0/simple_delegator.rbs
+++ b/stdlib/delegate/0/simple_delegator.rbs
@@ -1,0 +1,98 @@
+# <!-- rdoc-file=lib/delegate.rb -->
+# A concrete implementation of Delegator, this class provides the means to
+# delegate all supported method calls to the object passed into the constructor
+# and even to change the object being delegated to at a later time with
+# #__setobj__.
+#
+#     class User
+#       def born_on
+#         Date.new(1989, 9, 10)
+#       end
+#     end
+#
+#     require 'delegate'
+#
+#     class UserDecorator < SimpleDelegator
+#       def birth_year
+#         born_on.year
+#       end
+#     end
+#
+#     decorated_user = UserDecorator.new(User.new)
+#     decorated_user.birth_year  #=> 1989
+#     decorated_user.__getobj__  #=> #<User: ...>
+#
+# A SimpleDelegator instance can take advantage of the fact that SimpleDelegator
+# is a subclass of `Delegator` to call `super` to have methods called on the
+# object being delegated to.
+#
+#     class SuperArray < SimpleDelegator
+#       def [](*args)
+#         super + 1
+#       end
+#     end
+#
+#     SuperArray.new([1])[0]  #=> 2
+#
+# Here's a simple example that takes advantage of the fact that
+# SimpleDelegator's delegation object can be changed at any time.
+#
+#     class Stats
+#       def initialize
+#         @source = SimpleDelegator.new([])
+#       end
+#
+#       def stats(records)
+#         @source.__setobj__(records)
+#
+#         "Elements:  #{@source.size}\n" +
+#         " Non-Nil:  #{@source.compact.size}\n" +
+#         "  Unique:  #{@source.uniq.size}\n"
+#       end
+#     end
+#
+#     s = Stats.new
+#     puts s.stats(%w{James Edward Gray II})
+#     puts
+#     puts s.stats([1, 2, 3, nil, 4, 5, 1, 2])
+#
+# Prints:
+#
+#     Elements:  4
+#      Non-Nil:  4
+#       Unique:  4
+#
+#     Elements:  8
+#      Non-Nil:  7
+#       Unique:  6
+#
+class SimpleDelegator < Delegator
+  public
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - __getobj__() { || ... }
+  # -->
+  # Returns the current object method calls are being delegated to.
+  #
+  def __getobj__: () -> untyped
+
+  # <!--
+  #   rdoc-file=lib/delegate.rb
+  #   - __setobj__(obj)
+  # -->
+  # Changes the delegate object to *obj*.
+  #
+  # It's important to note that this does **not** cause SimpleDelegator's methods
+  # to change.  Because of this, you probably only want to change delegation to
+  # objects of the same type as the original delegate.
+  #
+  # Here's an example of changing the delegation object.
+  #
+  #     names = SimpleDelegator.new(%w{James Edward Gray II})
+  #     puts names[1]    # => Edward
+  #     names.__setobj__(%w{Gavin Sinclair})
+  #     puts names[1]    # => Sinclair
+  #
+  def __setobj__: (untyped obj) -> untyped
+end


### PR DESCRIPTION
Closes #1474 

We are adding the type definition of the library to `rbs` repo, not to the repository of `delegate` gem. This is because it's a *default* gem, which is more tightly coupled to ruby distribution than *bundled* gems.