### PR TITLE
Add the _Duration type

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -219,6 +219,26 @@ interface _Exception
                | (String arg0) -> Exception
 end
 
+# A type that's used for durations.
+#
+# All numeric types implement this, but custom classes can also implement it if desired.
+#
+# Usage of `_Duration` is fairly common throughout the stdlib, such as in `Kernel#sleep`,
+# `IO#timeout=`, and `TCPSocket#new`'s `connet_timeout` field.
+interface _Duration
+  # Returns `[seconds, nanoseconds]`.
+  #
+  # The `seconds` should be a whole number of seconds, whereas the `nanoseconds` should be smaller
+  # than one. For example, `3.125.divmod(1)` would yield `[3, 0.125]`
+  def divmod: (1) -> [int, _DurationNSecs]
+end
+
+# The nanoseconds part of `_Duration`'s return value. See it for details
+interface _DurationNSecs
+  # Convert `self` into a whole number of seconds.
+  def *: (1_000_000_000) -> int
+end
+
 # Represents an `Integer`, or a type convertible to it (via `.to_int`).
 #
 type int = Integer | _ToInt

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -162,6 +162,29 @@ module WithAliases
 
   alias with_untyped with_boolish
 
+  def with_duration(seconds: 1, nanoseconds: 0)
+    duration_obj = BlankSlate.new.__with_object_methods(:define_singleton_method)
+    nanosecs_obj = BlankSlate.new.__with_object_methods(:define_singleton_method)
+
+    secs = nanosecs = nil
+    duration_obj.define_singleton_method :divmod do |x|
+      flunk "Expected `1` for argument to divmod, got #{x.inspect}" unless 1.equal? x
+      [secs, nanosecs_obj]
+    end
+    nanosecs_obj.define_singleton_method :* do |x|
+      flunk "Expected `1000000000` for argument to *, got #{x.inspect}" unless 1000000000.equal? x
+      nanosecs
+    end
+
+    with_int seconds do |s|
+      secs = s
+      with_int nanoseconds do |ns|
+        nanosecs = ns
+        yield duration_obj
+      end
+    end
+  end
+
   def with_range(start, stop, exclude_end = false)
     # If you need fixed starting and stopping points, you can just do `with_range with(1), with(2)`.
     raise ArgumentError, '`start` must be from a `with` method' unless start.is_a? WithEnum


### PR DESCRIPTION
This adds the `_Duration` type, which is used in most places that need a timeout in the standard lib (eg `Kernel#sleep`, `IO#timeout=`, `Mutex#sleep`, `TCPSocket#initialize`'s `connect_timeout` field, etc.

I couldn't find a good place to put it (it doesn't make much sense under `Time`, because `Time` doesn't even use it), so I ended up putting it under `builtins.rbs`