### PR TITLE
deprecate _ArefFromStringToString and encode_fallback

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -3575,8 +3575,10 @@ class String
   def valid_encoding?: () -> bool
 end
 
+%a{steep:deprecated}
 interface _ArefFromStringToString
   def []: (String) -> String
 end
 
+%a{steep:deprecated}
 type String::encode_fallback = Hash[String, String] | Proc | Method | _ArefFromStringToString


### PR DESCRIPTION
This marks the now-unused interfaces as deprecated
