### PR TITLE
Make Pathame() argument type more accurate

### DIFF
--- a/stdlib/pathname/0/pathname.rbs
+++ b/stdlib/pathname/0/pathname.rbs
@@ -1410,5 +1410,5 @@ module Kernel
   #
   # See also Pathname::new for more information.
   #
-  def self?.Pathname: (String | Pathname) -> Pathname
+  def self?.Pathname: (string | Pathname) -> Pathname
 end

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -817,3 +817,23 @@ class PathnameInstanceTest < Test::Unit::TestCase
                      Pathname(File.expand_path(__FILE__)), :zero?
   end
 end
+
+class PathnameKernelTest < Test::Unit::TestCase
+  include TestHelper
+  library 'pathname'
+  testing '::Kernel'
+
+  def test_Pathname
+    with_string("Gemfile") do
+      assert_send_type(
+        "(::string) -> ::Pathname",
+        self, :Pathname, _1
+      )
+    end
+
+    assert_send_type(
+      "(::Pathname) -> ::Pathname",
+      self, :Pathname, Pathname.pwd
+    )
+  end
+end


### PR DESCRIPTION
Currently, `Pathname()` argument's type is declared as `string | Pathname` but actually it accepts objects which responds to `#to_str`.

I agree for this patch to be distributed under RBS's license.
