### PR TITLE
Support Delegator object

### DIFF
--- a/lib/rbs/test.rb
+++ b/lib/rbs/test.rb
@@ -21,6 +21,7 @@ module RBS
     PP = Kernel.instance_method(:pp)
     INSPECT = Kernel.instance_method(:inspect)
     METHODS = Kernel.instance_method(:methods)
+    RESPOND_TOP = Kernel.instance_method(:respond_to?)
 
     class ArgumentsReturn
       include Guaranteed::Inspect

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -296,10 +296,9 @@ module RBS
                             end
           val.is_a?(singleton_class)
         when Types::Interface
-          methods = Set.new(Test.call(val, METHODS))
           if (definition = builder.build_interface(type.name.absolute!))
             definition.methods.each_key.all? do |method_name|
-              methods.member?(method_name)
+              Test.call(val, RESPOND_TOP, method_name)
             end
           end
         when Types::Variable

--- a/sig/test.rbs
+++ b/sig/test.rbs
@@ -30,6 +30,9 @@ module RBS
     # Kernel#singleton_class
     SINGLETON_CLASS: UnboundMethod
 
+    # Kernel#respond_to?
+    RESPOND_TOP: UnboundMethod
+
     class ArgumentsReturn
       type exit_type = :return | :exception | :break
 

--- a/test/rbs/test/tester_test.rb
+++ b/test/rbs/test/tester_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-
+require "delegate"
 require "rbs/test"
 
 class RBS::Test::TesterTest < Test::Unit::TestCase
@@ -94,6 +94,59 @@ EOF
           CallTrace.new(
             method_name: :foo,
             method_call: ArgumentsReturn.return(arguments: [Foo.new], value: nil),
+            block_calls: [],
+            block_given: false
+          )
+        )
+      end
+    end
+  end
+
+  class Response < Delegator
+    attr_accessor :data
+
+    def initialize(data)
+      @data = data
+    end
+
+    def __getobj__
+      @data
+    end
+  end
+
+  class Data < Struct.new(:foo)
+  end
+
+  def test_delegator
+    SignatureManager.new(system_builtin: true) do |manager|
+      manager.files[Pathname("foo.rbs")] = <<EOF
+module RBS
+  module Test
+    module TesterTest
+      interface _Response
+        def data: () -> Data
+        def foo: () -> Integer
+      end
+      class Foo
+        def get_response: () -> _Response
+      end
+      class Data
+        def foo: () -> Integer
+      end
+    end
+  end
+end
+EOF
+      manager.build do |env, path|
+        builder = RBS::DefinitionBuilder.new(env: env)
+        definition = builder.build_instance(type_name("::RBS::Test::TesterTest::Foo"))
+        value = Response.new(Data.new(42))
+        checker = RBS::Test::Tester::MethodCallTester.new(Object, builder, definition, kind: :instance, sample_size: 100, unchecked_classes: [])
+        checker.call(
+          Object.new,
+          CallTrace.new(
+            method_name: :get_response,
+            method_call: ArgumentsReturn.return(arguments: [], value: value),
             block_calls: [],
             block_given: false
           )


### PR DESCRIPTION
The Delegator class intentionally rewrites `#methods`, but the rewrite does not work in `Test.call` and the type using interface does not pass the test.

The `#respond_to?` is not rewritten, so the Delegator class is supported by using `#respond_to?` instead of `#methods`.