### PR TITLE
Add more details error message for UnresolvedOverloadingError

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -35,6 +35,17 @@ module RBS
         if es.size == 1
           errors.push(*es[0])
         else
+          RBS.logger.warn do
+            message = +"[#{self_class}#{method_name}] UnresolvedOverloadingError "
+            message << method.method_types.zip(es).map do |method_type, es|
+              msg = +"method_type=`#{method_type}`"
+              details = es.map do |e|
+                "\"#{Errors.to_string(e).sub("[#{e.klass.name}#{e.method_name}] ", "") }\""
+              end.join(', ')
+              msg << " details=[#{details}]"
+            end.join(', ')
+            message
+          end
           errors << Errors::UnresolvedOverloadingError.new(
             klass: self_class,
             method_name: method_name,

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -517,22 +517,28 @@ EOF
             assert_instance_of RBS::Test::Errors::ReturnTypeError, errors[0]
           end
 
-          typecheck.overloaded_call(
-            foo.methods[:foo],
-            "#foo",
-            Test::CallTrace.new(
-              method_name: :foo,
-              method_call: Test::ArgumentsReturn.return(
-                arguments: [3],
-                value: 30
+          begin
+            RBS.logger_output = logger = StringIO.new
+            typecheck.overloaded_call(
+              foo.methods[:foo],
+              "#foo",
+              Test::CallTrace.new(
+                method_name: :foo,
+                method_call: Test::ArgumentsReturn.return(
+                  arguments: [3],
+                  value: 30
+                ),
+                block_calls: [],
+                block_given: false
               ),
-              block_calls: [],
-              block_given: false
-            ),
-            errors: []
-          ).tap do |errors|
-            assert_equal 1, errors.size
-            assert_instance_of RBS::Test::Errors::UnresolvedOverloadingError, errors[0]
+              errors: []
+            ).tap do |errors|
+              assert_equal 1, errors.size
+              assert_instance_of RBS::Test::Errors::UnresolvedOverloadingError, errors[0]
+              assert_match '[Object#foo] UnresolvedOverloadingError method_type=`() -> ::String` details=["ArgumentError: expected method type () -> ::String", "ReturnTypeError: expected `::String` but returns `30`"], method_type=`(::Integer) -> ::String` details=["ReturnTypeError: expected `::String` but returns `30`"]', logger.string
+            end
+          ensure
+            RBS.logger_output = nil
           end
         end
       end


### PR DESCRIPTION
In `RBS::Test`, if an exception `UnresolvedOverloadingError` is reported, the following message is displayed, but we don't know the details of what did not match.

```
[Object#foo] UnresolvedOverloadingError: couldn't find a suitable overloading
```

I suggest that detailed information also be logged as follows.

```
W, [2023-12-19T13:35:17.268712 #21135]  WARN -- rbs: [Object#foo] UnresolvedOverloadingError method_type=`() -> ::String` details=["ArgumentError: expected method type () -> ::String", "ReturnTypeError: expected `::String` but returns `30`"], method_type=`(::Integer) -> ::String` details=["ReturnTypeError: expected `::String` but returns `30`"]
[Object#foo] UnresolvedOverloadingError: couldn't find a suitable overloading
```

I have made it so that the detailed information is output in the logger so that it can be turned off if not needed.