### PR TITLE
Change return type of lifecycle hooks in `minitest` to be `void`

### DIFF
--- a/stdlib/minitest/0/minitest/test/lifecycle_hooks.rbs
+++ b/stdlib/minitest/0/minitest/test/lifecycle_hooks.rbs
@@ -39,7 +39,7 @@ module Minitest::Test::LifecycleHooks
   #       include MyMinitestPlugin
   #     end
   #
-  def before_setup: () -> nil
+  def before_setup: () -> void
 
   # <!--
   #   rdoc-file=lib/minitest/test.rb
@@ -47,7 +47,7 @@ module Minitest::Test::LifecycleHooks
   # -->
   # Runs before every test. Use this to set up before each test run.
   #
-  def setup: () -> nil
+  def setup: () -> void
 
   # <!--
   #   rdoc-file=lib/minitest/test.rb
@@ -58,7 +58,7 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  def after_setup: () -> nil
+  def after_setup: () -> void
 
   # <!--
   #   rdoc-file=lib/minitest/test.rb
@@ -69,7 +69,7 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  def before_teardown: () -> nil
+  def before_teardown: () -> void
 
   # <!--
   #   rdoc-file=lib/minitest/test.rb
@@ -77,7 +77,7 @@ module Minitest::Test::LifecycleHooks
   # -->
   # Runs after every test. Use this to clean up after each test run.
   #
-  def teardown: () -> nil
+  def teardown: () -> void
 
   # <!--
   #   rdoc-file=lib/minitest/test.rb
@@ -88,5 +88,5 @@ module Minitest::Test::LifecycleHooks
   #
   # See #before_setup for an example.
   #
-  def after_teardown: () -> nil
+  def after_teardown: () -> void
 end

--- a/test/stdlib/Minitest_test.rb
+++ b/test/stdlib/Minitest_test.rb
@@ -43,3 +43,20 @@ class MinitestSingletonTest < Test::Unit::TestCase
   end
 end
 
+class MinitestTestLifecycleHooksTest < Test::Unit::TestCase
+  include TestHelper
+
+  library "minitest"
+  testing "Minitest::Test::LifecycleHooks"
+
+  class LifecycleSetup < Minitest::Test
+    def setup
+      @foo = 123
+    end
+  end  
+
+  def test_setup_return_type_void
+    test = LifecycleSetup.new("setup")
+    assert_send_type  "() -> void", test, :setup
+  end
+end


### PR DESCRIPTION
Hi all, many thanks for all the work on RBS.

I am proposing a change to the Lifecycle hooks of `Minitest::Test` so that they are `void` instead of `nil`.

Otherwise any time we use the `setup` hook for example, we need to explicitly return `nil` but normally we don't care what we return from these methods. The return value is not used in `minitest` I believe (https://github.com/minitest/minitest/blob/master/lib/minitest/test.rb#L91)

I wasn't really sure about how to use the `assert_send_type` test helper but I tried to write a test anyway.

Let me know what you think.

