### PR TITLE
Fix klass name if klass is singleton_class

### DIFF
--- a/lib/rbs/test/errors.rb
+++ b/lib/rbs/test/errors.rb
@@ -41,7 +41,12 @@ module RBS
       end
 
       def self.to_string(error)
-        method = "#{error.klass.name}#{error.method_name}"
+        name = if error.klass.singleton_class?
+          inspect_(error.klass).sub(/\A#<Class:(.*)>\z/, '\1')
+        else
+          error.klass.name
+        end
+        method = "#{name}#{error.method_name}"
         case error
         when ArgumentTypeError
           "[#{method}] ArgumentTypeError: expected #{format_param error.param} but given `#{inspect_(error.value)}`"


### PR DESCRIPTION
When I type-check the singleton method, there is no class/module name in the method name display.

```
[.foo] ReturnTypeError: expected `Integer` but returns `"a"`
```

This is due to the fact that the `#name` of the singleton class returns `nil`.

To solve the problem, I extracted the original class/module name from the string when `#inspect` is called.