### PR TITLE
Improve interface check by method parameters

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -308,13 +308,13 @@ module RBS
           val.is_a?(singleton_class)
         when Types::Interface
           if (definition = builder.build_interface(type.name.absolute!))
-            definition.methods.each_key.all? do |method_name|
+            definition.methods.each.all? do |method_name, method|
               next false unless Test.call(val, RESPOND_TOP, method_name)
 
               meth = Test.call(val, METHOD, method_name)
-              definition.methods[method_name].defs.all? do |type_def|
-                type_def.member.overloads.any? do |overload|
-                  match_method_parameters?(meth.parameters, overload.method_type)
+              method.defs.all? do |type_def|
+                type_def.member.overloads.all? do |overload|
+                  callable_argument?(meth.parameters, overload.method_type)
                 end
               end
             end
@@ -346,42 +346,69 @@ module RBS
 
       private
 
-      def match_method_parameters?(parameters, method_type)
-        fun = method_type.type.dup
+      def callable_argument?(parameters, method_type)
+        fun = method_type.type
+        take_has_rest = !!parameters.find { |(op, _)| op == :rest }
 
-        fun.required_positionals.each do |param|
-          op, _ = parameters.shift
-          return false unless op == :req
+        fun.required_positionals.each do
+          op, _ = parameters.first
+          return false if op.nil? || op == :keyreq || op == :key || op == :keyrest
+          parameters.shift if op == :req || op == :opt
         end
-        fun.optional_positionals.each do |param|
-          op, _ = parameters.shift
-          return false unless op == :opt
+
+        fun.optional_positionals.each do
+          op, _ = parameters.first
+          return false if op.nil? || op == :req || op == :keyreq || op == :key || op == :keyrest
+          parameters.shift if op == :opt
         end
+
         if fun.rest_positionals
           op, _ = parameters.shift
-          return false unless op == :rest
-        end
-        fun.trailing_positionals.each do |param|
-          op, _ = parameters.shift
-          return false unless op == :req
+          return false if op.nil? || op != :rest
         end
 
-        fun.required_keywords.each do |key, param|
-          return false unless parameters.reject! { |op, name| op == :keyreq && name == key }
-        end
-        fun.optional_keywords.each do |key, param|
-          return false unless parameters.reject! { |op, name| op == :key && name == key }
-        end
-        if fun.rest_keywords
-          op, _ = parameters.shift
-          return false unless op == :keyrest
+        fun.trailing_positionals.each do
+          op, _ = parameters.first
+          return false if !take_has_rest && (op.nil? || op == :keyreq || op == :key || op == :keyrest)
+          index = parameters.find_index { |(op, _)| op == :req }
+          parameters.delete_at(index) if index
         end
 
-        parameters.delete_if do |op, _|
-          op == :block
+        if fun.has_keyword?
+          return false if !take_has_rest && parameters.empty?
+
+          fun.required_keywords.each do |name, _|
+            return false if !take_has_rest && parameters.empty?
+            index = parameters.find_index { |(op, n)| (op == :keyreq || op == :key) && n == name }
+            parameters.delete_at(index) if index
+          end
+
+          if !fun.optional_keywords.empty?
+            fun.optional_keywords.each do |name, _|
+              return false if !take_has_rest && parameters.empty?
+              index = parameters.find_index { |(op, n)| op == :key && n == name }
+              parameters.delete_at(index) if index
+            end
+            op, _ = parameters.first
+            return false if op == :req
+          end
+
+          if fun.rest_keywords
+            op, _ = parameters.first
+            return false if (!take_has_rest && op.nil?)
+            # f(a) allows (Integer, a: Integer)
+            return false if op == :req && fun.required_keywords.empty?
+          end
+
+          op, _ = parameters.first
+          return true if (op == :req || op == :opt) && parameters.length == 1
         end
 
-        parameters.empty?
+        # rest required arguments
+        op, _ = parameters.first
+        return false if op == :req || op == :keyreq
+
+        true
       end
     end
   end

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -198,9 +198,6 @@ EOF
           end
           assert yes
           assert typecheck.value(success, parse_type(interface))
-        rescue
-          p [:success, definer, interface]
-          raise
         end
 
         [
@@ -252,9 +249,6 @@ EOF
           end
           refute no
           refute typecheck.value(failure, parse_type(interface))
-        rescue
-          p [:failure, definer, interface]
-          raise
         end
       end
     end

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -73,165 +73,188 @@ EOF
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
 interface _NoArgs
-  def args: () -> void
+  def f: () -> void
 end
 interface _PosArgs
-  def args: (Integer) -> void
+  def f: (Integer) -> void
 end
 interface _OptArgs
-  def args: (?Integer) -> void
+  def f: (?Integer) -> void
 end
 interface _PosOptArgs
-  def args: (Integer, ?String) -> void
+  def f: (Integer, ?String) -> void
 end
 interface _RestArgs
-  def args: (*Integer) -> void
+  def f: (*Integer) -> void
 end
 interface _TrailingArgs
-  def args: (*Integer, Integer) -> void
+  def f: (*Integer, Integer) -> void
 end
 interface _ReqKeyArgs
-  def args: (a: Integer, b: String) -> void
+  def f: (a: Integer, b: String) -> void
 end
 interface _OptKeyArgs
-  def args: (?a: Integer, ?b: String) -> void
+  def f: (?a: Integer, ?b: String) -> void
 end
 interface _PosReqKeyArgs
-  def args: (Integer a, b: Integer) -> void
+  def f: (Integer a, b: Integer) -> void
 end
 interface _RestKeyArgs
-  def args: (**Integer) -> void
+  def f: (**Integer) -> void
 end
 interface _PosRestKeyArgs
-  def args: (Integer, **Integer) -> void
+  def f: (Integer, **Integer) -> void
 end
 interface _ReqKeyRestKeyArgs
-  def args: (a: Integer, **Integer) -> void
+  def f: (a: Integer, **Integer) -> void
 end
 interface _ReqBlockArgs
-  def args: () { (Integer) -> void } -> void
+  def f: () { (Integer) -> void } -> void
 end
 interface _OptBlockArgs
-  def args: () ?{ (Integer) -> void } -> void
+  def f: () ?{ (Integer) -> void } -> void
 end
 interface _AllArgs
-  def args: (Integer, ?Integer, *Integer, Integer, e: Integer, ?f: Integer, **Integer) -> void
+  def f: (Integer, ?Integer, *Integer, Integer, e: Integer, ?f: Integer, **Integer) -> void
 end
 interface _Overload
-  def args: (Integer) -> void
+  def f: (Integer) -> void
           | (Integer, Integer) -> void
 end
 EOF
       manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
         typecheck = Test::TypeCheck.new(
           self_class: Integer,
-          builder: DefinitionBuilder.new(env: env),
+          builder: builder,
           sample_size: 100,
           unchecked_classes: []
         )
 
         [
-          [ ->(o) { def o.args(); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, &b); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a = nil); end }, '::_OptArgs' ],
-          [ ->(o) { def o.args(a, b = nil); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(*r); end }, '::_RestArgs' ],
-          [ ->(o) { def o.args(*r, a); end }, '::_TrailingArgs' ],
-          [ ->(o) { def o.args(a:, b:); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(b:, a:); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(a: 1, b: 'b'); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(b: 'b', a: 1); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(a, b:); end }, '::_PosReqKeyArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a, **rk); end }, '::_PosRestKeyArgs' ],
-          [ ->(o) { def o.args(a:, **rk); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(); end }, '::_ReqBlockArgs' ],
-          [ ->(o) { def o.args(&b); end }, '::_ReqBlockArgs' ],
-          [ ->(o) { def o.args(); end }, '::_OptBlockArgs' ],
-          [ ->(o) { def o.args(&b); end }, '::_OptBlockArgs' ],
-          [ ->(o) { def o.args(a, b = nil, *c, d, e:, f: nil, **g); end }, '::_AllArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_Overload' ],
-          [ ->(o) { def o.args(a, b); end }, '::_Overload' ],
+          [ ->(o) { def o.f(); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(a = nil); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(*r, **rk); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(...); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a = nil); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, &b); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, b = nil); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(*a); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, *r); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, **kr); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a = nil); end }, '::_OptArgs' ],
+          [ ->(o) { def o.f(a, b = nil); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(*a); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(a, *r); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_RestArgs' ],
+          [ ->(o) { def o.f(*r, a); end }, '::_TrailingArgs' ],
+          [ ->(o) { def o.f(a:, b:); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(b:, a:); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a:, b: 1); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(*a); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a = {}); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a = {}, b = {}); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a: 1, b: 'b'); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(b: 'b', a: 1); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(a = {}); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(a, b:); end }, '::_PosReqKeyArgs' ],
+          [ ->(o) { def o.f(a, b); end }, '::_PosReqKeyArgs' ],
+          [ ->(o) { def o.f(a, b = nil); end }, '::_PosReqKeyArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(*r, **rk); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a: nil, **rk); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a = {}); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a, **rk); end }, '::_PosRestKeyArgs' ],
+          [ ->(o) { def o.f(a, b = {}); end }, '::_PosRestKeyArgs' ],
+          [ ->(o) { def o.f(a:, **rk); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(a: nil, **rk); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(a = nil); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(); end }, '::_ReqBlockArgs' ],
+          [ ->(o) { def o.f(&b); end }, '::_ReqBlockArgs' ],
+          [ ->(o) { def o.f(); end }, '::_OptBlockArgs' ],
+          [ ->(o) { def o.f(&b); end }, '::_OptBlockArgs' ],
+          [ ->(o) { def o.f(a, b = nil, *c, d, e:, f: nil, **g); end }, '::_AllArgs' ],
+          [ ->(o) { def o.f(*r); end }, '::_AllArgs' ],
+          [ ->(o) { def o.f(...); end }, '::_AllArgs' ],
+          [ ->(o) { def o.f(a, b = nil); end }, '::_Overload' ],
+          [ ->(o) { def o.f(a = nil, b = nil); end }, '::_Overload' ],
+          [ ->(o) { def o.f(*r); end }, '::_Overload' ],
         ].each do |definer, interface|
           success = Object.new
           definer.call(success)
+
+          yes = ArgumentChecker.new(builder: builder, interface: interface).no_argument_error?(:f) do |args, kwargs, block|
+            success.f(*args, **kwargs, &block)
+          end
+          assert yes
           assert typecheck.value(success, parse_type(interface))
+        rescue
+          p [:success, definer, interface]
+          raise
         end
 
         [
-          [ ->(o) { def o.args(a = nil); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(*r); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(*r, **rk); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(...); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(a:); end }, '::_NoArgs' ],
-          [ ->(o) { def o.args(a, b = nil); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(*a); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, *r); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, **kr); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, b); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, b, *r); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a: 1); end }, '::_PosArgs' ],
-          [ ->(o) { def o.args(a, &b); end }, '::_OptArgs' ],
-          [ ->(o) { def o.args(*a); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(a, *r); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(a, b); end }, '::_PosOptArgs' ],
-          [ ->(o) { def o.args(); end }, '::_RestArgs' ],
-          [ ->(o) { def o.args(a, *r); end }, '::_RestArgs' ],
-          [ ->(o) { def o.args(*r, a); end }, '::_RestArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_TrailingArgs' ],
-          [ ->(o) { def o.args(a, *b, c); end }, '::_TrailingArgs' ],
-          [ ->(o) { def o.args(a:, b: 1); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(*a); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(a = {}); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(a = {}, b = {}); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(a:, b:, c:); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(b:); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(b: 1); end }, '::_ReqKeyArgs' ],
-          [ ->(o) { def o.args(*r); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(a = {}); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(a:, b: 'b'); end }, '::_OptKeyArgs' ],
-          [ ->(o) { def o.args(a, b); end }, '::_PosReqKeyArgs' ],
-          [ ->(o) { def o.args(a, b = nil); end }, '::_PosReqKeyArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_PosReqKeyArgs' ],
-          [ ->(o) { def o.args(a, z:); end }, '::_PosReqKeyArgs' ],
-          [ ->(o) { def o.args(*a, **rk); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a: nil, **rk); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a = {}); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a:); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a:, **rk); end }, '::_RestKeyArgs' ],
-          [ ->(o) { def o.args(a: nil, **rk); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(a); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(a = nil); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(a:); end }, '::_ReqKeyRestKeyArgs' ],
-          [ ->(o) { def o.args(a, b = {}); end }, '::_PosRestKeyArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_PosRestKeyArgs' ],
-          [ ->(o) { def o.args(*r); end }, '::_AllArgs' ],
-          [ ->(o) { def o.args(...); end }, '::_AllArgs' ],
-          [ ->(o) { def o.args(); end }, '::_AllArgs' ],
-          [ ->(o) { def o.args(**rk); end }, '::_AllArgs' ],
-          [ ->(o) { def o.args(a = nil); end }, '::_Overload' ],
-          [ ->(o) { def o.args(a = nil, b = nil); end }, '::_Overload' ],
-          [ ->(o) { def o.args(*r); end }, '::_Overload' ],
-          [ ->(o) { def o.args(); end }, '::_Overload' ],
-          [ ->(o) { def o.args(a, b, c); end }, '::_Overload' ],
+          [ ->(o) { def o.f(a); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(a:); end }, '::_NoArgs' ],
+          [ ->(o) { def o.f(); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, b); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, b, *r); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a: 1); end }, '::_PosArgs' ],
+          [ ->(o) { def o.f(a, &b); end }, '::_OptArgs' ],
+          [ ->(o) { def o.f(); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(a, b); end }, '::_PosOptArgs' ],
+          [ ->(o) { def o.f(); end }, '::_RestArgs' ],
+          [ ->(o) { def o.f(a, *r); end }, '::_RestArgs' ],
+          [ ->(o) { def o.f(*r, a); end }, '::_RestArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_TrailingArgs' ],
+          [ ->(o) { def o.f(a, *b, c); end }, '::_TrailingArgs' ],
+          [ ->(o) { def o.f(); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a:, b:, c:); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a:); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(a: 1); end }, '::_ReqKeyArgs' ],
+          [ ->(o) { def o.f(); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(a:, b: 'b'); end }, '::_OptKeyArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_PosReqKeyArgs' ],
+          [ ->(o) { def o.f(a, z:); end }, '::_PosReqKeyArgs' ],
+          [ ->(o) { def o.f(); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a:); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(a:, **rk); end }, '::_RestKeyArgs' ],
+          [ ->(o) { def o.f(); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(a:); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(a, **b); end }, '::_ReqKeyRestKeyArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_PosRestKeyArgs' ],
+          [ ->(o) { def o.f(); end }, '::_AllArgs' ],
+          [ ->(o) { def o.f(**rk); end }, '::_AllArgs' ],
+          [ ->(o) { def o.f(a, b); end }, '::_Overload' ],
+          [ ->(o) { def o.f(a); end }, '::_Overload' ],
+          [ ->(o) { def o.f(a = nil); end }, '::_Overload' ],
+          [ ->(o) { def o.f(); end }, '::_Overload' ],
+          [ ->(o) { def o.f(a, b, c); end }, '::_Overload' ],
         ].each do |definer, interface|
           failure = Object.new
           definer.call(failure)
+
+          no = ArgumentChecker.new(builder: builder, interface: interface).no_argument_error?(:f) do |args, kwargs, block|
+            failure.f(*args, **kwargs, &block)
+          end
+          refute no
           refute typecheck.value(failure, parse_type(interface))
+        rescue
+          p [:failure, definer, interface]
+          raise
         end
       end
     end


### PR DESCRIPTION
Regarding checking interfaces, in addition to checking with `#respond_to?`, I believe that comparing `Method#parameters` with types can provide a more accurate interface check.

As an implementation, I've made it so that a match only occurs if the method has exactly the same arguments as the type notation. 
Does this match with the philosophy of RBS? 
For example, the following code actually works. 

```rbs
# sample.rbs
class Sample
  def foo: (a: Integer, b: String) -> void
end
```

```rb
# sample.rb
class Sample
  def foo(a = {})
    p a # { :a => 1, :b => 'b' }
  end
end

Sample.new.foo(a: 1, b: 'b')
```

However, for instance, steep would report `Ruby::MethodArityMismatch` and `Ruby::DifferentMethodParameterKind`. 
What kind of checks should be attempted with RBS alone?