### PR TITLE
Refactor Git source by using `git?` method

### DIFF
--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -152,12 +152,7 @@ module RBS
         private def need_to_fetch?(revision)
           return true unless commit_hash?
 
-          begin
-            git('cat-file', '-e', revision)
-            false
-          rescue CommandError
-            true
-          end
+          !git?('cat-file', '-e', revision)
         end
 
         private def git_dir


### PR DESCRIPTION
`git?` has been defined but not used. This method is useful for `need_to_fetch?` method.