### PR TITLE
Updated Regexp

### DIFF
--- a/core/regexp.rbs
+++ b/core/regexp.rbs
@@ -1332,56 +1332,41 @@
 # *   [Rubular](https://rubular.com/).
 #
 class Regexp
-  # <!--
-  #   rdoc-file=re.c
-  #   - Regexp.new(string, options = 0, timeout: nil) -> regexp
-  #   - Regexp.new(regexp, timeout: nil) -> regexp
-  # -->
-  # With argument `string` given, returns a new regexp with the given string and
-  # options:
+  # Represents an object's ability to be converted to a `Regexp`.
   #
-  #     r = Regexp.new('foo') # => /foo/
-  #     r.source              # => "foo"
-  #     r.options             # => 0
+  # This is only used in `Regexp.try_convert` and `Regexp.union` within the standard library.
+  interface _ToRegexp
+    # Converts `self` to a `Regexp`.
+    def to_regexp: () -> Regexp
+  end
+
+  class TimeoutError < RegexpError
+  end
+
+  # <!-- rdoc-file=re.c -->
+  # see Regexp.options and Regexp.new
   #
-  # Optional argument `options` is one of the following:
+  EXTENDED: Integer
+
+  # <!-- rdoc-file=re.c -->
+  # see Regexp.options and Regexp.new
   #
-  # *   A String of options:
+  FIXEDENCODING: Integer
+
+  # <!-- rdoc-file=re.c -->
+  # see Regexp.options and Regexp.new
   #
-  #         Regexp.new('foo', 'i')  # => /foo/i
-  #         Regexp.new('foo', 'im') # => /foo/im
+  IGNORECASE: Integer
+
+  # <!-- rdoc-file=re.c -->
+  # see Regexp.options and Regexp.new
   #
-  # *   The bit-wise OR of one or more of the constants Regexp::EXTENDED,
-  #     Regexp::IGNORECASE, Regexp::MULTILINE, and Regexp::NOENCODING:
+  MULTILINE: Integer
+
+  # <!-- rdoc-file=re.c -->
+  # see Regexp.options and Regexp.new
   #
-  #         Regexp.new('foo', Regexp::IGNORECASE) # => /foo/i
-  #         Regexp.new('foo', Regexp::EXTENDED)   # => /foo/x
-  #         Regexp.new('foo', Regexp::MULTILINE)  # => /foo/m
-  #         Regexp.new('foo', Regexp::NOENCODING)  # => /foo/n
-  #         flags = Regexp::IGNORECASE | Regexp::EXTENDED |  Regexp::MULTILINE
-  #         Regexp.new('foo', flags)              # => /foo/mix
-  #
-  # *   `nil` or `false`, which is ignored.
-  # *   Any other truthy value, in which case the regexp will be case-insensitive.
-  #
-  #
-  # If optional keyword argument `timeout` is given, its float value overrides the
-  # timeout interval for the class, Regexp.timeout. If `nil` is passed as
-  # +timeout, it uses the timeout interval for the class, Regexp.timeout.
-  #
-  # With argument `regexp` given, returns a new regexp. The source, options,
-  # timeout are the same as `regexp`. `options` and `n_flag` arguments are
-  # ineffective.  The timeout can be overridden by `timeout` keyword.
-  #
-  #     options = Regexp::MULTILINE
-  #     r = Regexp.new('foo', options, timeout: 1.1) # => /foo/m
-  #     r2 = Regexp.new(r)                           # => /foo/m
-  #     r2.timeout                                   # => 1.1
-  #     r3 = Regexp.new(r, timeout: 3.14)            # => /foo/m
-  #     r3.timeout                                   # => 3.14
-  #
-  def initialize: (String string, ?String | Integer | nil | false options, ?timeout: Float?) -> Object
-                | (Regexp regexp, ?timeout: Float?) -> void
+  NOENCODING: Integer
 
   # <!--
   #   rdoc-file=re.c
@@ -1444,8 +1429,7 @@ class Regexp
   #     Regexp.last_match('foo') # Raises IndexError.
   #
   def self.last_match: () -> MatchData?
-                     | (Integer n) -> String?
-                     | (interned n) -> String?
+                     | (MatchData::capture capture) -> String?
 
   # <!--
   #   rdoc-file=re.c
@@ -1466,7 +1450,8 @@ class Regexp
   #
   # (*1): https://doi.org/10.1109/SP40001.2021.00032
   #
-  def self.linear_time?: () -> bool
+  def self.linear_time?: (Regexp regex, ?nil, ?timeout: untyped) -> bool
+                       | (string regex, ?int | string | bool | nil options, ?timeout: untyped) -> bool
 
   # <!--
   #   rdoc-file=re.c
@@ -1482,7 +1467,7 @@ class Regexp
   #     r = Regexp.new(Regexp.escape(s)) # => /\\\\\\\*\\\?\\\{\\\}\\\./
   #     r.match(s)                       # => #<MatchData "\\\\\\*\\?\\{\\}\\.">
   #
-  def self.quote: (interned str) -> String
+  alias self.quote self.escape
 
   # <!--
   #   rdoc-file=re.c
@@ -1501,7 +1486,8 @@ class Regexp
   #
   # Raises an exception unless `object.to_regexp` returns a regexp.
   #
-  def self.try_convert: (untyped obj) -> Regexp?
+  def self.try_convert: (Regexp | _ToRegexp regexp_like) -> Regexp
+                      | (untyped other) -> Regexp?
 
   # <!--
   #   rdoc-file=re.c
@@ -1524,7 +1510,7 @@ class Regexp
   #     Regexp.timeout = 1
   #     /^a*b?a*$/ =~ "a" * 100000 + "x" #=> regexp match timeout (RuntimeError)
   #
-  def self.timeout=: (Float?) -> Float?
+  def self.timeout=: [T < _ToF] (T timeout) -> T
 
   # <!--
   #   rdoc-file=re.c
@@ -1558,11 +1544,62 @@ class Regexp
   #
   # If any regexp pattern contains captures, the behavior is unspecified.
   #
-  def self.union: () -> Regexp
-                | (String | Regexp pat1, *String | Regexp pat2) -> Regexp
-                | (::Array[String | Regexp]) -> Regexp
+  def self.union: (*_ToRegexp | string patterns) -> Regexp
+                | (array[_ToRegexp | string] patterns) -> Regexp
+                | (Symbol | [Symbol] symbol_pattern) -> Regexp
 
-  public
+  # <!--
+  #   rdoc-file=re.c
+  #   - Regexp.new(string, options = 0, timeout: nil) -> regexp
+  #   - Regexp.new(regexp, timeout: nil) -> regexp
+  # -->
+  # With argument `string` given, returns a new regexp with the given string and
+  # options:
+  #
+  #     r = Regexp.new('foo') # => /foo/
+  #     r.source              # => "foo"
+  #     r.options             # => 0
+  #
+  # Optional argument `options` is one of the following:
+  #
+  # *   A String of options:
+  #
+  #         Regexp.new('foo', 'i')  # => /foo/i
+  #         Regexp.new('foo', 'im') # => /foo/im
+  #
+  # *   The bit-wise OR of one or more of the constants Regexp::EXTENDED,
+  #     Regexp::IGNORECASE, Regexp::MULTILINE, and Regexp::NOENCODING:
+  #
+  #         Regexp.new('foo', Regexp::IGNORECASE) # => /foo/i
+  #         Regexp.new('foo', Regexp::EXTENDED)   # => /foo/x
+  #         Regexp.new('foo', Regexp::MULTILINE)  # => /foo/m
+  #         Regexp.new('foo', Regexp::NOENCODING)  # => /foo/n
+  #         flags = Regexp::IGNORECASE | Regexp::EXTENDED |  Regexp::MULTILINE
+  #         Regexp.new('foo', flags)              # => /foo/mix
+  #
+  # *   `nil` or `false`, which is ignored.
+  # *   Any other truthy value, in which case the regexp will be case-insensitive.
+  #
+  #
+  # If optional keyword argument `timeout` is given, its float value overrides the
+  # timeout interval for the class, Regexp.timeout. If `nil` is passed as
+  # +timeout, it uses the timeout interval for the class, Regexp.timeout.
+  #
+  # With argument `regexp` given, returns a new regexp. The source, options,
+  # timeout are the same as `regexp`. `options` and `n_flag` arguments are
+  # ineffective.  The timeout can be overridden by `timeout` keyword.
+  #
+  #     options = Regexp::MULTILINE
+  #     r = Regexp.new('foo', options, timeout: 1.1) # => /foo/m
+  #     r2 = Regexp.new(r)                           # => /foo/m
+  #     r2.timeout                                   # => 1.1
+  #     r3 = Regexp.new(r, timeout: 3.14)            # => /foo/m
+  #     r3.timeout                                   # => 3.14
+  #
+  def initialize: (Regexp regexp, ?timeout: _ToF?) -> self
+                | (string pattern, ?int | string | bool | nil options, ?timeout: _ToF?) -> self
+
+  def initialize_copy: (self object) -> self
 
   # <!-- rdoc-file=re.c -->
   # Returns `true` if `object` is another Regexp whose pattern, flags, and
@@ -1648,7 +1685,8 @@ class Regexp
   #     /(?<foo>\w+)\s*=\s*#{r}/ =~ 'x = y'
   #     p foo # Undefined local variable
   #
-  def =~: (String? | Symbol | _ToStr str) -> Integer?
+  def =~: (interned? string) -> Integer?
+        | (nil) -> nil
 
   # <!--
   #   rdoc-file=re.c
@@ -1683,7 +1721,7 @@ class Regexp
   #     /foo/ == Regexp.new('food')                         # => false
   #     /foo/ == Regexp.new("abc".force_encoding("euc-jp")) # => false
   #
-  def eql?: (untyped other) -> bool
+  alias eql? ==
 
   # <!--
   #   rdoc-file=re.c
@@ -1774,8 +1812,9 @@ class Regexp
   #      /(.)(.)(.)/.match("abc")[2] # => "b"
   #      /(.)(.)/.match("abc", 1)[2] # => "c"
   #
-  def match: (String? | Symbol | _ToStr str, ?Integer pos) -> MatchData?
-           | [T] (String? | Symbol | _ToStr str, ?Integer pos) { (MatchData) -> T } -> T?
+  def match: (interned? str, ?int offset) -> MatchData?
+           | [T] (interned? str, ?int offset) { (MatchData matchdata) -> T } -> T?
+           | (nil, ?int offset) ?{ (MatchData matchdata) -> void } -> nil
 
   # <!--
   #   rdoc-file=re.c
@@ -1791,7 +1830,8 @@ class Regexp
   #     /P.../.match?("Ruby")    # => false
   #     $&                       # => nil
   #
-  def match?: (String? | Symbol | _ToStr str, ?Integer pos) -> bool
+  def match?: (interned str, ?int offset) -> bool
+            | (nil, ?int offset) -> false
 
   # <!--
   #   rdoc-file=re.c
@@ -1810,7 +1850,7 @@ class Regexp
   #     /(?<foo>.)(?<foo>.)/.named_captures # => {"foo"=>[1, 2]}
   #     /(.)(.)/.named_captures             # => {}
   #
-  def named_captures: () -> ::Hash[String, ::Array[Integer]]
+  def named_captures: () -> Hash[String, Array[Integer]]
 
   # <!--
   #   rdoc-file=re.c
@@ -1823,7 +1863,7 @@ class Regexp
   #     /(?<foo>.)(?<foo>.)/.names          # => ["foo"]
   #     /(.)(.)/.names                      # => []
   #
-  def names: () -> ::Array[String]
+  def names: () -> Array[String]
 
   # <!--
   #   rdoc-file=re.c
@@ -1933,33 +1973,4 @@ class Regexp
   #     ~ /at/ # => 7
   #
   def ~: () -> Integer?
-
-  private
-
-  def initialize_copy: (self object) -> self
 end
-
-# <!-- rdoc-file=re.c -->
-# see Regexp.options and Regexp.new
-#
-Regexp::EXTENDED: Integer
-
-# <!-- rdoc-file=re.c -->
-# see Regexp.options and Regexp.new
-#
-Regexp::FIXEDENCODING: Integer
-
-# <!-- rdoc-file=re.c -->
-# see Regexp.options and Regexp.new
-#
-Regexp::IGNORECASE: Integer
-
-# <!-- rdoc-file=re.c -->
-# see Regexp.options and Regexp.new
-#
-Regexp::MULTILINE: Integer
-
-# <!-- rdoc-file=re.c -->
-# see Regexp.options and Regexp.new
-#
-Regexp::NOENCODING: Integer

--- a/lib/rbs/unit_test/spy.rb
+++ b/lib/rbs/unit_test/spy.rb
@@ -128,7 +128,7 @@ module RBS
                 end
               end.ruby2_keywords
             )
-          end.new()
+          end.allocate()
         end
       end
     end


### PR DESCRIPTION
This PR updates `Regexp` and related constants/classes, along with completely overhauling the tests. Changes in bold are a bit larger.

More specifically, this:
-  `Regexp::_ToRegexp`: Added, used in `Regexp.{try_convert,union}`.
- `Regexp::TimeoutError` Added
- `Regexp::{EXTENDED,FIXEDENCODING,IGNORECASE,MULTILINE,NOENCODING}`: Moved inside `Regexp`
- `Regexp.last_match`: Now uses `MatchData::capture`
- ** `Regexp.linear_time?`: Filled out the signature (the old one was entirely incorrect)**
- `Regexp.quote`: Now an alias for `Regexp.escape`
- `Regexp.try_convert`: Now has a case for `_ToRegexp`
- `Regexp.timeout=`: Now returns its argument, split out the `nil` case
- **`Regexp.union`: Now uses `_ToRegexp` and implicit `array`. Also added in the `Symbol` case (which is only used if the only argument is a symbol)**
- **`Regexp#initialize`: Updated to have `Regexp` case, along with implicit arguments**
- `Regexp#=~`: Now uses `interned`, split out the `nil` case
- `Regexp#eql?`: Now an alias for `==`
- `Regexp#match{,?}`: Now uses `interned`, split out the `nil` case, `offset` is now `int`