### PR TITLE
Fix type for Symbol#=~

### DIFF
--- a/core/symbol.rbs
+++ b/core/symbol.rbs
@@ -175,7 +175,8 @@ class Symbol
   # Equivalent to `symbol.to_s =~ object`, including possible updates to global
   # variables; see String#=~.
   #
-  def =~: (untyped obj) -> Integer?
+  def =~: (Regexp regex) -> Integer?
+        | [T] (String::_MatchAgainst[self, T] object) -> T
 
   # <!--
   #   rdoc-file=string.c

--- a/test/stdlib/Symbol_test.rb
+++ b/test/stdlib/Symbol_test.rb
@@ -42,6 +42,13 @@ class SymbolInstanceTest < Test::Unit::TestCase
                      :a, :=~, /a/
     assert_send_type "(nil) -> nil",
                      :a, :=~, nil
+
+    matcher = BlankSlate.new
+    def matcher.=~(rhs)
+      :world
+    end
+    assert_send_type '(String::_MatchAgainst[String, Symbol]) -> Symbol',
+                     :hello, :=~, matcher
   end
 
   def test_aref


### PR DESCRIPTION
`untyped` is too broad.

```rb
:sym =~ 1
# => undefined method `=~' for an instance of Integer (NoMethodError)
```