### PR TITLE
Fix method name tag on assertion

### DIFF
--- a/lib/rbs/test/errors.rb
+++ b/lib/rbs/test/errors.rb
@@ -40,32 +40,37 @@ module RBS
         end
       end
 
-      def self.to_string(error)
-        name = if error.klass.singleton_class?
-          inspect_(error.klass).sub(/\A#<Class:(.*)>\z/, '\1')
+      def self.method_tag(error)
+        if error.klass.singleton_class?
+          name = inspect_(error.klass).sub(/\A#<Class:(.*)>\z/, '\1')
+          method_name = ".#{error.method_name}"
         else
-          error.klass.name
+          name = error.klass.name
+          method_name = "##{error.method_name}"
         end
-        method = "#{name}#{error.method_name}"
+        "[#{name}#{method_name}]"
+      end
+
+      def self.to_string(error)
         case error
         when ArgumentTypeError
-          "[#{method}] ArgumentTypeError: expected #{format_param error.param} but given `#{inspect_(error.value)}`"
+          "#{method_tag(error)} ArgumentTypeError: expected #{format_param error.param} but given `#{inspect_(error.value)}`"
         when BlockArgumentTypeError
-          "[#{method}] BlockArgumentTypeError: expected #{format_param error.param} but given `#{inspect_(error.value)}`"
+          "#{method_tag(error)} BlockArgumentTypeError: expected #{format_param error.param} but given `#{inspect_(error.value)}`"
         when ArgumentError
-          "[#{method}] ArgumentError: expected method type #{error.method_type}"
+          "#{method_tag(error)} ArgumentError: expected method type #{error.method_type}"
         when BlockArgumentError
-          "[#{method}] BlockArgumentError: expected method type #{error.method_type}"
+          "#{method_tag(error)} BlockArgumentError: expected method type #{error.method_type}"
         when ReturnTypeError
-          "[#{method}] ReturnTypeError: expected `#{error.type}` but returns `#{inspect_(error.value)}`"
+          "#{method_tag(error)} ReturnTypeError: expected `#{error.type}` but returns `#{inspect_(error.value)}`"
         when BlockReturnTypeError
-          "[#{method}] BlockReturnTypeError: expected `#{error.type}` but returns `#{inspect_(error.value)}`"
+          "#{method_tag(error)} BlockReturnTypeError: expected `#{error.type}` but returns `#{inspect_(error.value)}`"
         when UnexpectedBlockError
-          "[#{method}] UnexpectedBlockError: unexpected block is given for `#{error.method_type}`"
+          "#{method_tag(error)} UnexpectedBlockError: unexpected block is given for `#{error.method_type}`"
         when MissingBlockError
-          "[#{method}] MissingBlockError: required block is missing for `#{error.method_type}`"
+          "#{method_tag(error)} MissingBlockError: required block is missing for `#{error.method_type}`"
         when UnresolvedOverloadingError
-          "[#{method}] UnresolvedOverloadingError: couldn't find a suitable overloading"
+          "#{method_tag(error)} UnresolvedOverloadingError: couldn't find a suitable overloading"
         else
           raise "Unexpected error: #{inspect_(error)}"
         end

--- a/lib/rbs/test/tester.rb
+++ b/lib/rbs/test/tester.rb
@@ -149,7 +149,7 @@ module RBS
           method = definition.methods[method_name]
           if method
             RBS.logger.debug { "Type checking `#{self_class}#{format_method_name(method_name)}`..."}
-            errors = check.overloaded_call(method, format_method_name(method_name), trace, errors: [])
+            errors = check.overloaded_call(method, method_name, trace, errors: [])
 
             if errors.empty?
               RBS.logger.debug { "No type error detected 👏" }

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -35,22 +35,24 @@ module RBS
         if es.size == 1
           errors.push(*es[0])
         else
+          error = Errors::UnresolvedOverloadingError.new(
+            klass: self_class,
+            method_name: method_name,
+            method_types: method.method_types
+          )
           RBS.logger.warn do
-            message = +"[#{self_class}#{method_name}] UnresolvedOverloadingError "
+            tag = Errors.method_tag(error)
+            message = +"#{tag} UnresolvedOverloadingError "
             message << method.method_types.zip(es).map do |method_type, es|
               msg = +"method_type=`#{method_type}`"
               details = es.map do |e|
-                "\"#{Errors.to_string(e).sub("[#{e.klass.name}#{e.method_name}] ", "") }\""
+                "\"#{Errors.to_string(e).sub("#{tag} ", "") }\""
               end.join(', ')
               msg << " details=[#{details}]"
             end.join(', ')
             message
           end
-          errors << Errors::UnresolvedOverloadingError.new(
-            klass: self_class,
-            method_name: method_name,
-            method_types: method.method_types
-          )
+          errors << error
         end
 
         errors

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -190,7 +190,7 @@ EOF
 
         parse_method_type("(Integer) -> String").tap do |method_type|
           errors = []
-          typecheck.return "#foo",
+          typecheck.return :foo,
                            method_type,
                            method_type.type,
                            Test::ArgumentsReturn.exception(arguments: [1], exception: RuntimeError.new("test")),
@@ -199,7 +199,7 @@ EOF
           assert_empty errors
 
           errors.clear
-          typecheck.return "#foo",
+          typecheck.return :foo,
                            method_type,
                            method_type.type,
                            Test::ArgumentsReturn.return(arguments: [1], value: "5"),
@@ -210,7 +210,7 @@ EOF
 
         parse_method_type("(Integer) -> bot").tap do |method_type|
           errors = []
-          typecheck.return "#foo",
+          typecheck.return :foo,
                            method_type,
                            method_type.type,
                            Test::ArgumentsReturn.exception(arguments: [1], exception: RuntimeError.new("test")),
@@ -219,7 +219,7 @@ EOF
           assert_empty errors
 
           errors.clear
-          typecheck.return "#foo",
+          typecheck.return :foo,
                            method_type,
                            method_type.type,
                            Test::ArgumentsReturn.return(arguments: [1], value: "5"),
@@ -243,7 +243,7 @@ EOF
 
         parse_method_type("() -> Integer").tap do |method_type|
           errors = []
-          typecheck.return ".foo",
+          typecheck.return :foo,
                            method_type,
                            method_type.type,
                            Test::ArgumentsReturn.return(arguments: [], value: 'a'),
@@ -309,7 +309,7 @@ EOF
 
         parse_method_type("(Integer) -> String").tap do |method_type|
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [1], value: "1"),
@@ -319,7 +319,7 @@ EOF
           assert_empty errors
 
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: ["1"], value: "1"),
@@ -329,7 +329,7 @@ EOF
           assert errors.any? {|error| error.is_a?(Test::Errors::ArgumentTypeError) }
 
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [1, 2], value: "1"),
@@ -339,7 +339,7 @@ EOF
           assert errors.any? {|error| error.is_a?(Test::Errors::ArgumentError) }
 
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ hello: :world }], value: "1"),
@@ -351,7 +351,7 @@ EOF
 
         parse_method_type("(foo: Integer, ?bar: String, **Symbol) -> String").tap do |method_type|
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ foo: 31, baz: :baz }], value: "1"),
@@ -361,7 +361,7 @@ EOF
           assert_empty errors
 
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ foo: "foo" }], value: "1"),
@@ -371,7 +371,7 @@ EOF
           assert errors.any? {|error| error.is_a?(Test::Errors::ArgumentTypeError) }
 
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ bar: "bar" }], value: "1"),
@@ -383,7 +383,7 @@ EOF
 
         parse_method_type("(?String, ?encoding: String) -> String").tap do |method_type|
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ encoding: "ASCII-8BIT" }], value: "foo"),
@@ -395,7 +395,7 @@ EOF
 
         parse_method_type("(parent: untyped, type: untyped) -> untyped").tap do |method_type|
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [{ parent: nil, type: nil }], value: nil),
@@ -407,7 +407,7 @@ EOF
 
         parse_method_type("(Integer?, *String) -> String").tap do |method_type|
           errors = []
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [1], value: "1"),
@@ -416,7 +416,7 @@ EOF
                          argument_error: Test::Errors::ArgumentError
           assert_empty errors
 
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [1, ''], value: "1"),
@@ -425,7 +425,7 @@ EOF
                          argument_error: Test::Errors::ArgumentError
           assert_empty errors
 
-          typecheck.args "#foo",
+          typecheck.args :foo,
                          method_type,
                          method_type.type,
                          Test::ArgumentsReturn.return(arguments: [1, '', ''], value: "1"),
@@ -510,7 +510,7 @@ EOF
         builder.build_instance(type_name("::Foo")).tap do |foo|
           typecheck.overloaded_call(
             foo.methods[:foo],
-            "#foo",
+            :foo,
             Test::CallTrace.new(
               method_name: :foo,
               method_call: Test::ArgumentsReturn.return(
@@ -547,7 +547,7 @@ EOF
             RBS.logger_output = logger = StringIO.new
             typecheck.overloaded_call(
               foo.methods[:foo],
-              "#foo",
+              :foo,
               Test::CallTrace.new(
                 method_name: :foo,
                 method_call: Test::ArgumentsReturn.return(
@@ -561,7 +561,7 @@ EOF
             ).tap do |errors|
               assert_equal 1, errors.size
               assert_instance_of RBS::Test::Errors::UnresolvedOverloadingError, errors[0]
-              assert_match '[Object#foo] UnresolvedOverloadingError method_type=`() -> ::String` details=["ArgumentError: expected method type () -> ::String", "ReturnTypeError: expected `::String` but returns `30`"], method_type=`(::Integer) -> ::String` details=["ReturnTypeError: expected `::String` but returns `30`"]', logger.string
+              assert_include logger.string, '[Object#foo] UnresolvedOverloadingError method_type=`() -> ::String` details=["ArgumentError: expected method type () -> ::String", "ReturnTypeError: expected `::String` but returns `30`"], method_type=`(::Integer) -> ::String` details=["ReturnTypeError: expected `::String` but returns `30`"]'
             end
           ensure
             RBS.logger_output = nil


### PR DESCRIPTION
Fixed incorrect method tag display for failure indication when using `assert_send_type`.

e.g.)
```
<["[Integerpow] ArgumentTypeError: expected `Integer` but given `0.1`"]> was expected to be empty.
          ^^ missing `#`
```

I have also reorganized the code so that similar mistakes are less likely to occur.