### PR TITLE
Add Numeric Node's check for parse rbs

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -584,6 +584,14 @@ module RBS
           Types::Literal.new(literal: false, location: nil)
         when :NIL
           Types::Bases::Nil.new(location: nil)
+        when :INTEGER
+          Types::Literal.new(literal: node.children[0], location: nil)
+        when :FLOAT
+          BuiltinNames::Float.instance_type
+        when :RATIONAL, :IMAGINARY
+          lit = node.children[0]
+          type_name = TypeName.new(name: lit.class.name.to_sym, namespace: Namespace.root)
+          Types::ClassInstance.new(name: type_name, args: [], location: nil)
         when :LIT
           lit = node.children[0]
           case lit
@@ -686,6 +694,12 @@ module RBS
 
       def param_type(node, default: Types::Bases::Any.new(location: nil))
         case node.type
+        when :INTEGER
+          BuiltinNames::Integer.instance_type
+        when :FLOAT
+          BuiltinNames::Float.instance_type
+        when :RATIONAL, :IMAGINARY
+          BuiltinNames::Numeric.instance_type
         when :LIT
           case node.children[0]
           when Symbol

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -698,8 +698,10 @@ module RBS
           BuiltinNames::Integer.instance_type
         when :FLOAT
           BuiltinNames::Float.instance_type
-        when :RATIONAL, :IMAGINARY
-          BuiltinNames::Numeric.instance_type
+        when :RATIONAL
+          Types::ClassInstance.new(name: TypeName("::Rational"), args: [], location: nil)
+        when :IMAGINARY
+          Types::ClassInstance.new(name: TypeName("::Complex"), args: [], location: nil)
         when :LIT
           case node.children[0]
           when Symbol


### PR DESCRIPTION
I'll introduce  Numeric Node's for the parser in https://github.com/ruby/ruby/pull/9417.

This changed the behavior of the rbs parse process and caused the test to fail.

This pull request has been modified to check Numeric Node's in parse process.