### PR TITLE
Fix 3.4 `prototype rb` failure

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -603,6 +603,11 @@ module RBS
             end
           when Integer
             Types::Literal.new(literal: lit, location: nil)
+          when String
+            # For Ruby <=3.3 which generates `LIT` node for string literals inside Hash literal.
+            # "a"             => STR node
+            # { "a" => nil }  => LIT node
+            Types::Literal.new(literal: lit, location: nil)
           else
             type_name = TypeName.new(name: lit.class.name.to_sym, namespace: Namespace.root)
             Types::ClassInstance.new(name: type_name, args: [], location: nil)

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -1033,7 +1033,7 @@ end
       [%{1..2}, %{::Range[::Integer]}],
       [%{{}}, %{::Hash[untyped, untyped]}],
       [%{{a: nil}}, %{ { a: nil } }],
-      [%{{"a" => /b/}}, %{ ::Hash[::String, ::Regexp] }],
+      [%({"a" => /b/}), %({ 'a' => ::Regexp })],
     ].each do |rb, rbs|
       node = RubyVM::AbstractSyntaxTree.parse("_ = #{rb}").children[2]
       assert_equal RBS::Parser.parse_type(rbs), parser.literal_to_type(node.children[1])


### PR DESCRIPTION
`prototype rb` in Ruby 3.4 generates record type for more hash literals, with keys of string literals.

That was because the parser <=3.3 generates `LIT` node for hash keys.

```
# In Ruby 3.3
irb(main):001> RubyVM::AbstractSyntaxTree.parse('"a"')
=> (SCOPE@1:0-1:3 tbl: [] args: nil body: (STR@1:0-1:3 "a"))
irb(main):002> RubyVM::AbstractSyntaxTree.parse('{ "a" => 1 }')
=> (SCOPE@1:0-1:12 tbl: [] args: nil body: (HASH@1:0-1:12 (LIST@1:2-1:10 (LIT@1:2-1:5 "a") (LIT@1:9-1:10 1) nil)))
```

Ruby 3.4 fixed this issue generating `STR` node for hash keys too and caused test failure.

This PR updates the test to expect a record type, and test if `LIT` is for a string for <=3.3. This will change the result of `rbs prototype rb` to generate more record types for hash literals.