### PR TITLE
parser: enable record types with optional fields

### DIFF
--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -234,10 +234,10 @@ VALUE rbs_literal(VALUE literal, VALUE location) {
   );
 }
 
-VALUE rbs_record(VALUE fields, VALUE location) {
+VALUE rbs_record(VALUE fields,VALUE location) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
-  rb_hash_aset(args, ID2SYM(rb_intern("fields")), fields);
+  rb_hash_aset(args, ID2SYM(rb_intern("all_fields")), fields);
 
   return CLASS_NEW_INSTANCE(
     RBS_Types_Record,
@@ -588,4 +588,3 @@ VALUE rbs_ast_directives_use_wildcard_clause(VALUE namespace, VALUE location) {
 
   return CLASS_NEW_INSTANCE(RBS_AST_Directives_Use_WildcardClause, 1, &kwargs);
 }
-

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -301,15 +301,20 @@ module RBS
     end
 
     class Record
-      attr_reader fields: Hash[Symbol, t]
+      attr_reader all_fields: Hash[Symbol, [t, bool]]
 
       type loc = Location[bot, bot]
 
       def initialize: (fields: Hash[Symbol, t], location: loc?) -> void
+                    | (all_fields: Hash[Symbol, [t, bool]], location: loc?) -> void
 
       include _TypeBase
 
       attr_reader location: loc?
+
+      def fields: () -> Hash[Symbol, t]
+
+      def optional_fields: () -> Hash[Symbol, t]?
 
       def map_type: () { (t) -> t } -> Record
                   | () -> Enumerator[t, Record]

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -670,6 +670,15 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
   end
 
   def test_record_with_optional_key
+    Parser.parse_type("{ ?foo: untyped }").yield_self do |type|
+      assert_instance_of Types::Record, type
+      assert_equal({}, type.fields)
+      assert_equal({
+                     foo: Types::Bases::Any.new(location: nil),
+                   }, type.optional_fields)
+      assert_equal "{ ?foo: untyped }", type.location.source
+    end
+
     error = assert_raises(RBS::ParsingError) do
       Parser.parse_type("{ 1?: untyped }")
     end


### PR DESCRIPTION
this enables richer definitions of record types, which can only be defined nowadays with Hash[Symbol, untyped].

To handle #504 