### PR TITLE
Fix RBS loading precedence

### DIFF
--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -65,8 +65,8 @@ module RBS
 
       def sources
         @sources ||= [
-          Sources::Stdlib.instance,
           Sources::Rubygems.instance,
+          Sources::Stdlib.instance,
           *@data['sources'].map { |c| Sources.from_config_entry(c, base_directory: @config_path.dirname) }
         ]
       end


### PR DESCRIPTION
We are working to move RBS files of default/bundled gems from `ruby/rbs` repo to repositories of each gem. This PR is to load gem bundled RBS files even if it's also bundled in rbs-gem.

We may want to backport this patch to RBS 3.4, because we plan to move type definition of `mutex_m`.