### PR TITLE
Clarify deprecation state of `--silent` option of `rbs validate`

### DIFF
--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -66,8 +66,8 @@ Examples:
   $ rbs validate
 EOU
 
-          opts.on("--silent") do
-            RBS.print_warning { "`--silent` option is deprecated." }
+          opts.on("--silent", "This option has been deprecated and does nothing.") do
+            RBS.print_warning { "`--silent` option is deprecated because it's silent by default. You can use --log-level option of rbs command to display more information." }
           end
           opts.on("--[no-]exit-error-on-syntax-error", "exit(1) if syntax error is detected") {|bool|
             exit_error = bool

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -259,7 +259,7 @@ singleton(::BasicObject)
 
     with_cli do |cli|
       cli.run(%w(--log-level=warn validate --silent))
-      assert_match(/`--silent` option is deprecated.$/, stdout.string)
+      assert_match(/`--silent` option is deprecated because it's silent by default\. You can use --log-level option of rbs command to display more information\.$/, stdout.string)
     end
   end
 


### PR DESCRIPTION
Currently `--silent` option just displays ``"`--silent` option is deprecated." ``. The user cannot decide what they should do from this message. So I updated the message to describe that the silent mode is default and they can use `--log-level` option also.

ref: https://github.com/ruby/rbs/pull/1648

cc/@ksss