### PR TITLE
Fix test failures on Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,12 @@ gem "dbm"
 gem 'digest'
 gem 'tempfile'
 gem "rdoc"
+gem "bigdecimal"
+gem "abbrev"
+gem "base64"
+gem "mutex_m"
+gem "nkf"
+gem "fileutils"
 
 # Test gems
 gem "rbs-amber", path: "test/assets/test-gem"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,12 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     dbm (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)
+    fileutils (1.7.2)
     goodcheck (3.1.0)
       marcel (>= 1.0, < 2.0)
       psych (>= 3.1, < 5.0)
@@ -30,10 +33,12 @@ GEM
     language_server-protocol (3.17.0.3)
     marcel (1.0.2)
     minitest (5.21.2)
+    mutex_m (0.2.0)
     net-protocol (0.2.2)
       timeout
     net-smtp (0.4.0.1)
       net-protocol
+    nkf (0.2.0)
     parallel (1.24.0)
     parser (3.3.0.4)
       ast (~> 2.4.1)
@@ -94,13 +99,19 @@ PLATFORMS
   x86_64-darwin-20
 
 DEPENDENCIES
+  abbrev
+  base64
+  bigdecimal
   dbm
   digest
+  fileutils
   goodcheck
   json
   json-schema
   minitest
+  mutex_m
   net-smtp
+  nkf
   rake
   rake-compiler
   rbs!

--- a/stdlib/fileutils/0/fileutils.rbs
+++ b/stdlib/fileutils/0/fileutils.rbs
@@ -1771,5 +1771,5 @@ module FileUtils
   #
   # Related: FileUtils.touch.
   #
-  def self?.uptodate?: (path new, pathlist old_list) -> bool
+  def self?.uptodate?: (path new, _Each[path] old_list) -> bool
 end

--- a/test/stdlib/FileUtils_test.rb
+++ b/test/stdlib/FileUtils_test.rb
@@ -606,14 +606,8 @@ class FileUtilsSingletonTest < Test::Unit::TestCase
   end
 
   def test_uptodate?
-    assert_send_type  "(String, String) -> bool",
-                      FileUtils, :uptodate?, "foo", "bar"
     assert_send_type  "(String, Array[String | ToStr | ToPath]) -> bool",
                       FileUtils, :uptodate?, "foo", ["bar", ToStr.new("bar"), ToPath.new("bar")]
-    assert_send_type  "(ToStr, ToStr) -> bool",
-                      FileUtils, :uptodate?, ToStr.new("foo"), ToStr.new("bar")
-    assert_send_type  "(ToPath, ToPath) -> bool",
-                      FileUtils, :uptodate?, ToPath.new("foo"), ToPath.new("bar")
   end
 end
 
@@ -970,7 +964,10 @@ class FileUtilsInstanceTest < Test::Unit::TestCase
   end
 
   def test_uptodate?
-    assert_send_type  "(String, String) -> bool",
-                      Foo.new, :uptodate?, "foo", "bar"
+    in_tmpdir do
+      FileUtils.touch "foo"
+      assert_send_type  "(String, Array[String]) -> bool",
+                        Foo.new, :uptodate?, "foo", ["bar"]
+    end
   end
 end


### PR DESCRIPTION
* Add gems, which is bundled out on Ruby 3.4
* Run `bundle install` during tests
* Fix `FileUtils` types