### PR TITLE
Update type for CSV.foreach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "rbs-amber", path: "test/assets/test-gem"
 
 # Bundled gems
 gem "net-smtp"
+gem 'csv'
 
 group :minitest do
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
+    csv (3.2.8)
     dbm (1.1.0)
     diff-lcs (1.5.0)
     digest (3.1.1)
@@ -102,6 +103,7 @@ DEPENDENCIES
   abbrev
   base64
   bigdecimal
+  csv
   dbm
   digest
   fileutils

--- a/stdlib/csv/0/csv.rbs
+++ b/stdlib/csv/0/csv.rbs
@@ -1722,7 +1722,10 @@ class CSV < Object
   #     would read `UTF-32BE` data from the file but transcode it to `UTF-8`
   #     before parsing.
   #
-  def self.foreach: [U] (String | IO | StringIO path, ?::Hash[Symbol, U] options) { (::Array[String?] arg0) -> void } -> void
+  def self.foreach: (String | IO path, ?String mode, headers: true, **untyped options) { (::CSV::Row arg0) -> void } -> void
+                  | (String | IO path, ?String mode, headers: true, **untyped options) -> Enumerator[::CSV::Row, void]
+                  | (String | IO path, ?String mode, **untyped options) { (::Array[String?] arg0) -> void } -> void
+                  | (String | IO path, ?String mode, **untyped options) -> Enumerator[::Array[String?], void]
 
   # <!--
   #   rdoc-file=lib/csv.rb

--- a/test/stdlib/CSV_test.rb
+++ b/test/stdlib/CSV_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "csv"
+
+class CSVSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  library 'csv'
+  testing "singleton(::CSV)"
+
+  def test_foreach
+    tmpdir = Dir.mktmpdir
+    path = File.join(tmpdir, "example.csv")
+    File.write(path, "a,b,c\n1,2,3\n")
+
+    string_array_block = ->(row) { row.size }
+    assert_send_type "(String path) { (Array[String?]) -> void } -> void",
+                     CSV, :foreach, path, &string_array_block
+    assert_send_type "(IO path) { (Array[String?]) -> void } -> void",
+                     CSV, :foreach, File.open(path), &string_array_block
+
+    csv_row_array_block = ->(row) { row.fields }
+    assert_send_type "(String path, headers: true) { (CSV::Row) -> void } -> void",
+                     CSV, :foreach, path, headers: true, &csv_row_array_block
+    assert_send_type "(String path, headers: false) { (Array[String?]) -> void } -> void",
+                     CSV, :foreach, path, headers: false, &string_array_block
+    assert_send_type "(IO path, headers: bool) { (CSV::Row) -> void } -> void",
+                     CSV, :foreach, File.open(path), headers: true, &csv_row_array_block
+
+    assert_send_type "(String path, **untyped) -> Enumerator[Array[String?], void]",
+                     CSV, :foreach, path, encoding: 'UTF-8'
+    assert_send_type "(String path, headers: bool) -> Enumerator[CSV::Row, void]",
+                     CSV, :foreach, path, headers: true
+    assert_send_type "(String path, headers: bool, **untyped) -> Enumerator[CSV::Row, void]",
+                     CSV, :foreach, path, headers: true, encoding: 'UTF-8'
+  end
+end


### PR DESCRIPTION
This Pull Request updates the type signatures of `CSV.foreach` in RBS. 
When CSV.foreach is called with the headers keyword argument, the block parameter or the elements of the returned Enumerator are of type `CSV::Row`. If the headers argument is not provided, the elements of the Enumerator will be arrays with elements of type String. 

This change accurately reflects the behavior of CSV.foreach depending on the presence of the headers keyword argument.

This Pull Request does not include changes for other methods that accept the headers keyword argument and have behavior variations based on this argument. After this Pull Request is merged, I plan to address these methods in a separate Pull Request.

Thanks.

CSV.foreach: https://github.com/ruby/csv/blob/0cba3e766d34373043b4ca0bbae93c8de12014f0/lib/csv.rb#L1332

