### PR TITLE
Prevent resource leak with type/method-type parser when reaching EOF.

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2763,6 +2763,7 @@ rbsparser_parse_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos, V
   parserstate *parser = alloc_parser(buffer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
 
   if (parser->next_token.type == pEOF) {
+    free_parser(parser);
     return Qnil;
   }
 
@@ -2783,6 +2784,7 @@ rbsparser_parse_method_type(VALUE self, VALUE buffer, VALUE start_pos, VALUE end
   parserstate *parser = alloc_parser(buffer, FIX2INT(start_pos), FIX2INT(end_pos), variables);
 
   if (parser->next_token.type == pEOF) {
+    free_parser(parser);
     return Qnil;
   }
 


### PR DESCRIPTION
A static analyzer detected a resource leak. `alloc_parser` allocates via calloc. Then if the `next_token` type is EOF the parser is not freed and we return. I do not think this is registered with GC, since it is manually freed in the methods later on. Therefore my conclusion is that freeing it was forgotten, unless there is more going on than I am aware of.

Local run of `bundle exec rake test` passed with Ruby 3.3.0.

Output of the analyzer:
```
RESOURCE_LEAK:
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2755: alloc_fn: Storage is returned from allocation function "alloc_parser".
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2755: var_assign: Assigning: "parser" = storage returned from "alloc_parser(buffer, RB_FIX2INT(start_pos), RB_FIX2INT(end_pos), variables)".
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2758: leaked_storage: Variable "parser" going out of scope leaks the storage it points to.
# 2756|   
# 2757|     if (parser->next_token.type == pEOF) {
# 2758|->     return Qnil;
# 2759|     }
# 2760|   

RESOURCE_LEAK:
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2775: alloc_fn: Storage is returned from allocation function "alloc_parser".
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2775: var_assign: Assigning: "parser" = storage returned from "alloc_parser(buffer, RB_FIX2INT(start_pos), RB_FIX2INT(end_pos), variables)".
ruby-3.3.0/.bundle/gems/rbs-3.4.0/ext/rbs_extension/parser.c:2778: leaked_storage: Variable "parser" going out of scope leaks the storage it points to.
# 2776|   
# 2777|     if (parser->next_token.type == pEOF) {
# 2778|->     return Qnil;
# 2779|     }
# 2780|   
```