### PR TITLE
uri: Use `instance` instead of static type as return type

### DIFF
--- a/stdlib/uri/0/generic.rbs
+++ b/stdlib/uri/0/generic.rbs
@@ -154,7 +154,7 @@ module URI
     # then it does URI::Escape.escape all URI components and tries again.
     #
     def self.build2: (Array[nil | String | Integer]) -> URI::Generic
-                   | ({ scheme: String?, userinfo: String?, host: String?, port: Integer?, registry: String?, path: String?, opaque: String?, query: String?, fragment: String? }) -> URI::Generic
+                   | ({ scheme: String?, userinfo: String?, host: String?, port: Integer?, registry: String?, path: String?, opaque: String?, query: String?, fragment: String? }) -> instance
 
     # <!--
     #   rdoc-file=lib/uri/generic.rb
@@ -172,7 +172,7 @@ module URI
     # See ::new for hash keys to use or for order of array items.
     #
     def self.build: (Array[nil | String | Integer]) -> URI::Generic
-                  | ({ scheme: String?, userinfo: String?, host: String?, port: Integer?, registry: String?, path: String?, opaque: String?, query: String?, fragment: String? }) -> URI::Generic
+                  | ({ scheme: String?, userinfo: String?, host: String?, port: Integer?, registry: String?, path: String?, opaque: String?, query: String?, fragment: String? }) -> instance
 
     # <!--
     #   rdoc-file=lib/uri/generic.rb

--- a/stdlib/uri/0/http.rbs
+++ b/stdlib/uri/0/http.rbs
@@ -45,8 +45,8 @@ module URI
     # Currently, if passed userinfo components this method generates invalid HTTP
     # URIs as per RFC 1738.
     #
-    def self.build: (Array[String | Integer] args) -> URI::HTTP
-                  | ({ userinfo: String?, host: String?, port: Integer?, path: String?, query: String?, fragment: String? }) -> URI::HTTP
+    def self.build: (Array[String | Integer] args) -> instance
+                  | ({ userinfo: String?, host: String?, port: Integer?, path: String?, query: String?, fragment: String? }) -> instance
 
     # <!--
     #   rdoc-file=lib/uri/http.rb

--- a/test/stdlib/uri/https_test.rb
+++ b/test/stdlib/uri/https_test.rb
@@ -1,0 +1,58 @@
+require_relative '../test_helper'
+require 'uri'
+
+class URIHTTPSSingletonTest < Test::Unit::TestCase
+  include TestHelper
+  library 'uri'
+  testing 'singleton(::URI::HTTPS)'
+
+  def test_build
+    assert_send_type  '(Array[String | Integer] args) -> URI::HTTPS',
+                      URI::HTTPS, :build,
+                      [
+                        'user:pass',
+                        'localhost',
+                        443,
+                        '/foo/bar',
+                        't=1',
+                        'baz'
+                      ]
+
+    assert_send_type  '({ userinfo: String, host: String, port: Integer, path: String, query: String, fragment: String }) -> URI::HTTPS',
+                      URI::HTTPS, :build,
+                      {
+                        userinfo: 'user:pass',
+                        host: 'localhost',
+                        port: 443,
+                        path: '/foo/bar',
+                        query: 't=1',
+                        fragment: 'baz'
+                      }
+
+    assert_send_type  '({ userinfo: nil, host: nil, port: nil, path: nil, query: nil, fragment: nil }) -> URI::HTTPS',
+                      URI::HTTPS, :build,
+                      {
+                        userinfo: nil,
+                        host: nil,
+                        port: nil,
+                        path: nil,
+                        query: nil,
+                        fragment: nil
+                      }
+  end
+end
+
+class URIHTTPSInstanceTest < Test::Unit::TestCase
+  include TestHelper
+  library 'uri'
+  testing '::URI::HTTPS'
+
+  def https
+    ::URI::HTTPS.build({ userinfo: 'user:pass', host: 'localhost', port: 80, path: '/foo/bar', query: 't=1', fragment: 'baz' })
+  end
+
+  def test_request_uri
+    assert_send_type  '() -> String',
+                      https, :request_uri
+  end
+end


### PR DESCRIPTION
In the three methods I've modified the return type is always an instance of the class the method is called on, however they were hardcoded to a specific class.

I ran into `URI::HTTPS.Build` thinking it returns a `URI::HTTP`, which prompted this PR, but I decided to go up the chain and saw `URI::Generic` did the same thing (`URI::Generic` returns the result of `self.new`, so `instance` is a more true-to-code return type).