### PR TITLE
Stop reusing `fd`

### DIFF
--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -35,19 +35,16 @@ class IOSingletonTest < Test::Unit::TestCase
 
   def test_open
     Dir.mktmpdir do |dir|
-      fd = IO.sysopen(File.expand_path(__FILE__))
-
       assert_send_type "(Integer) -> IO",
-                       IO, :open, fd
+                       IO, :open, IO.sysopen(File.expand_path(__FILE__))
       assert_send_type "(ToInt, String) -> IO",
-                       IO, :open, ToInt.new(fd), "r"
+                       IO, :open, ToInt.new(IO.sysopen(File.expand_path(__FILE__))), "r"
       assert_send_type "(Integer) { (IO) -> Integer } -> Integer",
-                       IO, :open, fd do |io| io.read.size end
+                       IO, :open, IO.sysopen(File.expand_path(__FILE__)), &proc {|io| io.read.size }
 
-      fd = IO.sysopen(File.expand_path(__FILE__))
       assert_send_type(
         "(ToInt, path: String) -> IO",
-        IO, :open, ToInt.new(fd), path: "<<TEST>>"
+        IO, :open, ToInt.new(IO.sysopen(File.expand_path(__FILE__))), path: "<<TEST>>"
       )
     end
   end


### PR DESCRIPTION
An error is reported in ruby CI.

```
Error: test_file?(FileTestSingletonTest): Errno::EBADF: Bad file descriptor
  test/stdlib/FileTest_test.rb:13:in `close'
```

We find there are reusing a `fd` in test. So, we assume the `EBADF` is happening by:

1. `sysopen` in `IO_test` returns a file descriptor `N`
2. `N` is passed to two `IO.open` calls during test
3. The first `IO` instance is closed by GC, but the second one is still alive
4. The `sysopen` in `FileTest_test` returns `N`, so another `IO` instance with the file descriptor is created
5. There are two `IO` instances associated to `N`, one created in `IO_test`, other created in `FileTest_test`
6. `IO` is closed by GC successfully, because `N` is opened in `FileTest_test`
7. Calling `close` in `FileTest_test` raises an error, because `N` is already closed

We hope this fix solves the problem. 🤞 