### PR TITLE
Fix prototype for ruby-3.4

### DIFF
--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -587,7 +587,7 @@ module RBS
           end
         when :DSYM
           BuiltinNames::Symbol.instance_type
-        when :DREGX
+        when :DREGX, :REGX
           BuiltinNames::Regexp.instance_type
         when :TRUE
           Types::Literal.new(literal: true, location: nil)


### PR DESCRIPTION
It seems like ruby-3.4 introduced `REGX` node.