### PR TITLE
[rbs diff] Fix error when empty manifest.yaml

### DIFF
--- a/lib/rbs/diff.rb
+++ b/lib/rbs/diff.rb
@@ -83,7 +83,7 @@ module RBS
         manifest_pathname = dir_pathname / 'manifest.yaml'
         if manifest_pathname.exist?
           manifest = YAML.safe_load(manifest_pathname.read)
-          if manifest['dependencies']
+          if manifest && manifest['dependencies']
             manifest['dependencies'].each do |dependency|
               loader.add(library: dependency['name'], version: nil)
             end


### PR DESCRIPTION
I have found a problem with an error when manifest.yaml exists but is all comments.

```
rbs/lib/rbs/diff.rb:86:in `block in build_env': undefined method `[]' for nil (NoMethodError)

          if manifest['dependencies']
                     ^^^^^^^^^^^^^^^^
```