### PR TITLE
Make the test suite compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.0', '3.1', '3.2', '3.3', head]
+        rubyopt: [""]
         job:
           - test
         include:
@@ -21,6 +22,12 @@ jobs:
             job: stdlib_test rubocop
           - ruby: "3.3"
             job: stdlib_test
+          - ruby: "3.3"
+            job: test
+            rubyopt: "--enable-frozen-string-literal"
+          - ruby: "3.3"
+            job: stdlib_test
+            rubyopt: "--enable-frozen-string-literal"
           - ruby: "3.3"
             job: lexer compile confirm_lexer
           - ruby: "3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     abbrev (0.1.2)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -29,7 +29,7 @@ GEM
       rainbow (>= 3.0, < 4.0)
       strong_json (>= 1.1, < 2.2)
     json (2.7.1)
-    json-schema (4.1.1)
+    json-schema (4.2.0)
       addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
     marcel (1.0.2)
@@ -47,7 +47,7 @@ GEM
     power_assert (2.0.3)
     psych (4.0.6)
       stringio
-    public_suffix (5.0.3)
+    public_suffix (5.0.4)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.1.0)

--- a/test/stdlib/ARGF_test.rb
+++ b/test/stdlib/ARGF_test.rb
@@ -263,7 +263,7 @@ class ARGFTest < Test::Unit::TestCase
     assert_send_type  "(::int length) -> ::String",
                       ARGF.class.new(__FILE__), :read, 1
     assert_send_type  "(::int length, ::string outbuf) -> ::String",
-                      ARGF.class.new(__FILE__), :read, 1, ""
+                      ARGF.class.new(__FILE__), :read, 1, +""
     assert_send_type  "(::int length) -> nil",
                       ARGF.class.new(Tempfile.new), :read, 1
   end
@@ -272,7 +272,7 @@ class ARGFTest < Test::Unit::TestCase
     assert_send_type  "(::int maxlen) -> ::String",
                       ARGF.class.new(__FILE__), :read_nonblock, 1
     assert_send_type  "(::int maxlen, ::string buf) -> ::String",
-                      ARGF.class.new(__FILE__), :read_nonblock, 1, ""
+                      ARGF.class.new(__FILE__), :read_nonblock, 1, +""
   end
 
   def test_readbyte
@@ -289,7 +289,7 @@ class ARGFTest < Test::Unit::TestCase
     assert_send_type  "(::int maxlen) -> ::String",
                       ARGF.class.new(__FILE__), :readpartial, 1
     assert_send_type  "(::int maxlen, ::string buf) -> ::String",
-                      ARGF.class.new(__FILE__), :readpartial, 1, ""
+                      ARGF.class.new(__FILE__), :readpartial, 1, +""
   end
 
   def test_rewind

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -597,7 +597,7 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :pack, ToStr.new("ccc")
 
     assert_send_type "(String, buffer: String) -> String",
-                     [1,2,3], :pack, "ccc", buffer: ""
+                     [1,2,3], :pack, "ccc", buffer: +""
     assert_send_type "(String, buffer: nil) -> String",
                      [1,2,3], :pack, "ccc", buffer: nil
     refute_send_type "(ToStr, buffer: ToStr) -> String",

--- a/test/stdlib/Encoding_test.rb
+++ b/test/stdlib/Encoding_test.rb
@@ -232,7 +232,7 @@ class Encoding_InvalidByteSequenceErrorInstanceTest < Test::Unit::TestCase
 
   def error_object
     ec = Encoding::Converter.new('UTF-8', 'ISO-8859-1')
-    ec.primitive_convert("\xf1abcd", '')
+    ec.primitive_convert(+"\xf1abcd", +'')
     ec.last_error
   end
 end
@@ -271,7 +271,7 @@ class Encoding_UndefinedConversionErrorTest < Test::Unit::TestCase
 
   def error_object
     ec = Encoding::Converter.new('EUC-JP', 'ISO-8859-1')
-    ec.primitive_convert("\xa4\xa2", '')
+    ec.primitive_convert(+"\xa4\xa2", +'')
     ec.last_error
   end
 end

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -211,7 +211,7 @@ class EnumerableTest2 < Test::Unit::TestCase
   end
 
   def test_inject
-    assert_send_type "(String init, Symbol method) -> untyped", TestEnumerable.new, :inject, '', :<<
+    assert_send_type "(String init, Symbol method) -> untyped", TestEnumerable.new, :inject, +'', :<<
     assert_send_type "(Symbol method) -> String", TestEnumerable.new, :inject, :+
     assert_send_type("(Integer initial) { (Integer, String) -> Integer } -> Integer", TestEnumerable.new, :inject, 0) do |memo, item|
       memo ^ item.hash

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -262,11 +262,11 @@ class IOInstanceTest < Test::Unit::TestCase
       assert_send_type "(nil) -> String",
                        io, :read, nil
       assert_send_type "(Integer, String) -> String",
-                       io, :read, 0, "buffer"
+                       io, :read, 0, +"buffer"
       assert_send_type "(Integer, String) -> nil",
-                       io, :read, 1, "buffer"
+                       io, :read, 1, +"buffer"
       assert_send_type "(nil, String) -> String",
-                       io, :read, nil, "buffer"
+                       io, :read, nil, +"buffer"
     end
   end
 
@@ -275,7 +275,7 @@ class IOInstanceTest < Test::Unit::TestCase
       assert_send_type "(Integer) -> String",
                        io, :readpartial, 10
       assert_send_type "(Integer, String) -> String",
-                       io, :readpartial, 10, "buffer"
+                       io, :readpartial, 10, +"buffer"
     end
   end
 

--- a/test/stdlib/ObjectSpace_test.rb
+++ b/test/stdlib/ObjectSpace_test.rb
@@ -23,9 +23,9 @@ class ObjectSpaceTest < Test::Unit::TestCase
 
   def test_define_finalizer
     assert_send_type "(top, ^(Integer) -> void) -> [Integer, Proc]",
-                     ObjectSpace, :define_finalizer, "abc", ->(id) { "id: #{id}" }
+                     ObjectSpace, :define_finalizer, +"abc", ->(id) { "id: #{id}" }
     assert_send_type "(top) { (Integer) -> void } -> [Integer, Proc]",
-                     ObjectSpace, :define_finalizer, "abc" do |id| "id: #{id}" end
+                     ObjectSpace, :define_finalizer, +"abc" do |id| "id: #{id}" end
   end
 
   def test_each_object
@@ -53,7 +53,7 @@ class ObjectSpaceTest < Test::Unit::TestCase
 
   def test_undefine_finalizer
     assert_send_type "(String) -> String",
-                     ObjectSpace, :undefine_finalizer, "abc"
+                     ObjectSpace, :undefine_finalizer, +"abc"
     assert_send_type "(Array) -> Array",
                      ObjectSpace, :undefine_finalizer, []
   end

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -16,12 +16,12 @@ class StringIOTest < StdlibTest
   end
 
   def test_close_write
-    io = StringIO.new('example')
+    io = StringIO.new(+'example')
     io.close_write
   end
 
   def test_closed_write?
-    io = StringIO.new('example')
+    io = StringIO.new(+'example')
     io.closed_write?
     io.close_write
     io.closed_write?

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: false
 require_relative 'test_helper'
 
 # TODO: encode, encode!, byteslice

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -85,7 +85,7 @@ class Writer
   attr_reader :buffer
 
   def initialize
-    @buffer = ""
+    @buffer = +""
   end
 
   def write(*vals)


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205
Ref: https://github.com/voxpupuli/json-schema/pull/508

Since `rbs` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.

~~NB: The `json-schema` fix was merged, but not sure when it will be released. I don't know if using a git gem is a blocker?~~