### PR TITLE
String gsub!

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -2098,7 +2098,7 @@ class String
   # Related: String#sub, String#gsub, String#sub!.
   #
   def gsub!: (Regexp | string pattern, string | hash[String, _ToS] replacement) -> self?
-           | (Regexp | string pattern) -> Enumerator[String, self]
+           | (Regexp | string pattern) -> Enumerator[String, self?]
            | (Regexp | string pattern) { (String match) -> _ToS } -> self?
 
   # <!--

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -283,19 +283,22 @@ module RBS
                 end
               end
 
-              each_sample(values).all? do |v|
+              value_check = values.empty? || each_sample(values).all? do |v|
                 if v.size == 1
                   # Only one block argument.
                   value(v[0], type.args[0]) || value(v, type.args[0])
                 else
                   value(v, type.args[0])
                 end
-              end &&
-                if ret.equal?(self)
-                  type.args[1].is_a?(Types::Bases::Bottom)
-                else
-                  value(ret, type.args[1])
-                end
+              end
+
+              return_check = if ret.equal?(self)
+                type.args[1].is_a?(Types::Bases::Bottom)
+              else
+                value(ret, type.args[1])
+              end
+
+              value_check && return_check
             end
           else
             Test.call(val, IS_AP, klass)

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -60,6 +60,8 @@ EOF
 
         assert typecheck.value([1,2,3].each, parse_type("Enumerator[Integer, Array[Integer]]"))
         assert typecheck.value(loop, parse_type("Enumerator[nil, bot]"))
+        assert typecheck.value([].each, parse_type("Enumerator[String, Array[String]]"))
+        assert typecheck.value([].each, parse_type("Enumerator[Integer, Array[Integer]]"))
 
         assert typecheck.value(true, parse_type("bool"))
         assert typecheck.value(false, parse_type("bool"))

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -962,7 +962,7 @@ class StringInstanceTest < Test::Unit::TestCase
     with_string('l').and /l/ do |pattern|
       assert_send_type  '(Regexp | string) -> Enumerator[String, String]',
                         +'hello', :gsub!, pattern
-      assert_send_type  '(Regexp | string) -> Enumerator[String, String]',
+      assert_send_type  '(Regexp | string) -> Enumerator[String, nil]',
                         +'heya', :gsub!, pattern
 
       assert_send_type  '(Regexp | string) { (String) -> _ToS } -> String',

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -959,8 +959,6 @@ class StringInstanceTest < Test::Unit::TestCase
   end
 
   def test_gsub!
-    omit 'There is currently a bug that prevents `.gsub!` from being testable'
-
     with_string('l').and /l/ do |pattern|
       assert_send_type  '(Regexp | string) -> Enumerator[String, String]',
                         +'hello', :gsub!, pattern


### PR DESCRIPTION
I found next pattern.

```rb
'a'.gsub!(/b/).each { }
#=> nil
```

And I also fixed the cause of the `test_gsub!` being omit.
Then I have also added more test cases.