### PR TITLE
Requires at least one argument.

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2333,7 +2333,7 @@ module Kernel : BasicObject
   #     k.extend(Mod)   #=> #<Klass:0x401b3bc8>
   #     k.hello         #=> "Hello from Mod.\n"
   #
-  def extend: (*Module) -> self
+  def extend: (Module, *Module) -> self
 
   # <!--
   #   rdoc-file=object.c

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -814,7 +814,7 @@ class Module < Object
   # -->
   # Invokes Module.append_features on each parameter in reverse order.
   #
-  def include: (*Module arg0) -> self
+  def include: (Module, *Module arg0) -> self
 
   # <!--
   #   rdoc-file=object.c
@@ -1163,7 +1163,7 @@ class Module < Object
   # -->
   # Invokes Module.prepend_features on each parameter in reverse order.
   #
-  def prepend: (*Module arg0) -> self
+  def prepend: (Module, *Module arg0) -> self
 
   # <!--
   #   rdoc-file=eval.c

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -916,6 +916,13 @@ class KernelInstanceTest < Test::Unit::TestCase
 
   testing "::Kernel"
 
+  def test_extend
+    assert_send_type "(Module) -> Object",
+                      Object.new, :extend, Module.new
+    assert_send_type "(Module, Module) -> Object",
+                      Object.new, :extend, Module.new, Module.new
+  end
+
   def test_define_singleton_method
     obj = Object.new
 

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -27,6 +27,20 @@ class ModuleInstanceTest < Test::Unit::TestCase
     BAR = 1
   end
 
+  def test_include
+    assert_send_type "(Module) -> Module",
+                     Module.new, :include, Module.new
+    assert_send_type "(Module, Module) -> Module",
+                     Module.new, :include, Module.new, Module.new
+  end
+
+  def test_prepend
+    assert_send_type "(Module) -> Module",
+                     Module.new, :prepend, Module.new
+    assert_send_type "(Module, Module) -> Module",
+                     Module.new, :prepend, Module.new, Module.new
+  end
+
   def test_refine
     assert_send_type "(Module) { () -> void } -> Refinement",
                      Foo, :refine, String do nil end


### PR DESCRIPTION
Fixed to require at least one argument, since only the rest argument would also allow zero arguments.