### PR TITLE
Zone is nilable

### DIFF
--- a/core/time.rbs
+++ b/core/time.rbs
@@ -1353,7 +1353,7 @@ class Time < Object
   # The returned array is suitable for use as an argument to Time.utc or
   # Time.local to create a new `Time` object.
   #
-  def to_a: () -> [ Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, bool, String ]
+  def to_a: () -> [ Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, bool, String? ]
 
   # <!--
   #   rdoc-file=time.c
@@ -1584,7 +1584,7 @@ class Time < Object
   #     Time.utc(2000, 1, 1).zone # => "UTC"
   #     Time.new(2000, 1, 1).zone # => "Central Standard Time"
   #
-  def zone: () -> String
+  def zone: () -> String?
 
   # <!-- rdoc-file=time.c -->
   # Like Time.utc, except that the returned `Time` object has the local timezone,

--- a/test/stdlib/Time_test.rb
+++ b/test/stdlib/Time_test.rb
@@ -343,6 +343,25 @@ class TimeSingletonTest < Test::Unit::TestCase
   end
 end
 
+class TimeInstanceTest < Test::Unit::TestCase
+  include TestHelper
+  testing "::Time"
+
+  def test_to_a
+    assert_send_type "() -> [ Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, bool, String ]",
+                     Time.now, :to_a
+    assert_send_type "() -> [ Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, bool, nil ]",
+                     Time.now(in: 0), :to_a
+  end
+
+  def test_zone
+    assert_send_type "() -> String",
+                     Time.now, :zone
+    assert_send_type "() -> nil",
+                     Time.now(in: 0), :zone
+  end
+end
+
 class TimeInDateTest < Test::Unit::TestCase
   include TestHelper
 


### PR DESCRIPTION
The `Time#zone` can be `nil`.

ruby/spec:
https://github.com/ruby/spec/blob/e2f39fe241d6e0443f3b9e9f989f4cc6a061d06c/core/time/zone_spec.rb#L14-L16