### PR TITLE
Always be private

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -630,12 +630,12 @@ module RBS
         end
 
         # @type var accessibility: RBS::Definition::accessibility
-        accessibility = if method.name == :initialize
-                          :private
-                        else
-                          method.accessibility
-                        end
-
+        accessibility =
+          if original.instance? && [:initialize, :initialize_copy, :initialize_clone, :initialize_dup, :respond_to_missing?].include?(method.name)
+            :private
+          else
+            method.accessibility
+          end
         # Skip setting up `super_method` if `implemented_in` is `nil`, that means the type doesn't have implementation.
         # This typically happens if the type is an interface.
         if implemented_in

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1134,7 +1134,19 @@ EOF
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
 class Hello
+  public
+
   def initialize: (String) -> void
+  def initialize_copy: (self) -> self
+  def initialize_clone: (self) -> self
+  def initialize_dup: (self) -> self
+  def respond_to_missing?: () -> bool
+
+  def self.initialize: (String) -> void
+  def self.initialize_copy: (self) -> self
+  def self.initialize_clone: (self) -> self
+  def self.initialize_dup: (self) -> self
+  def self.respond_to_missing?: () -> bool
 end
 EOF
 
@@ -1144,11 +1156,20 @@ EOF
         builder.build_instance(type_name("::Hello")).tap do |definition|
           assert_instance_of Definition, definition
           assert_method_definition definition.methods[:initialize], ["(::String) -> void"], accessibility: :private
+          assert_method_definition definition.methods[:initialize_copy], ["(self) -> self"], accessibility: :private
+          assert_method_definition definition.methods[:initialize_clone], ["(self) -> self"], accessibility: :private
+          assert_method_definition definition.methods[:initialize_dup], ["(self) -> self"], accessibility: :private
+          assert_method_definition definition.methods[:respond_to_missing?], ["() -> bool"], accessibility: :private
         end
 
         builder.build_singleton(type_name("::Hello")).yield_self do |definition|
           assert_instance_of Definition, definition
           assert_method_definition definition.methods[:new], ["(::String) -> ::Hello"], accessibility: :public
+          assert_method_definition definition.methods[:initialize], ["(::String) -> void"], accessibility: :public
+          assert_method_definition definition.methods[:initialize_copy], ["(self) -> self"], accessibility: :public
+          assert_method_definition definition.methods[:initialize_clone], ["(self) -> self"], accessibility: :public
+          assert_method_definition definition.methods[:initialize_dup], ["(self) -> self"], accessibility: :public
+          assert_method_definition definition.methods[:respond_to_missing?], ["() -> bool"], accessibility: :public
         end
       end
     end


### PR DESCRIPTION
Instance methods of `#initialize`, `#initialize_copy`, `#initialize_clone`, `#initialize_dup` and `#respond_to_missing?` are always private in CRuby.

https://github.com/ruby/ruby/blob/69579ed57a2aa1c3ad739417db70564d570bf2c1/vm_method.c#L966-L977

I think it would be difficult to always mandate this behavior in the RBS signature, so I suggest that it be automatically set to private.