### PR TITLE
Refine Digest

### DIFF
--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -74,7 +74,7 @@ module Digest
   # -->
   # Returns a BubbleBabble encoded version of a given *string*.
   #
-  def self.bubblebabble: (String) -> String
+  def self.bubblebabble: (string) -> String
 
   def self.const_missing: (Symbol name) -> singleton(::Digest::Base)
 
@@ -84,13 +84,13 @@ module Digest
   # -->
   # Generates a hex-encoded version of a given *string*.
   #
-  def self.hexencode: (String) -> String
+  def self.hexencode: (string) -> String
 
   private
 
-  def bubblebabble: (String) -> String
+  def bubblebabble: (string) -> String
 
-  def hexencode: (String) -> String
+  def hexencode: (string) -> String
 end
 
 # <!-- rdoc-file=ext/digest/lib/digest.rb -->
@@ -111,7 +111,7 @@ module Digest::Instance
   # The update() method and the left-shift operator are overridden by each
   # implementation subclass. (One should be an alias for the other)
   #
-  def <<: (String) -> self
+  def <<: (string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -122,7 +122,7 @@ module Digest::Instance
   # of the digest object.  If another digest instance is given, checks whether
   # they have the same hash value.  Otherwise returns false.
   #
-  def ==: (::Digest::Instance | String) -> bool
+  def ==: (instance | string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -138,7 +138,7 @@ module Digest::Instance
   # In either case, the return value is properly padded with '=' and contains no
   # line feeds.
   #
-  def base64digest: (?String? str) -> String
+  def base64digest: (?string? str) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -146,7 +146,7 @@ module Digest::Instance
   # -->
   # Returns the resulting hash value and resets the digest to the initial state.
   #
-  def base64digest!: () -> String
+  def base64digest!: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -156,7 +156,7 @@ module Digest::Instance
   #
   # This method is overridden by each implementation subclass.
   #
-  def block_length: () -> Integer
+  def block_length: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/bubblebabble/bubblebabble.c
@@ -164,7 +164,7 @@ module Digest::Instance
   # -->
   # Returns the resulting hash value in a Bubblebabble encoded form.
   #
-  def bubblebabble: () -> String
+  def bubblebabble: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -177,7 +177,7 @@ module Digest::Instance
   # If a *string* is given, returns the hash value for the given *string*,
   # resetting the digest to the initial state before and after the process.
   #
-  def digest: (?String) -> String
+  def digest: (?string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -185,7 +185,7 @@ module Digest::Instance
   # -->
   # Returns the resulting hash value and resets the digest to the initial state.
   #
-  def digest!: () -> String
+  def digest!: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -196,7 +196,7 @@ module Digest::Instance
   # This method should be overridden by each implementation subclass. If not,
   # digest_obj.digest().length() is returned.
   #
-  def digest_length: () -> Integer
+  def digest_length: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -204,7 +204,7 @@ module Digest::Instance
   # -->
   # Updates the digest with the contents of a given file *name* and returns self.
   #
-  def file: (String name) -> self
+  def file: (string name) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -218,7 +218,7 @@ module Digest::Instance
   # hex-encoded form, resetting the digest to the initial state before and after
   # the process.
   #
-  def hexdigest: (?String) -> String
+  def hexdigest: (?string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -227,7 +227,7 @@ module Digest::Instance
   # Returns the resulting hash value in a hex-encoded form and resets the digest
   # to the initial state.
   #
-  def hexdigest!: () -> String
+  def hexdigest!: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -235,7 +235,7 @@ module Digest::Instance
   # -->
   # Creates a printable version of the digest object.
   #
-  def inspect: () -> String
+  def inspect: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -244,7 +244,7 @@ module Digest::Instance
   # -->
   # Returns digest_obj.digest_length().
   #
-  def length: () -> Integer
+  def length: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -253,7 +253,7 @@ module Digest::Instance
   # Returns a new, initialized copy of the digest object.  Equivalent to
   # digest_obj.clone().reset().
   #
-  def new: () -> ::Digest::Base
+  def new: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -263,12 +263,12 @@ module Digest::Instance
   #
   # This method is overridden by each implementation subclass.
   #
-  def reset: () -> self
+  def reset: () -> bot
 
   # <!-- rdoc-file=ext/digest/digest.c -->
   # Returns digest_obj.digest_length().
   #
-  def size: () -> Integer
+  def size: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -276,19 +276,10 @@ module Digest::Instance
   # -->
   # Returns digest_obj.hexdigest().
   #
-  def to_s: () -> String
+  def to_s: () -> bot
 
-  # <!--
-  #   rdoc-file=ext/digest/digest.c
-  #   - digest_obj.update(string) -> digest_obj
-  #   - digest_obj << string -> digest_obj
-  # -->
-  # Updates the digest using a given *string* and returns self.
-  #
-  # The update() method and the left-shift operator are overridden by each
-  # implementation subclass. (One should be an alias for the other)
-  #
-  def update: (String) -> self
+  %a{annotate:rdoc:skip}
+  alias update <<
 
   private
 
@@ -303,7 +294,7 @@ module Digest::Instance
   # uninitialized.  Do not call this method from outside.  Use #digest!() instead,
   # which ensures that internal data be reset for security reasons.
   #
-  def finish: () -> self
+  def finish: () -> bot
 end
 
 # <!-- rdoc-file=ext/digest/digest.c -->
@@ -319,7 +310,7 @@ class Digest::Class
   # Returns the base64 encoded hash value of a given *string*.  The return value
   # is properly padded with '=' and contains no line feeds.
   #
-  def self.base64digest: (String str, *untyped) -> String
+  def self.base64digest: (string str) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/bubblebabble/bubblebabble.c
@@ -327,7 +318,7 @@ class Digest::Class
   # -->
   # Returns the BubbleBabble encoded hash value of a given *string*.
   #
-  def self.bubblebabble: (String, *untyped) -> String
+  def self.bubblebabble: (string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -338,7 +329,7 @@ class Digest::Class
   # any, are passed through to the constructor and the *string* is passed to
   # #digest().
   #
-  def self.digest: (String, *untyped) -> String
+  def self.digest: (string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -350,7 +341,7 @@ class Digest::Class
   #     p Digest::SHA256.file("X11R6.8.2-src.tar.bz2").hexdigest
   #     # => "f02e3c85572dc9ad7cb77c2a638e3be24cc1b5bea9fdbb0b0299c9668475c534"
   #
-  def self.file: (String name, *untyped) -> ::Digest::Class
+  def self.file: (string name) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -359,11 +350,11 @@ class Digest::Class
   # Returns the hex-encoded hash value of a given *string*.  This is almost
   # equivalent to Digest.hexencode(Digest::Class.new(*parameters).digest(string)).
   #
-  def self.hexdigest: (String, *untyped) -> String
+  def self.hexdigest: (string) -> bot
 
   private
 
-  def initialize: () -> self
+  def initialize: () -> void
 end
 
 # <!-- rdoc-file=ext/digest/digest.c -->
@@ -403,12 +394,13 @@ end
 #                 Data_Wrap_Struct(0, 0, 0, (void *)&sha1));
 #
 class Digest::Base < Digest::Class
-  public
+  def self.new: () -> bot
+  def self.allocate: () -> bot
 
   # <!-- rdoc-file=ext/digest/digest.c -->
   # Update the digest using given *string* and return `self`.
   #
-  def <<: (String) -> self
+  def <<: (string) -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -416,7 +408,7 @@ class Digest::Base < Digest::Class
   # -->
   # Return the block length of the digest in bytes.
   #
-  def block_length: () -> Integer
+  def block_length: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -424,7 +416,7 @@ class Digest::Base < Digest::Class
   # -->
   # Return the length of the hash value in bytes.
   #
-  def digest_length: () -> Integer
+  def digest_length: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -432,7 +424,7 @@ class Digest::Base < Digest::Class
   # -->
   # Reset the digest to its initial state and return `self`.
   #
-  def reset: () -> self
+  def reset: () -> bot
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -441,13 +433,75 @@ class Digest::Base < Digest::Class
   # -->
   # Update the digest using given *string* and return `self`.
   #
-  def update: (String) -> self
+  def update: (string) -> bot
 
   private
 
+  def finish: () -> bot
+
+  def initialize_copy: (self) -> bot
+end
+
+interface Digest::_InstanceMethods
+  def <<: (string) -> self
+
+  def ==: (instance | string) -> bool
+
+  def base64digest: (?string?) -> String
+
+  def base64digest!: () -> String
+
+  def block_length: () -> Integer
+
+  def bubblebabble: () -> String
+
+  def digest: (?string) -> String
+
+  def digest!: () -> string
+
+  def digest_length: () -> Integer
+
+  def file: (string name) -> instance
+
+  def hexdigest: (?string) -> String
+
+  def hexdigest!: () -> String
+
+  def inspect: () -> String
+
+  def length: () -> Integer
+
+  def new: () -> self
+
+  def reset: () -> self
+
+  def size: () -> Integer
+
+  def to_s: () -> String
+
+  alias update <<
+
+  # private
   def finish: () -> String
 
-  def initialize_copy: (::Digest::Base) -> self
+  # private
+  def initialize_copy: (self) -> self
+end
+
+interface Digest::_SimpleClassMethods
+  def new: () -> instance
+
+  def allocate: () -> instance
+
+  def base64digest: (string) -> String
+
+  def bubblebabble: (string) -> String
+
+  def digest: (string) -> String
+
+  def file: (string) -> instance
+
+  def hexdigest: (string) -> String
 end
 
 # <!-- rdoc-file=ext/digest/sha1/sha1init.c -->
@@ -477,6 +531,8 @@ end
 #     sha1.hexdigest                        # => "6f9b9af3..."
 #
 class Digest::SHA1 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
 # <!-- rdoc-file=ext/digest/md5/md5init.c -->
@@ -503,6 +559,8 @@ end
 #     md5.hexdigest                        # => "78e73102..."
 #
 class Digest::MD5 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
 # <!-- rdoc-file=ext/digest/rmd160/rmd160init.c -->
@@ -529,15 +587,44 @@ end
 #     rmd160.hexdigest                        # => "1dddbe1b..."
 #
 class Digest::RMD160 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
+# <!-- rdoc-file=ext/digest/sha2/sha2init.c -->
+# Classes for calculating message digests using the SHA-256/384/512 Secure Hash
+# Algorithm(s) by NIST (the US' National Institute of Standards and Technology),
+# described in FIPS PUB 180-2.
+#
+# See SHA2.
+#
 class Digest::SHA256 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
+# <!-- rdoc-file=ext/digest/sha2/sha2init.c -->
+# Classes for calculating message digests using the SHA-256/384/512 Secure Hash
+# Algorithm(s) by NIST (the US' National Institute of Standards and Technology),
+# described in FIPS PUB 180-2.
+#
+# See SHA2.
+#
 class Digest::SHA384 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
+# <!-- rdoc-file=ext/digest/sha2/sha2init.c -->
+# Classes for calculating message digests using the SHA-256/384/512 Secure Hash
+# Algorithm(s) by NIST (the US' National Institute of Standards and Technology),
+# described in FIPS PUB 180-2.
+#
+# See SHA2.
+#
 class Digest::SHA512 < Digest::Base
+  include Digest::_InstanceMethods
+  extend Digest::_SimpleClassMethods
 end
 
 %a{annotate:rdoc:skip}
@@ -560,5 +647,5 @@ class Object
   #     Digest(:Foo)
   #     # => LoadError: library not found for class Digest::Foo -- digest/foo
   #
-  def Digest: (interned name) -> singleton(::Digest::Base)
+  def Digest: (interned name) -> singleton(::Digest::Class)
 end

--- a/test/stdlib/digest/DigestMD5_test.rb
+++ b/test/stdlib/digest/DigestMD5_test.rb
@@ -9,28 +9,38 @@ class DigestMD5SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::MD5)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::MD5, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::MD5, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::MD5, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::MD5, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::MD5, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::MD5',
+                      ::Digest::MD5, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::MD5, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestMD5InstanceTest < Test::Unit::TestCase
   testing '::Digest::MD5'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::MD5',
+                        ::Digest::MD5.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestMD5InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::MD5',
+                      ::Digest::MD5.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestMD5InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::MD5',
+    assert_send_type '(Digest::MD5) -> Digest::MD5',
                      ::Digest::MD5.new, :initialize_copy, ::Digest::MD5.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::MD5) -> bool',
                      ::Digest::MD5.new, :==, ::Digest::MD5.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::MD5.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::MD5.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::MD5.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::MD5.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::MD5.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::MD5.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestMD5InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::MD5.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::MD5.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :digest
+                     ::Digest::MD5.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::MD5',
+                       ::Digest::MD5.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::MD5.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::MD5.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/DigestRMD160_test.rb
+++ b/test/stdlib/digest/DigestRMD160_test.rb
@@ -9,28 +9,38 @@ class DigestRMD160SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::RMD160)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::RMD160, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::RMD160, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::RMD160, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::RMD160, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::RMD160, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::RMD160',
+                      ::Digest::RMD160, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::RMD160, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestRMD160InstanceTest < Test::Unit::TestCase
   testing '::Digest::RMD160'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::RMD160',
+                        ::Digest::RMD160.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestRMD160InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::RMD160',
+                      ::Digest::RMD160.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestRMD160InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::RMD160',
+    assert_send_type '(Digest::RMD160) -> Digest::RMD160',
                      ::Digest::RMD160.new, :initialize_copy, ::Digest::RMD160.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::RMD160) -> bool',
                      ::Digest::RMD160.new, :==, ::Digest::RMD160.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::RMD160.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::RMD160.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::RMD160.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::RMD160.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::RMD160.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::RMD160.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestRMD160InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::RMD160.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::RMD160.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :digest
+                     ::Digest::RMD160.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::RMD160',
+                       ::Digest::RMD160.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::RMD160.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::RMD160.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/DigestSHA1_test.rb
+++ b/test/stdlib/digest/DigestSHA1_test.rb
@@ -9,28 +9,38 @@ class DigestSHA1SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::SHA1)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA1, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::SHA1, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA1, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA1, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA1, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::SHA1',
+                      ::Digest::SHA1, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA1, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestSHA1InstanceTest < Test::Unit::TestCase
   testing '::Digest::SHA1'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::SHA1',
+                        ::Digest::SHA1.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestSHA1InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::SHA1',
+                      ::Digest::SHA1.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestSHA1InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA1',
+    assert_send_type '(Digest::SHA1) -> Digest::SHA1',
                      ::Digest::SHA1.new, :initialize_copy, ::Digest::SHA1.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::SHA1) -> bool',
                      ::Digest::SHA1.new, :==, ::Digest::SHA1.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA1.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::SHA1.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA1.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::SHA1.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA1.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::SHA1.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestSHA1InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA1.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA1.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :digest
+                     ::Digest::SHA1.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::SHA1',
+                       ::Digest::SHA1.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA1.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA1.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/DigestSHA256_test.rb
+++ b/test/stdlib/digest/DigestSHA256_test.rb
@@ -9,28 +9,38 @@ class DigestSHA256SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::SHA256)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA256, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::SHA256, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA256, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA256, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA256, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::SHA256',
+                      ::Digest::SHA256, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA256, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestSHA256InstanceTest < Test::Unit::TestCase
   testing '::Digest::SHA256'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::SHA256',
+                        ::Digest::SHA256.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestSHA256InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::SHA256',
+                      ::Digest::SHA256.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestSHA256InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA256',
+    assert_send_type '(Digest::SHA256) -> Digest::SHA256',
                      ::Digest::SHA256.new, :initialize_copy, ::Digest::SHA256.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::SHA256) -> bool',
                      ::Digest::SHA256.new, :==, ::Digest::SHA256.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA256.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::SHA256.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA256.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::SHA256.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA256.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::SHA256.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestSHA256InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA256.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA256.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :digest
+                     ::Digest::SHA256.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::SHA256',
+                       ::Digest::SHA256.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA256.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA256.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/DigestSHA384_test.rb
+++ b/test/stdlib/digest/DigestSHA384_test.rb
@@ -9,28 +9,38 @@ class DigestSHA384SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::SHA384)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA384, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::SHA384, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA384, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA384, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA384, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::SHA384',
+                      ::Digest::SHA384, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA384, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestSHA384InstanceTest < Test::Unit::TestCase
   testing '::Digest::SHA384'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::SHA384',
+                        ::Digest::SHA384.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestSHA384InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::SHA384',
+                      ::Digest::SHA384.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestSHA384InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA384',
+    assert_send_type '(Digest::SHA384) -> Digest::SHA384',
                      ::Digest::SHA384.new, :initialize_copy, ::Digest::SHA384.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::SHA384) -> bool',
                      ::Digest::SHA384.new, :==, ::Digest::SHA384.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA384.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::SHA384.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA384.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::SHA384.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA384.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::SHA384.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestSHA384InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA384.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA384.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :digest
+                     ::Digest::SHA384.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::SHA384',
+                       ::Digest::SHA384.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA384.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA384.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/DigestSHA512_test.rb
+++ b/test/stdlib/digest/DigestSHA512_test.rb
@@ -9,28 +9,38 @@ class DigestSHA512SingletonTest < Test::Unit::TestCase
   testing 'singleton(::Digest::SHA512)'
 
   def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA512, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                       ::Digest::SHA512, :base64digest, str
+    end
   end
 
   def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :bubblebabble, '_bubblebabble_'
+    with_string('_bubblebabble_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA512, :bubblebabble, str
+    end
   end
 
   def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA512, :digest, str
+    end
   end
 
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA512, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> ::Digest::SHA512',
+                      ::Digest::SHA512, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                      ::Digest::SHA512, :hexdigest, str
+    end
   end
 end
 
@@ -41,8 +51,10 @@ class DigestSHA512InstanceTest < Test::Unit::TestCase
   testing '::Digest::SHA512'
 
   def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :<<, '_binary_left_shift_'
+    with_string('_binary_left_shift_') do |str|
+      assert_send_type '(::string) -> Digest::SHA512',
+                        ::Digest::SHA512.new, :<<, str
+    end
   end
 
   def test_block_length
@@ -61,8 +73,10 @@ class DigestSHA512InstanceTest < Test::Unit::TestCase
   end
 
   def test_update
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :update, '_update_'
+    with_string('_update_') do |str|
+      assert_send_type '(::string) -> Digest::SHA512',
+                      ::Digest::SHA512.new, :update, str
+    end
   end
 
   def test_finish
@@ -71,27 +85,31 @@ class DigestSHA512InstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA512',
+    assert_send_type '(Digest::SHA512) -> Digest::SHA512',
                      ::Digest::SHA512.new, :initialize_copy, ::Digest::SHA512.new
   end
 
   def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
+    assert_send_type '(::Digest::SHA512) -> bool',
                      ::Digest::SHA512.new, :==, ::Digest::SHA512.new
 
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA512.new, :==, '_equal_'
+    with_string('_equal_') do |str|
+      assert_send_type '(::string) -> bool',
+                      ::Digest::SHA512.new, :==, str
+    end
   end
 
   def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA512.new, :base64digest
 
-    assert_send_type '(?::String? str) -> ::String',
+    assert_send_type '(nil) -> ::String',
                      ::Digest::SHA512.new, :base64digest, nil
 
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA512.new, :base64digest, '_base64digest_'
+    with_string('_base64digest_') do |str|
+      assert_send_type '(::string str) -> ::String',
+                      ::Digest::SHA512.new, :base64digest, str
+    end
   end
 
   def test_base64digest_bang
@@ -105,29 +123,35 @@ class DigestSHA512InstanceTest < Test::Unit::TestCase
   end
 
   def test_digest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA512.new, :digest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :digest, '_digest_'
+    with_string('_digest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA512.new, :digest, str
+    end
   end
 
   def test_digest_bang
     assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :digest
+                     ::Digest::SHA512.new, :digest!
   end
 
   def test_file
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :file, 'README.md'
+    with_string('README.md') do |str|
+      assert_send_type '(::string) -> Digest::SHA512',
+                       ::Digest::SHA512.new, :file, str
+    end
   end
 
   def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
+    assert_send_type '() -> ::String',
                      ::Digest::SHA512.new, :hexdigest
 
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :hexdigest, '_hexdigest_'
+    with_string('_hexdigest_') do |str|
+      assert_send_type '(::string) -> ::String',
+                       ::Digest::SHA512.new, :hexdigest, str
+    end
   end
 
   def test_hexdigest_bang

--- a/test/stdlib/digest/Digest_test.rb
+++ b/test/stdlib/digest/Digest_test.rb
@@ -8,24 +8,23 @@ class DigestSingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest)'
 
-
   def test_const_missing
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :SHA1
 
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :MD5
 
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :RMD160
 
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :SHA256
 
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :SHA384
 
-    assert_send_type  '(::Symbol name) -> singleton(::Digest::Base)',
+    assert_send_type  '(::Symbol name) -> singleton(::Digest::Class)',
                       ::Digest, :const_missing, :SHA512
   end
 
@@ -59,6 +58,9 @@ class DigestInstanceTest < Test::Unit::TestCase
   end
 end
 
+class ::Digest::Foo < ::Digest::Class
+end
+
 class DigestRootTest < Test::Unit::TestCase
   include TestHelper
 
@@ -66,40 +68,9 @@ class DigestRootTest < Test::Unit::TestCase
   testing '::Object'
 
   def test_digest
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :SHA1
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'SHA1'
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :MD5
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'MD5'
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :RMD160
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'RMD160'
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :SHA256
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'SHA256'
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :SHA384
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'SHA384'
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, :SHA512
-
-    assert_send_type  '(::String | ::Symbol name) -> singleton(::Digest::Base)',
-                      ::Digest, :Digest, 'SHA512'
+    with_interned(:Foo) do |sym|
+      assert_send_type '(interned name) -> singleton(::Digest::Class)',
+                       ::Object, :Digest, :Foo
+    end
   end
 end


### PR DESCRIPTION
- Should be return bot for methods of abstruct class. Use interface instead.
- The number of arguments of Digest::Class methods cannot be determined because they are delegated to the inherited initialize.
- Fix some types.

### Good points

- Become a more accurate signatures.

### Bad points

- Comments are effectively lost because annotations cannot be automatically written on the interface.