### PR TITLE
Use array instead of linked list for rbs  location's child

### DIFF
--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -1,5 +1,8 @@
 #include "rbs_extension.h"
 
+#define RBS_LOC_REQUIRED_P(loc, i) ((loc)->list->required_p & (1 << (i)))
+#define RBS_LOC_OPTIONAL_P(loc, i) (!RBS_LOC_REQUIRED_P((loc), (i)))
+
 VALUE RBS_Location;
 
 position rbs_loc_position(int char_pos) {
@@ -220,7 +223,7 @@ static VALUE location_aref(VALUE self, VALUE name) {
     if (loc->list->entries[i].name == id) {
       range result = loc->list->entries[i].rg;
 
-      if (!(loc->list->required_p & (1 << i)) && null_range_p(result)) {
+      if (RBS_LOC_OPTIONAL_P(loc, i) && null_range_p(result)) {
         return Qnil;
       } else {
         return rbs_new_location(loc->buffer, result);
@@ -239,7 +242,7 @@ static VALUE location_optional_keys(VALUE self) {
   rbs_loc_list *list = loc->list;
 
   for (unsigned short i = 0; i < list->len; i++) {
-    if (!(list->required_p & (1 << i))) {
+    if (RBS_LOC_OPTIONAL_P(loc, i)) {
       rb_ary_push(keys, ID2SYM(list->entries[i].name));
 
     }
@@ -255,7 +258,7 @@ static VALUE location_required_keys(VALUE self) {
   rbs_loc_list *list = loc->list;
 
   for (unsigned short i = 0; i < list->len; i++) {
-    if (list->required_p & (1 << i)) {
+    if (RBS_LOC_REQUIRED_P(loc, i)) {
       rb_ary_push(keys, ID2SYM(list->entries[i].name));
     }
   }

--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -12,6 +12,7 @@ position rbs_loc_position3(int char_pos, int line, int column) {
   return pos;
 }
 
+// TODO: check max size
 void rbs_loc_alloc_children(rbs_loc *loc, unsigned short size) {
   size_t s = sizeof(rbs_loc_list) + sizeof(rbs_loc_entry) * size;
   loc->list = malloc(s);
@@ -21,6 +22,7 @@ void rbs_loc_alloc_children(rbs_loc *loc, unsigned short size) {
   loc->list->cap = size;
 }
 
+// TODO: check max size
 void rbs_loc_alloc_adding_children(rbs_loc *loc) {
   if (loc->list == NULL) {
     rbs_loc_alloc_children(loc, 1);
@@ -156,7 +158,6 @@ static VALUE location_end_loc(VALUE self) {
   }
 }
 
-// TODO: Check if we need to allocate more space
 static VALUE location_add_required_child(VALUE self, VALUE name, VALUE start, VALUE end) {
   rbs_loc *loc = rbs_check_location(self);
 
@@ -169,7 +170,6 @@ static VALUE location_add_required_child(VALUE self, VALUE name, VALUE start, VA
   return Qnil;
 }
 
-// TODO: Check if we need to allocate more space
 static VALUE location_add_optional_child(VALUE self, VALUE name, VALUE start, VALUE end) {
   rbs_loc *loc = rbs_check_location(self);
 
@@ -224,11 +224,12 @@ static VALUE location_optional_keys(VALUE self) {
   VALUE keys = rb_ary_new();
 
   rbs_loc *loc = rbs_check_location(self);
-  rbs_loc_list list = *loc->list;
+  rbs_loc_list *list = loc->list;
 
-  for (unsigned short i = 0; i < list.len; i++) {
-    if (!(list.required_p & (1 << i))) {
-      rb_ary_push(keys, ID2SYM(list.entries[i].name));
+  for (unsigned short i = 0; i < list->len; i++) {
+    if (!(list->required_p & (1 << i))) {
+      rb_ary_push(keys, ID2SYM(list->entries[i].name));
+
     }
   }
 
@@ -239,11 +240,11 @@ static VALUE location_required_keys(VALUE self) {
   VALUE keys = rb_ary_new();
 
   rbs_loc *loc = rbs_check_location(self);
-  rbs_loc_list list = *loc->list;
+  rbs_loc_list *list = loc->list;
 
-  for (unsigned short i = 0; i < list.len; i++) {
-    if (list.required_p & (1 << i)) {
-      rb_ary_push(keys, ID2SYM(list.entries[i].name));
+  for (unsigned short i = 0; i < list->len; i++) {
+    if (list->required_p & (1 << i)) {
+      rb_ary_push(keys, ID2SYM(list->entries[i].name));
     }
   }
 

--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -22,15 +22,15 @@ static void check_children_max(unsigned short n) {
   }
 }
 
-void rbs_loc_alloc_children(rbs_loc *loc, unsigned short size) {
-  check_children_max(size);
+void rbs_loc_alloc_children(rbs_loc *loc, unsigned short cap) {
+  check_children_max(cap);
 
-  size_t s = sizeof(rbs_loc_children) + sizeof(rbs_loc_entry) * size;
+  size_t s = sizeof(rbs_loc_children) + sizeof(rbs_loc_entry) * cap;
   loc->children = malloc(s);
 
   loc->children->len = 0;
   loc->children->required_p = 0;
-  loc->children->cap = size;
+  loc->children->cap = cap;
 }
 
 static void check_children_cap(rbs_loc *loc) {

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -9,17 +9,22 @@
  * */
 extern VALUE RBS_Location;
 
-typedef struct rbs_loc_list {
+typedef struct {
   ID name;
   range rg;
-  struct rbs_loc_list *next;
+} rbs_loc_entry;
+
+typedef struct {
+  unsigned short len;
+  unsigned short cap;
+  unsigned int required_p;
+  rbs_loc_entry entries[0];
 } rbs_loc_list;
 
 typedef struct {
   VALUE buffer;
   range rg;
-  rbs_loc_list *requireds;
-  rbs_loc_list *optionals;
+  rbs_loc_list *list;
 } rbs_loc;
 
 /**

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -14,10 +14,12 @@ typedef struct {
   range rg;
 } rbs_loc_entry;
 
+typedef unsigned int rbs_loc_entry_bitmap;
+
 typedef struct {
   unsigned short len;
   unsigned short cap;
-  unsigned int required_p;
+  rbs_loc_entry_bitmap required_p;
   rbs_loc_entry entries[0];
 } rbs_loc_list;
 

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -39,15 +39,24 @@ VALUE rbs_new_location(VALUE buffer, range rg);
  * */
 rbs_loc *rbs_check_location(VALUE location);
 
+/**
+ * Allocate memory for child locations.
+ *
+ * Do not call twice for the same location.
+ * */
 void rbs_loc_alloc_children(rbs_loc *loc, unsigned short cap);
 
 /**
  * Add a required child range with given name.
+ *
+ * Allocate memory for children with rbs_loc_alloc_children before calling this function.
  * */
 void rbs_loc_add_required_child(rbs_loc *loc, ID name, range r);
 
 /**
  * Add an optional child range with given name.
+ *
+ * Allocate memory for children with rbs_loc_alloc_children before calling this function.
  * */
 void rbs_loc_add_optional_child(rbs_loc *loc, ID name, range r);
 

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -21,12 +21,12 @@ typedef struct {
   unsigned short cap;
   rbs_loc_entry_bitmap required_p;
   rbs_loc_entry entries[0];
-} rbs_loc_list;
+} rbs_loc_children;
 
 typedef struct {
   VALUE buffer;
   range rg;
-  rbs_loc_list *list;
+  rbs_loc_children *children;
 } rbs_loc;
 
 /**

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -39,6 +39,8 @@ VALUE rbs_new_location(VALUE buffer, range rg);
  * */
 rbs_loc *rbs_check_location(VALUE location);
 
+void rbs_loc_alloc_children(rbs_loc *loc, unsigned short cap);
+
 /**
  * Add a required child range with given name.
  * */

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -265,6 +265,7 @@ static VALUE parse_function_param(parserstate *state) {
 
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 1);
     rbs_loc_add_optional_child(loc, rb_intern("name"), NULL_RANGE);
 
     return rbs_function_param(type, Qnil, location);
@@ -287,6 +288,7 @@ static VALUE parse_function_param(parserstate *state) {
     VALUE name = rb_to_symbol(rbs_unquote_string(state, state->current_token.range, 0));
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 1);
     rbs_loc_add_optional_child(loc, rb_intern("name"), name_range);
 
     return rbs_function_param(type, name, location);
@@ -840,6 +842,7 @@ static VALUE parse_instance_type(parserstate *state, bool parse_alias) {
 
     VALUE location = rbs_new_location(state->buffer, type_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 2);
     rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
     rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
 
@@ -874,6 +877,7 @@ static VALUE parse_singleton_type(parserstate *state) {
 
   VALUE location = rbs_new_location(state->buffer, type_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 1);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
 
   return rbs_class_singleton(typename, location);
@@ -1129,6 +1133,7 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
 
       VALUE location = rbs_new_location(state->buffer, param_range);
       rbs_loc *loc = rbs_check_location(location);
+      rbs_loc_alloc_children(loc, 4);
       rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
       rbs_loc_add_optional_child(loc, rb_intern("variance"), variance_range);
       rbs_loc_add_optional_child(loc, rb_intern("unchecked"), unchecked_range);
@@ -1189,6 +1194,7 @@ VALUE parse_method_type(parserstate *state) {
 
   VALUE location = rbs_new_location(state->buffer, rg);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 2);
   rbs_loc_add_required_child(loc, rb_intern("type"), type_range);
   rbs_loc_add_optional_child(loc, rb_intern("type_params"), params_range);
 
@@ -1228,6 +1234,7 @@ VALUE parse_global_decl(parserstate *state) {
 
   location = rbs_new_location(state->buffer, decl_range);
   loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 2);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
 
@@ -1261,6 +1268,7 @@ VALUE parse_const_decl(parserstate *state) {
 
   location = rbs_new_location(state->buffer, decl_range);
   loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 2);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
 
@@ -1294,6 +1302,7 @@ VALUE parse_type_decl(parserstate *state, position comment_pos, VALUE annotation
 
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 4);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_optional_child(loc, rb_intern("type_params"), params_range);
@@ -1635,6 +1644,7 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
 
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 5);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_optional_child(loc, rb_intern("kind"), kind_range);
@@ -1739,6 +1749,7 @@ VALUE parse_mixin_member(parserstate *state, bool from_interface, position comme
 
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 3);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
@@ -1802,6 +1813,7 @@ VALUE parse_alias_member(parserstate *state, bool instance_only, position commen
   member_range.end = state->current_token.range.end;
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 5);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("new_name"), new_name_range);
   rbs_loc_add_required_child(loc, rb_intern("old_name"), old_name_range);
@@ -1905,6 +1917,7 @@ VALUE parse_variable_member(parserstate *state, position comment_pos, VALUE anno
 
   location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 3);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
   rbs_loc_add_optional_child(loc, rb_intern("kind"), kind_range);
@@ -2049,6 +2062,7 @@ VALUE parse_attribute_member(parserstate *state, position comment_pos, VALUE ann
 
   location = rbs_new_location(state->buffer, member_range);
   loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 7);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
@@ -2146,6 +2160,7 @@ VALUE parse_interface_decl(parserstate *state, position comment_pos, VALUE annot
 
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 4);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
@@ -2191,6 +2206,7 @@ void parse_module_self_types(parserstate *state, VALUE array) {
 
     VALUE location = rbs_new_location(state->buffer, self_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 2);
     rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
     rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
 
@@ -2327,6 +2343,7 @@ VALUE parse_module_decl0(parserstate *state, range keyword_range, VALUE module_n
 
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 6);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
@@ -2376,6 +2393,7 @@ VALUE parse_module_decl(parserstate *state, position comment_pos, VALUE annotati
 
     VALUE location = rbs_new_location(state->buffer, decl_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 4);
     rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
     rbs_loc_add_required_child(loc, rb_intern("new_name"), module_name_range);
     rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
@@ -2412,6 +2430,7 @@ VALUE parse_class_decl_super(parserstate *state, range *lt_range) {
 
     location = rbs_new_location(state->buffer, super_range);
     loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 2);
     rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
     rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
 
@@ -2454,6 +2473,7 @@ VALUE parse_class_decl0(parserstate *state, range keyword_range, VALUE name, ran
 
   location = rbs_new_location(state->buffer, decl_range);
   loc = rbs_check_location(location);
+  rbs_loc_alloc_children(loc, 5);
   rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
   rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
   rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
@@ -2499,6 +2519,7 @@ VALUE parse_class_decl(parserstate *state, position comment_pos, VALUE annotatio
 
     VALUE location = rbs_new_location(state->buffer, decl_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 4);
     rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
     rbs_loc_add_required_child(loc, rb_intern("new_name"), class_name_range);
     rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
@@ -2672,6 +2693,7 @@ void parse_use_clauses(parserstate *state, VALUE clauses) {
 
         VALUE location = rbs_new_location(state->buffer, clause_range);
         rbs_loc *loc = rbs_check_location(location);
+        rbs_loc_alloc_children(loc, 3);
         rbs_loc_add_required_child(loc, rb_intern("type_name"), type_name_range);
         rbs_loc_add_optional_child(loc, rb_intern("keyword"), keyword_range);
         rbs_loc_add_optional_child(loc, rb_intern("new_name"), new_name_range);
@@ -2689,6 +2711,7 @@ void parse_use_clauses(parserstate *state, VALUE clauses) {
 
         VALUE location = rbs_new_location(state->buffer, clause_range);
         rbs_loc *loc = rbs_check_location(location);
+        rbs_loc_alloc_children(loc, 2);
         rbs_loc_add_required_child(loc, rb_intern("namespace"), namespace_range);
         rbs_loc_add_required_child(loc, rb_intern("star"), star_range);
 
@@ -2731,6 +2754,7 @@ VALUE parse_use_directive(parserstate *state) {
 
     VALUE location = rbs_new_location(state->buffer, directive_range);
     rbs_loc *loc = rbs_check_location(location);
+    rbs_loc_alloc_children(loc, 1);
     rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
 
     return rbs_ast_directives_use(clauses, location);

--- a/test/rbs/location_test.rb
+++ b/test/rbs/location_test.rb
@@ -5,11 +5,6 @@ class RBS::LocationTest < Test::Unit::TestCase
   Location = RBS::Location
 
   def test_location_source
-    buffer = Buffer.new(name: Pathname("foo.rbs"), content: <<-CONTENT)
-123
-abc
-    CONTENT
-
     Location.new(buffer, 0, 4).yield_self do |location|
       assert_equal 0, location.start_pos
       assert_equal 4, location.end_pos
@@ -30,11 +25,6 @@ abc
   end
 
   def test_location_child
-    buffer = Buffer.new(name: Pathname("foo.rbs"), content: <<-CONTENT)
-123
-abc
-    CONTENT
-
     Location.new(buffer, 0, 8).yield_self do |location|
       location.add_optional_child(:num, 0...2)
       location.add_optional_child(:hira, nil)
@@ -47,5 +37,51 @@ abc
       assert_equal [:num, :hira].sort, location.each_optional_key.to_a.sort
       assert_equal [:alpha], location.each_required_key.to_a
     end
+  end
+
+  def test_location_initialize_copy
+    loc = Location.new(buffer, 0, 8)
+    loc.add_optional_child(:num, 0...2)
+    loc.add_required_child(:alpha, 4...7)
+    assert_equal loc, loc.dup
+    assert_equal loc[:num], loc.dup[:num]
+    assert_equal loc[:alpha], loc.dup[:alpha]
+  end
+
+  def test_location_aref
+    loc_without_child = Location.new(buffer, 0, 8)
+    assert_raise RuntimeError do
+      loc_without_child[:not_exist]
+    end
+    loc = Location.new(buffer, 0, 8)
+    loc.add_optional_child(:num, 0...2)
+    loc.add_required_child(:alpha, 4...7)
+    assert_equal "12", loc[:num].source
+    assert_equal "abc", loc[:alpha].source
+  end
+
+  def test_location_start_pos
+    loc = Location.new(buffer, 0, 8)
+    assert_equal 0, loc.start_pos
+  end
+
+  def test_location_end_pos
+    loc = Location.new(buffer, 0, 8)
+    assert_equal 8, loc.end_pos
+  end
+
+  def test_location_to_s
+    loc = Location.new(buffer, 0, 7)
+    assert_equal "foo.rbs:1:0...2:3", loc.to_s
+  end
+
+  private
+
+  def buffer(content: nil)
+    content ||= <<~CONTENT
+      123
+      abc
+    CONTENT
+    Buffer.new(name: Pathname("foo.rbs"), content: content)
   end
 end


### PR DESCRIPTION
This PR reduces memory usage by replacing the linked list with an array for `RBS::Location`.

`RBS::Location` has child locations. They are implemented as two linked lists, but this is not memory efficient. 
Therefore this PR replaces the linked lists with an array.



This PR is the first part of memory usage improvement for `RBS::Location`. I'll try reducing memory with another approach. See this document for more information. https://hackmd.io/QNkMU6roTqSn_iXb2ENhsA


## Data structure


This is the previous data structure.
Comments are byte sizes (on my 64bits local machine).

```c
typedef struct rbs_loc_list {
  ID name; // 8
  range rg; // 32
  struct rbs_loc_list *next; // 8
} rbs_loc_list; // 48

typedef struct {
  VALUE buffer; // 8
  range rg; // 32
  rbs_loc_list *requireds; // 8
  rbs_loc_list *optionals; // 8
} rbs_loc; // 56
```

By this change, these structs are changed to the following:

```c
typedef struct {
  ID name; // 8
  range rg; // 32
} rbs_loc_entry; // 40

typedef unsigned int rbs_loc_entry_bitmap;

typedef struct {
  unsigned short len;  // 2
  unsigned short cap;  // 2
  rbs_loc_entry_bitmap required_p; // 4
  rbs_loc_entry entries[0]; // 0
} rbs_loc_children; // 8

typedef struct {
  VALUE buffer; // 8
  range rg; // 32
  rbs_loc_children *children; // 8
} rbs_loc; // 48
```

The byte size is changed like following:

* If `rbs_loc` does not have children:
  * before: 56 bytes
  * after: 48 bytes
* If `rbs_loc` has children:
  * before: 56 + (48 * size) bytes
  * after: 48 + 8 + (40 * size) bytes

## Benchmarking


### Memory Usage

With `bundle exec ruby benchmark/memory_new_env.rb` and `benchmark/memory_new_rails_env.rb`

before

```
$ bundle exec ruby benchmark/memory_new_env.rb
Total allocated: 43027240 bytes (363668 objects)
Total retained:  12315720 bytes (98104 objects)

retained memory by class
-----------------------------------
   4261392  String
   3899952  RBS::Location
   1262864  Array
   1086272  Hash
    257840  RBS::Types::Function

$ bundle exec ruby benchmark/memory_new_rails_env.rb
Total allocated: 224460224 bytes (1994661 objects)
Total retained:  57453656 bytes (553231 objects)

retained memory by class
-----------------------------------
  21650208  RBS::Location
  11885144  String
   7415928  Array
   6143008  Hash
   1481920  RBS::Types::Function
```

after

```console
$ bundle exec ruby benchmark/memory_new_env.rb
Total allocated: 42677872 bytes (363668 objects)
Total retained:  11966352 bytes (98104 objects)

retained memory by class
-----------------------------------
   4261392  String
   3550584  RBS::Location
   1262864  Array
   1086272  Hash
    257840  RBS::Types::Function

$ bundle exec ruby benchmark/memory_new_rails_env.rb
Total allocated: 222420976 bytes (1994661 objects)
Total retained:  55414424 bytes (553231 objects)

retained memory by class
-----------------------------------
  19610976  RBS::Location
  11885144  String
   7415928  Array
   6143008  Hash
   1481920  RBS::Types::Function
```

The retained memory is reduced 3% (349kb) on the core env and 4% (2MB) on the Rails env.

### Execution time

With `bundle exec ruby benchmark/benchmark_new_env.rb`.




before

```console
Warming up --------------------------------------
             new_env     1.000 i/100ms
       new_rails_env     1.000 i/100ms
Calculating -------------------------------------
             new_env      6.146 (± 0.0%) i/s -     62.000 in  10.136343s
       new_rails_env      0.966 (± 0.0%) i/s -     10.000 in  10.377986s
```

after

```console
Warming up --------------------------------------
             new_env     1.000 i/100ms
       new_rails_env     1.000 i/100ms
Calculating -------------------------------------
             new_env      6.399 (±15.6%) i/s -     64.000 in  10.070012s
       new_rails_env      1.013 (± 0.0%) i/s -     11.000 in  10.910335s
```

It is 1.04x faster on the core env and 1.05x faster on the Rails env.


