### PR TITLE
Add location for attribute

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -669,7 +669,7 @@ module RBS
                 ]
               ),
               block: nil,
-              location: nil
+              location: original.location
             )
           else
             # getter
@@ -677,7 +677,7 @@ module RBS
               type_params: [],
               type: Types::Function.empty(attr_type),
               block: nil,
-              location: nil
+              location: original.location
             )
           end
 

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -1088,13 +1088,17 @@ EOF
           assert_instance_of Definition, definition
 
           assert_method_definition definition.methods[:instance_reader], ["() -> ::String"]
+          assert_equal definition.methods[:instance_reader].method_types.first.location.source, "attr_reader instance_reader: String"
           assert_ivar_definition definition.instance_variables[:@instance_reader], "::String"
 
           assert_method_definition definition.methods[:instance_writer=], ["(::Integer instance_writer) -> ::Integer"]
+          assert_equal definition.methods[:instance_writer=].method_types.first.location.source, "attr_writer instance_writer(@writer): Integer"
           assert_ivar_definition definition.instance_variables[:@writer], "::Integer"
 
           assert_method_definition definition.methods[:instance_accessor], ["() -> ::Symbol"]
+          assert_equal definition.methods[:instance_accessor].method_types.first.location.source, "attr_accessor instance_accessor(): Symbol"
           assert_method_definition definition.methods[:instance_accessor=], ["(::Symbol instance_accessor) -> ::Symbol"]
+          assert_equal definition.methods[:instance_accessor=].method_types.first.location.source, "attr_accessor instance_accessor(): Symbol"
           assert_nil definition.instance_variables[:@instance_accessor]
         end
       end
@@ -1117,13 +1121,17 @@ EOF
           assert_instance_of Definition, definition
 
           assert_method_definition definition.methods[:reader], ["() -> ::String"]
+          assert_equal definition.methods[:reader].method_types.first.location.source, "attr_reader self.reader: String"
           assert_ivar_definition definition.instance_variables[:@reader], "::String"
 
           assert_method_definition definition.methods[:writer=], ["(::Integer writer) -> ::Integer"]
+          assert_equal definition.methods[:writer=].method_types.first.location.source, "attr_writer self.writer(@writer): Integer"
           assert_ivar_definition definition.instance_variables[:@writer], "::Integer"
 
           assert_method_definition definition.methods[:accessor], ["() -> ::Symbol"]
+          assert_equal definition.methods[:accessor].method_types.first.location.source, "attr_accessor self.accessor(): Symbol"
           assert_method_definition definition.methods[:accessor=], ["(::Symbol accessor) -> ::Symbol"]
+          assert_equal definition.methods[:accessor=].method_types.first.location.source, "attr_accessor self.accessor(): Symbol"
           assert_nil definition.instance_variables[:@accessor]
         end
       end


### PR DESCRIPTION
I noticed that location is not set for the attribute method. Is this intentional?

I actually have some problems with the `rbs method` command, such as not being able to find the location where the attribute method is defined.

I think it is better to have attribute location than not to have it, so I fixed it.

---

Before

```
$ bundle exec rbs -r rbs method --singleton RBS::Test suffix
::RBS::Test.suffix
  defined_in: ::RBS::Test
  implementation: ::RBS::Test
  accessibility: public
  types:
      () -> ::String   at
```

After

```
$ bundle exec rbs -r rbs method --singleton RBS::Test suffix
::RBS::Test.suffix
  defined_in: ::RBS::Test
  implementation: ::RBS::Test
  accessibility: public
  types:
      () -> ::String   at /Users/ksss/src/github.com/ksss/rbs/sig/test.rbs:76:4...76:37
```