### PR TITLE
Omit unnecessary field from location range

### DIFF
--- a/ext/rbs_extension/lexer.c
+++ b/ext/rbs_extension/lexer.c
@@ -116,7 +116,7 @@ token rbsparser_next_token(lexstate *state) {
 yy1:
 	rbs_skip(state);
 #line 144 "ext/rbs_extension/lexer.re"
-	{ return next_token(state, pEOF); }
+	{ return next_eof_token(state); }
 #line 121 "ext/rbs_extension/lexer.c"
 yy2:
 	rbs_skip(state);

--- a/ext/rbs_extension/lexer.h
+++ b/ext/rbs_extension/lexer.h
@@ -167,6 +167,11 @@ void skipn(lexstate *state, size_t size);
  * */
 token next_token(lexstate *state, enum TokenType type);
 
+/**
+ * Return new token with EOF type.
+ * */
+token next_eof_token(lexstate *state);
+
 token rbsparser_next_token(lexstate *state);
 
 void print_token(token tok);

--- a/ext/rbs_extension/lexer.re
+++ b/ext/rbs_extension/lexer.re
@@ -141,7 +141,7 @@ token rbsparser_next_token(lexstate *state) {
       skip = ([ \t]+|[\r\n]);
 
       skip     { return next_token(state, tTRIVIA); }
-      "\x00"   { return next_token(state, pEOF); }
+      "\x00"   { return next_eof_token(state); }
       *        { return next_token(state, ErrorToken); }
   */
 }

--- a/ext/rbs_extension/lexstate.c
+++ b/ext/rbs_extension/lexstate.c
@@ -129,6 +129,22 @@ token next_token(lexstate *state, enum TokenType type) {
   return t;
 }
 
+token next_eof_token(lexstate *state) {
+  if (state->current.byte_pos == RSTRING_LEN(state->string)+1) {
+    // End of String
+    token t;
+    t.type = pEOF;
+    t.range.start = state->start;
+    t.range.end = state->start;
+    state->start = state->current;
+
+    return t;
+  } else {
+    // NULL byte in the middle of the string
+    return next_token(state, pEOF);
+  }
+}
+
 void rbs_skip(lexstate *state) {
   if (!state->last_char) {
     peek(state);

--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -158,15 +158,6 @@ static VALUE location_end_pos(VALUE self) {
   return INT2FIX(loc->rg.end);
 }
 
-// TODO: remove it
-static VALUE location_start_loc(VALUE self) {
-  return Qnil;
-}
-
-static VALUE location_end_loc(VALUE self) {
-  return Qnil;
-}
-
 static VALUE location_add_required_child(VALUE self, VALUE name, VALUE start, VALUE end) {
   rbs_loc *loc = rbs_check_location(self);
 
@@ -293,8 +284,6 @@ void rbs__init_location(void) {
   rb_define_method(RBS_Location, "buffer", location_buffer, 0);
   rb_define_method(RBS_Location, "start_pos", location_start_pos, 0);
   rb_define_method(RBS_Location, "end_pos", location_end_pos, 0);
-  rb_define_private_method(RBS_Location, "_start_loc", location_start_loc, 0);
-  rb_define_private_method(RBS_Location, "_end_loc", location_end_loc, 0);
   rb_define_method(RBS_Location, "_add_required_child", location_add_required_child, 3);
   rb_define_method(RBS_Location, "_add_optional_child", location_add_optional_child, 3);
   rb_define_method(RBS_Location, "_add_optional_no_child", location_add_optional_no_child, 1);

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -10,8 +10,13 @@
 extern VALUE RBS_Location;
 
 typedef struct {
+  int start;
+  int end;
+} rbs_loc_range;
+
+typedef struct {
   ID name;
-  range rg;
+  rbs_loc_range rg;
 } rbs_loc_entry;
 
 typedef unsigned int rbs_loc_entry_bitmap;
@@ -27,7 +32,7 @@ typedef struct {
 
 typedef struct {
   VALUE buffer;
-  range rg;
+  rbs_loc_range rg;
   rbs_loc_children *children; // NULL when no children is allocated
 } rbs_loc;
 

--- a/lib/rbs/buffer.rb
+++ b/lib/rbs/buffer.rb
@@ -25,6 +25,11 @@ module RBS
             @ranges << range
             offset += size
           end
+
+          if !content.end_with?("\n") && content.size > 0
+            @ranges[-1] = @ranges[-1].begin...(@ranges[-1].end+1)
+          end
+
           @ranges
         end
     end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -35,7 +35,7 @@ module RBS
       return msg unless location.start_line == location.end_line
 
       indent = " " * location.start_column
-      marker = "^" * (location.end_column - location.start_column)
+      marker = "^" * ([location.end_column - location.start_column, 1].max or raise)
 
       io = StringIO.new
       io.puts msg

--- a/lib/rbs/location_aux.rb
+++ b/lib/rbs/location_aux.rb
@@ -49,15 +49,11 @@ module RBS
     end
 
     def start_loc
-      @start_loc ||= begin
-        _start_loc || buffer.pos_to_loc(start_pos)
-      end
+      @start_loc ||= buffer.pos_to_loc(start_pos)
     end
 
     def end_loc
-      @end_loc ||= begin
-        _end_loc || buffer.pos_to_loc(end_pos)
-      end
+      @end_loc ||= buffer.pos_to_loc(end_pos)
     end
 
     def range

--- a/sig/location.rbs
+++ b/sig/location.rbs
@@ -99,9 +99,6 @@ module RBS
 
     private
 
-    def _start_loc: () -> Buffer::loc?
-    def _end_loc: () -> Buffer::loc?
-
     def _add_required_child: (RequiredChildKeys name, Integer start_pos, Integer end_pos) -> void
     def _add_optional_child: (OptionalChildKeys name, Integer start_pos, Integer end_pos) -> void
     def _add_optional_no_child: (OptionalChildKeys name) -> void

--- a/test/rbs/buffer_test.rb
+++ b/test/rbs/buffer_test.rb
@@ -37,4 +37,34 @@ abc
 
     assert_equal 8, buffer.last_position
   end
+
+  def test_buffer_with_no_eol
+    buffer = Buffer.new(name: Pathname("foo.rbs"), content: "123\nabc")
+
+    assert_equal ["123\n", "abc"], buffer.lines
+    assert_equal [0...4, 4...8], buffer.ranges
+
+    assert_equal [1, 0], buffer.pos_to_loc(0)
+    assert_equal [1, 1], buffer.pos_to_loc(1)
+    assert_equal [1, 2], buffer.pos_to_loc(2)
+    assert_equal [1, 3], buffer.pos_to_loc(3)
+    assert_equal [2, 0], buffer.pos_to_loc(4)
+    assert_equal [2, 1], buffer.pos_to_loc(5)
+    assert_equal [2, 2], buffer.pos_to_loc(6)
+    assert_equal [2, 3], buffer.pos_to_loc(7)
+
+    assert_equal 0, buffer.loc_to_pos([1, 0])
+    assert_equal 1, buffer.loc_to_pos([1, 1])
+    assert_equal 2, buffer.loc_to_pos([1, 2])
+    assert_equal 3, buffer.loc_to_pos([1, 3])
+    assert_equal 4, buffer.loc_to_pos([2, 0])
+    assert_equal 5, buffer.loc_to_pos([2, 1])
+    assert_equal 6, buffer.loc_to_pos([2, 2])
+    assert_equal 7, buffer.loc_to_pos([2, 3])
+
+    assert_equal "123", buffer.content[buffer.loc_to_pos([1,0])...buffer.loc_to_pos([1,3])]
+    assert_equal "123\n", buffer.content[buffer.loc_to_pos([1,0])...buffer.loc_to_pos([2,0])]
+
+    assert_equal 7, buffer.last_position
+  end
 end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -912,7 +912,7 @@ singleton(::BasicObject)
 
       assert_raises(SystemExit) { cli.run(['parse', '--method-type', '-e', '()']) }
       assert_equal [
-        "-e:1:2...1:3: Syntax error: expected a token `pARROW`, token=`` (pEOF) (RBS::ParsingError)",
+        "-e:1:2...1:2: Syntax error: expected a token `pARROW`, token=`` (pEOF) (RBS::ParsingError)",
         "",
         "  ()",
         "    ^"

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -834,6 +834,6 @@ RBS
     assert_equal [:tTRIVIA, "\n", 52...53], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
     assert_equal [:kEND, 'end', 53...56], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
     assert_equal [:tTRIVIA, "\n", 56...57], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
-    assert_equal [:pEOF, '', 57...58], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
+    assert_equal [:pEOF, '', 57...57], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
   end
 end


### PR DESCRIPTION
This PR reduces memory usage for `RBS::Location` by omitting unnecessary fields.

Previously `RBS::Location` had byte pos, char pos, line, and column. But they are caches except for char pos. These caches are rarely accessed. So we can drop them from `RBS::Location`.




design doc: https://hackmd.io/QNkMU6roTqSn_iXb2ENhsA

## Benchmarking

I used `benchmark/memory_new_rails_env.rb` for the benchmark.
It decreases 15% memory.

```
# Before
Total retained:  52372539 bytes (459882 objects)

allocated memory by class
-----------------------------------
 152307312  Hash
  20146528  RBS::Location
  15744181  String
  15124312  Array


# After
Total retained:  44234355 bytes (459882 objects)

allocated memory by class
-----------------------------------
 152307312  Hash
  15744181  String
  15124312  Array
  12008296  RBS::Location
```


---



This PR also fixes two problems of the current implementations.

First, `Buffer#pos_to_loc` returns the wrong line and column for the EOS position of a string without the end of a newline. For example, the location for `abc|` (`|` is the cursor) should be `[1, 3]`, but `#pos_to_loc` unexpectedly returns `[2, 0]`.
This problem is fixed in https://github.com/ruby/rbs/pull/1788/commits/81b44e1de4fd1f9b737b8d8cd8aa660b17bb952c



Second, `#pos_to_loc` returns an unexpected value when the position is located EOF.
The cause is that the parser determines the length of EOF as 1. Then, the `RBS::Location` of the `pEOF` token contains an out-of-range position. Because an EOF has a length in C String, but it doesn't have a length in Ruby String.
I changed the length of EOF token to zero to fix this problem. 
https://github.com/ruby/rbs/pull/1788/commits/16006c2c8cce5d29995936c2ca507be0268aba97

