### PR TITLE
Should focus on `String.new` not `String#initialize`.

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -703,7 +703,7 @@ class String
   #
   #     String.new('hello', encoding: 'UTF-8', capacity: 25)
   #
-  def initialize: (?string source, ?encoding: encoding?, ?capacity: int?) -> self
+  def initialize: (?string source, ?encoding: encoding, ?capacity: int) -> void
 
   # <!--
   #   rdoc-file=string.c

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -7,6 +7,26 @@ class StringSingletonTest < Test::Unit::TestCase
 
   testing 'singleton(::String)'
 
+  def test_new
+    assert_send_type  '() -> String',
+                      String, :new
+
+    with_string do |source|
+      assert_send_type  '(string) -> String',
+                        String, :new, source
+    end
+
+    with_encoding do |encoding|
+      assert_send_type  '(encoding: encoding) -> String',
+                        String, :new, encoding: encoding
+    end
+
+    with_int do |capacity|
+      assert_send_type  '(capacity: int) -> String',
+                        String, :new, capacity: capacity
+    end
+  end
+
   def test_try_convert
     assert_send_type  '(String) -> String',
                       String, :try_convert, 'foo'
@@ -71,26 +91,6 @@ class StringInstanceTest < Test::Unit::TestCase
                       normal.dup, method, :turkic, :lithuanian
     assert_send_type  '(:turkic, :lithuanian) -> nil',
                       nochange.dup, method, :turkic, :lithuanian
-  end
-
-  def test_initialize
-    assert_send_type  '() -> String',
-                      String.allocate, :initialize
-
-    with_string do |source|
-      assert_send_type  '(string) -> String',
-                        String.allocate, :initialize, source
-    end
-
-    with_encoding.and_nil do |encoding|
-      assert_send_type  '(encoding: encoding?) -> String',
-                        String.allocate, :initialize, encoding: encoding
-    end
-
-    with_int.and_nil do |capacity|
-      assert_send_type  '(capacity: int?) -> String',
-                        String.allocate, :initialize, capacity: capacity
-    end
   end
 
   def test_initialize_copy


### PR DESCRIPTION
There is a slight difference in the allowed types between `String#initialize` and `String#new`.

The current signature focuses on `String#initialize`, and includes cases where `String.new` would fail.

```rb
String.new(capacity: nil)
#=> no implicit conversion from nil to integer (TypeError)
```

There's an option to separate the signatures for `String.new` and `String#initialize`, but it's hard to see the benefit of allowing `capacity` and `encoding` to be nil.

In this revision, I've changed to a signature that only works with `String.new`.
I believe this is simpler and more practical.