### PR TITLE
Fix SEGV with parse negative position

### DIFF
--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -277,6 +277,10 @@ parserstate *alloc_parser(VALUE buffer, int start_pos, int end_pos, VALUE variab
 
   StringValue(string);
 
+  if (start_pos < 0 || end_pos < 0) {
+    rb_raise(rb_eArgError, "negative position range: %d...%d", start_pos, end_pos);
+  }
+
   lexstate *lexer = calloc(1, sizeof(lexstate));
   lexer->string = string;
   lexer->current.line = 1;

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -717,6 +717,12 @@ RBS
     end
   end
 
+  def test_negative_range
+    assert_raises ArgumentError do
+      RBS::Parser.parse_type("a", range: -2...-1)
+    end
+  end
+
   def test_parse_eof_nil
     code = buffer("type1   ")
 


### PR DESCRIPTION
I've found the following cases. It will raise SEGV.

```rb
RBS::Parser.parse_type("a", range: -2...-1)
```