### PR TITLE
_ToInt is not allowed when there are 3 arguments on `String#bytesplice`

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -1185,7 +1185,7 @@ class String
   # offset does not land on character (codepoint) boundary, an IndexError will be
   # raised.
   #
-  def bytesplice: (int start, int length, string str) -> String
+  def bytesplice: (Integer start, int length, string str) -> String
                 | (int start, int length, string str, int str_start, int str_length) -> String
                 | (range[int?] range, string str, ?range[int?] str_range) -> String
 

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -387,8 +387,10 @@ class StringInstanceTest < Test::Unit::TestCase
                         +'hello', :bytesplice,  1, 2, string
 
       if RUBY_VERSION >= "3.3.0"
-        assert_send_type  '(Integer, Integer, string, Integer, Integer) -> String',
-                          +'hello', :bytesplice,  1, 2, string, 3, 4
+        with_int 1 do |start|
+          assert_send_type  '(int, Integer, string, Integer, Integer) -> String',
+                            +'hello', :bytesplice,  start, 2, string, 3, 4
+        end
       end
 
       with_range with_int(1).and_nil, with_int(2).and_nil do |range|


### PR DESCRIPTION
When 5 arguments, it is allowed.

ref: https://github.com/ruby/ruby/blame/dae503874d3aa054c4e7ae86e03d1338ab40ddc2/string.c#L6429