### PR TITLE
More details `Set.new`

### DIFF
--- a/core/set.rbs
+++ b/core/set.rbs
@@ -197,9 +197,9 @@ class Set[unchecked out A]
   #     Set.new(1..5)                         #=> #<Set: {1, 2, 3, 4, 5}>
   #     Set.new([1, 2, 3]) { |x| x * x }      #=> #<Set: {1, 4, 9}>
   #
-  def initialize: (_Each[A]) -> untyped
-                | [X] (_Each[X]) { (X) -> A } -> untyped
-                | (?nil) -> untyped
+  def initialize: (Object & _Each[A & Hash::_Key]) -> void
+                | [X] (Object & _Each[X]) { (X) -> (A & Hash::_Key) } -> void
+                | (?nil) -> void
 
   # <!--
   #   rdoc-file=lib/set.rb

--- a/lib/rbs/test.rb
+++ b/lib/rbs/test.rb
@@ -72,6 +72,7 @@ module RBS
     end
 
     CallTrace = Struct.new(:method_name, :method_call, :block_calls, :block_given, keyword_init: true)
+    CallTrace.include Guaranteed::Inspect
 
     class <<self
       attr_accessor :suffix

--- a/test/stdlib/Set_test.rb
+++ b/test/stdlib/Set_test.rb
@@ -24,3 +24,45 @@ class SetTest < Test::Unit::TestCase
     )
   end
 end
+
+class SetSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing "singleton(::Set)"
+
+  def test_new
+    assert_send_type "() -> ::Set[untyped]", Set, :new
+    assert_send_type "(nil) -> ::Set[untyped]", Set, :new, nil
+    assert_send_type "(Array[Integer]) -> Set[Integer]", Set, :new, [1, 2]
+    assert_send_type "(Range[Integer]) -> Set[Integer]", Set, :new, 1..5
+    assert_send_type "(Array[Integer]) { (Integer) -> Integer } -> Set[Integer]",
+                     Set, :new, [1, 2, 3] do |x| x * x end
+
+    o = Object.new
+    def o.each
+      hash_key = BasicObject.new
+      def hash_key.hash = 12345
+      def hash_key.eql?(_) = true
+      yield hash_key
+      yield hash_key
+      yield hash_key
+    end
+    assert_send_type "(Object & _Each[Hash::_Key]) -> Set[Hash::_Key]",
+                     Set, :new, o
+
+    o = Object.new
+    def o.each
+      yield BasicObject.new
+      yield BasicObject.new
+      yield BasicObject.new
+    end
+    block = proc do |x|
+      hash_key = BasicObject.new
+      def hash_key.hash = 12345
+      def hash_key.eql?(_) = true
+      hash_key
+    end
+    assert_send_type "(Object & _Each[BasicObject]) { (BasicObject) -> Hash::_Key } -> Set",
+                     Set, :new, o, &block
+  end
+end


### PR DESCRIPTION
Since the implementation of Set is Hash, the key must have a `hash` method.

```
$ ruby -e 'Set.new([BasicObject.new])'
/Users/ksss/.rbenv/versions/3.3.0/lib/ruby/3.3.0/set.rb:509:in `add': undefined method `hash' for an instance of BasicObject (NoMethodError)

    @hash[o] = true
         ^^^^^
```


The type argument `A` for Set should strictly be `A < Hash::_Key`. However, making this change would break compatibility, so it cannot be done.
In practice, using BasicObject is rare, so there is no need to make this change.