### PR TITLE
redefine superclass in Object as always returning a class

### DIFF
--- a/core/basic_object.rbs
+++ b/core/basic_object.rbs
@@ -369,4 +369,6 @@ class BasicObject
   #     Undefining one
   #
   def singleton_method_undefined: (Symbol name) -> nil
+
+  def self.superclass -> nil
 end

--- a/core/class.rbs
+++ b/core/class.rbs
@@ -216,5 +216,5 @@ class Class < Module
   #
   #     BasicObject.superclass   #=> nil
   #
-  def superclass: () -> Class?
+  # def superclass: () -> Class?
 end

--- a/core/object.rbs
+++ b/core/object.rbs
@@ -107,6 +107,8 @@
 #
 class Object < BasicObject
   include Kernel
+
+  def self.superclass() -> Class
 end
 
 # A previous incarnation of `interned` for backward-compatibility (see #1499)


### PR DESCRIPTION
the only instance of a nil superclass is basic object.

This is a proposal to make this definition more precise.