### PR TITLE
allow rest type arg for tuples

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -966,13 +966,44 @@ static VALUE parse_simple(parserstate *state) {
     range rg;
     rg.start = state->current_token.range.start;
     VALUE types = rb_ary_new();
+    VALUE rest_type = Qnil;
+    // parses type args with additional rest type arg
     if (state->next_token.type != pRBRACKET) {
-      parse_type_list(state, pRBRACKET, types);
+      while (true) {
+        rb_ary_push(types, parse_type(state));
+
+        if (state->next_token.type == pCOMMA) {
+          parser_advance(state);
+          if (state->next_token.type == pRBRACKET) {
+            break;
+          } else if (state->next_token.type == pSTAR) {
+            parser_advance(state);
+            rest_type = parse_type(state);
+            if (state->next_token.type != pRBRACKET) {
+              raise_syntax_error(
+                state,
+                state->next_token,
+                "tuple end expected"
+              );
+            }
+            break;
+          }
+        } else {
+          if (state->next_token.type == pRBRACKET) {
+            break;
+          }
+          raise_syntax_error(
+            state,
+            state->next_token,
+            "comma delimited type list is expected"
+          );
+        }
+      }
     }
     parser_advance_assert(state, pRBRACKET);
     rg.end = state->current_token.range.end;
 
-    return rbs_tuple(types, rbs_new_location(state->buffer, rg));
+    return rbs_tuple2(types, rbs_new_location(state->buffer, rg), rest_type);
   }
   case pAREF_OPR: {
     return rbs_tuple(rb_ary_new(), rbs_new_location(state->buffer, state->current_token.range));

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -132,6 +132,21 @@ VALUE rbs_tuple(VALUE types, VALUE location) {
   );
 }
 
+VALUE rbs_tuple2(VALUE types, VALUE location, VALUE rest_type) {
+  VALUE args = rb_hash_new();
+  rb_hash_aset(args, ID2SYM(rb_intern("types")), types);
+  rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
+  if (rest_type) {
+    rb_hash_aset(args, ID2SYM(rb_intern("rest_type")), rest_type);
+  }
+
+  return CLASS_NEW_INSTANCE(
+    RBS_Types_Tuple,
+    1,
+    &args
+  );
+}
+
 VALUE rbs_optional(VALUE type, VALUE location) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("type")), type);

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -39,6 +39,7 @@ VALUE rbs_optional(VALUE type, VALUE location);
 VALUE rbs_proc(VALUE function, VALUE block, VALUE location, VALUE self_type);
 VALUE rbs_record(VALUE fields, VALUE location);
 VALUE rbs_tuple(VALUE types, VALUE location);
+VALUE rbs_tuple2(VALUE types, VALUE location, VALUE rest_type);
 VALUE rbs_type_name(VALUE namespace, VALUE name);
 VALUE rbs_union(VALUE types, VALUE location);
 VALUE rbs_variable(VALUE name, VALUE location);

--- a/test/rbs/schema_test.rb
+++ b/test/rbs/schema_test.rb
@@ -96,6 +96,7 @@ class RBS::SchemaTest < Test::Unit::TestCase
     refute_type parse_type("Foo"), "alias"
 
     assert_type parse_type("[Integer]"), "tuple"
+    assert_type parse_type("[Integer, *String]"), "tuple"
     refute_type parse_type("Foo"), "tuple"
 
     assert_type parse_type("{ id: Integer, name: String }"), "record"

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -203,6 +203,15 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
       assert_equal [], type.types
       assert_equal "[]", type.location.source
     end
+
+    Parser.parse_type("[untyped, *untyped]").yield_self do |type|
+      assert_instance_of Types::Tuple, type
+      assert_equal [
+                     Types::Bases::Any.new(location: nil),
+                   ], type.types
+      assert_equal Types::Bases::Any.new(location: nil), type.rest_type
+      assert_equal "[untyped, *untyped]", type.location.source
+    end
   end
 
   def test_union_intersection


### PR DESCRIPTION
Proposal to address #1791 : addes a `rest_type` to Tuple class, which shall be used to type variable size tail elements of tuples.

I just don't know where to add the type checking logic now.
