### PR TITLE
Fix block return type

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -293,7 +293,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # lazy fashion (see Enumerator#size). It can either be a value or a callable
   # object.
   #
-  def initialize: (?Integer arg0) { (Enumerator::Yielder arg0) -> void } -> void
+  def initialize: (?Integer arg0) { (Enumerator::Yielder arg0) -> Return } -> void
 
   # <!--
   #   rdoc-file=enumerator.c

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -18,12 +18,23 @@ class EnumeratorTest < Test::Unit::TestCase
     assert_send_type "(String) -> Enumerator[[Integer, String], String]", g, :with_object, ''
     assert_send_type "(String) { (Integer, String) -> untyped } -> String", g, :with_object, '' do end
   end
+
+  def test_each
+    enum = Enumerator.new { [1,2,3] }
+    assert_send_type "() { (Integer) -> nil } -> [1,2,3]",
+                     enum, :each do end
+  end
 end
 
 class EnumeratorSingletonTest < Test::Unit::TestCase
   include TestHelper
 
   testing "singleton(::Enumerator)"
+
+  def test_new
+    assert_send_type "() { (Enumerator::Yielder) -> 12345 } -> void",
+                     Enumerator, :new do 12345 end
+  end
 
   def test_produce
     assert_send_type(

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -32,7 +32,7 @@ class EnumeratorSingletonTest < Test::Unit::TestCase
   testing "singleton(::Enumerator)"
 
   def test_new
-    assert_send_type "() { (Enumerator::Yielder) -> 12345 } -> void",
+    assert_send_type "() { (Enumerator::Yielder) -> 12345 } -> Enumerator[untyped, 12345]",
                      Enumerator, :new do 12345 end
   end
 


### PR DESCRIPTION
The return value of the block set by `Enumerator#initialize` is used as the return value of `Enumerator#each`, so the return value of the block should be `Return`.

```rb
Enumerator.new { :hello }.each {}
#=> :hello
```