### PR TITLE
Add Timeout::ExitException 

### DIFF
--- a/stdlib/timeout/0/timeout.rbs
+++ b/stdlib/timeout/0/timeout.rbs
@@ -63,6 +63,12 @@ module Timeout
 end
 
 # <!-- rdoc-file=lib/timeout.rb -->
+# Internal error raised to when a timeout is triggered.
+#
+class Timeout::ExitException < Exception
+end
+
+# <!-- rdoc-file=lib/timeout.rb -->
 # Raised by Timeout.timeout when the block times out.
 #
 class Timeout::Error < RuntimeError


### PR DESCRIPTION
Timeout::ExitException is an internal error.
However, it can appear in Ruby code.

```rb
Timeout.timeout(3) do
  begin
    long_run
  rescue StandardError => e
    logger.error(e)
    raise
  rescue Timeout::ExitException
    # skip logging
    raise
  end
end
```