### PR TITLE
Remove deprecated API since RBS v1

### DIFF
--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -62,20 +62,6 @@ module RBS
 
       super "#{Location.to_string location}: Syntax error: #{error_message}, token=`#{location.source}` (#{token_type})"
     end
-
-    def error_value
-      RBS.print_warning {
-        "#{self.class.name}#error_value is deprecated and will be deleted in RBS 2.0. Consider using `location.source` instead."
-      }
-      location.source
-    end
-
-    def token_str
-      RBS.print_warning {
-        "#{self.class.name}#token_str is deprecated and will be deleted in RBS 2.0. Consider using `token_type` instead."
-      }
-      token_type
-    end
   end
 
   class InvalidTypeApplicationError < DefinitionError

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -28,11 +28,6 @@ module RBS
       end
     end
 
-    autoload :SyntaxError, "rbs/parser_compat/syntax_error"
-    autoload :SemanticsError, "rbs/parser_compat/semantics_error"
-    autoload :LexerError, "rbs/parser_compat/lexer_error"
-    autoload :LocatedValue, "rbs/parser_compat/located_value"
-
     KEYWORDS = %w(
       bool
       bot

--- a/lib/rbs/parser_compat/lexer_error.rb
+++ b/lib/rbs/parser_compat/lexer_error.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RBS.print_warning {
-  "RBS::Parser::LexerError is deprecated and will be deleted in RBS 2.0."
-}
-RBS::Parser::LexerError = RBS::ParsingError

--- a/lib/rbs/parser_compat/located_value.rb
+++ b/lib/rbs/parser_compat/located_value.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RBS.print_warning {
-  "RBS::Parser::LocatedValue is deprecated and will be deleted in RBS 2.0."
-}
-class RBS::Parser::LocatedValue
-end

--- a/lib/rbs/parser_compat/semantics_error.rb
+++ b/lib/rbs/parser_compat/semantics_error.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RBS.print_warning {
-  "RBS::Parser::SemanticsError is deprecated and will be deleted in RBS 2.0."
-}
-RBS::Parser::SemanticsError = RBS::ParsingError

--- a/lib/rbs/parser_compat/syntax_error.rb
+++ b/lib/rbs/parser_compat/syntax_error.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RBS.print_warning {
-  "RBS::Parser::SyntaxError is deprecated and will be deleted in RBS 2.0."
-}
-RBS::Parser::SyntaxError = RBS::ParsingError


### PR DESCRIPTION
They have been deprecated since RBS v1 and they should be removed on RBS v2, but not yet.

This PR removes these deprecated APIs. 