### PR TITLE
Function types with untyped parameter

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -45,6 +45,7 @@ _literal_ ::= _string-literal_
             | `false`
 
 _proc_ ::= `^` _parameters?_ _self-type-binding?_ _block?_ `->` _type_
+         | `^` `(` `?` `)` _self-type-binding?_ _block?_ `->` _type_      # Proc type with untyped parameter
 ```
 
 ### Class instance type
@@ -310,6 +311,7 @@ end
 
 ```markdown
 _method-type_ ::= _parameters?_ _block?_ `->` _type_                # Method type
+                | `(` `?` `)` `->` _type_                           # Method type with untyped parameters
 
 _parameters?_ ::=                   (Empty)
                 | _parameters_      (Parameters)
@@ -333,9 +335,11 @@ _var-name_ ::= /[a-z]\w*/
 _self-type-binding?_ =                              (Empty)
                      | `[` `self` `:` _type_ `]`    (Self type binding)
 
-_block?_ =                                                           (No block)
+_block?_ =                                                            (No block)
          | `{` _parameters_ _self-type-binding?_ `->` _type_ `}`      (Block)
+         | `{` `(` `?` `)` `->` _type_ `}`                            (Block with untyped parameters)
          | `?` `{` _parameters_ _self-type-binding?_ `->` _type_ `}`  (Optional block)
+         | `?` `{` `(` `?` `)` `->` _type_ `}`                        (Optional block with untyped parameters)
 ```
 
 ### Parameters

--- a/ext/rbs_extension/constants.c
+++ b/ext/rbs_extension/constants.c
@@ -61,6 +61,7 @@ VALUE RBS_Types_ClassInstance;
 VALUE RBS_Types_ClassSingleton;
 VALUE RBS_Types_Function_Param;
 VALUE RBS_Types_Function;
+VALUE RBS_Types_UntypedFunction;
 VALUE RBS_Types_Interface;
 VALUE RBS_Types_Intersection;
 VALUE RBS_Types_Literal;
@@ -138,6 +139,7 @@ void rbs__init_constants(void) {
   IMPORT_CONSTANT(RBS_Types_ClassInstance, RBS_Types, "ClassInstance");
   IMPORT_CONSTANT(RBS_Types_ClassSingleton, RBS_Types, "ClassSingleton");
   IMPORT_CONSTANT(RBS_Types_Function, RBS_Types, "Function");
+  IMPORT_CONSTANT(RBS_Types_UntypedFunction, RBS_Types, "UntypedFunction");
   IMPORT_CONSTANT(RBS_Types_Function_Param, RBS_Types_Function, "Param");
   IMPORT_CONSTANT(RBS_Types_Interface, RBS_Types, "Interface");
   IMPORT_CONSTANT(RBS_Types_Intersection, RBS_Types, "Intersection");

--- a/ext/rbs_extension/constants.h
+++ b/ext/rbs_extension/constants.h
@@ -64,6 +64,7 @@ extern VALUE RBS_Types_ClassInstance;
 extern VALUE RBS_Types_ClassSingleton;
 extern VALUE RBS_Types_Function_Param;
 extern VALUE RBS_Types_Function;
+extern VALUE RBS_Types_UntypedFunction;
 extern VALUE RBS_Types_Interface;
 extern VALUE RBS_Types_Intersection;
 extern VALUE RBS_Types_Literal;

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -170,6 +170,17 @@ VALUE rbs_function_param(VALUE type, VALUE name, VALUE location) {
   );
 }
 
+VALUE rbs_untyped_function(VALUE return_type) {
+  VALUE args = rb_hash_new();
+  rb_hash_aset(args, ID2SYM(rb_intern("return_type")), return_type);
+
+  return CLASS_NEW_INSTANCE(
+    RBS_Types_UntypedFunction,
+    1,
+    &args
+  );
+}
+
 VALUE rbs_function(
   VALUE required_positional_params,
   VALUE optional_positional_params,

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -30,6 +30,7 @@ VALUE rbs_class_instance(VALUE typename, VALUE type_args, VALUE location);
 VALUE rbs_class_singleton(VALUE typename, VALUE location);
 VALUE rbs_function_param(VALUE type, VALUE name, VALUE location);
 VALUE rbs_function(VALUE required_positional_params, VALUE optional_positional_params, VALUE rest_positional_params, VALUE trailing_positional_params, VALUE required_keywords, VALUE optional_keywords, VALUE rest_keywords, VALUE return_type);
+VALUE rbs_untyped_function(VALUE return_type);
 VALUE rbs_interface(VALUE typename, VALUE type_args, VALUE location);
 VALUE rbs_intersection(VALUE types, VALUE location);
 VALUE rbs_literal(VALUE literal, VALUE location);

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -317,7 +317,11 @@ module RBS
                 Types::Function::Param.new(name: name, type: type)
               end
 
-              method_type.update(type: method_type.type.update(required_positionals: required_positionals))
+              if method_type.type.is_a?(RBS::Types::Function)
+                method_type.update(type: method_type.type.update(required_positionals: required_positionals))
+              else
+                method_type
+              end
             end
           when :type_parameters
             type_params = []
@@ -446,18 +450,22 @@ module RBS
           end
         end
 
-        method_type.update(
-          type: method_type.type.update(
-            required_positionals: required_positionals,
-            optional_positionals: optional_positionals,
-            rest_positionals: rest_positionals,
-            trailing_positionals: trailing_positionals,
-            required_keywords: required_keywords,
-            optional_keywords: optional_keywords,
-            rest_keywords: rest_keywords
-          ),
-          block: method_block
-        )
+        if method_type.type.is_a?(Types::Function)
+          method_type.update(
+            type: method_type.type.update(
+              required_positionals: required_positionals,
+              optional_positionals: optional_positionals,
+              rest_positionals: rest_positionals,
+              trailing_positionals: trailing_positionals,
+              required_keywords: required_keywords,
+              optional_keywords: optional_keywords,
+              rest_keywords: rest_keywords
+            ),
+            block: method_block
+          )
+        else
+          method_type
+        end
       end
 
       def type_of(type_node, variables:)

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1202,6 +1202,84 @@ module RBS
       end
     end
 
+    class UntypedFunction
+      attr_reader :return_type
+
+      def initialize(return_type:)
+        @return_type = return_type
+      end
+
+      def free_variables(acc = Set.new)
+        return_type.free_variables(acc)
+      end
+
+      def map_type(&block)
+        if block
+          update(return_type: yield(return_type))
+        else
+          enum_for :map_type
+        end
+      end
+
+      def each_type(&block)
+        if block
+          yield return_type
+        else
+          enum_for :each_type
+        end
+      end
+
+      def each_param(&block)
+        if block
+          # noop
+        else
+          enum_for :each_param
+        end
+      end
+
+      def to_json(state = _ = nil)
+        {
+          return_type: return_type
+        }.to_json(state)
+      end
+
+      def sub(subst)
+        map_type { _1.sub(subst) }
+      end
+
+      def with_return_type(ty)
+        update(return_type: ty)
+      end
+
+      def update(return_type: self.return_type)
+        UntypedFunction.new(return_type: return_type)
+      end
+
+      def empty?
+        true
+      end
+
+      def has_self_type?
+        return_type.has_self_type?
+      end
+
+      def has_classish_type?
+        return_type.has_classish_type?
+      end
+
+      def with_nonreturn_void
+        false
+      end
+
+      def param_to_s
+        "?"
+      end
+
+      def return_to_s
+        return_type.to_s(1)
+      end
+    end
+
     class Block
       attr_reader :type
       attr_reader :required

--- a/sig/method_types.rbs
+++ b/sig/method_types.rbs
@@ -14,11 +14,11 @@ module RBS
     type loc = def_loc | attr_loc
 
     attr_reader type_params: Array[AST::TypeParam]
-    attr_reader type: Types::Function
+    attr_reader type: Types::function
     attr_reader block: Types::Block?
     attr_reader location: loc?
 
-    def initialize: (type_params: Array[AST::TypeParam], type: Types::Function, block: Types::Block?, location: loc?) -> void
+    def initialize: (type_params: Array[AST::TypeParam], type: Types::function, block: Types::Block?, location: loc?) -> void
 
     def ==: (untyped other) -> bool
 
@@ -29,7 +29,7 @@ module RBS
     #
     def sub: (Substitution) -> MethodType
 
-    def update: (?type_params: Array[AST::TypeParam], ?type: Types::Function, ?block: Types::Block?, ?location: loc?) -> MethodType
+    def update: (?type_params: Array[AST::TypeParam], ?type: Types::function, ?block: Types::Block?, ?location: loc?) -> MethodType
 
     def free_variables: (?Set[Symbol] set) -> Set[Symbol]
 

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -448,13 +448,58 @@ module RBS
       def with_nonreturn_void?: () -> bool
     end
 
+    # Function type without type checking arguments
+    #
+    class UntypedFunction
+      attr_reader return_type: t
+
+      def initialize: (return_type: t) -> void
+
+      def free_variables: (?Set[Symbol]) -> Set[Symbol]
+
+      def map_type: { (t) -> t } -> UntypedFunction
+                  | -> Enumerator[t, UntypedFunction]
+
+      def map_type_name: () { (TypeName, Location[untyped, untyped]?, t) -> TypeName } -> UntypedFunction
+
+      def each_type: () { (t) -> void } -> void
+                   | -> Enumerator[t, void]
+
+      def each_param: () { (Function::Param) -> void } -> void
+                    | -> Enumerator[Function::Param, void]
+
+      include _ToJson
+
+      def sub: (Substitution) -> UntypedFunction
+
+      def with_return_type: (t) -> UntypedFunction
+
+      def update: (?return_type: t) -> UntypedFunction
+
+      def empty?: () -> bool
+
+      def has_self_type?: () -> bool
+
+      def has_classish_type?: () -> bool
+
+      def with_nonreturn_void?: () -> bool
+
+      # Returns `?`
+      def param_to_s: () -> String
+
+      # Returns `return_type.to_s(1)`
+      def return_to_s: () -> String
+    end
+
+    type function = Types::Function | Types::UntypedFunction
+
     class Block
-      attr_reader type: Types::Function
+      attr_reader type: function
       attr_reader required: bool
 
       attr_reader self_type: t?
 
-      def initialize: (type: Types::Function, ?self_type: t?, required: boolish) -> void
+      def initialize: (type: function, ?self_type: t?, required: boolish) -> void
 
       def ==: (untyped other) -> bool
 
@@ -470,14 +515,14 @@ module RBS
     end
 
     class Proc
-      attr_reader type: Function
+      attr_reader type: function
       attr_reader block: Block?
 
       attr_reader self_type: t?
 
       type loc = Location[bot, bot]
 
-      def initialize: (location: loc?, type: Function, ?self_type: t?, block: Block?) -> void
+      def initialize: (location: loc?, type: function, ?self_type: t?, block: Block?) -> void
 
       include _TypeBase
 

--- a/sig/variance_calculator.rbs
+++ b/sig/variance_calculator.rbs
@@ -73,14 +73,14 @@ module RBS
     def in_inherit: (name: TypeName, args: Array[Types::t], variables: Array[Symbol]) -> Result
 
     # The type name must be normalized
-    # 
+    #
     def in_type_alias: (name: TypeName) -> Result
 
     private
 
     def type: (Types::t, result: Result, context: variance) -> void
 
-    def function: (Types::Function, result: Result, context: variance) -> void
+    def function: (Types::function, result: Result, context: variance) -> void
 
     def negate: (variance) -> variance
   end

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -751,4 +751,20 @@ RBS
       RBS::Parser.parse_method_type("() -> void () -> void", range: 0..., require_eof: true)
     end
   end
+
+  def test_proc__untyped_function
+    RBS::Parser.parse_type("^(?) -> Integer").tap do |type|
+      assert_instance_of RBS::Types::UntypedFunction, type.type
+    end
+
+    RBS::Parser.parse_type("^() { (?) -> String } -> Integer").tap do |type|
+      assert_instance_of RBS::Types::UntypedFunction, type.block.type
+    end
+  end
+
+  def test_proc__untyped_function_parse_error
+    assert_raises(RBS::ParsingError) do
+      RBS::Parser.parse_type("^(?) { (?) -> void } -> Integer")
+    end
+  end
 end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -62,7 +62,7 @@ end
 
     assert_write parser.decls, <<-EOF
 class Hello
-  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped, ?f: ::Integer, **untyped g) { () -> untyped } -> nil
+  def hello: (untyped a, ?::Integer b, *untyped c, untyped d, e: untyped, ?f: ::Integer, **untyped g) { (?) -> untyped } -> nil
 
   def self.world: () { (untyped, untyped, untyped, x: untyped, y: untyped) -> untyped } -> untyped
 
@@ -1070,14 +1070,14 @@ end
       # Ruby <=3.3 generates AST without kwrest args for `...` args
       assert_write parser.decls, <<~RBS
         module M
-          def foo: (*untyped) ?{ () -> untyped } -> nil
+          def foo: (*untyped) ?{ (?) -> untyped } -> nil
         end
       RBS
     else
       # Ruby 3.4 generates AST with kwrest args for `...` args
       assert_write parser.decls, <<~RBS
         module M
-          def foo: (*untyped, **untyped) ?{ () -> untyped } -> nil
+          def foo: (*untyped, **untyped) ?{ (?) -> untyped } -> nil
         end
       RBS
     end


### PR DESCRIPTION
This PR adds *untyped function parameters*, which means there is no static  type checking on parameters/blocks given to method calls and block yields.

```rbs
class Foo
  def foo: (?) -> void                     # #foo accepts any argument
  def bar: () { (?) -> Integer } -> void   # #bar accepts any block which returns Integer
end
```


See https://github.com/ruby/rbs/issues/1335