### PR TITLE
Fix proc type syntax

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -45,7 +45,7 @@ _literal_ ::= _string-literal_
             | `false`
 
 _proc_ ::= `^` _parameters?_ _self-type-binding?_ _block?_ `->` _type_
-         | `^` `(` `?` `)` _self-type-binding?_ _block?_ `->` _type_      # Proc type with untyped parameter
+         | `^` `(` `?` `)` `->` _type_                                   # Proc type with untyped parameter
 ```
 
 ### Class instance type


### PR DESCRIPTION
I mean the `(?) -> void` type accepts any block. The syntax definition of *proc* type in #1806 is incorrect and caused some confusion.

Related to #1335 