### PR TITLE
Use ShellSession syntax highlight in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gem "rbs"
 
 The gem ships with the `rbs` command line tool to demonstrate what it can do and help develop RBS.
 
-```bash
+```sh-session
 $ rbs version
 $ rbs list
 $ rbs ancestors ::Object
@@ -98,7 +98,7 @@ end
 
 Running prototype on the above will automatically generate
 
-```
+```sh-session
 $ rbs prototype rb person.rb
 class Person
   @name: untyped

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gem "rbs"
 
 The gem ships with the `rbs` command line tool to demonstrate what it can do and help develop RBS.
 
-```sh-session
+```console
 $ rbs version
 $ rbs list
 $ rbs ancestors ::Object
@@ -98,7 +98,7 @@ end
 
 Running prototype on the above will automatically generate
 
-```sh-session
+```console
 $ rbs prototype rb person.rb
 class Person
   @name: untyped


### PR DESCRIPTION
`sh-session` is supported by GitHub (Linguist):
https://github.com/github-linguist/linguist/blob/e2012cd67867e6287ae5ee96c8fe0b92f9a88efa/lib/linguist/languages.yml#L6615

Compare:

| Before | After |
|--------|--------|
| <img width="424" alt="image" src="https://github.com/ruby/rbs/assets/473530/93a551d4-ea81-4365-b84b-0565236817fe"> | <img width="406" alt="image" src="https://github.com/ruby/rbs/assets/473530/d3ce04de-c340-4e10-96f9-b32a0c41e934"> | 