### PR TITLE
Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     allow:
       - dependency-type: all
 
@@ -12,7 +12,7 @@ updates:
     directory: "/steep"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     allow:
       - dependency-type: all
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,11 +5,20 @@ permissions:
   pull-requests: write
   contents: write
 
+env:
+  blocker_files: rbs.gemspec Gemfile steep/Gemfile
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Abort if blocker files are changed
+        run: git diff --exit-code ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ env.blocker_files }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
Follow up https://github.com/ruby/rbs/pull/1833.

* Limit open PR count to 3
* Skip auto-merge if `.gemspec` is updated, because it's a change to next release
* Skip auto-merge if `Gemfile` is updated, just to make it more conservative