### PR TITLE
Add explicit dependency on the `logger` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     rbs (3.5.0)
+      logger
 
 PATH
   remote: test/assets/test-gem

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0"
+  spec.add_dependency "logger"
 end


### PR DESCRIPTION
This is being bundled, starting in Ruby 3.4 it will warn: https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c