### PR TITLE
Drop dependency on `abbrev`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     rbs (3.5.0.pre.2)
-      abbrev
 
 PATH
   remote: test/assets/test-gem

--- a/Steepfile
+++ b/Steepfile
@@ -8,7 +8,7 @@ target :lib do
     # "lib/rbs/test.rb"
   )
 
-  library "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest', 'abbrev', 'prettyprint', 'yaml', "psych", "securerandom"
+  library "pathname", "json", "logger", "monitor", "tsort", "uri", 'dbm', 'pstore', 'singleton', 'shellwords', 'fileutils', 'find', 'digest', 'prettyprint', 'yaml', "psych", "securerandom"
   signature "stdlib/strscan/0/"
   signature "stdlib/optparse/0/"
   signature "stdlib/rdoc/0/"

--- a/docs/gem.md
+++ b/docs/gem.md
@@ -31,7 +31,6 @@ Assume you have three RBS files in your gem package:
 
 ```yaml
 dependencies:
-  - name: abbrev
   - name: json
   - name: logger
   - name: optparse

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -3,7 +3,6 @@
 require "open3"
 require "optparse"
 require "shellwords"
-require "abbrev"
 require "stringio"
 
 module RBS
@@ -1062,14 +1061,13 @@ EOB
       config_path = options.config_path or raise
       lock_path = Collection::Config.to_lockfile_path(config_path)
 
-      subcommand = Abbrev.abbrev(['install', 'update', 'help'])[args[0]] || args[0]
-      case subcommand
-      when 'install'
+      case args[0]
+      when 'install', 'instal', 'insta', 'inst', 'ins', 'in', 'i'
         unless params[:frozen]
           Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
-      when 'update'
+      when 'update', 'updat', 'upda', 'upd', 'up', 'u'
         # TODO: Be aware of argv to update only specified gem
         Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
@@ -1107,7 +1105,7 @@ EOB
           exit 1
         end
         Collection::Cleaner.new(lockfile_path: lock_path)
-      when 'help'
+      when 'help', 'hel', 'he', 'h'
         puts opts.help
       else
         puts opts.help

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -41,5 +41,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.0"
-  spec.add_dependency "abbrev"
 end

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -5,4 +5,3 @@ dependencies:
   - name: optparse
   - name: tsort
   - name: rdoc
-  - name: abbrev


### PR DESCRIPTION
Pulling in something extra just for this seems pretty wasteful in my opinion