### PR TITLE
Revise `#divmod` method so that `sleep` can accept `Float` and `Rational`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,6 +32,8 @@ jobs:
             job: lexer compile confirm_lexer
           - ruby: "3.3"
             job: rubocop validate test_doc build test_generate_stdlib raap
+          - ruby: "3.3"
+            job: typecheck_test
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -64,6 +66,10 @@ jobs:
           echo "NO_MINITEST=true" >> $GITHUB_ENV
           bundle config set --local without 'minitest'
         if: ${{ contains(matrix.ruby, 'head') }}
+      - name: Skip installing type checkers
+        if: ${{ ! contains(matrix.job, 'typecheck_test') }}
+        run: |
+          bundle config set without 'typecheck_test'
       - name: bin/setup
         run: |
           bin/setup

--- a/Gemfile
+++ b/Gemfile
@@ -40,3 +40,7 @@ gem 'csv'
 group :minitest do
   gem "minitest"
 end
+
+group :typecheck_test do
+  gem "steep", "~> 1.7.0.dev", require: false
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,26 +13,47 @@ GEM
   remote: https://rubygems.org/
   specs:
     abbrev (0.1.2)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     base64 (0.2.0)
     benchmark-ips (2.13.0)
     bigdecimal (3.1.8)
+    concurrent-ruby (1.3.1)
+    connection_pool (2.4.1)
     csv (3.3.0)
     dbm (1.1.0)
     diff-lcs (1.5.1)
     digest (3.1.1)
+    drb (2.2.1)
+    ffi (1.17.0)
+    ffi (1.17.0-x86_64-darwin)
     fileutils (1.7.2)
     goodcheck (3.1.0)
       marcel (>= 1.0, < 2.0)
       psych (>= 3.1, < 5.0)
       rainbow (>= 3.0, < 4.0)
       strong_json (>= 1.1, < 2.2)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
     json (2.7.2)
     json-schema (4.3.0)
       addressable (>= 2.8)
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.0)
     marcel (1.0.4)
     memory_profiler (1.0.1)
     minitest (5.23.1)
@@ -58,6 +79,9 @@ GEM
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.2)
@@ -92,14 +116,34 @@ GEM
     rubocop-rubycw (0.1.6)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
+    securerandom (0.3.1)
     stackprof (0.2.26)
+    steep (1.7.0.dev.4)
+      activesupport (>= 5.1)
+      concurrent-ruby (>= 1.1.10)
+      csv (>= 3.0.9)
+      fileutils (>= 1.1.0)
+      json (>= 2.1.0)
+      language_server-protocol (>= 3.15, < 4.0)
+      listen (~> 3.0)
+      logger (>= 1.3.0)
+      parser (>= 3.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rbs (>= 3.5.0.pre)
+      securerandom (>= 0.1)
+      strscan (>= 1.0.0)
+      terminal-table (>= 2, < 4)
     stringio (3.1.0)
     strong_json (2.1.2)
     strscan (3.1.0)
     tempfile (0.2.1)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     test-unit (3.6.2)
       power_assert
     timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
 
 PLATFORMS
@@ -133,6 +177,7 @@ DEPENDENCIES
   rubocop
   rubocop-rubycw
   stackprof
+  steep (~> 1.7.0.dev)
   tempfile
   test-unit
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ Rake::TestTask.new(:test => :compile) do |t|
   end
 end
 
-multitask :default => [:test, :stdlib_test, :rubocop, :validate, :test_doc]
+multitask :default => [:test, :stdlib_test, :typecheck_test, :rubocop, :validate, :test_doc]
 
 task :lexer do
   sh "re2c -W --no-generation-date -o ext/rbs_extension/lexer.c ext/rbs_extension/lexer.re"
@@ -90,6 +90,19 @@ task :stdlib_test => :compile do
   # TODO: Ractor tests need to be run in a separate process
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/Ractor_test.rb"
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/Encoding_test.rb"
+end
+
+task :typecheck_test => :compile do
+  FileList["test/typecheck/*"].each do |test|
+    Dir.chdir(test) do
+      expectations = File.join(test, "steep_expectations.yml")
+      if File.exist?(expectations)
+        sh "steep check --with_expectations"
+      else
+        sh "steep check"
+      end
+    end
+  end
 end
 
 task :raap => :compile do

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -442,7 +442,8 @@ class Float < Numeric
   #     13.0.divmod(4.0)            # => [3, 1.0]
   #     13.0.divmod(Rational(4, 1)) # => [3, 1.0]
   #
-  def divmod: (Numeric) -> [ Numeric, Numeric ]
+  def divmod: (Integer | Float | Rational) -> [ Integer, Float ]
+            | (Numeric) -> [ Numeric, Numeric ]
 
   def dup: () -> self
 

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -766,7 +766,8 @@ class Integer < Numeric
   #     13.divmod(Rational(4, 1)) # => [3, (1/1)]
   #
   def divmod: (Integer) -> [ Integer, Integer ]
-            | (Float) -> [ Float, Float ]
+            | (Float) -> [ Integer, Float ]
+            | (Rational) -> [ Integer, Rational ]
             | (Numeric) -> [ Numeric, Numeric ]
 
   # <!--

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -245,7 +245,8 @@ class Rational < Numeric
 
   def div: (Numeric) -> Integer
 
-  def divmod: (Numeric) -> [ Numeric, Numeric ]
+  def divmod: (Integer | Float | Rational) -> [ Integer, Rational ]
+            | (Numeric) -> [ Numeric, Numeric ]
 
   def dup: () -> self
 

--- a/test/typecheck/sleep/Steepfile
+++ b/test/typecheck/sleep/Steepfile
@@ -1,0 +1,7 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/sleep/sleep.rb
+++ b/test/typecheck/sleep/sleep.rb
@@ -1,0 +1,3 @@
+sleep 1
+sleep 1.0
+sleep 1.to_r


### PR DESCRIPTION
This PR also adds `typecheck_test` rake task. Some complicated type definition causes unexpected type errors that cannot be detected using runtime tests.