### PR TITLE
Retry Refine Digest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -106,7 +106,7 @@ task :typecheck_test => :compile do
 end
 
 task :raap => :compile do
-  sh %q[cat test/raap.txt | egrep -v '^#|^$' | xargs bundle exec raap]
+  sh %q[ruby test/raap.rb | xargs bundle exec raap -r digest/bubblebabble --library digest --allow-private]
 end
 
 task :rubocop do

--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -74,7 +74,7 @@ module Digest
   # -->
   # Returns a BubbleBabble encoded version of a given *string*.
   #
-  def self.bubblebabble: (String) -> String
+  def self.bubblebabble: (string) -> String
 
   def self.const_missing: (Symbol name) -> singleton(::Digest::Base)
 
@@ -84,13 +84,13 @@ module Digest
   # -->
   # Generates a hex-encoded version of a given *string*.
   #
-  def self.hexencode: (String) -> String
+  def self.hexencode: (string) -> String
 
   private
 
-  def bubblebabble: (String) -> String
+  def bubblebabble: (string) -> String
 
-  def hexencode: (String) -> String
+  def hexencode: (string) -> String
 end
 
 # <!-- rdoc-file=ext/digest/lib/digest.rb -->
@@ -111,7 +111,7 @@ module Digest::Instance
   # The update() method and the left-shift operator are overridden by each
   # implementation subclass. (One should be an alias for the other)
   #
-  def <<: (String) -> self
+  def <<: (string) -> self
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -122,7 +122,7 @@ module Digest::Instance
   # of the digest object.  If another digest instance is given, checks whether
   # they have the same hash value.  Otherwise returns false.
   #
-  def ==: (::Digest::Instance | String) -> bool
+  def ==: (instance | string) -> bool
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -138,7 +138,7 @@ module Digest::Instance
   # In either case, the return value is properly padded with '=' and contains no
   # line feeds.
   #
-  def base64digest: (?String? str) -> String
+  def base64digest: (?string? str) -> String
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -177,7 +177,7 @@ module Digest::Instance
   # If a *string* is given, returns the hash value for the given *string*,
   # resetting the digest to the initial state before and after the process.
   #
-  def digest: (?String) -> String
+  def digest: (?string) -> String
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -204,7 +204,7 @@ module Digest::Instance
   # -->
   # Updates the digest with the contents of a given file *name* and returns self.
   #
-  def file: (String name) -> self
+  def file: (string name) -> instance
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -218,7 +218,7 @@ module Digest::Instance
   # hex-encoded form, resetting the digest to the initial state before and after
   # the process.
   #
-  def hexdigest: (?String) -> String
+  def hexdigest: (?string) -> String
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -253,7 +253,7 @@ module Digest::Instance
   # Returns a new, initialized copy of the digest object.  Equivalent to
   # digest_obj.clone().reset().
   #
-  def new: () -> ::Digest::Base
+  def new: () -> instance
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -288,7 +288,7 @@ module Digest::Instance
   # The update() method and the left-shift operator are overridden by each
   # implementation subclass. (One should be an alias for the other)
   #
-  def update: (String) -> self
+  def update: (string) -> self
 
   private
 
@@ -319,7 +319,7 @@ class Digest::Class
   # Returns the base64 encoded hash value of a given *string*.  The return value
   # is properly padded with '=' and contains no line feeds.
   #
-  def self.base64digest: (String str, *untyped) -> String
+  def self.base64digest: (string str) -> String
 
   # <!--
   #   rdoc-file=ext/digest/bubblebabble/bubblebabble.c
@@ -327,7 +327,7 @@ class Digest::Class
   # -->
   # Returns the BubbleBabble encoded hash value of a given *string*.
   #
-  def self.bubblebabble: (String, *untyped) -> String
+  def self.bubblebabble: (string) -> String
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -338,7 +338,7 @@ class Digest::Class
   # any, are passed through to the constructor and the *string* is passed to
   # #digest().
   #
-  def self.digest: (String, *untyped) -> String
+  def self.digest: (string) -> String
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -350,7 +350,7 @@ class Digest::Class
   #     p Digest::SHA256.file("X11R6.8.2-src.tar.bz2").hexdigest
   #     # => "f02e3c85572dc9ad7cb77c2a638e3be24cc1b5bea9fdbb0b0299c9668475c534"
   #
-  def self.file: (String name, *untyped) -> ::Digest::Class
+  def self.file: (string name) -> instance
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -359,11 +359,11 @@ class Digest::Class
   # Returns the hex-encoded hash value of a given *string*.  This is almost
   # equivalent to Digest.hexencode(Digest::Class.new(*parameters).digest(string)).
   #
-  def self.hexdigest: (String, *untyped) -> String
+  def self.hexdigest: (string) -> String
 
   private
 
-  def initialize: () -> self
+  def initialize: () -> void
 end
 
 # <!-- rdoc-file=ext/digest/digest.c -->
@@ -408,7 +408,7 @@ class Digest::Base < Digest::Class
   # <!-- rdoc-file=ext/digest/digest.c -->
   # Update the digest using given *string* and return `self`.
   #
-  def <<: (String) -> self
+  def <<: (string) -> self
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -434,20 +434,14 @@ class Digest::Base < Digest::Class
   #
   def reset: () -> self
 
-  # <!--
-  #   rdoc-file=ext/digest/digest.c
-  #   - digest_base.update(string) -> digest_base
-  #   - digest_base << string -> digest_base
-  # -->
-  # Update the digest using given *string* and return `self`.
-  #
-  def update: (String) -> self
+  %a{annotate:rdoc:skip}
+  alias update <<
 
   private
 
   def finish: () -> String
 
-  def initialize_copy: (::Digest::Base) -> self
+  def initialize_copy: (self) -> self
 end
 
 # <!-- rdoc-file=ext/digest/sha1/sha1init.c -->

--- a/test/raap.rb
+++ b/test/raap.rb
@@ -1,0 +1,52 @@
+# Specify the class/module and method names to be executed by RaaP.
+# By prefixing with `!`, you can skip testing a method.
+
+puts 'Set[Integer]'
+puts 'Enumerable[Integer]#to_set'
+
+%w[
+  MD5
+  SHA1
+  RMD160
+  SHA256
+  SHA384
+  SHA512
+].each do |klass|
+  %w[
+    base64digest
+    bubblebabble
+    digest
+    hexdigest
+  ].each do |singleton_method|
+    puts "Digest::#{klass}.#{singleton_method}"
+  end
+
+  %w[
+    <<
+    ==
+    block_length
+    digest_length
+    reset
+    update
+    base64digest
+    base64digest!
+    block_length
+    bubblebabble
+    digest
+    digest!
+    digest_length
+    hexdigest
+    hexdigest!
+    inspect
+    length
+    new
+    reset
+    size
+    to_s
+    update
+    finish
+    initialize_copy
+  ].each do |instance_method|
+    puts "Digest::#{klass}##{instance_method}"
+  end
+end

--- a/test/raap.txt
+++ b/test/raap.txt
@@ -1,6 +1,0 @@
-# Specify the class/module and method names to be executed by RaaP.
-# By prefixing with `!`, you can skip testing a method.
-# Lines beginning with `#` are comments.
-
-Set[Integer]
-Enumerable[Integer]#to_set

--- a/test/stdlib/digest/DigestMD5_test.rb
+++ b/test/stdlib/digest/DigestMD5_test.rb
@@ -8,29 +8,11 @@ class DigestMD5SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::MD5)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::MD5, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::MD5, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::MD5, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::MD5',
+                      ::Digest::MD5, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestMD5InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::MD5'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::MD5.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::MD5.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::MD5',
-                     ::Digest::MD5.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::MD5',
-                     ::Digest::MD5.new, :initialize_copy, ::Digest::MD5.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::MD5.new, :==, ::Digest::MD5.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::MD5.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::MD5.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::MD5.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::MD5.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::MD5',
-                     ::Digest::MD5.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::MD5.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::MD5.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::MD5.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::MD5.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::MD5.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::MD5',
+                      ::Digest::MD5.new, :file, name
+    end
   end
 end

--- a/test/stdlib/digest/DigestRMD160_test.rb
+++ b/test/stdlib/digest/DigestRMD160_test.rb
@@ -8,29 +8,11 @@ class DigestRMD160SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::RMD160)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::RMD160, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::RMD160, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::RMD160, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::RMD160',
+                      ::Digest::RMD160, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestRMD160InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::RMD160'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::RMD160.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::RMD160.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::RMD160',
-                     ::Digest::RMD160.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :initialize_copy, ::Digest::RMD160.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::RMD160.new, :==, ::Digest::RMD160.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::RMD160.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::RMD160.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::RMD160.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::RMD160.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::RMD160',
-                     ::Digest::RMD160.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::RMD160.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::RMD160.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::RMD160.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::RMD160.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::RMD160.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::RMD160',
+                      ::Digest::RMD160.new, :file, name
+    end
   end
 end

--- a/test/stdlib/digest/DigestSHA1_test.rb
+++ b/test/stdlib/digest/DigestSHA1_test.rb
@@ -8,29 +8,11 @@ class DigestSHA1SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::SHA1)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA1, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA1, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA1, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::SHA1',
+                      ::Digest::SHA1, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestSHA1InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::SHA1'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA1.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA1.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::SHA1',
-                     ::Digest::SHA1.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :initialize_copy, ::Digest::SHA1.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA1.new, :==, ::Digest::SHA1.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA1.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA1.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA1.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA1.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::SHA1',
-                     ::Digest::SHA1.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA1.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA1.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::SHA1.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA1.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA1.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::SHA1',
+                      ::Digest::SHA1.new, :file, name
+    end
   end
 end

--- a/test/stdlib/digest/DigestSHA256_test.rb
+++ b/test/stdlib/digest/DigestSHA256_test.rb
@@ -8,29 +8,11 @@ class DigestSHA256SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::SHA256)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA256, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA256, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA256, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::SHA256',
+                      ::Digest::SHA256, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestSHA256InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::SHA256'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA256.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA256.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::SHA256',
-                     ::Digest::SHA256.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :initialize_copy, ::Digest::SHA256.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA256.new, :==, ::Digest::SHA256.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA256.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA256.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA256.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA256.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::SHA256',
-                     ::Digest::SHA256.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA256.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA256.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::SHA256.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA256.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA256.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::SHA256',
+                      ::Digest::SHA256.new, :file, name
+    end
   end
 end

--- a/test/stdlib/digest/DigestSHA384_test.rb
+++ b/test/stdlib/digest/DigestSHA384_test.rb
@@ -8,29 +8,11 @@ class DigestSHA384SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::SHA384)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA384, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA384, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA384, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::SHA384',
+                      ::Digest::SHA384, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestSHA384InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::SHA384'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA384.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA384.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::SHA384',
-                     ::Digest::SHA384.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :initialize_copy, ::Digest::SHA384.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA384.new, :==, ::Digest::SHA384.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA384.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA384.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA384.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA384.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::SHA384',
-                     ::Digest::SHA384.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA384.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA384.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::SHA384.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA384.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA384.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::SHA384',
+                      ::Digest::SHA384.new, :file, name
+    end
   end
 end

--- a/test/stdlib/digest/DigestSHA512_test.rb
+++ b/test/stdlib/digest/DigestSHA512_test.rb
@@ -8,29 +8,11 @@ class DigestSHA512SingletonTest < Test::Unit::TestCase
   library 'digest'
   testing 'singleton(::Digest::SHA512)'
 
-  def test_base64digest
-    assert_send_type '(::String str) -> ::String',
-                     ::Digest::SHA512, :base64digest, '_base64digest_'
-  end
-
-  def test_bubblebabble
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :bubblebabble, '_bubblebabble_'
-  end
-
-  def test_digest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :digest, '_digest_'
-  end
-
   def test_file
-    assert_send_type '(::String) -> ::Digest::Class',
-                     ::Digest::SHA512, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(::String) -> ::String',
-                     ::Digest::SHA512, :hexdigest, '_hexdigest_'
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> ::Digest::SHA512',
+                      ::Digest::SHA512, :file, name
+    end
   end
 end
 
@@ -40,123 +22,10 @@ class DigestSHA512InstanceTest < Test::Unit::TestCase
   library 'digest'
   testing '::Digest::SHA512'
 
-  def test_left_shift
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :<<, '_binary_left_shift_'
-  end
-
-  def test_block_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA512.new, :block_length
-  end
-
-  def test_digest_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA512.new, :digest_length
-  end
-
-  def test_reset
-    assert_send_type '() -> Digest::SHA512',
-                     ::Digest::SHA512.new, :reset
-  end
-
-  def test_update
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :update, '_update_'
-  end
-
-  def test_finish
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :finish
-  end
-
-  def test_initialize_copy
-    assert_send_type '(::Digest::Base) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :initialize_copy, ::Digest::SHA512.new
-  end
-
-  def test_equal
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA512.new, :==, ::Digest::SHA512.new
-
-    assert_send_type '(::Digest::Instance | ::String) -> bool',
-                     ::Digest::SHA512.new, :==, '_equal_'
-  end
-
-  def test_base64digest
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA512.new, :base64digest
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA512.new, :base64digest, nil
-
-    assert_send_type '(?::String? str) -> ::String',
-                     ::Digest::SHA512.new, :base64digest, '_base64digest_'
-  end
-
-  def test_base64digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :base64digest!
-  end
-
-  def test_bubblebabble
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :bubblebabble
-  end
-
-  def test_digest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :digest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :digest, '_digest_'
-  end
-
-  def test_digest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :digest
-  end
-
   def test_file
-    assert_send_type '(::String) -> Digest::SHA512',
-                     ::Digest::SHA512.new, :file, 'README.md'
-  end
-
-  def test_hexdigest
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :hexdigest
-
-    assert_send_type '(?::String) -> ::String',
-                     ::Digest::SHA512.new, :hexdigest, '_hexdigest_'
-  end
-
-  def test_hexdigest_bang
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :hexdigest!
-  end
-
-  def test_inspect
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :inspect
-  end
-
-  def test_length
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA512.new, :length
-  end
-
-  def test_new
-    assert_send_type '() -> ::Digest::Base',
-                     ::Digest::SHA512.new, :new
-  end
-
-  def test_size
-    assert_send_type '() -> ::Integer',
-                     ::Digest::SHA512.new, :size
-  end
-
-  def test_to_s
-    assert_send_type '() -> ::String',
-                     ::Digest::SHA512.new, :to_s
+    with_string('README.md') do |name|
+      assert_send_type '(string) -> Digest::SHA512',
+                      ::Digest::SHA512.new, :file, name
+    end
   end
 end


### PR DESCRIPTION
This PR is a retry of https://github.com/ruby/rbs/pull/1779 .

I have stopped returning `bot`.
Then I changed testing method to raap.
The Digest classes require a lot of changes when modifying RBS. If the behavior is mechanical, using raap to handle these changes can reduce management costs compared to manually updating test code. This allows us to focus on changing the signatures.