### PR TITLE
Make it a syntax error when the keys of keyword and record are duplicated.

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -726,6 +726,16 @@ static VALUE parse_proc_type(parserstate *state) {
   return rbs_proc(function, block, loc, proc_self);
 }
 
+static void check_key_duplication(parserstate *state, VALUE fields, VALUE key) {
+  if (!NIL_P(rb_hash_aref(fields, key))) {
+    raise_syntax_error(
+      state,
+      state->current_token,
+      "duplicated record key"
+    );
+  }
+}
+
 /**
  * ... `{` ... `}` ...
  *        >   >
@@ -757,6 +767,7 @@ VALUE parse_record_attributes(parserstate *state) {
     if (is_keyword(state)) {
       // { foo: type } syntax
       key = parse_keyword_key(state);
+      check_key_duplication(state, fields, key);
       parser_advance_assert(state, pCOLON);
     } else {
       // { key => type } syntax
@@ -778,6 +789,7 @@ VALUE parse_record_attributes(parserstate *state) {
           "unexpected record key token"
         );
       }
+      check_key_duplication(state, fields, key);
       parser_advance_assert(state, pFATARROW);
     }
     type = parse_type(state);


### PR DESCRIPTION
Ref https://github.com/ruby/rbs/issues/742

I have made it so that a syntax error is raised when required keyword arguments and optional keyword arguments have duplicate keys.

```rb
$ bundle exec ruby -r rbs -e 'RBS::Parser.parse_method_type("(a: top, a: top) -> void")'
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:15:in `_parse_method_type': a.rbs:1:9...1:10: Syntax error: duplicated keyword argument, token=`a` (tLIDENT) (RBS::ParsingError)

  (a: top, a: top) -> void
           ^
```

Similarly, for record types, I have made it so that a syntax error is raised when there are duplicate keys between required keys and optional keys.

```rb
$ bundle exec ruby -r rbs -e 'RBS::Parser.parse_type("{ a: top, a: top }")'
/Users/ksss/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:10:in `_parse_type': a.rbs:1:10...1:11: Syntax error: duplicated record key, token=`a` (tLIDENT) (RBS::ParsingError)

  { a: top, a: top }
            ^
```

### Benchmark

There appears to be no noticeable deterioration.

```console
$ bundle exec ruby benchmark/benchmark_new_env.rb

# master
ruby 3.3.2 (2024-05-30 revision e5a195edf6) [arm64-darwin22]
Warming up --------------------------------------
             new_env     1.000 i/100ms
       new_rails_env     1.000 i/100ms
Calculating -------------------------------------
             new_env      8.175 (±12.2%) i/s -     81.000 in  10.027816s
       new_rails_env      1.465 (± 0.0%) i/s -     15.000 in  10.281491s

# duplicate-keyword-arguments
ruby 3.3.2 (2024-05-30 revision e5a195edf6) [arm64-darwin22]
Warming up --------------------------------------
             new_env     1.000 i/100ms
       new_rails_env     1.000 i/100ms
Calculating -------------------------------------
             new_env      8.896 (±11.2%) i/s -     88.000 in  10.020704s
       new_rails_env      1.494 (± 0.0%) i/s -     15.000 in  10.076984s
```
