### PR TITLE
Update windows test setup

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -76,21 +76,3 @@ jobs:
       - name: Run test
         run: |
           bundle exec rake ${{ matrix.job }}
-
-  windows:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2019, windows-2022]
-        ruby: [ucrt, mswin]
-    steps:
-      - uses: actions/checkout@v4
-      - name: load ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-      - name: rake-compiler
-        run: gem install rake-compiler
-      - name: compile
-        run: rake compile

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,12 +8,12 @@ on:
   merge_group: {}
 
 jobs:
-  test:
+  compile:
     runs-on: "windows-latest"
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ucrt, mswin]
+        ruby: ['3.2', '3.3', ucrt, mswin]
     steps:
       - uses: actions/checkout@v4
       - name: load ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,11 +9,10 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: "windows-latest"
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2022]
         ruby: [ucrt, mswin]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,27 @@
+name: Ruby on Windows
+
+on:
+  push:
+    branches:
+      - master
+  pull_request: {}
+  merge_group: {}
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2019, windows-2022]
+        ruby: [ucrt, mswin]
+    steps:
+      - uses: actions/checkout@v4
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: rake-compiler
+        run: gem install rake-compiler
+      - name: compile
+        run: rake compile


### PR DESCRIPTION
* Extract `windows.yml` for CI jobs on Windows
* Run the jobs only on `windows-latest`
* Add released ruby versions
* It still tests only compilation

Closes #1884 