### PR TITLE
stdlib: Add type for CSV::Row#initialize

### DIFF
--- a/stdlib/csv/0/csv.rbs
+++ b/stdlib/csv/0/csv.rbs
@@ -2289,6 +2289,33 @@ class CSV::Row < Object
 
   # <!--
   #   rdoc-file=lib/csv/row.rb
+  #   - CSV::Row.new(headers, fields, header_row = false) -> csv_row
+  # -->
+  # Returns the new CSV::Row instance constructed from arguments `headers` and
+  # `fields`; both should be Arrays; note that the fields need not be Strings:
+  #     row = CSV::Row.new(['Name', 'Value'], ['foo', 0])
+  #     row # => #<CSV::Row "Name":"foo" "Value":0>
+  #
+  # If the Array lengths are different, the shorter is `nil`-filled:
+  #     row = CSV::Row.new(['Name', 'Value', 'Date', 'Size'], ['foo', 0])
+  #     row # => #<CSV::Row "Name":"foo" "Value":0 "Date":nil "Size":nil>
+  #
+  # Each CSV::Row object is either a *field row* or a *header row*; by default, a
+  # new row is a field row;  for the row created above:
+  #     row.field_row? # => true
+  #     row.header_row? # => false
+  #
+  # If the optional argument `header_row` is given as `true`, the created row is a
+  # header row:
+  #     row = CSV::Row.new(['Name', 'Value'], ['foo', 0], header_row = true)
+  #     row # => #<CSV::Row "Name":"foo" "Value":0>
+  #     row.field_row? # => false
+  #     row.header_row? # => true
+  #
+  def initialize: (Array[untyped] headers, Array[untyped] fields, ?header_row: bool) -> void
+
+  # <!--
+  #   rdoc-file=lib/csv/row.rb
   #   - row << [header, value] -> self
   #   - row << hash -> self
   #   - row << value -> self

--- a/test/stdlib/CSV_Row_test.rb
+++ b/test/stdlib/CSV_Row_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "csv"
+
+class CSV::RowSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  library 'csv'
+  testing "singleton(::CSV::Row)"
+
+  def test_initialize
+    assert_send_type "(Array[String] headers, Array[String] fields, ?header_row: bool) -> void",
+                     CSV::Row, :new, ["header1", "header2"], ["row1_1", "row1_2"], header_row: true
+    assert_send_type "(Array[String] headers, Array[String] fields) -> void",
+                     CSV::Row, :new, ["header1", "header2"], ["row1_1", "row1_2"]
+    assert_send_type "(Array[Symbol] headers, Array[Symbol] fields) -> void",
+                     CSV::Row, :new, [:header1, :header2], [:row_1, :row_2]
+    assert_send_type "(Array[Integer] headers, Array[Integer] fields) -> void",
+                     CSV::Row, :new, [1, 2], [1, 2]
+  end
+end


### PR DESCRIPTION
Add type to CSV::Row#initialize in stdlib because the type does not exist.

The content of the headers array is `untyped`, because any object can be specified as long as it is an Ruby object.

I placed the test files directly under the `stdlib` directory, but please let me know if you need to create more directories like `stdlib/csv`!