### PR TITLE
[Enumerator#initialize] support `nil`, `#call` and `#to_int`

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -269,6 +269,10 @@ class Enumerator[unchecked out Elem, out Return] < Object
   #
   def feed: (Elem arg0) -> NilClass
 
+  interface _Call
+    def call: () -> untyped
+  end
+
   # <!--
   #   rdoc-file=enumerator.c
   #   - Enumerator.new(size = nil) { |yielder| ... }
@@ -293,7 +297,7 @@ class Enumerator[unchecked out Elem, out Return] < Object
   # lazy fashion (see Enumerator#size). It can either be a value or a callable
   # object.
   #
-  def initialize: (?Integer arg0) { (Enumerator::Yielder arg0) -> Return } -> void
+  def initialize: (?(nil | _Call | ::_ToInt) arg0) { (Enumerator::Yielder arg0) -> Return } -> void
 
   # <!--
   #   rdoc-file=enumerator.c

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -34,6 +34,21 @@ class EnumeratorSingletonTest < Test::Unit::TestCase
   def test_new
     assert_send_type "() { (Enumerator::Yielder) -> 12345 } -> Enumerator[untyped, 12345]",
                      Enumerator, :new do 12345 end
+
+    assert_send_type "(123) { (Enumerator::Yielder) -> nil } -> Enumerator[untyped, nil]",
+                     Enumerator, :new, 123 do nil end
+
+    o = Object.new
+    def o.call = 'hi'
+    assert_send_type "(Enumerator::_Call) { (Enumerator::Yielder) -> nil } -> Enumerator[untyped, nil]",
+                     Enumerator, :new, o do nil end
+    assert_send_type "(Enumerator::_Call) { (Enumerator::Yielder) -> nil } -> Enumerator[untyped, nil]",
+                     Enumerator, :new, ->{'hi'} do nil end
+
+    with_int(123) do |int|
+      assert_send_type "(_ToInt) { (Enumerator::Yielder) -> nil } -> Enumerator[untyped, nil]",
+                       Enumerator, :new, int do nil end
+    end
   end
 
   def test_produce


### PR DESCRIPTION
Argument of `Enumerator#initialize` allows `nil`, `#call` and `#to_int` object.
Included `Float::INFINITY` in `#to_int`.

https://github.com/ruby/ruby/blob/ac9e84df3d0b06e62498aafbca99e8f8475ec142/enumerator.c#L437-L451