### PR TITLE
Fix #1905: Fix typo in UntypedFunction

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1267,7 +1267,7 @@ module RBS
         return_type.has_classish_type?
       end
 
-      def with_nonreturn_void
+      def with_nonreturn_void?
         false
       end
 


### PR DESCRIPTION
The method name was incorrect. `#with_nonreturn_void` should be renamed to `#with_nonreturn_void?`.

refs: #1905 