### PR TITLE
stdlib/zlib: Add types for singleton methods of GzipReader

### DIFF
--- a/stdlib/zlib/0/gzip_reader.rbs
+++ b/stdlib/zlib/0/gzip_reader.rbs
@@ -122,6 +122,9 @@ module Zlib
   class GzipReader < Zlib::GzipFile
     include Enumerable[String]
 
+    def self.wrap: (IO io) -> instance
+                 | (IO io) { (instance gz) -> void } -> void
+
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - Zlib::GzipReader.open(filename) {|gz| ... }
@@ -130,7 +133,8 @@ module Zlib
     # GzipReader object associated with that file.  Further details of this method
     # are in Zlib::GzipReader.new and ZLib::GzipFile.wrap.
     #
-    def self.open: (String filename) { (instance gz) -> void } -> instance
+    def self.open: (String | _ToPath filename) -> instance
+                 | (String | _ToPath filename) { (instance gz) -> void } -> void
 
     # <!--
     #   rdoc-file=ext/zlib/zlib.c

--- a/test/stdlib/zlib/GzipReader_test.rb
+++ b/test/stdlib/zlib/GzipReader_test.rb
@@ -1,0 +1,44 @@
+require_relative "../test_helper"
+require "zlib"
+require "tempfile"
+require "pathname"
+
+class ZlibGzipReaderSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  library "zlib"
+  testing "singleton(::Zlib::GzipReader)"
+
+  def test_open
+    Dir.mktmpdir do |tmpdir|
+      path = File.join(tmpdir, "test.gz")
+      Zlib::GzipWriter.open(path) { _1.puts "hello" }
+
+      assert_send_type "(String filename) -> Zlib::GzipReader",
+                       Zlib::GzipReader, :open, path
+      assert_send_type "(_ToPath filename) -> Zlib::GzipReader",
+                       Zlib::GzipReader, :open, Pathname(path)
+      assert_send_type "(String filename) { (Zlib::GzipReader) -> void } -> void",
+                       Zlib::GzipReader, :open, path do |_| _ end
+      assert_send_type "(_ToPath filename) { (Zlib::GzipReader) -> void } -> void",
+                       Zlib::GzipReader, :open, Pathname(path) do |_| _ end
+    end
+  end
+
+  def test_wrap
+    Dir.mktmpdir do |tmpdir|
+      path = File.join(tmpdir, "test.gz")
+      Zlib::GzipWriter.open(path) { _1.puts "hello" }
+
+      File.open(path) do |io|
+        assert_send_type "(IO io) -> Zlib::GzipReader",
+                         Zlib::GzipReader, :wrap, io
+
+        io.rewind
+
+        assert_send_type "(IO io) { (Zlib::GzipReader gz) -> void } -> void",
+                         Zlib::GzipReader, :wrap, io do |_| _ end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add types for singleton methods of GzipReader.

Also, fix the incorrect types.