### PR TITLE
Use `File.open` instead of `IO.sysopen`

### DIFF
--- a/test/stdlib/FileTest_test.rb
+++ b/test/stdlib/FileTest_test.rb
@@ -6,7 +6,7 @@ class FileTestSingletonTest < Test::Unit::TestCase
   testing "singleton(::FileTest)"
 
 
-  def with_path_io(path: __FILE__, io: default=IO.open(IO.sysopen(File.expand_path(__FILE__))), &block)
+  def with_path_io(path: __FILE__, io: default=File.open(File.expand_path(__FILE__)), &block)
     with_path(path, &block)
     with_io(io, &block)
   ensure


### PR DESCRIPTION
The `default.close` line sometimes raises an error:

https://github.com/ruby/actions/actions/runs/9667790393/job/26670618280#step:16:330

```
  ===============================================================================
  Error: test_grpowned?(FileTestSingletonTest): Errno::EBADF: Bad file descriptor
  test/stdlib/FileTest_test.rb:13:in 'IO#close'
  test/stdlib/FileTest_test.rb:13:in 'FileTestSingletonTest#with_path_io'
  test/stdlib/FileTest_test.rb:73:in 'FileTestSingletonTest#test_grpowned?'
  test/stdlib/io/Buffer_test.rb:67: warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!
  ===============================================================================
```

It's not very clear what is happening, but this PR is trying to use `File` instance instead of `IO` instance. Will run the Ruby CI with this patch and see what will happen.