### PR TITLE
[prototype] Remove redundant access modifier

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -332,8 +332,6 @@ module RBS
 
         public_instance_methods = mod.public_instance_methods.select {|name| target_method?(mod, instance: name) }
         unless public_instance_methods.empty?
-          members << AST::Members::Public.new(location: nil)
-
           public_instance_methods.sort.each do |name|
             method = mod.instance_method(name)
             next if todo_object&.skip_instance_method?(module_name: module_name_absolute, method: method, accessibility: :public)

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -76,8 +76,6 @@ module RBS
 
         def self.baz: () { (*untyped) -> untyped } -> untyped
 
-        public
-
         alias bar foo
 
         def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped) -> untyped
@@ -145,8 +143,6 @@ module RBS
 
         def self.baz: () { (*untyped) -> untyped } -> untyped
 
-        public
-
         alias bar foo
 
         def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped) -> untyped
@@ -191,8 +187,6 @@ module RBS
       class ChildClass < ::RBS::RuntimePrototypeTest::IncludeTests::SuperClass
         def self.foo: () -> untyped
 
-        public
-
         def bar: () -> untyped
 
         def foo: () -> untyped
@@ -200,8 +194,6 @@ module RBS
 
       class SuperClass
         def self.foo: () -> untyped
-
-        public
 
         def foo: () -> untyped
       end
@@ -266,8 +258,6 @@ end
 module RBS
   class RuntimePrototypeTest < ::Test::Unit::TestCase
     class TestForArgumentForwarding
-      public
-
       def foo: (*untyped) { (*untyped) -> untyped } -> untyped
     end
   end
@@ -416,8 +406,6 @@ end
             module RBS
               class RuntimePrototypeTest < ::Test::Unit::TestCase
                 class TestForYield
-                  public
-
                   def m1: () { () -> untyped } -> untyped
 
                   def m2: () { (untyped) -> untyped } -> untyped
@@ -592,8 +580,6 @@ end
               class DefineMethodAlias
                 def self.qux: () -> untyped
 
-                public
-
                 def bar: () -> untyped
 
                 private
@@ -664,8 +650,6 @@ end
 
                 def self.singleton_todo: () -> untyped
 
-                public
-
                 def public_todo: () -> untyped
 
                 private
@@ -685,8 +669,6 @@ end
           module RBS
             class RuntimePrototypeTest < ::Test::Unit::TestCase
               module TodoModule
-                public
-
                 def public_todo: () -> untyped
               end
             end
@@ -952,8 +934,6 @@ end
             class RuntimePrototypeTest < ::Test::Unit::TestCase
               class Redefined
                 def self.constants: () -> untyped
-
-                public
 
                 def class: () -> untyped
               end


### PR DESCRIPTION
Method visibility is public by default.
`public` is always redundant because the order in which methods appear is always guaranteed at `rbs prototype runtime`.