### PR TITLE
Add `Enumerator::_Each` interface

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -130,6 +130,13 @@
 class Enumerator[unchecked out Elem, out Return] < Object
   include Enumerable[Elem]
 
+  # A convenience interface for `each` with optional block
+  #
+  interface _Each[out E, out R]
+    def each: () { (E) -> void } -> R
+            | () -> Enumerator[E, R]
+  end
+
   # <!--
   #   rdoc-file=enumerator.c
   #   - Enumerator.produce(initial = nil) { |prev| block } -> enumerator

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -64,7 +64,7 @@ Interface type denotes _type of a value which can be a subtype of the interface_
 
 ```rbs
 _ToS                          # _ToS interface
-::MyApp::_Each[String]        # Interface name with namespace and type application
+::Enumerator::_Each[String]   # Interface name with namespace and type application
 ```
 
 ### Alias type


### PR DESCRIPTION
It is a common pattern for `#each` to support both yielding to a block and returning an `Enumerator` when no block given.
I add this interface as a convenience for library classes; it is _not_ a replacement for `::_Each`, which does not require no-block support.

> soutaro just for clarity, I'm not arguing for a revision of the existing one, but to add a new one. The reasoning is, the current `_Each` already describes the requirement for implementing a class decorated with `Enumerable`. But an `_EnumEach` is common enough (IMO) to warrant defining it as a common interface (as most core and stdlib enumerables already do it).
> ⸺ https://github.com/ruby/rbs/issues/424#issuecomment-712034447

I put this interface under the `Enumerator` namespace to represent how it’s a “special” edition.
Regarding why I’m sticking with `_Each`:
> I think `_MethodName` should be restricted to interfaces that implement that `method_name` minimally.
> […]
> If you want to specify that your class implements `each` "correctly", then yes, you should have these two interfaces and a shorthand might be useful.
> ⸺ https://github.com/ruby/rbs/issues/424#issuecomment-711449179

* Resolves #424
  * more like – necroposts it 😁
  * Feel free to continue discussing the design in the issue and leave just the technical details here.