### PR TITLE
Type signature updates for Enumerable, Module, Range, Array

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1082,7 +1082,7 @@ class Array[unchecked out Elem] < Object
   #     a.at(0) # => :foo
   #     a.at(2) # => 2
   #
-  def at: (int index) -> Elem?
+  def at: %a{implicitly-returns-nil} (int index) -> Elem
 
   # <!--
   #   rdoc-file=array.c
@@ -1378,7 +1378,7 @@ class Array[unchecked out Elem] < Object
   #
   # If `index` is too small (far from zero), returns nil.
   #
-  def delete_at: (int index) -> Elem?
+  def delete_at: %a{implicitly-returns-nil} (int index) -> Elem
 
   # <!--
   #   rdoc-file=array.c
@@ -1942,7 +1942,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: #last.
   #
-  def first: () -> Elem?
+  def first: %a{implicitly-returns-nil} () -> Elem
            | (int n) -> ::Array[Elem]
 
   # <!--
@@ -2241,7 +2241,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: #first.
   #
-  def last: () -> Elem?
+  def last: %a{implicitly-returns-nil} () -> Elem
           | (int n) -> ::Array[Elem]
 
   # <!--
@@ -2321,8 +2321,8 @@ class Array[unchecked out Elem] < Object
   #
   #     ['0', '00', '000'].max(2) {|a, b| a.size <=> b.size } # => ["000", "00"]
   #
-  def max: () -> Elem?
-         | () { (Elem a, Elem b) -> ::Integer? } -> Elem?
+  def max: %a{implicitly-returns-nil} () -> Elem
+         | %a{implicitly-returns-nil} () { (Elem a, Elem b) -> ::Integer? } -> Elem
          | (int n) -> ::Array[Elem]
          | (int n) { (Elem a, Elem b) -> ::Integer? } -> ::Array[Elem]
 
@@ -3118,7 +3118,7 @@ class Array[unchecked out Elem] < Object
   #     a.sample(random: Random.new(1))     #=> 6
   #     a.sample(4, random: Random.new(1))  #=> [6, 10, 9, 2]
   #
-  def sample: (?random: _Rand rng) -> Elem?
+  def sample: %a{implicitly-returns-nil} (?random: _Rand rng) -> Elem
             | (int n, ?random: _Rand rng) -> ::Array[Elem]
 
   # <!--
@@ -3197,7 +3197,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: #push, #pop, #unshift.
   #
-  def shift: () -> Elem?
+  def shift: %a{implicitly-returns-nil} () -> Elem
            | (int n) -> ::Array[Elem]
 
   # <!--
@@ -3323,7 +3323,7 @@ class Array[unchecked out Elem] < Object
   #     # Raises TypeError (no implicit conversion of Symbol into Integer):
   #     a[:foo]
   #
-  def slice: (int index) -> Elem?
+  def slice: %a{implicitly-returns-nil} (int index) -> Elem
            | (int start, int length) -> ::Array[Elem]?
            | (::Range[::Integer] range) -> ::Array[Elem]?
 
@@ -3393,7 +3393,7 @@ class Array[unchecked out Elem] < Object
   #     a.slice!(-2..2) # => ["bar", 2]
   #     a # => [:foo]
   #
-  def slice!: (int index) -> Elem?
+  def slice!: %a{implicitly-returns-nil} (int index) -> Elem
             | (int start, int length) -> ::Array[Elem]?
             | (::Range[::Integer] range) -> ::Array[Elem]?
 

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -528,6 +528,12 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def entries: () -> ::Array[Elem]
 
+  def enum_for: (Symbol method, *untyped, **untyped) ?{ (*untyped, **untyped) -> Integer } -> Enumerator[untyped, untyped]
+    | () ?{ () -> Integer } -> Enumerator[Elem, self]
+
+  %a{annotate:rdoc:skip}
+  alias to_enum enum_for
+
   # <!--
   #   rdoc-file=enum.c
   #   - select {|element| ... } -> array

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -396,7 +396,7 @@ class Module < Object
   #
   #     Hello there!
   #
-  def class_exec: [U] (*untyped args) { () -> U } -> U
+  def class_exec: [U, V] (*V args) { (*V args) [self: self] -> U } -> U
 
   # <!--
   #   rdoc-file=object.c

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -245,6 +245,36 @@ class Range[out Elem] < Object
 
   # <!--
   #   rdoc-file=range.c
+  #   - %(n) {|element| ... } -> self
+  #   - %(n)                  -> enumerator
+  # -->
+  # Iterates over the elements of `self`.
+  #
+  # With a block given, calls the block with selected elements of the range;
+  # returns `self`:
+  #
+  #     a = []
+  #     (1..5).%(2) {|element| a.push(element) } # => 1..5
+  #     a # => [1, 3, 5]
+  #     a = []
+  #     ('a'..'e').%(2) {|element| a.push(element) } # => "a".."e"
+  #     a # => ["a", "c", "e"]
+  #
+  # With no block given, returns an enumerator, which will be of class
+  # Enumerator::ArithmeticSequence if `self` is numeric; otherwise of class
+  # Enumerator:
+  #
+  #     e = (1..5) % 2 # => ((1..5).%(2))
+  #     e.class        # => Enumerator::ArithmeticSequence
+  #     ('a'..'e') % 2 # =>  #<Enumerator: ...>
+  #
+  # Related: Range#step.
+  #
+  def %: (Numeric | int n) -> Enumerator[Elem, self]
+    | (Numeric | int n) { (Elem element) -> void } -> self
+
+  # <!--
+  #   rdoc-file=range.c
   #   - self == other -> true or false
   # -->
   # Returns `true` if and only if:

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -3,6 +3,13 @@ require_relative "test_helper"
 class EnumerableTest < StdlibTest
   target Enumerable
 
+  def test_enum_for
+    enumerable.enum_for
+    enumerable.enum_for { 0 }
+    enumerable.enum_for(:each)
+    enumerable.enum_for(:each) { 0 }
+  end
+
   def test_find_all
     enumerable.find_all
     enumerable.find_all { |x| x.even? }
@@ -192,6 +199,13 @@ class EnumerableTest2 < Test::Unit::TestCase
       "(Integer) { (Array[String]) -> void } -> EnumerableTest2::TestEnumerable",
       TestEnumerable.new, :each_slice, 2
     ) do end
+  end
+
+  def test_enum_for
+    assert_send_type(
+      "() ?{ () -> Integer } -> Enumerator[String, EnumerableTest2::TestEnumerable]",
+      TestEnumerable.new, :enum_for
+    )
   end
 
   def test_find_index

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -130,6 +130,12 @@ class ModuleInstanceTest < Test::Unit::TestCase
                      Foo, :class_eval do nil end
   end
 
+  def test_class_exec
+    assert_send_type '(*String) { (*String) [self: Foo] -> Integer } -> Integer',
+                      Foo, :class_exec, '1', '2' do |*x| x.join.to_i end
+  end
+
+
   def test_alias_method
     mod = Module.new do
       def foo

--- a/test/stdlib/Range_test.rb
+++ b/test/stdlib/Range_test.rb
@@ -94,6 +94,11 @@ class RangeTest < StdlibTest
     (1..10).min(3) { |i, j| i <=> j }
   end
 
+  def test_percent
+    (1..10).%(2)
+    ('A'...'Z').%(2) { |s| s.downcase }
+  end
+
   def test_size
     (1..10).size
     ('A'...'Z').size


### PR DESCRIPTION
These are some type signature updates, mostly following on from the discussion here: https://github.com/ruby/rbs/pull/1226, but also some additional ones on top of it.

I've made the following changes:
* `Enumerable` - added a more specific type override for `enum_for`/`to_enum` for the default (`:each`/no-arg) case; this override means that we know the `Enumerator` returned will be iterating over elements of type `Elem`. I think that this is a sensible override to provide because of the type from `_Each`. I wasn't sure if the overrides should go here or in the `_Each` interface, but it felt strange putting more things into `_Each` when it's currently clean and simple.

* `Module` - improved the type signature for `class_exec` to be similar to `instance_exec`. Specifically it now shows that arguments passed are forwarded to the block, and that the block has a `self` type based on the receiver.

* `Range` - added a type signature for `%` as it was missing. This one is a copy/paste from `step`, minus the optional parameters.

* `Array` - added some more `%a{implicitly-returns-nil}` annotations. I've only added them in locations that looked similar to the original for `[]`, where they may return `nil` if an index is out of bounds or the array is empty, as this is typically knowledge that is checked beforehand. Happy to reduce the number added though if it is too many. I haven't added any to `Enumerable` as there is no size/length/empty methods, so `Hash#first` will not have this annotation.

Let me know if there's anything I missed or items you'd like me to change.