### PR TITLE
Loosen the self-type constraint for Net::HTTPHeader

### DIFF
--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -2437,7 +2437,7 @@ module Net
   # *   #each_name: Passes each field name to the block.
   # *   #each_value: Passes each string field value to the block.
   #
-  module HTTPHeader
+  module HTTPHeader : BasicObject
     # <!--
     #   rdoc-file=lib/net/http/header.rb
     #   - initialize_http_header(initheader)


### PR DESCRIPTION
Net::HTTPHeader could be included by classes that do not inherit `::Object` and we need to loosen the self-type constraint.

For example, [HTTParty::Response::Headers](https://github.com/ruby/gem_rbs_collection/blob/97c2a835c0a21a5e54204eca5f1c9caba2dbd89c/gems/httparty/0.18/httparty.rbs#L452-L453), which includes `Net::HTTPHeader`, inherits `SimpleDelegator < Delegator < BasicObject`. With the current definition, it causes an error like below:

```
/workspaces/gem_rbs_collection/gems/httparty/0.18/_test/.gem_rbs_collection/httparty/0.18/httparty.rbs:453:6: [error] Module self type constraint in type `::HTTParty::Response::Headers` doesn't satisfy: `::HTTParty::Response::Headers <: ::Object`
│ Diagnostic ID: RBS::ModuleSelfTypeError
│
└       include Net::HTTPHeader
        ~~~~~~~~~~~~~~~~~~~~~~~
```

Note that to reproduce the error above, you need to modify the manifest.yml like below:

```patch
diff --git a/gems/httparty/0.18/manifest.yaml b/gems/httparty/0.18/manifest.yaml
index a5128c3..8d0d7ab 100644
--- a/gems/httparty/0.18/manifest.yaml
+++ b/gems/httparty/0.18/manifest.yaml
@@ -1,3 +1,4 @@
 dependencies:
   - name: uri
   - name: net-http
+  - name: delegate
```

I also considered defining an interface instead of using BasicObject at first, but it seems the following syntax is illegal.

```rbs
interface _HasHeader
  @header: Hash[String,  untyped]
end
```