### PR TITLE
Use untyped blocks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,8 @@ jobs:
           bundler: none
       - name: Set working directory as safe
         run: git config --global --add safe.directory $(pwd)
+      - name: Set up permission
+        run: chmod -R o-w /opt/hostedtoolcache/Ruby
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,4 +182,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.4.18
+   2.5.16

--- a/core/basic_object.rbs
+++ b/core/basic_object.rbs
@@ -163,7 +163,7 @@ class BasicObject
   #     k = Klass.new
   #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
   #
-  def __send__: (interned name, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped
+  def __send__: (interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped
 
   # <!-- rdoc-file=object.c -->
   # Equality --- At the Object level, #== returns `true` only if `obj` and `other`
@@ -248,7 +248,7 @@ class BasicObject
   #     k = KlassWithSecret.new
   #     k.instance_exec(5) {|x| @secret+x }   #=> 104
   #
-  def instance_exec: [U, V] (*V args) { (*V args) [self: self] -> U } -> U
+  def instance_exec: [U] (*untyped, **untyped) { (?) [self: self] -> U } -> U
 
   # <!--
   #   rdoc-file=object.c
@@ -295,7 +295,7 @@ class BasicObject
   #     r.mm      #=> 2000
   #     r.foo     #=> NoMethodError
   #
-  def method_missing: (Symbol, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped
+  def method_missing: (Symbol, *untyped, **untyped) ?{ (?) -> untyped } -> untyped
 
   # <!--
   #   rdoc-file=object.c

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -528,7 +528,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def entries: () -> ::Array[Elem]
 
-  def enum_for: (Symbol method, *untyped, **untyped) ?{ (*untyped, **untyped) -> Integer } -> Enumerator[untyped, untyped]
+  def enum_for: (Symbol method, *untyped, **untyped) ?{ (?) -> Integer } -> Enumerator[untyped, untyped]
     | () ?{ () -> Integer } -> Enumerator[Elem, self]
 
   %a{annotate:rdoc:skip}

--- a/core/fiber.rbs
+++ b/core/fiber.rbs
@@ -268,7 +268,7 @@ class Fiber < Object
   # Explicitly using `storage: true` is currently experimental and may change in
   # the future.
   #
-  def initialize: (?blocking: boolish, ?storage: true | Hash[interned, untyped] | nil) { (*untyped) -> void } -> void
+  def initialize: (?blocking: boolish, ?storage: true | Hash[interned, untyped] | nil) { (?) -> void } -> void
 
   # <!--
   #   rdoc-file=cont.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -2153,7 +2153,7 @@ module Kernel : BasicObject
   #     chris.greet("Hi") #=> "Hi, I'm Chris!"
   #
   def define_singleton_method: (interned, Method | UnboundMethod | Proc method) -> Symbol
-                             | (interned) { (*untyped) -> untyped } -> Symbol
+                             | (interned) { (?) -> untyped } -> Symbol
 
   # <!--
   #   rdoc-file=io.c
@@ -2267,7 +2267,7 @@ module Kernel : BasicObject
   #     enum.first(4) # => [1, 1, 1, 2]
   #     enum.size # => 42
   #
-  def enum_for: (Symbol method, *untyped, **untyped) ?{ (*untyped, **untyped) -> Integer } -> Enumerator[untyped, untyped]
+  def enum_for: (Symbol method, *untyped, **untyped) ?{ (?) -> Integer } -> Enumerator[untyped, untyped]
               | () ?{ () -> Integer } -> Enumerator[untyped, self]
 
   %a{annotate:rdoc:skip}
@@ -2722,7 +2722,7 @@ module Kernel : BasicObject
   #
   #     1.public_send(:puts, "hello")  # causes NoMethodError
   #
-  def public_send: (interned name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  def public_send: (interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped
 
   # <!--
   #   rdoc-file=object.c
@@ -2808,7 +2808,7 @@ module Kernel : BasicObject
   #     k = Klass.new
   #     k.send :hello, "gentle", "readers"   #=> "Hello gentle readers"
   #
-  def send: (interned name, *untyped args) ?{ (*untyped) -> untyped } -> untyped
+  def send: (interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped
 
   # <!--
   #   rdoc-file=object.c

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -396,7 +396,7 @@ class Module < Object
   #
   #     Hello there!
   #
-  def class_exec: [U, V] (*V args) { (*V args) [self: self] -> U } -> U
+  def class_exec: [U] (*untyped, **untyped) { (?) [self: self] -> U } -> U
 
   # <!--
   #   rdoc-file=object.c
@@ -1106,7 +1106,7 @@ class Module < Object
   #
   #     Hello there!
   #
-  def module_exec: [U] (*untyped args) { (*untyped args) -> U } -> U
+  def module_exec: [U] (*untyped, **untyped) { (?) [self: self] -> U } -> U
 
   # <!--
   #   rdoc-file=vm_method.c

--- a/core/proc.rbs
+++ b/core/proc.rbs
@@ -480,7 +480,7 @@ class Proc < Object
   #
   #     Proc.new    #=> ArgumentError
   #
-  def initialize: () { (*untyped) -> untyped } -> void
+  def initialize: () { (?) -> untyped } -> void
 
   # <!--
   #   rdoc-file=proc.c

--- a/core/ractor.rbs
+++ b/core/ractor.rbs
@@ -355,7 +355,7 @@ class Ractor
   #     p r
   #     #=> #<Ractor:#3 my ractor test.rb:1 terminated>
   #
-  def self.new: (*untyped args, ?name: string) { (*untyped) -> untyped } -> Ractor
+  def self.new: (*untyped args, ?name: string) { (?) -> untyped } -> Ractor
 
   # <!--
   #   rdoc-file=ractor.rb

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -382,7 +382,7 @@ class Thread < Object
   # If you're going to subclass Thread, be sure to call super in your `initialize`
   # method, otherwise a ThreadError will be raised.
   #
-  def initialize: (*untyped) { (*untyped) -> void } -> void
+  def initialize: (*untyped) { (?) -> void } -> void
 
   # <!--
   #   rdoc-file=thread.c
@@ -1178,7 +1178,7 @@ class Thread < Object
   # calling `start` in that subclass will not invoke the subclass's `initialize`
   # method.
   #
-  def self.start: (*untyped args) { (*untyped) -> void } -> instance
+  def self.start: (*untyped args) { (?) -> void } -> instance
 
   # <!--
   #   rdoc-file=thread.c

--- a/core/unbound_method.rbs
+++ b/core/unbound_method.rbs
@@ -325,5 +325,5 @@ class UnboundMethod
   # arguments. This is semantically equivalent to `umeth.bind(recv).call(args,
   # ...)`.
   #
-  def bind_call: (untyped recv, *untyped, **untyped) ?{ (*untyped, **untyped) -> untyped } -> untyped
+  def bind_call: (untyped recv, *untyped, **untyped) ?{ (?) -> untyped } -> untyped
 end

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -150,6 +150,8 @@ module RBS
       end
 
       def zip_args(args, fun, &block)
+        return true if fun.is_a?(Types::UntypedFunction)
+        
         case
         when args.empty?
           if fun.required_positionals.empty? && fun.trailing_positionals.empty? && fun.required_keywords.empty?

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1278,6 +1278,17 @@ module RBS
       def return_to_s
         return_type.to_s(1)
       end
+
+      def ==(other)
+        other.is_a?(UntypedFunction) && other.return_type == return_type
+      end
+
+      alias eql? ==
+
+      def hash
+        self.class.hash ^ return_type.hash
+      end
+
     end
 
     class Block

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -446,6 +446,12 @@ module RBS
       def has_classish_type?: () -> bool
 
       def with_nonreturn_void?: () -> bool
+
+      def ==: (untyped) -> bool
+
+      alias eql? ==
+
+      def hash: () -> Integer
     end
 
     # Function type without type checking arguments
@@ -489,6 +495,12 @@ module RBS
 
       # Returns `return_type.to_s(1)`
       def return_to_s: () -> String
+
+      def ==: (untyped) -> bool
+
+      alias eql? ==
+
+      def hash: () -> Integer
     end
 
     type function = Types::Function | Types::UntypedFunction

--- a/steep/Gemfile.lock
+++ b/steep/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   steep
 
 BUNDLED WITH
-   2.4.18
+   2.5.16

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2328,12 +2328,12 @@ end
       definition_builder = RBS::DefinitionBuilder.new(env: env.resolve_type_names)
       definition_builder.build_instance(TypeName("::Foo")).tap do |defn|
         defn.methods[:request].tap do |m|
-          assert_equal ["(::interned name, *untyped args) ?{ (*untyped) -> untyped } -> untyped"], m.method_types.map(&:to_s)
+          assert_equal ["(::interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped"], m.method_types.map(&:to_s)
         end
       end
       definition_builder.build_instance(TypeName("::Mod")).tap do |defn|
         defn.methods[:request].tap do |m|
-          assert_equal ["(::interned name, *untyped args) ?{ (*untyped) -> untyped } -> untyped"], m.method_types.map(&:to_s)
+          assert_equal ["(::interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped"], m.method_types.map(&:to_s)
         end
       end
   end

--- a/test/stdlib/Module_test.rb
+++ b/test/stdlib/Module_test.rb
@@ -135,7 +135,6 @@ class ModuleInstanceTest < Test::Unit::TestCase
                       Foo, :class_exec, '1', '2' do |*x| x.join.to_i end
   end
 
-
   def test_alias_method
     mod = Module.new do
       def foo

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -296,37 +296,37 @@ SIG
   end
 end
 
-if $0.end_with?("_test.rb")
-  at_exit do
-    argv = ARGV.dup
-    test_unit_args = []
+# if $0.end_with?("_test.rb")
+#   at_exit do
+#     argv = ARGV.dup
+#     test_unit_args = []
 
-    OptionParser.new do |opts|
-      opts.on("--name NAME") do |name|
-        name = name.gsub(/(\A\/)|(\/\Z)/, '')
-        klass_name, method_name = name.split("#", 2)
+#     OptionParser.new do |opts|
+#       opts.on("--name NAME") do |name|
+#         name = name.gsub(/(\A\/)|(\/\Z)/, '')
+#         klass_name, method_name = name.split("#", 2)
 
-        constant = ObjectSpace.each_object(Class).find do |klass|
-          if klass.name
-            klass.name == klass_name || klass.name.end_with?("::#{klass_name}")
-          end
-        end
+#         constant = ObjectSpace.each_object(Class).find do |klass|
+#           if klass.name
+#             klass.name == klass_name || klass.name.end_with?("::#{klass_name}")
+#           end
+#         end
 
-        if constant
-          if method_name
-            test_unit_args << "--name"
-            test_unit_args << "#{constant.name}##{method_name}"
-          else
-            test_unit_args << "--testcase"
-            test_unit_args << constant.name
-          end
-        end
-      end
-    end.order!(argv)
-    test_unit_args.push(*argv)
+#         if constant
+#           if method_name
+#             test_unit_args << "--name"
+#             test_unit_args << "#{constant.name}##{method_name}"
+#           else
+#             test_unit_args << "--testcase"
+#             test_unit_args << constant.name
+#           end
+#         end
+#       end
+#     end.order!(argv)
+#     test_unit_args.push(*argv)
 
-    RBS.logger.info { "Forwarding to test-unit command line: #{test_unit_args.inspect}" }
+#     RBS.logger.info { "Forwarding to test-unit command line: #{test_unit_args.inspect}" }
 
-    Test::Unit::AutoRunner.run(false, nil, test_unit_args)
-  end
-end
+#     Test::Unit::AutoRunner.run(false, nil, test_unit_args)
+#   end
+# end

--- a/test/typecheck/untyped-blocks/Steepfile
+++ b/test/typecheck/untyped-blocks/Steepfile
@@ -1,0 +1,7 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/untyped-blocks/class_exec.rb
+++ b/test/typecheck/untyped-blocks/class_exec.rb
@@ -1,0 +1,23 @@
+Object.class_exec(1, "2", :hello) do |a, b, c|
+  # @type var a: Integer
+  # @type var b: String
+  # @type var c: Symbol
+
+  a + 2
+  b + "2"
+  c.id2name
+
+  self.name
+end
+
+Object.module_exec(1, "2", :hello) do |a, b, c|
+  # @type var a: Integer
+  # @type var b: String
+  # @type var c: Symbol
+
+  a + 2
+  b + "2"
+  c.id2name
+
+  self.name
+end

--- a/test/typecheck/untyped-blocks/class_exec.rb
+++ b/test/typecheck/untyped-blocks/class_exec.rb
@@ -3,8 +3,8 @@ Object.class_exec(1, "2", :hello) do |a, b, c|
   # @type var b: String
   # @type var c: Symbol
 
-  a + 2
-  b + "2"
+  p a + 2
+  p b + "2"
   c.id2name
 
   self.name
@@ -15,8 +15,8 @@ Object.module_exec(1, "2", :hello) do |a, b, c|
   # @type var b: String
   # @type var c: Symbol
 
-  a + 2
-  b + "2"
+  p a + 2
+  p b + "2"
   c.id2name
 
   self.name

--- a/test/typecheck/untyped-blocks/instance_exec.rb
+++ b/test/typecheck/untyped-blocks/instance_exec.rb
@@ -1,0 +1,12 @@
+
+"".instance_exec(1, "2", :hello) do |a, b, c|
+  # @type var a: Integer
+  # @type var b: String
+  # @type var c: Symbol
+
+  a + 2
+  b + "2"
+  c.id2name
+
+  self.size
+end

--- a/test/typecheck/untyped-blocks/instance_exec.rb
+++ b/test/typecheck/untyped-blocks/instance_exec.rb
@@ -4,8 +4,8 @@
   # @type var b: String
   # @type var c: Symbol
 
-  a + 2
-  b + "2"
+  p a + 2
+  p b + "2"
   c.id2name
 
   self.size

--- a/test/typecheck/untyped-blocks/proc.rb
+++ b/test/typecheck/untyped-blocks/proc.rb
@@ -1,0 +1,4 @@
+Proc.new do |x|
+  # @type var x: Integer
+  x + 1
+end

--- a/test/typecheck/untyped-blocks/send.rb
+++ b/test/typecheck/untyped-blocks/send.rb
@@ -2,22 +2,22 @@
   # @type var x: Integer
   # @type var y: String
 
-  x + 1
-  y + ""
+  p x + 1
+  p y + ""
 end
 
 1.send(:foo, 1, "a") do |x, y|
   # @type var x: Integer
   # @type var y: String
 
-  x + 1
-  y + ""
+  p x + 1
+  p y + ""
 end
 
 1.public_send(:foo, 1, "a") do |x, y|
   # @type var x: Integer
   # @type var y: String
 
-  x + 1
-  y + ""
+  p x + 1
+  p y + ""
 end

--- a/test/typecheck/untyped-blocks/send.rb
+++ b/test/typecheck/untyped-blocks/send.rb
@@ -1,0 +1,23 @@
+1.__send__(:foo, 1, "a") do |x, y|
+  # @type var x: Integer
+  # @type var y: String
+
+  x + 1
+  y + ""
+end
+
+1.send(:foo, 1, "a") do |x, y|
+  # @type var x: Integer
+  # @type var y: String
+
+  x + 1
+  y + ""
+end
+
+1.public_send(:foo, 1, "a") do |x, y|
+  # @type var x: Integer
+  # @type var y: String
+
+  x + 1
+  y + ""
+end

--- a/test/typecheck/untyped-blocks/thread.rb
+++ b/test/typecheck/untyped-blocks/thread.rb
@@ -1,0 +1,3 @@
+Thread.new(1,2,3) do |x, y, z|
+  x + y + z
+end


### PR DESCRIPTION
`() { (*untyped) -> void } -> void` means a block can receive any number of arguments. It is usually something different from what we want to methods like `#instance_exec`.

```rb
def instance_exec: [U] (*untyped) { (*untyped) [self: self] -> U } -> U
```

We don't need the blocks to accept any number of arguments, but the block should accept a specific set of arguments that is actually given to the `instance_eval` call. Unfortunately, this type cannot be written in RBS.

We then use the *untyped block params* syntax for this case.

Q: Why Steep doesn't detect a type error with `*untyped` types?
A: It might be a bug...