### PR TITLE
Allow alias to module-self-type from module

### DIFF
--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -116,6 +116,7 @@ module RBS
       Definition class_definition,
       MethodBuilder::Methods::Definition method_definition,
       Substitution subst,
+      Hash[Symbol, Definition::Method]? self_type_methods,
       defined_in: TypeName,
       ?implemented_in: TypeName?
     ) -> void
@@ -137,7 +138,8 @@ module RBS
       TypeName module_name,
       MethodBuilder::Methods module_methods,
       interface_methods interface_methods,
-      Substitution subst
+      Substitution subst,
+      Hash[Symbol, Definition::Method]? self_type_methods,
     ) -> void
 
     # Updates `definition` with methods and variables of `type_name` that can be a module or a class

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2686,4 +2686,23 @@ end
       end
     end
   end
+
+  def test_alias__to_module_self_indierect_method
+    SignatureManager.new(system_builtin: false) do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+module Kernel
+  alias foo __id__
+end
+
+module Foo
+end
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::Foo"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Defining an alias from a module to its module-self-type causes an error like

```
RBS::UnknownMethodAliasError: .../foo.rbs:2:2...2:18: Unknown method alias name: __id__ => foo (::Foo)
```

This PR fixes the problem.