### PR TITLE
Dedup empty arrays in parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     psych (4.0.6)
       stringio
     public_suffix (6.0.1)
-    raap (0.8.0)
+    raap (1.0.0)
       rbs (~> 3.0)
       timeout (~> 0.4)
     racc (1.8.1)

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1134,7 +1134,7 @@ VALUE parse_type(parserstate *state) {
   type_param ::= tUIDENT                            (module_type_params == false)
 */
 VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) {
-  VALUE params = rb_ary_new();
+  VALUE params = EMPTY_ARRAY;
 
   if (state->next_token.type == pLBRACKET) {
     parser_advance(state);
@@ -1210,6 +1210,7 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
       rbs_loc_add_optional_child(loc, rb_intern("upper_bound"), upper_bound_range);
 
       VALUE param = rbs_ast_type_param(name, variance, unchecked, upper_bound, location);
+      melt_array(&params);
       rb_ary_push(params, param);
 
       if (state->next_token.type == pCOMMA) {

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2267,7 +2267,7 @@ void parse_module_self_types(parserstate *state, VALUE array) {
     VALUE module_name = parse_type_name(state, CLASS_NAME | INTERFACE_NAME, &name_range);
     self_range.end = name_range.end;
 
-    VALUE args = rb_ary_new();
+    VALUE args = EMPTY_ARRAY;
     if (state->next_token.type == pLBRACKET) {
       parser_advance(state);
       args_range.start = state->current_token.range.start;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2283,6 +2283,7 @@ void parse_module_self_types(parserstate *state, VALUE array) {
     rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
 
     VALUE self_type = rbs_ast_decl_module_self(module_name, args, location);
+    melt_array(&array);
     rb_ary_push(array, self_type);
 
     if (state->next_token.type == pCOMMA) {
@@ -2394,7 +2395,7 @@ VALUE parse_module_decl0(parserstate *state, range keyword_range, VALUE module_n
   decl_range.start = keyword_range.start;
 
   VALUE type_params = parse_type_params(state, &type_params_range, true);
-  VALUE self_types = rb_ary_new();
+  VALUE self_types = EMPTY_ARRAY;
 
   if (state->next_token.type == pCOLON) {
     parser_advance(state);

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1461,6 +1461,7 @@ void parse_annotations(parserstate *state, VALUE annotations, position *annot_po
         *annot_pos = state->current_token.range.start;
       }
 
+      melt_array(&annotations);
       rb_ary_push(annotations, parse_annotation(state));
     } else {
       break;
@@ -1645,7 +1646,7 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
 
   bool loop = true;
   while (loop) {
-    VALUE annotations = rb_ary_new();
+    VALUE annotations = EMPTY_ARRAY;
     position overload_annot_pos = NullPosition;
 
     if (state->next_token.type == tANNOTATION) {
@@ -2166,7 +2167,7 @@ VALUE parse_interface_members(parserstate *state) {
   VALUE members = rb_ary_new();
 
   while (state->next_token.type != kEND) {
-    VALUE annotations = rb_ary_new();
+    VALUE annotations = EMPTY_ARRAY;
     position annot_pos = NullPosition;
 
     parse_annotations(state, annotations, &annot_pos);
@@ -2310,7 +2311,7 @@ VALUE parse_module_members(parserstate *state) {
 
   while (state->next_token.type != kEND) {
     VALUE member;
-    VALUE annotations = rb_ary_new();
+    VALUE annotations = EMPTY_ARRAY;
     position annot_pos = NullPosition;
 
     parse_annotations(state, annotations, &annot_pos);
@@ -2648,7 +2649,7 @@ VALUE parse_nested_decl(parserstate *state, const char *nested_in, position anno
 }
 
 VALUE parse_decl(parserstate *state) {
-  VALUE annotations = rb_ary_new();
+  VALUE annotations = EMPTY_ARRAY;
   position annot_pos = NullPosition;
 
   parse_annotations(state, annotations, &annot_pos);

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2253,7 +2253,7 @@ VALUE parse_interface_decl(parserstate *state, position comment_pos, VALUE annot
   module_self_type ::= <module_name>
                      | module_name `[` type_list <`]`>
 */
-void parse_module_self_types(parserstate *state, VALUE array) {
+void parse_module_self_types(parserstate *state, VALUE *array) {
   while (true) {
     range self_range;
     range name_range;
@@ -2282,8 +2282,8 @@ void parse_module_self_types(parserstate *state, VALUE array) {
     rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
 
     VALUE self_type = rbs_ast_decl_module_self(module_name, args, location);
-    melt_array(&array);
-    rb_ary_push(array, self_type);
+    melt_array(array);
+    rb_ary_push(*array, self_type);
 
     if (state->next_token.type == pCOMMA) {
       parser_advance(state);
@@ -2401,7 +2401,7 @@ VALUE parse_module_decl0(parserstate *state, range keyword_range, VALUE module_n
     parser_advance(state);
     colon_range = state->current_token.range;
     self_types_range.start = state->next_token.range.start;
-    parse_module_self_types(state, self_types);
+    parse_module_self_types(state, &self_types);
     self_types_range.end = state->current_token.range.end;
   } else {
     colon_range = NULL_RANGE;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2838,14 +2838,16 @@ VALUE parse_use_directive(parserstate *state) {
 }
 
 VALUE parse_signature(parserstate *state) {
-  VALUE dirs = rb_ary_new();
-  VALUE decls = rb_ary_new();
+  VALUE dirs = EMPTY_ARRAY;
+  VALUE decls = EMPTY_ARRAY;
 
   while (state->next_token.type == kUSE) {
+    melt_array(&dirs);
     rb_ary_push(dirs, parse_use_directive(state));
   }
 
   while (state->next_token.type != pEOF) {
+    melt_array(&decls);
     rb_ary_push(decls, parse_decl(state));
   }
 

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1039,7 +1039,7 @@ static VALUE parse_simple(parserstate *state) {
   case pLBRACKET: {
     range rg;
     rg.start = state->current_token.range.start;
-    VALUE types = rb_ary_new();
+    VALUE types = EMPTY_ARRAY;
     if (state->next_token.type != pRBRACKET) {
       parse_type_list(state, pRBRACKET, types);
     }
@@ -1049,7 +1049,7 @@ static VALUE parse_simple(parserstate *state) {
     return rbs_tuple(types, rbs_new_location(state->buffer, rg));
   }
   case pAREF_OPR: {
-    return rbs_tuple(rb_ary_new(), rbs_new_location(state->buffer, state->current_token.range));
+    return rbs_tuple(EMPTY_ARRAY, rbs_new_location(state->buffer, state->current_token.range));
   }
   case pLBRACE: {
     position start = state->current_token.range.start;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1448,7 +1448,7 @@ VALUE parse_annotation(parserstate *state) {
   annotations ::= {} annotation ... <annotation>
                 | {<>}
 */
-void parse_annotations(parserstate *state, VALUE annotations, position *annot_pos) {
+void parse_annotations(parserstate *state, VALUE *annotations, position *annot_pos) {
   *annot_pos = NullPosition;
 
   while (true) {
@@ -1459,8 +1459,8 @@ void parse_annotations(parserstate *state, VALUE annotations, position *annot_po
         *annot_pos = state->current_token.range.start;
       }
 
-      melt_array(&annotations);
-      rb_ary_push(annotations, parse_annotation(state));
+      melt_array(annotations);
+      rb_ary_push(*annotations, parse_annotation(state));
     } else {
       break;
     }
@@ -1648,7 +1648,7 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
     position overload_annot_pos = NullPosition;
 
     if (state->next_token.type == tANNOTATION) {
-      parse_annotations(state, annotations, &overload_annot_pos);
+      parse_annotations(state, &annotations, &overload_annot_pos);
     }
 
     switch (state->next_token.type) {
@@ -2168,7 +2168,7 @@ VALUE parse_interface_members(parserstate *state) {
     VALUE annotations = EMPTY_ARRAY;
     position annot_pos = NullPosition;
 
-    parse_annotations(state, annotations, &annot_pos);
+    parse_annotations(state, &annotations, &annot_pos);
 
     parser_advance(state);
 
@@ -2314,7 +2314,7 @@ VALUE parse_module_members(parserstate *state) {
     VALUE annotations = EMPTY_ARRAY;
     position annot_pos = NullPosition;
 
-    parse_annotations(state, annotations, &annot_pos);
+    parse_annotations(state, &annotations, &annot_pos);
 
     parser_advance(state);
 
@@ -2653,7 +2653,7 @@ VALUE parse_decl(parserstate *state) {
   VALUE annotations = EMPTY_ARRAY;
   position annot_pos = NullPosition;
 
-  parse_annotations(state, annotations, &annot_pos);
+  parse_annotations(state, &annotations, &annot_pos);
 
   parser_advance(state);
   switch (state->current_token.type) {

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1808,7 +1808,7 @@ VALUE parse_mixin_member(parserstate *state, bool from_interface, position comme
   parser_push_typevar_table(state, reset_typevar_scope);
 
   VALUE name;
-  VALUE args = rb_ary_new();
+  VALUE args = EMPTY_ARRAY;
   class_instance_name(
     state,
     from_interface ? INTERFACE_NAME : (INTERFACE_NAME | CLASS_NAME),

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2962,8 +2962,9 @@ rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
 void rbs__init_parser(void) {
   RBS_Parser = rb_define_class_under(RBS, "Parser", rb_cObject);
   rb_gc_register_mark_object(RBS_Parser);
-  rb_gc_register_address(&EMPTY_ARRAY);
-  EMPTY_ARRAY = rb_obj_freeze(rb_ary_new());
+  VALUE empty_array = rb_obj_freeze(rb_ary_new());
+  rb_gc_register_mark_object(empty_array);
+  EMPTY_ARRAY = empty_array;
 
   rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 5);
   rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 5);

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -227,10 +227,10 @@ VALUE parse_type_name(parserstate *state, TypeNameKind kind, range *rg) {
   type_list ::= {} type `,` ... <`,`> eol
               | {} type `,` ... `,` <type> eol
 */
-static VALUE parse_type_list(parserstate *state, enum TokenType eol, VALUE types) {
+static void parse_type_list(parserstate *state, enum TokenType eol, VALUE *types) {
   while (true) {
-    melt_array(&types);
-    rb_ary_push(types, parse_type(state));
+    melt_array(types);
+    rb_ary_push(*types, parse_type(state));
 
     if (state->next_token.type == pCOMMA) {
       parser_advance(state);
@@ -250,8 +250,6 @@ static VALUE parse_type_list(parserstate *state, enum TokenType eol, VALUE types
       }
     }
   }
-
-  return types;
 }
 
 static bool is_keyword_token(enum TokenType type) {
@@ -900,7 +898,7 @@ static VALUE parse_instance_type(parserstate *state, bool parse_alias) {
     if (state->next_token.type == pLBRACKET) {
       parser_advance(state);
       args_range.start = state->current_token.range.start;
-      parse_type_list(state, pRBRACKET, types);
+      parse_type_list(state, pRBRACKET, &types);
       parser_advance_assert(state, pRBRACKET);
       args_range.end = state->current_token.range.end;
     } else {
@@ -1041,7 +1039,7 @@ static VALUE parse_simple(parserstate *state) {
     rg.start = state->current_token.range.start;
     VALUE types = EMPTY_ARRAY;
     if (state->next_token.type != pRBRACKET) {
-      parse_type_list(state, pRBRACKET, types);
+      parse_type_list(state, pRBRACKET, &types);
     }
     parser_advance_assert(state, pRBRACKET);
     rg.end = state->current_token.range.end;
@@ -1749,7 +1747,7 @@ void class_instance_name(parserstate *state, TypeNameKind kind, VALUE *name, VAL
   if (state->next_token.type == pLBRACKET) {
     parser_advance(state);
     args_range->start = state->current_token.range.start;
-    parse_type_list(state, pRBRACKET, args);
+    parse_type_list(state, pRBRACKET, &args);
     parser_advance_assert(state, pRBRACKET);
     args_range->end = state->current_token.range.end;
   } else {
@@ -2272,7 +2270,7 @@ void parse_module_self_types(parserstate *state, VALUE array) {
     if (state->next_token.type == pLBRACKET) {
       parser_advance(state);
       args_range.start = state->current_token.range.start;
-      parse_type_list(state, pRBRACKET, args);
+      parse_type_list(state, pRBRACKET, &args);
       parser_advance(state);
       self_range.end = args_range.end = state->current_token.range.end;
     }

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -152,7 +152,7 @@ void parser_advance_no_gap(parserstate *state) {
 */
 VALUE parse_type_name(parserstate *state, TypeNameKind kind, range *rg) {
   VALUE absolute = Qfalse;
-  VALUE path = rb_ary_new();
+  VALUE path = EMPTY_ARRAY;
   VALUE namespace;
 
   if (rg) {
@@ -170,6 +170,7 @@ VALUE parse_type_name(parserstate *state, TypeNameKind kind, range *rg) {
     && state->current_token.range.end.byte_pos == state->next_token.range.start.byte_pos
     && state->next_token.range.end.byte_pos == state->next_token2.range.start.byte_pos
   ) {
+    melt_array(&path);
     rb_ary_push(path, ID2SYM(INTERN_TOKEN(state, state->current_token)));
 
     parser_advance(state);

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2696,10 +2696,11 @@ VALUE parse_namespace(parserstate *state, range *rg) {
     parser_advance(state);
   }
 
-  VALUE path = rb_ary_new();
+  VALUE path = EMPTY_ARRAY;
 
   while (true) {
     if (state->next_token.type == tUIDENT && state->next_token2.type == pCOLON2) {
+      melt_array(&path);
       rb_ary_push(path, ID2SYM(INTERN_TOKEN(state, state->next_token)));
       if (null_position_p(rg->start)) {
         rg->start = state->next_token.range.start;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -229,6 +229,7 @@ VALUE parse_type_name(parserstate *state, TypeNameKind kind, range *rg) {
 */
 static VALUE parse_type_list(parserstate *state, enum TokenType eol, VALUE types) {
   while (true) {
+    melt_array(&types);
     rb_ary_push(types, parse_type(state));
 
     if (state->next_token.type == pCOMMA) {
@@ -883,7 +884,7 @@ static VALUE parse_instance_type(parserstate *state, bool parse_alias) {
     }
 
     VALUE typename = parse_type_name(state, expected_kind, &name_range);
-    VALUE types = rb_ary_new();
+    VALUE types = EMPTY_ARRAY;
 
     TypeNameKind kind;
     if (state->current_token.type == tUIDENT) {

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2164,7 +2164,7 @@ VALUE parse_attribute_member(parserstate *state, position comment_pos, VALUE ann
                      | alias_member   (instance only)
 */
 VALUE parse_interface_members(parserstate *state) {
-  VALUE members = rb_ary_new();
+  VALUE members = EMPTY_ARRAY;
 
   while (state->next_token.type != kEND) {
     VALUE annotations = EMPTY_ARRAY;
@@ -2198,6 +2198,7 @@ VALUE parse_interface_members(parserstate *state) {
       );
     }
 
+    melt_array(&members);
     rb_ary_push(members, member);
   }
 

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2309,7 +2309,7 @@ VALUE parse_nested_decl(parserstate *state, const char *nested_in, position anno
                   | `private`
 */
 VALUE parse_module_members(parserstate *state) {
-  VALUE members = rb_ary_new();
+  VALUE members = EMPTY_ARRAY;
 
   while (state->next_token.type != kEND) {
     VALUE member;
@@ -2374,6 +2374,7 @@ VALUE parse_module_members(parserstate *state) {
       break;
     }
 
+    melt_array(&members);
     rb_ary_push(members, member);
   }
 

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2498,7 +2498,7 @@ VALUE parse_class_decl_super(parserstate *state, range *lt_range) {
     *lt_range = state->current_token.range;
     super_range.start = state->next_token.range.start;
 
-    args = rb_ary_new();
+    args = EMPTY_ARRAY;
     class_instance_name(state, CLASS_NAME, &name, args, &name_range, &args_range);
 
     super_range.end = state->current_token.range.end;

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1739,7 +1739,7 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
  *
  * @param kind
  * */
-void class_instance_name(parserstate *state, TypeNameKind kind, VALUE *name, VALUE args, range *name_range, range *args_range) {
+void class_instance_name(parserstate *state, TypeNameKind kind, VALUE *name, VALUE *args, range *name_range, range *args_range) {
   parser_advance(state);
 
   *name = parse_type_name(state, kind, name_range);
@@ -1747,7 +1747,7 @@ void class_instance_name(parserstate *state, TypeNameKind kind, VALUE *name, VAL
   if (state->next_token.type == pLBRACKET) {
     parser_advance(state);
     args_range->start = state->current_token.range.start;
-    parse_type_list(state, pRBRACKET, &args);
+    parse_type_list(state, pRBRACKET, args);
     parser_advance_assert(state, pRBRACKET);
     args_range->end = state->current_token.range.end;
   } else {
@@ -1810,7 +1810,7 @@ VALUE parse_mixin_member(parserstate *state, bool from_interface, position comme
   class_instance_name(
     state,
     from_interface ? INTERFACE_NAME : (INTERFACE_NAME | CLASS_NAME),
-    &name, args, &name_range, &args_range
+    &name, &args, &name_range, &args_range
   );
 
   parser_pop_typevar_table(state);
@@ -2497,7 +2497,7 @@ VALUE parse_class_decl_super(parserstate *state, range *lt_range) {
     super_range.start = state->next_token.range.start;
 
     args = EMPTY_ARRAY;
-    class_instance_name(state, CLASS_NAME, &name, args, &name_range, &args_range);
+    class_instance_name(state, CLASS_NAME, &name, &args, &name_range, &args_range);
 
     super_range.end = state->current_token.range.end;
 

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -104,6 +104,18 @@ module RBS
           @comment = comment
         end
 
+        def update(name: self.name, type_params: self.type_params, super_class: self.super_class, members: self.members, annotations: self.annotations, location: self.location, comment: self.comment)
+          self.class.new(
+            name: name,
+            type_params: type_params,
+            super_class: super_class,
+            members: members,
+            annotations: annotations,
+            location: location,
+            comment: comment
+          )
+        end
+
         def ==(other)
           other.is_a?(Class) &&
             other.name == name &&
@@ -192,6 +204,19 @@ module RBS
           @comment = comment
         end
 
+        def update(name: self.name, type_params: self.type_params, members: self.members, self_types: self.self_types, annotations: self.annotations, location: self.location, comment: self.comment)
+          self.class.new(
+            name: name,
+            type_params: type_params,
+            members: members,
+            self_types: self_types,
+            annotations: annotations,
+            location: location,
+            comment: comment
+          )
+        end
+
+
         def ==(other)
           other.is_a?(Module) &&
             other.name == name &&
@@ -237,6 +262,17 @@ module RBS
           @annotations = annotations
           @location = location
           @comment = comment
+        end
+
+        def update(name: self.name, type_params: self.type_params, members: self.members, annotations: self.annotations, location: self.location, comment: self.comment)
+          self.class.new(
+            name: name,
+            type_params: type_params,
+            members: members,
+            annotations: annotations,
+            location: location,
+            comment: comment
+          )
         end
 
         def ==(other)

--- a/lib/rbs/sorter.rb
+++ b/lib/rbs/sorter.rb
@@ -17,18 +17,18 @@ module RBS
       buffer = Buffer.new(name: path, content: path.read)
       _, _, sigs = Parser.parse_signature(buffer)
 
-      sigs.each do |m|
-        sort_decl! m
+      sigs = sigs.map do |m|
+        sort_decl m
       end
 
       stdout.puts "Writing #{path}..."
       path.open('w') do |out|
         writer = RBS::Writer.new(out: out)
-        writer.write sigs
+        writer.write _ = sigs
       end
     end
 
-    def sort_decl!(decl)
+    def sort_decl(decl)
       case decl
       when Declarations::Class, Declarations::Module, Declarations::Interface
         partitioned = {
@@ -52,7 +52,8 @@ module RBS
           private_instance_methods: [],
         } #: partitioned
 
-        decl.members.each { |m| sort_decl! m }
+        members = decl.members.map { |m| sort_decl m }
+        decl = decl.update(members: _ = members)
 
         visibility_annotated_members = [] #: Array[member]
 
@@ -188,7 +189,9 @@ module RBS
 
         members.push(*partitioned[:other_decls])
 
-        decl.members.replace(_ = members)
+        decl.update(members: _ = members)
+      else
+        decl
       end
     end
   end

--- a/sig/declarations.rbs
+++ b/sig/declarations.rbs
@@ -77,6 +77,8 @@ module RBS
 
         def initialize: (name: TypeName, type_params: Array[TypeParam], members: Array[member], super_class: Super?, annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
 
+        def update: (?name: TypeName, ?type_params: Array[TypeParam], ?members: Array[member], ?super_class: Super?, ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?) -> Declarations::Class
+
         include _HashEqual
         include _ToJson
       end
@@ -131,6 +133,8 @@ module RBS
 
         def initialize: (name: TypeName, type_params: Array[TypeParam], members: Array[member], location: loc?, annotations: Array[Annotation], self_types: Array[Self], comment: Comment?) -> void
 
+        def update: (?name: TypeName, ?type_params: Array[TypeParam], ?members: Array[member], ?location: loc?, ?annotations: Array[Annotation], ?self_types: Array[Self], ?comment: Comment?) -> Declarations::Module
+
         include _HashEqual
         include _ToJson
       end
@@ -159,6 +163,8 @@ module RBS
         attr_reader comment: Comment?
 
         def initialize: (name: TypeName, type_params: Array[TypeParam], members: Array[member], annotations: Array[Annotation], location: loc?, comment: Comment?) -> void
+
+        def update: (?name: TypeName, ?type_params: Array[TypeParam], ?members: Array[member], ?annotations: Array[Annotation], ?location: loc?, ?comment: Comment?) -> Declarations::Interface
 
         include MixinHelper
 

--- a/sig/sorter.rbs
+++ b/sig/sorter.rbs
@@ -36,6 +36,6 @@ module RBS
       other_decls: Array[member]
     }
 
-    def sort_decl!: (member decl) -> void
+    def sort_decl: (member decl) -> member
   end
 end


### PR DESCRIPTION
This patch dedups empty arrays allocated during parsing.



Currently, RBS allocates many arrays during parsing. It consumes a lot of memory.


This patch reduces memory usage by deduping empty arrays.


BTW, I'm also working on deduping empty Hashes. It caused a performance problem. Therefore this PR focuses on Array and I'll make another PR for Hash.


## Profiling


I've checked the memory usage by `benchmark/memory_new_rails_env.rb` script.


before:

```
Total allocated: 158965078 bytes (1615620 objects)
Total retained:  56607852 bytes (566708 objects)

(snip)

allocated memory by class
-----------------------------------
  81452592  Hash
  20455584  Array
  20114192  RBS::Location
  13382510  String
```

after:


```
Total allocated: 153021766 bytes (1466984 objects)
Total retained:  52321620 bytes (459558 objects)

(snip)

allocated memory by class
-----------------------------------
  81456912  Hash
  20114856  RBS::Location
  14508496  Array
  13380142  String
```


It reduced ~8% retained memory.


I've confirmed `steep check` works well with this patch. 