### PR TITLE
Support Range#step behavior change in Ruby 3.4

### DIFF
--- a/core/range.rbs
+++ b/core/range.rbs
@@ -1017,8 +1017,10 @@ class Range[out Elem] < Object
   #     ('a'..'e').step { p _1 }
   #     # Default step 1; prints: a, b, c, d, e
   #
-  def step: (?Numeric | int n) -> Enumerator[Elem, self]
-          | (?Numeric | int n) { (Elem element) -> void } -> self
+  def step: (?Numeric | int) -> Enumerator[Elem, self]
+          | (?Numeric | int) { (Elem element) -> void } -> self
+          | (untyped) -> Enumerator[Elem, self]
+          | (untyped) { (Elem element) -> void } -> self
 
   # <!--
   #   rdoc-file=range.c

--- a/test/stdlib/Range_test.rb
+++ b/test/stdlib/Range_test.rb
@@ -110,9 +110,14 @@ class RangeTest < StdlibTest
   def test_step
     (1..10).step
     (1..10).step(2)
+
     if_ruby(..."3.4.0", skip: false) do
       ('A'...'Z').step { |s| s.downcase }
       ('A'...'Z').step(2) { |s| s.downcase }
+    end
+
+    if_ruby("3.4.0"..., skip: false) do
+      ('A'...'AAA').step('A') { |s| s.downcase }
     end
   end
 

--- a/test/typecheck/range_step/Steepfile
+++ b/test/typecheck/range_step/Steepfile
@@ -1,0 +1,7 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/range_step/test.rb
+++ b/test/typecheck/range_step/test.rb
@@ -1,0 +1,10 @@
+# These are valid because step is a number.
+
+(1...3).step(1) { }
+("A".."C").step(1) { }
+
+# This works because "A" + "" is valid.
+("A".."C").step("") { }
+
+# This doesn't work but the type checker cannot detect it.
+("A".."C").step(Exception.new) { }


### PR DESCRIPTION
This is a PR to support this change in Ruby: https://github.com/ruby/ruby/pull/7444 (the design is approved by Matz, and the code itself is approved by the Ruby core team).

I am not sure how this actually should be addressed, so I will be thankful for any advice.

Basically, the essence of the change is that:
* Before Ruby 3.4, `Ruby#step`’s type signature was `step(Int step?)`
* After the linked PR, the signature would become `step(Addable step)`, with `Addable` being such that `Range#begin + step` will work and produce the next value.

So, my questions are:
1. How to describe that in RBS syntax?
2. How to adjust RBS `core/range.rbs` to specify that the signature was changed between 3.3 and 3.4?
3. How to proceed with those two PRs (into Ruby itself and into rbs)?

Please advise :pray: 