### PR TITLE
Make `FileFinder` faster by globbing all possible files

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -909,7 +909,7 @@ Options:
       syntax_error = false
       bufs = args.flat_map do |path|
         path = Pathname(path)
-        FileFinder.each_file(path, skip_hidden: false, immediate: true).map do |file_path|
+        FileFinder.each_file(path, skip_hidden: false).map do |file_path|
           Buffer.new(content: file_path.read, name: file_path)
         end
       end
@@ -1193,7 +1193,7 @@ EOB
       end
 
       minuend_paths.each do |minuend_path|
-        FileFinder.each_file(Pathname(minuend_path), immediate: true, skip_hidden: true) do |rbs_path|
+        FileFinder.each_file(Pathname(minuend_path), skip_hidden: true) do |rbs_path|
           buf = Buffer.new(name: rbs_path, content: rbs_path.read)
           _, dirs, decls = Parser.parse_signature(buf)
           subtracted = Subtractor.new(decls, subtrahend).call

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -152,7 +152,7 @@ module RBS
       each_dir do |source, dir|
         skip_hidden = !source.is_a?(Pathname)
 
-        FileFinder.each_file(dir, skip_hidden: skip_hidden, immediate: true) do |path|
+        FileFinder.each_file(dir, skip_hidden: skip_hidden) do |path|
           next if files.include?(path)
 
           files << path

--- a/lib/rbs/vendorer.rb
+++ b/lib/rbs/vendorer.rb
@@ -31,7 +31,7 @@ module RBS
 
       if core_root = loader.core_root
         RBS.logger.info "Vendoring core RBSs in #{vendor_dir + "core"}..."
-        FileFinder.each_file(core_root, immediate: false, skip_hidden: true) do |file_path|
+        FileFinder.each_file(core_root, skip_hidden: true) do |file_path|
           paths << [file_path, Pathname("core") + file_path.relative_path_from(core_root)]
         end
       end
@@ -43,7 +43,7 @@ module RBS
 
           RBS.logger.info "Vendoring #{lib.name}(#{spec.version}) RBSs in #{vendor_dir + dest_dir}..."
 
-          FileFinder.each_file(path, skip_hidden: true, immediate: false) do |file_path|
+          FileFinder.each_file(path, skip_hidden: true) do |file_path|
             paths << [file_path, dest_dir + file_path.relative_path_from(path)]
           end
 
@@ -52,7 +52,7 @@ module RBS
 
           RBS.logger.info "Vendoring #{lib.name}(#{path.version}) RBSs in #{vendor_dir + dest_dir}..."
 
-          FileFinder.each_file(path.path, skip_hidden: true, immediate: false) do |file_path|
+          FileFinder.each_file(path.path, skip_hidden: true) do |file_path|
             paths << [file_path, dest_dir + file_path.relative_path_from(path.path)]
           end
         else

--- a/sig/file_finder.rbs
+++ b/sig/file_finder.rbs
@@ -1,6 +1,28 @@
 module RBS
   module FileFinder
-    def self?.each_file: (Pathname path, immediate: boolish, skip_hidden: boolish) { (Pathname) -> void } -> void
-                        | (Pathname path, immediate: boolish, skip_hidden: boolish) -> Enumerator[Pathname, void]
+    # Enumerate RBS files under path
+    #
+    # When `path` is a file, it yields the path.
+    #
+    # ```rb
+    # FileFinder.each_file(Pathname("foo.rbs")) {} # => yields `foo.rbs`
+    # ```
+    #
+    # When `path` is a directory, it yields all `.rbs` files under the directory, recursively.
+    #
+    # * Skips files under directory starting with `_`, if `skip_hidden` is `true`
+    # * Yields files under directory starting with `_` even if `skip_hidden` is true, when the `_` directory is given explicitly, and `immediate:` is `true`
+    #
+    # ```rb
+    # FileFinder.each_file(Pathname("sig"), skip_hidden: false) {} # => yields all `.rbs` files under `sig`
+    # FileFinder.each_file(Pathname("sig"), skip_hidden: true) {} # => yields all `.rbs` files under `sig`, skips `_` directories
+    #
+    # FileFinder.each_file(Pathname("_hidden"), skip_hidden: true) {}  # => yields all `.rbs` files under `_hidden`, skips other `_` directories
+    # ```
+    #
+    # `immediate` keyword is unused and left for API compatibility.
+    # 
+    def self?.each_file: (Pathname path, ?immediate: top, skip_hidden: boolish) { (Pathname) -> void } -> void
+                        | (Pathname path, ?immediate: top, skip_hidden: boolish) -> Enumerator[Pathname, void]
   end
 end

--- a/test/rbs/file_finder_test.rb
+++ b/test/rbs/file_finder_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class RBS::FileFinderTest < Test::Unit::TestCase
+  FileFinder = RBS::FileFinder
+
+  def tmpdir
+    @tmpdir
+  end
+
+  def setup
+    super
+
+    @tmpdir = Pathname(Dir.mktmpdir)
+
+    (tmpdir / "sig").mkpath
+    (tmpdir / "sig/app").mkpath
+    (tmpdir / "sig/_internal/foo").mkpath
+    (tmpdir / "_private/app").mkpath
+    (tmpdir / "_private/_internal").mkpath
+
+    (tmpdir / "top").write("")
+    (tmpdir / "sig/a.rbs").write("")
+    (tmpdir / "sig/b.rbs").write("")
+    (tmpdir / "sig/_internal/foo/bar.rbs").write("")
+    (tmpdir / "_private/app/x.rbs").write("")
+    (tmpdir / "_private/_internal/y.rbs").write("")
+  end
+
+  def teardown
+    tmpdir.rmtree
+  end
+
+  def test_file_path
+    assert_equal [tmpdir + "sig/a.rbs"], FileFinder.each_file(tmpdir + "sig/a.rbs", skip_hidden: false).to_a
+    assert_equal [tmpdir + "sig/a.rbs"], FileFinder.each_file(tmpdir + "sig/a.rbs", skip_hidden: false).to_a
+
+    assert_equal [tmpdir + "top"], FileFinder.each_file(tmpdir + "top", skip_hidden: false).to_a
+  end
+
+  def test_dir_path
+    assert_equal [tmpdir + "sig/a.rbs", tmpdir + "sig/b.rbs"], FileFinder.each_file(tmpdir + "sig", skip_hidden: true).to_a
+    assert_equal [tmpdir + "sig/_internal/foo/bar.rbs", tmpdir + "sig/a.rbs", tmpdir + "sig/b.rbs"], FileFinder.each_file(tmpdir + "sig", skip_hidden: false).to_a
+
+    assert_equal [tmpdir + "_private/app/x.rbs"], FileFinder.each_file(tmpdir + "_private", skip_hidden: true).to_a
+    assert_equal [tmpdir + "_private/_internal/y.rbs", tmpdir + "_private/app/x.rbs"], FileFinder.each_file(tmpdir + "_private", skip_hidden: false).to_a
+  end
+end


### PR DESCRIPTION
The old implementation that recursively scans folder items is slow especially inside Docker on Mac containers, which is commonly used for devcontainer setups.