### PR TITLE
Isolate the case where the argument is Integer in the rand method

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1319,7 +1319,8 @@ module Kernel : BasicObject
   # See also Random.rand.
   #
   def self?.rand: (?0) -> Float
-                | (int arg0) -> (Integer | Float)
+                | (Integer arg0) -> Integer
+                | (_ToInt arg0) -> (Integer | Float)
                 | (::Range[Integer] arg0) -> Integer?
                 | (::Range[Float] arg0) -> Float?
 


### PR DESCRIPTION
Because it always returns Integer for non-zero integer values.

## Background

```rb
1 + rand(10)
```
Running steep check, this causes `UnresolvedOverloading`.
```
Integer + (Integer | Float)
```
Writing an expression like this seems to cause `UnresolvedOverloading`.

Although not a direct solution, this problem can be avoided if the possibility of a Float being returned when the argument is a non-zero integer can be eliminated.

Thank you.
