### PR TITLE
Fix #1988: Enumerable#chain should take enumerable objects

### DIFF
--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -1846,7 +1846,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     e = (1..3).chain([4, 5])
   #     e.to_a #=> [1, 2, 3, 4, 5]
   #
-  def chain: (*Enumerable[Elem] enumerables) -> ::Enumerator::Chain[Elem]
+  def chain: [Elem2] (*_Each[Elem2] enumerables) -> ::Enumerator::Chain[Elem | Elem2]
 
   # <!--
   #   rdoc-file=enum.c

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -1846,7 +1846,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     e = (1..3).chain([4, 5])
   #     e.to_a #=> [1, 2, 3, 4, 5]
   #
-  def chain: (*self enumerables) -> ::Enumerator::Chain[Elem]
+  def chain: (*Enumerable[Elem] enumerables) -> ::Enumerator::Chain[Elem]
 
   # <!--
   #   rdoc-file=enum.c


### PR DESCRIPTION
The `Enumerator::Chain#chain` type expects an instance of `Enumerator::Chain[Elem]` as its argument.  As a result, the nested `#chain` calls requires `Enumerator::Chain` object.

It should accept enumerable objects instead of the same kind of object (self).

refs: #1988