### PR TITLE
Improve generics

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1119,12 +1119,14 @@ VALUE parse_type(parserstate *state) {
   type_params ::= {} `[` type_param `,` ... <`]`>
                 | {<>}
 
-  type_param ::= kUNCHECKED? (kIN|kOUT|) tUIDENT    (module_type_params == true)
+  type_param ::= kUNCHECKED? (kIN|kOUT|) tUIDENT upper_bound? default_type?   (module_type_params == true)
 
-  type_param ::= tUIDENT                            (module_type_params == false)
+  type_param ::= tUIDENT upper_bound? default_type?                           (module_type_params == false)
 */
 VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) {
   VALUE params = EMPTY_ARRAY;
+
+  bool required_param_allowed = true;
 
   if (state->next_token.type == pLBRACKET) {
     parser_advance(state);
@@ -1136,12 +1138,14 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
       bool unchecked = false;
       VALUE variance = ID2SYM(rb_intern("invariant"));
       VALUE upper_bound = Qnil;
+      VALUE default_type = Qnil;
 
       range param_range = NULL_RANGE;
       range name_range;
       range variance_range = NULL_RANGE;
       range unchecked_range = NULL_RANGE;
       range upper_bound_range = NULL_RANGE;
+      range default_type_range = NULL_RANGE;
 
       param_range.start = state->next_token.range.start;
 
@@ -1184,12 +1188,23 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
         upper_bound_range.end = state->current_token.range.end;
       }
 
-        if (state->next_token.type == kSINGLETON) {
+      if (module_type_params) {
+        if (state->next_token.type == pEQ) {
           parser_advance(state);
-          upper_bound = parse_singleton_type(state);
+
+          default_type_range.start = state->current_token.range.start;
+          default_type = parse_type(state);
+          default_type_range.start = state->current_token.range.end;
+
+          required_param_allowed = false;
         } else {
-          parser_advance(state);
-          upper_bound = parse_instance_type(state, false);
+          if (!required_param_allowed) {
+            raise_syntax_error(
+              state,
+              state->current_token,
+              "required type parameter is not allowed after optional type parameter"
+            );
+          }
         }
       }
 
@@ -1202,8 +1217,9 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
       rbs_loc_add_optional_child(loc, rb_intern("variance"), variance_range);
       rbs_loc_add_optional_child(loc, rb_intern("unchecked"), unchecked_range);
       rbs_loc_add_optional_child(loc, rb_intern("upper_bound"), upper_bound_range);
+      rbs_loc_add_optional_child(loc, rb_intern("default"), default_type_range);
 
-      VALUE param = rbs_ast_type_param(name, variance, unchecked, upper_bound, location);
+      VALUE param = rbs_ast_type_param(name, variance, unchecked, upper_bound, default_type, location);
       melt_array(&params);
       rb_ary_push(params, param);
 

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1179,6 +1179,10 @@ VALUE parse_type_params(parserstate *state, range *rg, bool module_type_params) 
 
       if (state->next_token.type == pLT) {
         parser_advance(state);
+        upper_bound_range.start = state->current_token.range.start;
+        upper_bound = parse_type(state);
+        upper_bound_range.end = state->current_token.range.end;
+      }
 
         if (state->next_token.type == kSINGLETON) {
           parser_advance(state);

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -307,11 +307,12 @@ VALUE rbs_ast_annotation(VALUE string, VALUE location) {
   );
 }
 
-VALUE rbs_ast_type_param(VALUE name, VALUE variance, bool unchecked, VALUE upper_bound, VALUE location) {
+VALUE rbs_ast_type_param(VALUE name, VALUE variance, bool unchecked, VALUE upper_bound, VALUE default_type, VALUE location) {
   VALUE args = rb_hash_new();
   rb_hash_aset(args, ID2SYM(rb_intern("name")), name);
   rb_hash_aset(args, ID2SYM(rb_intern("variance")), variance);
   rb_hash_aset(args, ID2SYM(rb_intern("upper_bound")), upper_bound);
+  rb_hash_aset(args, ID2SYM(rb_intern("default_type")), default_type);
   rb_hash_aset(args, ID2SYM(rb_intern("location")), location);
 
   VALUE type_param = CLASS_NEW_INSTANCE(RBS_AST_TypeParam, 1, &args);

--- a/ext/rbs_extension/ruby_objs.h
+++ b/ext/rbs_extension/ruby_objs.h
@@ -6,7 +6,7 @@
 VALUE rbs_alias(VALUE typename, VALUE args, VALUE location);
 VALUE rbs_ast_annotation(VALUE string, VALUE location);
 VALUE rbs_ast_comment(VALUE string, VALUE location);
-VALUE rbs_ast_type_param(VALUE name, VALUE variance, bool unchecked, VALUE upper_bound, VALUE location);
+VALUE rbs_ast_type_param(VALUE name, VALUE variance, bool unchecked, VALUE upper_bound, VALUE default_type, VALUE location);
 VALUE rbs_ast_decl_type_alias(VALUE name, VALUE type_params, VALUE type, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_decl_class_super(VALUE name, VALUE args, VALUE location);
 VALUE rbs_ast_decl_class(VALUE name, VALUE type_params, VALUE super_class, VALUE members, VALUE annotations, VALUE location, VALUE comment);

--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -152,6 +152,41 @@ module RBS
 
         s
       end
+
+      def self.application(params, args)
+        subst = Substitution.new()
+
+        if params.empty?
+          return nil
+        end
+
+        min_count = params.count { _1.default_type.nil? }
+        max_count = params.size
+
+        unless min_count <= args.size && args.size <= max_count
+          raise "Invalid type application: required type params=#{min_count}, optional type params=#{max_count - min_count}, given args=#{args.size}"
+        end
+
+        params.zip(args).each do |param, arg|
+          if arg
+            subst.add(from: param.name, to: arg)
+          else
+            subst.add(from: param.name, to: param.default_type || raise)
+          end
+        end
+
+        subst
+      end
+
+      def self.normalize_args(params, args)
+        params.zip(args).filter_map do |param, arg|
+          if arg
+            arg
+          else
+            param.default_type
+          end
+        end
+      end
     end
   end
 end

--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -139,8 +139,8 @@ EOU
           )
 
           d.type_params.each do |param|
-            if ub = param.upper_bound
-              void_type_context_validator(ub)
+            if ub = param.upper_bound_type
+             void_type_context_validator(ub)
               no_self_type_validator(ub)
               no_classish_type_validator(ub)
             end

--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -94,7 +94,7 @@ EOU
       private
 
       def validate_class_module_definition
-        @env.class_decls.each do |name, decl|
+        @env.class_decls.each do |name, entry|
           RBS.logger.info "Validating class/module definition: `#{name}`..."
           @builder.build_instance(name).each_type do |type|
             @validator.validate_type type, context: nil
@@ -107,30 +107,47 @@ EOU
             @errors.add(error)
           end
 
-          case decl
+          case entry
           when Environment::ClassEntry
-            decl.decls.each do |decl|
+            entry.decls.each do |decl|
               if super_class = decl.decl.super_class
                 super_class.args.each do |arg|
                   void_type_context_validator(arg, true)
                   no_self_type_validator(arg)
                   no_classish_type_validator(arg)
+                  @validator.validate_type(arg, context: nil)
+                end
+
+                if super_entry = @env.normalized_class_entry(super_class.name)
+                  InvalidTypeApplicationError.check!(type_name: super_class.name, args: super_class.args, params: super_entry.type_params, location: super_class.location)
                 end
               end
             end
           when Environment::ModuleEntry
-            decl.decls.each do |decl|
+            entry.decls.each do |decl|
               decl.decl.self_types.each do |self_type|
                 self_type.args.each do |arg|
                   void_type_context_validator(arg, true)
                   no_self_type_validator(arg)
                   no_classish_type_validator(arg)
+                  @validator.validate_type(arg, context: nil)
+                end
+
+                self_params =
+                  if self_type.name.class?
+                    @env.normalized_module_entry(self_type.name)&.type_params
+                  else
+                    @env.interface_decls[self_type.name]&.decl&.type_params
+                  end
+
+                if self_params
+                  InvalidTypeApplicationError.check!(type_name: self_type.name, params: self_params, args: self_type.args, location: self_type.location)
                 end
               end
             end
           end
 
-          d = decl.primary.decl
+          d = entry.primary.decl
 
           @validator.validate_type_params(
             d.type_params,
@@ -140,13 +157,21 @@ EOU
 
           d.type_params.each do |param|
             if ub = param.upper_bound_type
-             void_type_context_validator(ub)
+              void_type_context_validator(ub)
               no_self_type_validator(ub)
               no_classish_type_validator(ub)
+              @validator.validate_type(ub, context: nil)
+            end
+
+            if dt = param.default_type
+              void_type_context_validator(dt)
+              no_self_type_validator(dt)
+              no_classish_type_validator(dt)
+              @validator.validate_type(dt, context: nil)
             end
           end
 
-          decl.decls.each do |d|
+          entry.decls.each do |d|
             d.decl.each_member do |member|
               case member
               when AST::Members::MethodDefinition
@@ -163,6 +188,15 @@ EOU
                     void_type_context_validator(arg, true)
                   end
                 end
+                params =
+                  if member.name.class?
+                    module_decl = @env.normalized_module_entry(member.name) or raise
+                    module_decl.type_params
+                  else
+                    interface_decl = @env.interface_decls.fetch(member.name)
+                    interface_decl.decl.type_params
+                  end
+                InvalidTypeApplicationError.check!(type_name: member.name, params: params, args: member.args, location: member.location)
               when AST::Members::Var
                 void_type_context_validator(member.type)
                 if member.is_a?(AST::Members::ClassVariable)

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -238,10 +238,11 @@ module RBS
       end
 
       def apply(args, location:)
+        # Assume default types of type parameters are already added to `args`
         InvalidTypeApplicationError.check!(
           type_name: type_name,
           args: args,
-          params: params,
+          params: params.map { AST::TypeParam.new(name: _1, variance: :invariant, upper_bound: nil, location: nil, default_type: nil) },
           location: location
         )
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -68,18 +68,23 @@ module RBS
     attr_reader :type_name
     attr_reader :args
     attr_reader :params
+    attr_reader :type_params
     attr_reader :location
 
     def initialize(type_name:, args:, params:, location:)
       @type_name = type_name
       @args = args
-      @params = params
+      @type_params = params
+      @params = params.map(&:name)
       @location = location
       super "#{Location.to_string location}: #{type_name} expects parameters [#{params.join(", ")}], but given args [#{args.join(", ")}]"
     end
 
     def self.check!(type_name:, args:, params:, location:)
-      unless args.size == params.size
+      min_arity = params.count { _1.default_type.nil? }
+      max_arity = params.size
+
+      unless min_arity <= args.size && args.size <= max_arity
         raise new(type_name: type_name, args: args, params: params, location: location)
       end
     end

--- a/lib/rbs/locator.rb
+++ b/lib/rbs/locator.rb
@@ -171,7 +171,7 @@ module RBS
       if test_loc(pos, location: type_param.location)
         array.unshift(type_param)
 
-        if upper_bound = type_param.upper_bound
+        if upper_bound = type_param.upper_bound_type
           find_in_type(pos, type: upper_bound, array: array) or
             find_in_loc(pos, location: type_param.location, array: array)
         else

--- a/lib/rbs/locator.rb
+++ b/lib/rbs/locator.rb
@@ -172,11 +172,14 @@ module RBS
         array.unshift(type_param)
 
         if upper_bound = type_param.upper_bound_type
-          find_in_type(pos, type: upper_bound, array: array) or
-            find_in_loc(pos, location: type_param.location, array: array)
-        else
-          find_in_loc(pos, location: type_param.location, array: array)
+          find_in_type(pos, type: upper_bound, array: array) and return true
         end
+
+        if default_type = type_param.default_type
+          find_in_type(pos, type: default_type, array: array) and return true
+        end
+
+        find_in_loc(pos, location: type_param.location, array: array)
 
         true
       else

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -236,7 +236,8 @@ module RBS
                 name: node.children[0],
                 variance: variance || :invariant,
                 location: nil,
-                upper_bound: nil
+                upper_bound: nil,
+                default_type: nil
               )
             end
           else

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -125,7 +125,7 @@ module RBS
       # @type var each_child: ^(Symbol) { (Symbol) -> void } -> void
       each_child = -> (name, &block) do
         if param = params.find {|p| p.name == name }
-          if b = param.upper_bound
+          if b = param.upper_bound_type
             b.free_variables.each do |tv|
               block[tv]
             end

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -43,7 +43,7 @@ module RBS
           InvalidTypeApplicationError.check!(
             type_name: type.name,
             args: type.args,
-            params: type_params.each.map(&:name),
+            params: type_params,
             location: type.location
           )
         end

--- a/sig/definition.rbs
+++ b/sig/definition.rbs
@@ -66,7 +66,7 @@ module RBS
       #
       def map_type: () { (Types::t) -> Types::t } -> Method
 
-      def map_type_bound: () { (AST::TypeParam::bound) -> AST::TypeParam::bound } -> Method
+      def map_type_bound: () { (Types::t) -> Types::t } -> Method
 
       def map_method_type: () { (MethodType) -> MethodType } -> Method
 

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -60,11 +60,12 @@ module RBS
     attr_reader type_name: TypeName
     attr_reader args: Array[Types::t]
     attr_reader params: Array[Symbol]
+    attr_reader type_params: Array[AST::TypeParam]
     attr_reader location: Location[untyped, untyped]?
 
-    def initialize: (type_name: TypeName, args: Array[Types::t], params: Array[Symbol], location: Location[untyped, untyped]?) -> void
+    def initialize: (type_name: TypeName, args: Array[Types::t], params: Array[AST::TypeParam], location: Location[untyped, untyped]?) -> void
 
-    def self.check!: (type_name: TypeName, args: Array[Types::t], params: Array[Symbol], location: Location[untyped, untyped]?) -> void
+    def self.check!: (type_name: TypeName, args: Array[Types::t], params: Array[AST::TypeParam], location: Location[untyped, untyped]?) -> void
   end
 
   class RecursiveAncestorError < DefinitionError

--- a/sig/method_types.rbs
+++ b/sig/method_types.rbs
@@ -40,7 +40,7 @@ module RBS
     #
     def map_type: () { (Types::t) -> Types::t } -> MethodType
 
-    def map_type_bound: () { (AST::TypeParam::bound) -> AST::TypeParam::bound } -> MethodType
+    def map_type_bound: () { (Types::t) -> Types::t } -> MethodType
 
     def each_type: () { (Types::t) -> void } -> void
                  | () -> Enumerator[Types::t, void]

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -4,12 +4,13 @@ module RBS
       # Key
       # ^^^ name
       #
-      # unchecked out Elem < _ToJson
-      # ^^^^^^^^^                    unchecked
-      #           ^^^                variance
-      #               ^^^^           name
-      #                    ^^^^^^^^^ upper_bound
-      type loc = Location[:name, :variance | :unchecked | :upper_bound]
+      # unchecked out Elem < _ToJson = untyped
+      # ^^^^^^^^^                                 unchecked
+      #           ^^^                             variance
+      #               ^^^^                        name
+      #                    ^^^^^^^^^              upper_bound
+      #                              ^^^^^^^^^    default
+      type loc = Location[:name, :variance | :unchecked | :upper_bound | :default]
 
       type variance = :invariant | :covariant | :contravariant
 
@@ -25,7 +26,7 @@ module RBS
 
       attr_reader default_type: Types::t?
 
-      def initialize: (name: Symbol, variance: variance, upper_bound: Types::t?, location: loc?) -> void
+      def initialize: (name: Symbol, variance: variance, upper_bound: Types::t?, location: loc?, ?default_type: Types::t?) -> void
 
       include _ToJson
 

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -19,9 +19,13 @@ module RBS
       attr_reader variance: variance
       attr_reader location: loc?
 
-      attr_reader upper_bound: bound?
+      %a{pure} def upper_bound: () -> bound?
 
-      def initialize: (name: Symbol, variance: variance, upper_bound: bound?, location: loc?) -> void
+      attr_reader upper_bound_type: Types::t?
+
+      attr_reader default_type: Types::t?
+
+      def initialize: (name: Symbol, variance: variance, upper_bound: Types::t?, location: loc?) -> void
 
       include _ToJson
 
@@ -37,7 +41,7 @@ module RBS
 
       def unchecked?: () -> bool
 
-      def map_type: () { (bound) -> bound } -> TypeParam
+      def map_type: () { (Types::t) -> Types::t } -> TypeParam
 
       # Helper function to resolve _class instance types_ to _type variables_.
       #

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -74,6 +74,33 @@ module RBS
       def self.rename: (Array[TypeParam], new_names: Array[Symbol]) -> Array[TypeParam]
 
       def to_s: () -> String
+
+      # Returns an application with respect to type params` default
+      #
+      def self.application: (Array[TypeParam], Array[Types::t]) -> Substitution?
+
+      # Returns an array of type args, that fills ommited types with the defaults
+      #
+      # ```rbs
+      # interface _Foo[T, S = untyped]
+      # end
+      # ```
+      #
+      # Normalizing type args with `_Foo` works as following:
+      #
+      # ```rbs
+      # _Foo[String]                   # => _Foo[String, untyped]
+      # _Foo[String, Integer]          # => _Foo[String, Integer]
+      # _Foo                           # => _Foo                            (Omitting missing args)
+      # _Foo[String, Integer, untyped] # => _Foo[String, Integer, untyped]  (Keeping extra args)
+      # ```
+      #
+      # Note that it allows iinvalid arities.
+      #
+      # * Missing args will be omitted
+      # * Extra args will be keeped
+      #
+      def self.normalize_args: (Array[TypeParam], Array[Types::t]) -> Array[Types::t]
     end
   end
 end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -379,11 +379,14 @@ singleton(::BasicObject)
     with_cli do |cli|
       Dir.mktmpdir do |dir|
         (Pathname(dir) + 'a.rbs').write(<<~RBS)
-        class Foo[A < _Each[B]]
-          def foo: [X < _Foo[Y]] () -> X
+          class Foo[A < _Each[B]]
+            def foo: [X < _Foo[Y]] () -> X
 
-          def bar: [X < _Foo[Y], Y < _Bar[Z], Z < _Baz[X]] () -> void
-        end
+            def bar: [X < _Foo[Y], Y < _Bar[Z], Z < _Baz[X]] () -> void
+          end
+
+          class B
+          end
         RBS
 
         assert_raises SystemExit do
@@ -428,6 +431,121 @@ singleton(::BasicObject)
         end
 
         assert_include stdout.string, "a.rbs:4:11...4:50: Cyclic type parameter bound is prohibited (RBS::CyclicTypeParameterBound)"
+      end
+    end
+  end
+
+  def test_validate__generics_default
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        (Pathname(dir) + 'a.rbs').write(<<~RBS)
+          module A[T = Integer]
+          end
+
+          class B[S = String]
+          end
+
+          interface _C[T = Symbol]
+          end
+
+          class Foo[T = A]
+            type t = A
+
+            def foo: () -> A
+
+            def self.bar: () -> B
+          end
+
+          class Bar < B
+            include A
+            extend A
+            include _C
+            extend _C
+          end
+
+          module Baz : A, _C
+          end
+        RBS
+
+        cli.run(["-I", dir, "validate"])
+      end
+    end
+  end
+
+  def test_validate__generics_default2
+    with_cli do |cli|
+      Dir.mktmpdir do |dir|
+        dir = Pathname(dir)
+
+        (dir + 'a.rbs').write(<<~RBS)
+          module A[T = Integer]
+          end
+
+          class B[S = String]
+          end
+
+          interface _C[T = Symbol]
+          end
+        RBS
+
+        (dir + "x0.rbs").write(<<~RBS)
+          class X0[T = A[Symbol, Symbol]]
+          end
+        RBS
+
+        (dir + "x1.rbs").write(<<~RBS)
+          class X1 < B[String, untyped]
+          end
+        RBS
+
+        (dir + "x2.rbs").write(<<~RBS)
+          class X2
+            include A[String, untyped]
+          end
+        RBS
+
+        (dir + "x3.rbs").write(<<~RBS)
+          class X3
+            include _C[String, untyped]
+          end
+        RBS
+
+        (dir + "x4.rbs").write(<<~RBS)
+          class X4
+            prepend A[String, untyped]
+          end
+        RBS
+
+        (dir + "x5.rbs").write(<<~RBS)
+          class X5
+            extend A[String, untyped]
+          end
+        RBS
+
+        (dir + "x6.rbs").write(<<~RBS)
+          class X6
+            extend _C[String, untyped]
+          end
+        RBS
+
+        (dir + "x7.rbs").write(<<~RBS)
+          module X7 : A[String, untyped]
+          end
+        RBS
+
+
+        assert_raises SystemExit do
+          cli.run(["-I", dir.to_s, "validate"])
+        end
+
+        assert_include stdout.string, "/x0.rbs:1:13...1:30: ::A expects parameters [T = ::Integer], but given args [::Symbol, ::Symbol] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x1.rbs:1:11...1:29: ::B expects parameters [S = ::String], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x2.rbs:2:2...2:28: ::A expects parameters [T = ::Integer], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x3.rbs:2:2...2:29: ::_C expects parameters [T = ::Symbol], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x4.rbs:2:2...2:28: ::A expects parameters [T = ::Integer], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x5.rbs:2:2...2:27: ::A expects parameters [T = ::Integer], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x6.rbs:2:2...2:28: ::_C expects parameters [T = ::Symbol], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
+        assert_include stdout.string, "/x7.rbs:1:12...1:30: ::A expects parameters [T = ::Integer], but given args [::String, untyped] (RBS::InvalidTypeApplicationError)"
       end
     end
   end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -2011,7 +2011,7 @@ end
 
   def test_generics_bound
     Parser.parse_signature(<<-EOF).tap do |_, _, decls|
-class Foo[X < _Each[Y], Y]
+class Foo[X < _Each[Y]?, Y]
   def foo: [X < Array[Y]] (X) -> X
 end
     EOF
@@ -2023,14 +2023,15 @@ end
           assert_equal :X, param.name
           assert_equal :invariant, param.variance
           refute_predicate param, :unchecked?
-          assert_equal parse_type("_Each[Y]", variables: [:Y]), param.upper_bound
+          assert_nil param.upper_bound
+          assert_equal parse_type("_Each[Y]?", variables: [:Y]), param.upper_bound_type
         end
 
         decl.type_params[1].tap do |param|
           assert_equal :Y, param.name
           assert_equal :invariant, param.variance
           refute_predicate param, :unchecked?
-          assert_nil param.upper_bound
+          assert_nil param.upper_bound_type
         end
 
         decl.members[0].tap do |member|
@@ -2039,6 +2040,7 @@ end
             assert_equal :invariant, param.variance
             refute_predicate param, :unchecked?
             assert_equal parse_type("Array[Y]", variables: [:Y]), param.upper_bound
+            assert_equal parse_type("Array[Y]", variables: [:Y]), param.upper_bound_type
           end
         end
       end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -2047,12 +2047,33 @@ end
     end
   end
 
-  def test_generics_bound_error
-    assert_raises RBS::ParsingError do
-      Parser.parse_signature(<<-EOF)
-        class Foo[X < string]
+  def test_generics_default
+    Parser.parse_signature(<<-EOF).tap do |_, _, decls|
+class Foo[X < _Each[String]? = Array[String]]
+end
+    EOF
+      decls[0].tap do |decl|
+        assert_instance_of Declarations::Class, decl
+
+        assert_equal 1, decl.type_params.size
+        decl.type_params[0].tap do |param|
+          assert_equal :X, param.name
+          assert_equal :invariant, param.variance
+          refute_predicate param, :unchecked?
+          assert_nil param.upper_bound
+          assert_equal parse_type("_Each[String]?"), param.upper_bound_type
+          assert_equal parse_type("Array[String]"), param.default_type
         end
-            EOF
+      end
+    end
+
+    assert_raises do
+      Parser.parse_signature(<<~EOF)
+        class Foo[X = untyped, Y]
+        end
+      EOF
+    end.tap do |error|
+      assert_match(/required type parameter is not allowed after optional type parameter/, error.message)
     end
   end
 


### PR DESCRIPTION
This PR implements two major improvements on generics.

1. Generics upper bound now can be any type
2. Generic type variable on module/class/interface/type alias can have default type

```rbs
class Foo[T < Object? = String?]
end
```