### PR TITLE
docs: An interface can include interfaces only and not modules

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -424,8 +424,10 @@ _visibility_ ::= `public` | `private`
 
 _attribute-type_ ::= `attr_reader` | `attr_writer` | `attr_accessor`
 
-_include-member_ ::= `include` _class-name_ _type-arguments_
-                   | `include` _interface-name_ _type-arguments_
+_include-member_ ::= _include-class-member_
+                   | _include-interface-member_
+_include-class-member_ ::= `include` _class-name_ _type-arguments_
+_include-interface-member_ :== `include` _interface-name_ _type-arguments_
 _extend-member_ ::= `extend` _class-name_ _type-arguments_
                   | `extend` _interface-name_ _type-arguments_
 _prepend-member_ ::= `prepend` _class-name_ _type-arguments_
@@ -621,7 +623,7 @@ _module-self-types_ ::= _class-name_ _type-arguments_ `,` _module-self-types_   
 _interface-decl_ ::= `interface` _interface-name_ _module-type-parameters_ _interface-members_ `end`
 
 _interface-members_ ::= _method-member_              # Method
-                      | _include-member_             # Mixin (include)
+                      | _include-interface-member_   # Mixin (include)
                       | _alias-member_               # Alias
 
 _type-alias-decl_ ::= `type` _alias-name_ _module-type-parameters_ `=` _type_


### PR DESCRIPTION
I found an interface can include interfaces only and not modules. Is my understanding correct?
If true, it's better to fix the syntax document.

Example:

```
# sig/example.rbs
module Foo
end

interface _Bar
  include Foo
end
```

```
bundle exec rbs -I sig validate                                                                                                                        ~/work/tmp/steep [main]
bundler: failed to load command: rbs (/Users/tkomiya/.dotfiles/_rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/bin/rbs)
/Users/tkomiya/.dotfiles/_rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rbs-3.5.3/lib/rbs/parser_aux.rb:20:in `_parse_signature': sig/example.rbs:5:10...5:13: Syntax error: expected one of interface name, token=`Foo` (tUIDENT) (RBS::ParsingError)

    include Foo
            ^^^

	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rbs-3.5.3/lib/rbs/parser_aux.rb:20:in `parse_signature'
	from /Users/tkomiya/.dotfiles/_rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rbs-3.5.3/lib/rbs/environment_loader.rb:161:in `block (2 levels) in each_signature'
(snip)
```