### PR TITLE
Skip `AbstractSyntaxTree` test with ruby-3.4

### DIFF
--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -389,7 +389,7 @@ end
     end
   end
 
-  if RUBY_VERSION >= '3.1'
+  if RUBY_VERSION >= '3.1' && RUBY_VERSION <= "3.3"
     class TestForYield
       def m1() yield end
       def m2() yield 42 end

--- a/test/stdlib/RubyVM_test.rb
+++ b/test/stdlib/RubyVM_test.rb
@@ -16,6 +16,7 @@ class RubyVM::AbstractSyntaxTreeSingletonTest < Test::Unit::TestCase
   end
 
   def test_of
+    return if RUBY_VERSION >= "3.4.0"
     assert_send_type "(::Proc | ::Method | ::UnboundMethod body, ?keep_script_lines: bool, ?error_tolerant: bool, ?keep_tokens: bool) -> ::RubyVM::AbstractSyntaxTree::Node?",
                      RubyVM::AbstractSyntaxTree, :of, method(:test_of)
   end


### PR DESCRIPTION
Prism is merged in ruby-3.4 and deprecated `AbstractSyntaxTree.of` method.

Related to https://github.com/ruby/rbs/pull/1983