### PR TITLE
Use generic class definitions with default types in `top`/`Enumerator``::_Each`

### DIFF
--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -170,12 +170,12 @@ interface _Inspect
   def inspect: () -> String
 end
 
-interface _Each[out A]
-  def each: () { (A) -> void } -> void
+interface _Each[out E, out R = void]
+  def each: () { (E) -> void } -> R
 end
 
-interface _EachEntry[out A]
-  def each_entry: () { (A) -> void } -> self
+interface _EachEntry[out E]
+  def each_entry: () { (E) -> void } -> self
 end
 
 interface _Reader

--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -132,7 +132,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
 
   # A convenience interface for `each` with optional block
   #
-  interface _Each[out E, out R]
+  interface _Each[out E, out R = self]
     def each: () { (E) -> void } -> R
             | () -> Enumerator[E, R]
   end


### PR DESCRIPTION
* Follow-up of #2004
* Follow-up of #1915
  * Resolves https://github.com/ruby/rbs/pull/1915#discussion_r1759636590

With this, `::_Each`, `Enumerator` and `Enumerator::_Each` matches each other (a bit) better.