### PR TITLE
Make `rand(Integer)` returns `Integer`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Rubycw/Rubycw:
   Enabled: true
   Exclude:
     - 'test/**/*_test.rb'
+    - 'test/typecheck/**/*.rb'
 
 RBS:
   Enabled: true

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1319,7 +1319,7 @@ module Kernel : BasicObject
   # See also Random.rand.
   #
   def self?.rand: (?0) -> Float
-                | (int arg0) -> (Integer | Float)
+                | (int arg0) -> Integer
                 | (::Range[Integer] arg0) -> Integer?
                 | (::Range[Float] arg0) -> Float?
 

--- a/core/random.rbs
+++ b/core/random.rbs
@@ -91,7 +91,7 @@ class Random < RBS::Unnamed::Random_Base
   #
   # See also Random#rand.
   #
-  def self.rand: () -> Float
+  def self.rand: (?0) -> Float
                | (Integer | ::Range[Integer] max) -> Integer
                | (Float | ::Range[Float] max) -> Float
                | [T < Numeric] (::Range[T]) -> T

--- a/core/rbs/unnamed/random.rbs
+++ b/core/rbs/unnamed/random.rbs
@@ -47,7 +47,7 @@ module RBS
       # (`-`) and add (`+`)methods, or rand will raise an ArgumentError.
       #
       %a{annotate:rdoc:copy:Random#rand}
-      def rand: () -> Float
+      def rand: (?0) -> Float
               | (Integer | ::Range[Integer] max) -> Integer
               | (Float | ::Range[Float] max) -> Float
 
@@ -200,13 +200,13 @@ module RBS
       # Generates formatted random number from raw random bytes. See Random#rand.
       #
       %a{annotate:rdoc:copy:Random::Formatter#rand}
-      def rand: () -> Float
-              | (?Float? n) -> Float
-              | (?Integer? n) -> Integer
-              | (?Numeric? n) -> Numeric
-              | (?::Range[Float]? n) -> Float
-              | (?::Range[Integer]? n) -> Integer
-              | (?::Range[Numeric]? n) -> Numeric
+      def rand: (?0) -> Float
+              | (Float? n) -> Float
+              | (Integer n) -> Integer
+              | (Numeric n) -> Numeric
+              | (::Range[Float] n) -> Float
+              | (::Range[Integer] n) -> Integer
+              | (::Range[Numeric] n) -> Numeric
 
       %a{annotate:rdoc:copy:Random::Formatter#random_byte}
       def random_bytes: (?Integer? n) -> String

--- a/test/typecheck/random/Steepfile
+++ b/test/typecheck/random/Steepfile
@@ -1,0 +1,7 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/random/test.rb
+++ b/test/typecheck/random/test.rb
@@ -1,0 +1,13 @@
+# @type var int: Integer
+# @type var float: Float
+
+float = rand(0)
+int = rand(1)
+
+i = 2
+int = rand(i)
+
+int = rand(1..10) || 0
+float = rand((1.0)..(2.2)) || 0.1
+
+int = rand(1.1)


### PR DESCRIPTION
Closes https://github.com/ruby/rbs/pull/1982

The `rand` implementation is a bit annoying for type checkers.

```rb
rand(0)    # Returns a Float
rand(1)    # Returns an Integer
```

The current type definition is sound that `rand(1)` returns `Integer | Float`, while it's really annoying because it returns `Integer` actually.

To make the type checkers more useful and match with our intuition, this PR makes the `rand(1)` returns `Integer`.

We assume the following pattern:

* When we really want an `Float` result, we usually pass `0` literal to `rand` -- `rand(0)` should return an `Float`
* When we pass some unknown integer value, we usually confirm the value is not `0`, because we don't want `Float` result -- `rand(i)` can return `Integer`, no `Float`

The type definition uses literal type `0` to make type of `rand(0)` call `Float`. And other `Integer` cases returns an `Integer`.

This is **unsound**, but we believe this is more practical and useful.