### PR TITLE
Allow RBS/Style/InitializeReturnType

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,8 @@ RBS/Style:
   Exclude:
     - 'sig/**/*'
     - 'test/**/*'
+RBS/Style/InitializeReturnType:
+  Enabled: true
 
 Lint/DuplicateMethods:
   Enabled: true

--- a/core/basic_object.rbs
+++ b/core/basic_object.rbs
@@ -256,7 +256,7 @@ class BasicObject
   # -->
   # Returns a new BasicObject.
   #
-  def initialize: () -> nil
+  def initialize: () -> void
 
   private
 

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -182,7 +182,7 @@ class Dir
   #     Dir.new('.').read.encoding                       # => #<Encoding:UTF-8>
   #     Dir.new('.', encoding: 'US-ASCII').read.encoding # => #<Encoding:US-ASCII>
   #
-  def initialize: (path dir, ?encoding: encoding?) -> self
+  def initialize: (path dir, ?encoding: encoding?) -> void
 
   # <!--
   #   rdoc-file=dir.rb

--- a/core/errors.rbs
+++ b/core/errors.rbs
@@ -597,7 +597,7 @@ class SystemCallError < StandardError
   # SystemCallError object. The error number is subsequently available via the
   # #errno method.
   #
-  def initialize: (string msg, Integer errno) -> SystemCallError
+  def initialize: (string msg, Integer errno) -> void
 
   # <!--
   #   rdoc-file=error.c

--- a/core/exception.rbs
+++ b/core/exception.rbs
@@ -250,7 +250,7 @@ class Exception
   # -->
   # Construct a new Exception object, optionally passing in a message.
   #
-  def initialize: (?string | _ToS message) -> self
+  def initialize: (?string | _ToS message) -> void
 
   # <!--
   #   rdoc-file=error.c

--- a/core/file.rbs
+++ b/core/file.rbs
@@ -875,7 +875,7 @@ class File < IO
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def initialize: (string | _ToPath | int file_name, ?string | int mode, ?int perm) -> File
+  def initialize: (string | _ToPath | int file_name, ?string | int mode, ?int perm) -> void
 
   # <!--
   #   rdoc-file=file.c

--- a/core/module.rbs
+++ b/core/module.rbs
@@ -904,7 +904,7 @@ class Module < Object
   # Assign the module to a constant (name starting uppercase) if you want to treat
   # it like a regular module.
   #
-  def initialize: () -> Object
+  def initialize: () -> void
                 | () { (Module arg0) -> untyped } -> void
 
   # <!--

--- a/core/regexp.rbs
+++ b/core/regexp.rbs
@@ -1596,8 +1596,8 @@ class Regexp
   #     r3 = Regexp.new(r, timeout: 3.14)            # => /foo/m
   #     r3.timeout                                   # => 3.14
   #
-  def initialize: (Regexp regexp, ?timeout: _ToF?) -> self
-                | (string pattern, ?int | string | bool | nil options, ?timeout: _ToF?) -> self
+  def initialize: (Regexp regexp, ?timeout: _ToF?) -> void
+                | (string pattern, ?int | string | bool | nil options, ?timeout: _ToF?) -> void
 
   def initialize_copy: (self object) -> self
 

--- a/stdlib/ipaddr/0/ipaddr.rbs
+++ b/stdlib/ipaddr/0/ipaddr.rbs
@@ -63,7 +63,7 @@ class IPAddr
   # as &, |, include? and ==, accept a string, or a packed in_addr value instead
   # of an IPAddr object.
   #
-  def initialize: (?String addr, ?untyped family) -> IPAddr
+  def initialize: (?String addr, ?untyped family) -> void
 
   # <!--
   #   rdoc-file=lib/ipaddr.rb

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -2078,7 +2078,7 @@ module Net
     #   - new(m, reqbody, resbody, uri_or_path, initheader = nil)
     # -->
     #
-    def initialize: (String m, boolish reqbody, boolish resbody, URI::Generic | String uri_or_path, ?headers initheader) -> Net::HTTP
+    def initialize: (String m, boolish reqbody, boolish resbody, URI::Generic | String uri_or_path, ?headers initheader) -> void
 
     # <!-- rdoc-file=lib/net/http/generic_request.rb -->
     # Returns the string method name for the request:

--- a/stdlib/psych/0/store.rbs
+++ b/stdlib/psych/0/store.rbs
@@ -45,7 +45,7 @@ class Psych::Store < ::PStore
   # Options passed in through `yaml_opts` will be used when converting the store
   # to YAML via Hash#to_yaml().
   #
-  def initialize: (*untyped o) -> Psych::Store
+  def initialize: (*untyped o) -> void
 
   def dump: (untyped table) -> String
 

--- a/stdlib/uri/0/ldap.rbs
+++ b/stdlib/uri/0/ldap.rbs
@@ -71,7 +71,7 @@ module URI
     #
     # See also URI::Generic.new.
     #
-    def initialize: (String schema, String? userinfo, String host, Integer? port, String? registry, String? path, String? opaque, String query, String? fragment) -> URI::LDAP
+    def initialize: (String schema, String? userinfo, String host, Integer? port, String? registry, String? path, String? opaque, String query, String? fragment) -> void
 
     # <!--
     #   rdoc-file=lib/uri/ldap.rb


### PR DESCRIPTION
Retry https://github.com/ruby/rbs/pull/1763 .

`#initialize` is often overridden, but specifying a return type can be inconvenient for type checking.

The `RBS/Style/InitializeReturnType` cop suggests specifying `void` as the return type when the return type of the `#initialize` method is not `untyped` or `void`.