### PR TITLE
writer: Preserve empty lines between decls for modules

### DIFF
--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -143,10 +143,10 @@ module RBS
         puts "module #{name_and_params(decl.name, decl.type_params)}#{self_type}"
 
         indent do
-          decl.members.each.with_index do |member, index|
-            if index > 0
-              puts
-            end
+          [nil, *decl.members].each_cons(2) do |prev, member|
+            raise unless member
+
+            preserve_empty_line prev, member
             write_member member
           end
         end

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -403,15 +403,11 @@ end
 
 module ::Foo : ::Foo::_Each[::Foo::String]
   attr_reader name: ::Foo::String
-
   attr_accessor size: Integer
-
   attr_writer email(@foo): ::String
 
   @created_at: ::Time
-
   self.@last_timestamp: ::Time?
-
   @@max_size: Integer
 
   include ::Enumerable[Integer]

--- a/test/rbs/subtractor_test.rb
+++ b/test/rbs/subtractor_test.rb
@@ -299,7 +299,6 @@ class RBS::SubtractorTest < Test::Unit::TestCase
     assert_subtracted <<~RBS, subtracted
       module M
         def y: () -> untyped
-
         def self.x: () -> untyped
       end
     RBS


### PR DESCRIPTION
https://github.com/ruby/rbs/pull/146 adds preservation empty lines between declarations feature to the classes.

This also introduces the same feature to the modules.  Before this change, our writer inserts a line to between all declarations.  It's a bit difficult to read.  Therefore, this increases the readability of the generated RBS files.