### PR TITLE
Prohibit `self` type as a generics default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,5 +43,5 @@ group :minitest do
 end
 
 group :typecheck_test do
-  gem "steep", "~> 1.7.1", require: false
+  gem "steep", "~> 1.8.0.pre", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,16 +13,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     abbrev (0.1.2)
-    activesupport (7.1.4)
+    activesupport (7.2.1)
       base64
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
-      mutex_m
-      tzinfo (~> 2.0)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
@@ -44,7 +45,7 @@ GEM
       psych (>= 3.1, < 5.0)
       rainbow (>= 3.0, < 4.0)
       strong_json (>= 1.1, < 2.2)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     json-schema (5.0.0)
@@ -119,7 +120,7 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
     stackprof (0.2.26)
-    steep (1.7.1)
+    steep (1.8.0.pre.2)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -130,7 +131,7 @@ GEM
       logger (>= 1.3.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (>= 3.5.0.pre)
+      rbs (~> 3.6.0.pre)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)
@@ -180,7 +181,7 @@ DEPENDENCIES
   rubocop-on-rbs
   rubocop-rubycw
   stackprof
-  steep (~> 1.7.1)
+  steep (~> 1.8.0.pre)
   tempfile
   test-unit
 

--- a/Rakefile
+++ b/Rakefile
@@ -56,7 +56,7 @@ end
 task :validate => :compile do
   require 'yaml'
 
-  sh "#{ruby} #{rbs} validate"
+  sh "#{ruby} #{rbs} validate --exit-error-on-syntax-error"
 
   libs = FileList["stdlib/*"].map {|path| File.basename(path).to_s }
 
@@ -72,7 +72,7 @@ task :validate => :compile do
   end
 
   libs.each do |lib|
-    sh "#{ruby} #{rbs} -r #{lib} validate"
+    sh "#{ruby} #{rbs} -r #{lib} validate --exit-error-on-syntax-error"
   end
 end
 

--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -132,7 +132,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
 
   # A convenience interface for `each` with optional block
   #
-  interface _Each[out E, out R = self]
+  interface _Each[out E, out R]
     def each: () { (E) -> void } -> R
             | () -> Enumerator[E, R]
   end

--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -165,6 +165,7 @@ EOU
 
             if dt = param.default_type
               void_type_context_validator(dt, true)
+              no_self_type_validator(dt)
               no_classish_type_validator(dt)
               @validator.validate_type(dt, context: nil)
             end
@@ -241,6 +242,7 @@ EOU
 
             if dt = param.default_type
               void_type_context_validator(dt, true)
+              no_self_type_validator(dt)
               no_classish_type_validator(dt)
               @validator.validate_type(dt, context: nil)
             end

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -562,16 +562,16 @@ singleton(::BasicObject)
 
           interface _C[T = self]
           end
-        RBS
 
-        (Pathname(dir) + 'b.rbs').write(<<~RBS)
           type t[T = self] = untyped
         RBS
 
         cli.run(["-I", dir, "validate"])
 
-        refute_operator stdout.string, :include?, "/a.rbs"
-        assert_include stdout.string, "/b.rbs:1:11...1:15: `self` type is not allowed in this context (RBS::WillSyntaxError)"
+        assert_include stdout.string, "/a.rbs:1:13...1:17: `self` type is not allowed in this context (RBS::WillSyntaxError)\n"
+        assert_include stdout.string, "/a.rbs:4:12...4:16: `self` type is not allowed in this context (RBS::WillSyntaxError)\n"
+        assert_include stdout.string, "/a.rbs:7:17...7:21: `self` type is not allowed in this context (RBS::WillSyntaxError)\n"
+        assert_include stdout.string, "/a.rbs:10:11...10:15: `self` type is not allowed in this context (RBS::WillSyntaxError)\n"
       end
     end
   end


### PR DESCRIPTION
I found the semantics is really complicated.

```rbs
interface _Foo[T = self]
  def foo: () -> T
end

class Foo
  def bar: () -> _Foo        # => This is translated to _Foo[self] by filling with default type, and returns _Foo[Foo]. Is this really what we want?
end
```