### PR TITLE
Update rubocop-on-rbs v1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,9 +110,9 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
-    rubocop-on-rbs (0.6.0)
+    rubocop-on-rbs (1.0.0)
       rbs (~> 3.5)
-      rubocop (~> 1.41)
+      rubocop (~> 1.61)
       zlib
     rubocop-rubycw (0.1.6)
       rubocop (~> 1.0)
@@ -145,7 +145,7 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
     zlib (3.1.1)
 
 PLATFORMS

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -600,8 +600,6 @@ class Array[unchecked out Elem] < Object
   #
   def self.try_convert: [U] (untyped) -> ::Array[U]?
 
-  public
-
   # <!--
   #   rdoc-file=array.c
   #   - array & other_array -> new_array

--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -109,8 +109,6 @@ class Complex < Numeric
   #
   alias self.rectangular self.rect
 
-  public
-
   # <!--
   #   rdoc-file=complex.c
   #   - complex * numeric -> new_complex

--- a/core/data.rbs
+++ b/core/data.rbs
@@ -183,8 +183,6 @@ class Data
 
   def self.allocate: () -> bot
 
-  public
-
   # <!--
   #   rdoc-file=struct.c
   #   - self == other -> true or false

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -759,8 +759,6 @@ class Dir
   #
   alias self.unlink self.delete
 
-  public
-
   # <!--
   #   rdoc-file=dir.c
   #   - chdir -> 0

--- a/core/encoding.rbs
+++ b/core/encoding.rbs
@@ -780,8 +780,6 @@ class Encoding::Converter < Object
                               ?xml: :text | :attr
                             ) -> conversion_path
 
-  public
-
   # <!--
   #   rdoc-file=transcode.c
   #   - ec == other        -> true or false

--- a/core/enumerator/product.rbs
+++ b/core/enumerator/product.rbs
@@ -44,8 +44,6 @@ class Enumerator[unchecked out Elem, out Return = void]
     #
     def initialize: (*_EachEntry[Elem]) -> void
 
-    public
-
     # <!--
     #   rdoc-file=enumerator.c
     #   - obj.each { |...| ... } -> obj

--- a/core/errors.rbs
+++ b/core/errors.rbs
@@ -270,8 +270,6 @@ class NameError[T] < StandardError
   #
   def initialize: (?string msg, ?String? name, ?receiver: T?) -> void
 
-  public
-
   # <!--
   #   rdoc-file=error.c
   #   - name_error.local_variables  ->  array
@@ -361,8 +359,6 @@ class NoMethodError[T] < NameError[T]
   # *receiver* argument stores an object whose method was called.
   #
   def initialize: (?string? msg, ?String? name, ?Array[untyped] args, ?boolish `private`, ?receiver: T?) -> void
-
-  public
 
   # <!--
   #   rdoc-file=error.c
@@ -470,8 +466,6 @@ class SignalException < Exception
   #
   def initialize: (?string sig_name) -> void
                 | (int sig_number, ?string sig_name) -> void
-
-  public
 
   def signm: () -> String
 
@@ -608,8 +602,6 @@ class SystemCallError < StandardError
   #
   def self.===: (untyped other) -> bool
 
-  public
-
   # <!--
   #   rdoc-file=error.c
   #   - system_call_error.errno   -> integer
@@ -636,8 +628,6 @@ class SystemExit < Exception
   def initialize: () -> void
                 | (string msg) -> void
                 | (true | false | int status, ?string msg) -> void
-
-  public
 
   # <!--
   #   rdoc-file=error.c
@@ -725,8 +715,6 @@ class UncaughtThrowError < ArgumentError
   #     UncaughtThrowError: uncaught throw "foo"
   #
   def initialize: (untyped tag, untyped value) -> void
-
-  public
 
   # <!--
   #   rdoc-file=vm_eval.c

--- a/core/file.rbs
+++ b/core/file.rbs
@@ -1769,8 +1769,6 @@ class File < IO
   #
   def self.zero?: (string | _ToPath | IO file_name) -> bool
 
-  public
-
   # <!--
   #   rdoc-file=file.c
   #   - file.atime    -> time

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -80,8 +80,6 @@
 # *   #truncate: Returns `self` truncated to a given precision.
 #
 class Float < Numeric
-  public
-
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> float

--- a/core/hash.rbs
+++ b/core/hash.rbs
@@ -559,8 +559,6 @@ class Hash[unchecked out K, unchecked out V] < Object
   def self.try_convert: [U, V] (_ToHash[U, V]) -> ::Hash[U, V]
                       | (untyped) -> (::Hash[untyped, untyped] | nil)
 
-  public
-
   # <!--
   #   rdoc-file=hash.c
   #   - hash < other_hash -> true or false

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -149,8 +149,6 @@ class Integer < Numeric
   def self.try_convert: (int) -> Integer
                       | (untyped) -> Integer?
 
-  public
-
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> real_number

--- a/core/io/buffer.rbs
+++ b/core/io/buffer.rbs
@@ -184,8 +184,6 @@ class IO
     #
     def self.string: (int) { (Buffer) -> void } -> String
 
-    public
-
     # <!--
     #   rdoc-file=io_buffer.c
     #   - <=>(other) -> true or false

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -162,8 +162,6 @@
 class Numeric
   include Comparable
 
-  public
-
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> real_numeric

--- a/core/object_space/weak_key_map.rbs
+++ b/core/object_space/weak_key_map.rbs
@@ -59,8 +59,6 @@ module ObjectSpace
   # sitting in the cache forever.
   #
   class WeakKeyMap[Key, Value]
-    public
-
     # <!--
     #   rdoc-file=weakmap.c
     #   - map[key] -> value

--- a/core/ractor.rbs
+++ b/core/ractor.rbs
@@ -597,8 +597,6 @@ class Ractor
   #
   def self.yield: (untyped obj, ?move: boolish) -> untyped
 
-  public
-
   # <!--
   #   rdoc-file=ractor.rb
   #   - <<(obj, move: false)
@@ -925,8 +923,6 @@ class Ractor
   #     # Ractor::MovedError (can not send any methods to a moved object)
   #
   class MovedObject < BasicObject
-    public
-
     # <!--
     #   rdoc-file=ractor.c
     #   - !(*args)
@@ -1007,8 +1003,6 @@ class Ractor
   #     end
   #
   class RemoteError < Ractor::Error
-    public
-
     def ractor: () -> Ractor
   end
 

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -48,8 +48,6 @@
 #                        #=> (1.0000000000000002+1.7320508075688772i)
 #
 class Rational < Numeric
-  public
-
   def %: (Integer) -> Rational
        | (Float) -> Float
        | (Rational) -> Rational

--- a/core/rbs/unnamed/argf.rbs
+++ b/core/rbs/unnamed/argf.rbs
@@ -45,8 +45,6 @@ module RBS
     class ARGFClass
       include Enumerable[String]
 
-      public
-
       # <!--
       #   rdoc-file=io.c
       #   - ARGF.argv  -> ARGV

--- a/stdlib/bigdecimal/0/big_decimal.rbs
+++ b/stdlib/bigdecimal/0/big_decimal.rbs
@@ -408,8 +408,6 @@ class BigDecimal < Numeric
   #
   def self.save_rounding_mode: () { (?nil) -> void } -> void
 
-  public
-
   # <!--
   #   rdoc-file=ext/bigdecimal/bigdecimal.c
   #   - a % b

--- a/stdlib/cgi/0/core.rbs
+++ b/stdlib/cgi/0/core.rbs
@@ -382,8 +382,6 @@ class CGI
   #
   def self.parse: (String query) -> Hash[String, Array[String]]
 
-  public
-
   # <!-- rdoc-file=lib/cgi/core.rb -->
   # Return the accept character set for this CGI instance.
   #
@@ -706,8 +704,6 @@ class CGI
     #
     def self.parse: (String raw_cookie) -> Hash[String, instance]
 
-    public
-
     # <!-- rdoc-file=lib/cgi/cookie.rb -->
     # Domain for which this cookie applies, as a `String`
     #
@@ -864,8 +860,6 @@ class CGI
   end
 
   module Escape
-    public
-
     # <!--
     #   rdoc-file=ext/cgi/escape/escape.c
     #   - CGI.escape(string) -> string
@@ -940,8 +934,6 @@ class CGI
   #     mode.
   #
   module QueryExtension
-    public
-
     # <!--
     #   rdoc-file=lib/cgi/core.rb
     #   - [](key)
@@ -1134,8 +1126,6 @@ class CGI
 
   module Util
     include CGI::Escape
-
-    public
 
     # <!--
     #   rdoc-file=lib/cgi/util.rb

--- a/stdlib/date/0/date.rbs
+++ b/stdlib/date/0/date.rbs
@@ -733,8 +733,6 @@ class Date
   #
   def self.xmlschema: (String str, ?Integer start) -> Date
 
-  public
-
   # <!--
   #   rdoc-file=ext/date/date_core.c
   #   - d + other  ->  date

--- a/stdlib/date/0/date_time.rbs
+++ b/stdlib/date/0/date_time.rbs
@@ -388,8 +388,6 @@ class DateTime < Date
   #
   def self.xmlschema: (String str, ?Integer start) -> DateTime
 
-  public
-
   # <!--
   #   rdoc-file=ext/date/date_core.c
   #   - deconstruct_keys(array_of_names_or_nil) -> hash

--- a/stdlib/dbm/0/dbm.rbs
+++ b/stdlib/dbm/0/dbm.rbs
@@ -74,8 +74,6 @@ class DBM
   def self.open: (String filename, ?Integer mode, ?Integer flags) -> DBM
                | [T] (String filename, ?Integer mode, ?Integer flags) { (DBM) -> T } -> T
 
-  public
-
   # <!--
   #   rdoc-file=ext/dbm/dbm.c
   #   - dbm[key] -> string value or nil

--- a/stdlib/delegate/0/delegator.rbs
+++ b/stdlib/delegate/0/delegator.rbs
@@ -40,8 +40,6 @@ class Delegator < BasicObject
 
   def self.public_api: () -> untyped
 
-  public
-
   # <!--
   #   rdoc-file=lib/delegate.rb
   #   - !()

--- a/stdlib/delegate/0/simple_delegator.rbs
+++ b/stdlib/delegate/0/simple_delegator.rbs
@@ -67,8 +67,6 @@
 #       Unique:  6
 #
 class SimpleDelegator < Delegator
-  public
-
   # <!--
   #   rdoc-file=lib/delegate.rb
   #   - __getobj__() { || ... }

--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -103,8 +103,6 @@ Digest::REQUIRE_MUTEX: Thread::Mutex
 # calculate message digest values.
 #
 module Digest::Instance
-  public
-
   # <!-- rdoc-file=ext/digest/digest.c -->
   # Updates the digest using a given *string* and returns self.
   #
@@ -403,8 +401,6 @@ end
 #                 Data_Wrap_Struct(0, 0, 0, (void *)&sha1));
 #
 class Digest::Base < Digest::Class
-  public
-
   # <!-- rdoc-file=ext/digest/digest.c -->
   # Update the digest using given *string* and return `self`.
   #

--- a/stdlib/etc/0/etc.rbs
+++ b/stdlib/etc/0/etc.rbs
@@ -709,8 +709,6 @@ module Etc
 
     def self.new: (*untyped) -> untyped
 
-    public
-
     def gid: () -> Integer
 
     def gid=: (Integer new_gid) -> void
@@ -806,8 +804,6 @@ module Etc
     def self.members: () -> untyped
 
     def self.new: (*untyped) -> untyped
-
-    public
 
     def change: () -> Integer
 

--- a/stdlib/logger/0/formatter.rbs
+++ b/stdlib/logger/0/formatter.rbs
@@ -4,8 +4,6 @@ class Logger
   # Default formatter for log messages.
   #
   class Formatter
-    public
-
     attr_accessor datetime_format: String?
 
     # <!--

--- a/stdlib/logger/0/log_device.rbs
+++ b/stdlib/logger/0/log_device.rbs
@@ -11,8 +11,6 @@ class Logger
     attr_reader dev: _WriteCloser
     attr_reader filename: String?
 
-    public
-
     # <!--
     #   rdoc-file=lib/logger/log_device.rb
     #   - close()

--- a/stdlib/logger/0/logger.rbs
+++ b/stdlib/logger/0/logger.rbs
@@ -357,8 +357,6 @@ class Logger
 
   include Logger::Severity
 
-  public
-
   # <!--
   #   rdoc-file=lib/logger.rb
   #   - <<(msg)

--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -10,8 +10,6 @@
 #     end
 #
 class Monitor
-  public
-
   # <!--
   #   rdoc-file=ext/monitor/monitor.c
   #   - enter()
@@ -195,8 +193,6 @@ module MonitorMixin
   #
   def self.extend_object: (untyped obj) -> untyped
 
-  public
-
   # <!--
   #   rdoc-file=ext/monitor/lib/monitor.rb
   #   - mon_enter()
@@ -303,8 +299,6 @@ end
 # calls while_wait and signal, this class should be documented.
 #
 class MonitorMixin::ConditionVariable
-  public
-
   # <!--
   #   rdoc-file=ext/monitor/lib/monitor.rb
   #   - broadcast()

--- a/stdlib/mutex_m/0/mutex_m.rbs
+++ b/stdlib/mutex_m/0/mutex_m.rbs
@@ -34,8 +34,6 @@ module Mutex_m
 
   def self.extend_object: (Object obj) -> untyped
 
-  public
-
   def mu_extended: () -> untyped
 
   # <!--

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -1485,8 +1485,6 @@ module Net
     def start: [T] () { (Net::HTTP) -> T } -> T
              | () -> Net::HTTP
 
-    public
-
     # <!--
     #   rdoc-file=lib/net/http.rb
     #   - finish()
@@ -1502,8 +1500,6 @@ module Net
     # Raises IOError if not in a session.
     #
     def finish: () -> void
-
-    public
 
     # <!--
     #   rdoc-file=lib/net/http.rb
@@ -1582,8 +1578,6 @@ module Net
     # -->
     #
     alias proxyport proxy_port
-
-    public
 
     # <!--
     #   rdoc-file=lib/net/http.rb
@@ -3975,8 +3969,6 @@ module Net
     # true if the response has a body.
     #
     def self.body_permitted?: () -> bool
-
-    public
 
     include Net::HTTPHeader
 

--- a/stdlib/observable/0/observable.rbs
+++ b/stdlib/observable/0/observable.rbs
@@ -130,8 +130,6 @@
 #     ticker.run
 #
 module Observable
-  public
-
   # <!--
   #   rdoc-file=lib/observer.rb
   #   - add_observer(observer, func=:update)

--- a/stdlib/open-uri/0/open-uri.rbs
+++ b/stdlib/open-uri/0/open-uri.rbs
@@ -21,7 +21,7 @@ module URI
   # We can accept URIs and strings that begin with http://, https:// and ftp://.
   # In these cases, the opened file object is extended by OpenURI::Meta.
   #
-  def self.open: (String name, ?String mode, ?Integer perm, ?untyped options) -> (StringIO & OpenURI::Meta | Tempfile & OpenURI::Meta)
+  def self.open: (String name, ?String mode, ?Integer perm, ?untyped options) -> ((StringIO & OpenURI::Meta) | (Tempfile & OpenURI::Meta))
                | [T] (String name, ?String mode, ?Integer perm, ?untyped options) { (StringIO | Tempfile) -> T } -> T
 end
 

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -934,8 +934,6 @@ module OpenSSL
     #     puts int2.value # => 1
     #
     class ASN1Data
-      public
-
       # <!-- rdoc-file=ext/openssl/ossl_asn1.c -->
       # Never `nil`. A boolean value indicating whether the encoding uses indefinite
       # length (in the case of parsing) or whether an indefinite length form shall be
@@ -1082,8 +1080,6 @@ module OpenSSL
     end
 
     class BitString < OpenSSL::ASN1::Primitive
-      public
-
       def unused_bits: () -> ::Integer
 
       def unused_bits=: (::Integer) -> ::Integer
@@ -1126,8 +1122,6 @@ module OpenSSL
     #
     class Constructive < OpenSSL::ASN1::ASN1Data
       include Enumerable[ASN1Data]
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_asn1.c
@@ -1192,8 +1186,6 @@ module OpenSSL
     end
 
     class EndOfContent < OpenSSL::ASN1::ASN1Data
-      public
-
       def to_der: () -> String
 
       private
@@ -1274,8 +1266,6 @@ module OpenSSL
       def value: () -> String
 
       def value=: (String) -> String
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_asn1.c
@@ -1393,8 +1383,6 @@ module OpenSSL
     #     prim_zero_tagged_explicit = <class>.new(value, 0, :EXPLICIT)
     #
     class Primitive < OpenSSL::ASN1::ASN1Data
-      public
-
       # <!-- rdoc-file=ext/openssl/ossl_asn1.c -->
       # May be used as a hint for encoding a value either implicitly or explicitly by
       # setting it either to `:IMPLICIT` or to `:EXPLICIT`. *tagging* is not set when
@@ -1534,8 +1522,6 @@ module OpenSSL
     # See also the man page BN_rand_range(3).
     #
     def self.rand_range: (untyped) -> untyped
-
-    public
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1949,8 +1935,6 @@ module OpenSSL
   #
   module Buffering
     include Enumerable[untyped]
-
-    public
 
     # <!--
     #   rdoc-file=ext/openssl/lib/openssl/buffering.rb
@@ -2490,8 +2474,6 @@ module OpenSSL
     #
     def self.ciphers: () -> Array[String]
 
-    public
-
     # <!--
     #   rdoc-file=ext/openssl/ossl_cipher.c
     #   - cipher.auth_data = string -> string
@@ -2908,8 +2890,6 @@ module OpenSSL
     #
     def self.parse_config: (IO io) -> Hash[String, Hash[String, String]]
 
-    public
-
     # <!--
     #   rdoc-file=ext/openssl/ossl_config.c
     #   - config[section] -> hash
@@ -3198,8 +3178,6 @@ module OpenSSL
     #
     def self.digest: (String name, String data) -> String
 
-    public
-
     # <!-- rdoc-file=ext/openssl/ossl_digest.c -->
     # Not every message digest can be computed in one single pass. If a message
     # digest is to be computed from several subsequent sources, then each may be
@@ -3456,8 +3434,6 @@ module OpenSSL
     #
     def self.load: (?String name) -> (true | nil)
 
-    public
-
     # <!--
     #   rdoc-file=ext/openssl/ossl_engine.c
     #   - engine.cipher(name) -> OpenSSL::Cipher
@@ -3688,8 +3664,6 @@ module OpenSSL
     #     #=> "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9"
     #
     def self.hexdigest: (String | Digest algo, String key, String data) -> String
-
-    public
 
     # <!-- rdoc-file=ext/openssl/ossl_hmac.c -->
     # Returns *hmac* updated with the message to be authenticated. Can be called
@@ -4046,8 +4020,6 @@ module OpenSSL
     #
     def self.included: (untyped base) -> untyped
 
-    public
-
     # <!--
     #   rdoc-file=ext/openssl/lib/openssl/marshal.rb
     #   - _dump(_level)
@@ -4056,8 +4028,6 @@ module OpenSSL
     def _dump: (untyped _level) -> untyped
 
     module ClassMethods
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/marshal.rb
       #   - _load(string)
@@ -4112,8 +4082,6 @@ module OpenSSL
     #     #proceed
     #
     class SPKI
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ns_spki.c
       #   - spki.challenge => string
@@ -4505,8 +4473,6 @@ module OpenSSL
     # detailed than a Response.
     #
     class BasicResponse
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ocsp.c
       #   - basic_response.add_nonce(nonce = nil)
@@ -4644,8 +4610,6 @@ module OpenSSL
     # status check can be performed.
     #
     class CertificateId
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ocsp.c
       #   - certificate_id.cmp(other) -> true or false
@@ -4747,8 +4711,6 @@ module OpenSSL
     # certificate or from a DER-encoded request created elsewhere.
     #
     class Request
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ocsp.c
       #   - request.add_certid(certificate_id) -> request
@@ -4884,8 +4846,6 @@ module OpenSSL
       #
       def self.create: (Integer status, ?BasicResponse response) -> instance
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ocsp.c
       #   - response.basic
@@ -4943,8 +4903,6 @@ module OpenSSL
     # which contains the basic information of the status of the certificate.
     #
     class SingleResponse
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ocsp.c
       #   - single_response.cert_status -> Integer
@@ -5089,8 +5047,6 @@ module OpenSSL
     #
     def self.create: (String pass, String name, PKey::PKey key, X509::Certificate cert, ?Array[X509::Certificate]? ca, ?String? key_pbe, ?String? cert_pbe, ?Integer? key_iter, ?Integer? mac_iter, ?Integer? keytype) -> instance
 
-    public
-
     def ca_certs: () -> Array[X509::Certificate]?
 
     def certificate: () -> X509::Certificate
@@ -5181,8 +5137,6 @@ module OpenSSL
     # -->
     #
     def self.write_smime: (instance pkcs7, ?String data, ?Integer flags) -> String
-
-    public
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_pkcs7.c
@@ -5393,8 +5347,6 @@ module OpenSSL
     end
 
     class RecipientInfo
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkcs7.c
       #   - enc_key()
@@ -5427,8 +5379,6 @@ module OpenSSL
     end
 
     class SignerInfo
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkcs7.c
       #   - issuer()
@@ -5579,8 +5529,6 @@ module OpenSSL
       # :   The generator.
       #
       def self.generate: (Integer size, ?Integer generator) -> instance
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/pkey.rb
@@ -5881,8 +5829,6 @@ module OpenSSL
       # :   The desired key size in bits.
       #
       def self.generate: (Integer size) -> instance
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkey_dsa.c
@@ -6279,8 +6225,6 @@ module OpenSSL
       #
       def self.generate: (String | Group pem_or_der_or_group_or_curve_name) -> instance
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkey_ec.c
       #   - key.check_key   => true
@@ -6596,8 +6540,6 @@ module OpenSSL
       type point_conversion_format = :compressed | :uncompressed | :hybrid
 
       class Group
-        public
-
         # <!-- rdoc-file=ext/openssl/ossl_pkey_ec.c -->
         # Returns `true` if the two groups use the same curve and have the same
         # parameters, `false` otherwise.
@@ -6803,8 +6745,6 @@ module OpenSSL
       end
 
       class Point
-        public
-
         # <!--
         #   rdoc-file=ext/openssl/ossl_pkey_ec.c
         #   - ==(p1)
@@ -6953,8 +6893,6 @@ module OpenSSL
     # *   OpenSSL::PKey::EC
     #
     class PKey
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkey.c
       #   - pkey.inspect -> string
@@ -7135,8 +7073,6 @@ module OpenSSL
       # :   An odd Integer, normally 3, 17, or 65537.
       #
       def self.generate: (Integer size, ?Integer exponent) -> instance
-
-      public
 
       def d: () -> BN?
 
@@ -7856,8 +7792,6 @@ module OpenSSL
     # be frozen afterward.
     #
     class SSLContext
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ssl.c
       #   - ctx.add_certificate(certificate, pkey [, extra_certs]) -> self
@@ -8767,8 +8701,6 @@ module OpenSSL
     class SSLServer
       include OpenSSL::SSL::SocketForwarder
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/ssl.rb
       #   - accept()
@@ -8858,8 +8790,6 @@ module OpenSSL
       #     sock.connect # Initiates a connection to localhost:443 with SSLContext
       #
       def self.open: (untyped remote_host, untyped remote_port, ?untyped local_host, ?untyped local_port, ?context: untyped) -> untyped
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_ssl.c
@@ -9250,8 +9180,6 @@ module OpenSSL
     end
 
     class Session
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ssl_session.c
       #   - session1 == session2 -> boolean
@@ -9350,8 +9278,6 @@ module OpenSSL
     end
 
     module SocketForwarder
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/ssl.rb
       #   - addr()
@@ -9549,8 +9475,6 @@ module OpenSSL
     #     factory.allowed_digests                                               -> array or nil
     #
     class Factory
-      public
-
       def additional_certs: () -> Array[X509::Certificate]?
 
       def additional_certs=: (Array[X509::Certificate]? certs) -> Array[X509::Certificate]?
@@ -9609,8 +9533,6 @@ module OpenSSL
     # *   algorithm, message_imprint, policy_id, and nonce are set to `false`
     #
     class Request
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ts.c
       #   - request.algorithm    -> string
@@ -9753,8 +9675,6 @@ module OpenSSL
     # Response.
     #
     class Response
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ts.c
       #   - response.failure_info -> nil or symbol
@@ -9917,8 +9837,6 @@ module OpenSSL
     # Response.
     #
     class TokenInfo
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_ts.c
       #   - token_info.algorithm -> string or nil
@@ -10287,8 +10205,6 @@ module OpenSSL
 
       extend OpenSSL::Marshal::ClassMethods
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/x509.rb
       #   - ==(other)
@@ -10358,8 +10274,6 @@ module OpenSSL
       include OpenSSL::Marshal
 
       extend OpenSSL::Marshal::ClassMethods
-
-      public
 
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/x509.rb
@@ -10637,8 +10551,6 @@ module OpenSSL
 
       extend OpenSSL::Marshal::ClassMethods
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_x509cert.c
       #   - cert1 == cert2 -> true | false
@@ -10867,8 +10779,6 @@ module OpenSSL
 
       extend OpenSSL::Marshal::ClassMethods
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/x509.rb
       #   - ==(other)
@@ -10980,8 +10890,6 @@ module OpenSSL
       module AuthorityInfoAccess
         include OpenSSL::X509::Extension::Helpers
 
-        public
-
         # <!--
         #   rdoc-file=ext/openssl/lib/openssl/x509.rb
         #   - ca_issuer_uris()
@@ -11018,8 +10926,6 @@ module OpenSSL
       module AuthorityKeyIdentifier
         include OpenSSL::X509::Extension::Helpers
 
-        public
-
         # <!--
         #   rdoc-file=ext/openssl/lib/openssl/x509.rb
         #   - authority_key_identifier()
@@ -11035,8 +10941,6 @@ module OpenSSL
       module CRLDistributionPoints
         include OpenSSL::X509::Extension::Helpers
 
-        public
-
         # <!--
         #   rdoc-file=ext/openssl/lib/openssl/x509.rb
         #   - crl_uris()
@@ -11050,8 +10954,6 @@ module OpenSSL
       end
 
       module Helpers
-        public
-
         # <!--
         #   rdoc-file=ext/openssl/lib/openssl/x509.rb
         #   - find_extension(oid)
@@ -11062,8 +10964,6 @@ module OpenSSL
 
       module SubjectKeyIdentifier
         include OpenSSL::X509::Extension::Helpers
-
-        public
 
         # <!--
         #   rdoc-file=ext/openssl/lib/openssl/x509.rb
@@ -11082,8 +10982,6 @@ module OpenSSL
     end
 
     class ExtensionFactory
-      public
-
       def config: () -> Config?
 
       def config=: (Config config) -> Config
@@ -11232,8 +11130,6 @@ module OpenSSL
       # See also #to_utf8 for the opposite operation.
       #
       def self.parse_rfc2253: (String str, ?template template) -> instance
-
-      public
 
       # <!-- rdoc-file=ext/openssl/ossl_x509name.c -->
       # Compares this Name with *other* and returns `0` if they are the same and `-1`
@@ -11506,8 +11402,6 @@ module OpenSSL
 
       extend OpenSSL::Marshal::ClassMethods
 
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/x509.rb
       #   - ==(other)
@@ -11649,8 +11543,6 @@ module OpenSSL
     end
 
     class Revoked
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/x509.rb
       #   - ==(other)
@@ -11770,8 +11662,6 @@ module OpenSSL
     #     ssl_socket = OpenSSL::SSL::SSLSocket.new tcp_socket, ssl_context
     #
     class Store
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_x509store.c
       #   - store.add_cert(cert) -> self
@@ -11980,8 +11870,6 @@ module OpenSSL
     # status involved.
     #
     class StoreContext
-      public
-
       # <!--
       #   rdoc-file=ext/openssl/ossl_x509store.c
       #   - stctx.chain -> nil | Array of X509::Certificate

--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -454,8 +454,6 @@ class OptionParser
   #
   def self.with: (?String banner, ?Integer width, ?String indent) ?{ (instance opts) -> void } -> instance
 
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - abort(mesg = $!)
@@ -1109,8 +1107,6 @@ module OptionParser::Arguable
   #
   def self.extend_object: (untyped obj) -> untyped
 
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - getopts(*args, symbolize_names: false)
@@ -1184,8 +1180,6 @@ end
 class OptionParser::CompletingHash < Hash[untyped, untyped]
   include OptionParser::Completion
 
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - match(key)
@@ -1213,8 +1207,6 @@ module OptionParser::Completion
   # -->
   #
   def self.regexp: (untyped key, untyped icase) -> untyped
-
-  public
 
   # <!--
   #   rdoc-file=lib/optparse.rb
@@ -1260,8 +1252,6 @@ OptionParser::InvalidOption::Reason: String
 # and converter pair. Also provides summary feature.
 #
 class OptionParser::List
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - accept(t, pat = /.*/m, &block)
@@ -1450,8 +1440,6 @@ class OptionParser::ParseError < RuntimeError
   #
   def self.filter_backtrace: (untyped array) -> untyped
 
-  public
-
   def additional: () -> untyped
 
   def additional=: (untyped) -> untyped
@@ -1553,8 +1541,6 @@ class OptionParser::Switch
   #
   def self.pattern: () -> untyped
 
-  public
-
   def add_banner: (untyped to) -> untyped
 
   def arg: () -> untyped
@@ -1650,8 +1636,6 @@ class OptionParser::Switch::NoArgument < OptionParser::Switch
   #
   def self.pattern: () -> untyped
 
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - parse(arg, argv) { |NeedlessArgument, arg| ... }
@@ -1665,8 +1649,6 @@ end
 # Switch that can omit argument.
 #
 class OptionParser::Switch::OptionalArgument < OptionParser::Switch
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - parse(arg, argv, &error)
@@ -1680,8 +1662,6 @@ end
 # Switch that takes an argument, which does not begin with '-' or is '-'.
 #
 class OptionParser::Switch::PlacedArgument < OptionParser::Switch
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - parse(arg, argv, &error)
@@ -1695,8 +1675,6 @@ end
 # Switch that takes an argument.
 #
 class OptionParser::Switch::RequiredArgument < OptionParser::Switch
-  public
-
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - parse(arg, argv)

--- a/stdlib/pathname/0/pathname.rbs
+++ b/stdlib/pathname/0/pathname.rbs
@@ -225,8 +225,6 @@ class Pathname
   #
   def self.pwd: () -> Pathname
 
-  public
-
   # <!--
   #   rdoc-file=ext/pathname/lib/pathname.rb
   #   - +(other)

--- a/stdlib/pstore/0/pstore.rbs
+++ b/stdlib/pstore/0/pstore.rbs
@@ -305,8 +305,6 @@
 #     end
 #
 class PStore
-  public
-
   # <!--
   #   rdoc-file=lib/pstore.rb
   #   - [](key)

--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -74,8 +74,6 @@ class Resolv
   #
   def self.getnames: (String address) -> Array[String]
 
-  public
-
   # <!--
   #   rdoc-file=lib/resolv.rb
   #   - each_address(name) { |name| ... }
@@ -178,8 +176,6 @@ class Resolv::DNS
                | (*untyped args) { (instance) -> void } -> void
 
   def self.random: (Integer arg) -> (Integer | Float)
-
-  public
 
   # <!--
   #   rdoc-file=lib/resolv.rb
@@ -395,8 +391,6 @@ class Resolv::DNS::Config
 
   def self.parse_resolv_conf: (String filename) -> Hash[Symbol, untyped]
 
-  public
-
   def generate_candidates: (String name) -> Array[Resolv::DNS::Name]
 
   def generate_timeouts: () -> Array[Integer | Float]
@@ -447,8 +441,6 @@ module Resolv::DNS::Label
 end
 
 class Resolv::DNS::Label::Str
-  public
-
   def eql?: (Resolv::DNS::Label::Str other) -> bool
 
   def downcase: () -> String
@@ -470,8 +462,6 @@ end
 
 class Resolv::DNS::Message
   def self.decode: (String m) -> instance
-
-  public
 
   def ==: (instance other) -> bool
 
@@ -541,8 +531,6 @@ class Resolv::DNS::Message
 end
 
 class Resolv::DNS::Message::MessageDecoder
-  public
-
   def get_bytes: (?Integer len) -> String
 
   def get_label: () -> Resolv::DNS::Label::Str
@@ -571,8 +559,6 @@ class Resolv::DNS::Message::MessageDecoder
 end
 
 class Resolv::DNS::Message::MessageEncoder
-  public
-
   def put_bytes: (string d) -> void
 
   def put_label: (_ToS d) -> void
@@ -612,8 +598,6 @@ class Resolv::DNS::Name
   # :   Creates a new Name.
   #
   def self.create: (Resolv::DNS::dns_name arg) -> untyped
-
-  public
 
   def ==: (instance other) -> bool
 
@@ -695,8 +679,6 @@ Resolv::DNS::OpCode::Update: Integer
 class Resolv::DNS::Query
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   def encode_rdata: (Resolv::DNS::Message::MessageEncoder msg) -> void
 end
 
@@ -740,8 +722,6 @@ Resolv::DNS::RCode::YXDomain: Integer
 Resolv::DNS::RCode::YXRRSet: Integer
 
 class Resolv::DNS::Requester
-  public
-
   def close: () -> void
 
   def request: (Resolv::DNS::Requester::Sender sender, Numeric tout) -> [ Resolv::DNS::Message, String ]
@@ -754,8 +734,6 @@ class Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::ConnectedUDP < Resolv::DNS::Requester
-  public
-
   def close: () -> void
 
   def lazy_initialize: () -> void
@@ -770,16 +748,12 @@ class Resolv::DNS::Requester::ConnectedUDP < Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::ConnectedUDP::Sender < Resolv::DNS::Requester::Sender
-  public
-
   def data: () -> String
 
   def send: () -> void
 end
 
 class Resolv::DNS::Requester::MDNSOneShot < Resolv::DNS::Requester::UnconnectedUDP
-  public
-
   def sender: (Resolv::DNS::Message msg, String data, ?String host, ?Integer port) -> Resolv::DNS::Requester::Sender
 
   def recv_reply: (Array[UDPSocket] readable_socks) -> [ String, String ]
@@ -798,8 +772,6 @@ class Resolv::DNS::Requester::Sender
 end
 
 class Resolv::DNS::Requester::TCP < Resolv::DNS::Requester
-  public
-
   def close: () -> untyped
 
   def recv_reply: (Array[TCPSocket] readable_socks) -> [ String, String ]
@@ -812,16 +784,12 @@ class Resolv::DNS::Requester::TCP < Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::TCP::Sender < Resolv::DNS::Requester::Sender
-  public
-
   def data: () -> String
 
   def send: () -> void
 end
 
 class Resolv::DNS::Requester::UnconnectedUDP < Resolv::DNS::Requester
-  public
-
   def close: () -> void
 
   def lazy_initialize: () -> void
@@ -836,8 +804,6 @@ class Resolv::DNS::Requester::UnconnectedUDP < Resolv::DNS::Requester
 end
 
 class Resolv::DNS::Requester::UnconnectedUDP::Sender < Resolv::DNS::Requester::Sender
-  public
-
   def data: () -> String
 
   def send: () -> void
@@ -854,8 +820,6 @@ class Resolv::DNS::Resource < Resolv::DNS::Query
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
   def self.get_class: (Integer type_value, Integer class_value) -> self
-
-  public
 
   def eql?: (Resolv::DNS::Resource other) -> bool
 
@@ -899,8 +863,6 @@ Resolv::DNS::Resource::CNAME::TypeValue: Integer
 class Resolv::DNS::Resource::DomainName < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   def encode_rdata: (Resolv::DNS::Message::MessageEncoder msg) -> void
 
   # <!-- rdoc-file=lib/resolv.rb -->
@@ -927,8 +889,6 @@ class Resolv::DNS::Resource::Generic < Resolv::DNS::Resource
 
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   # <!-- rdoc-file=lib/resolv.rb -->
   # Data for this generic resource.
   #
@@ -952,8 +912,6 @@ end
 #
 class Resolv::DNS::Resource::HINFO < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
-
-  public
 
   # <!-- rdoc-file=lib/resolv.rb -->
   # CPU architecture for this resource.
@@ -994,8 +952,6 @@ Resolv::DNS::Resource::IN::ClassValue: Integer
 class Resolv::DNS::Resource::IN::A < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   # <!-- rdoc-file=lib/resolv.rb -->
   # The Resolv::IPv4 address for this A.
   #
@@ -1023,8 +979,6 @@ Resolv::DNS::Resource::IN::A::TypeValue: Integer
 #
 class Resolv::DNS::Resource::IN::AAAA < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
-
-  public
 
   # <!-- rdoc-file=lib/resolv.rb -->
   # The Resolv::IPv6 address for this AAAA.
@@ -1119,8 +1073,6 @@ Resolv::DNS::Resource::IN::SOA::TypeValue: Integer
 class Resolv::DNS::Resource::IN::SRV < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   def encode_rdata: (Resolv::DNS::Message::MessageEncoder msg) -> void
 
   # <!-- rdoc-file=lib/resolv.rb -->
@@ -1191,8 +1143,6 @@ Resolv::DNS::Resource::IN::TXT::TypeValue: Integer
 class Resolv::DNS::Resource::IN::WKS < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   # <!-- rdoc-file=lib/resolv.rb -->
   # The host these services run on.
   #
@@ -1233,8 +1183,6 @@ Resolv::DNS::Resource::IN::WKS::TypeValue: Integer
 #
 class Resolv::DNS::Resource::LOC < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
-
-  public
 
   # <!-- rdoc-file=lib/resolv.rb -->
   # The altitude of the LOC above a reference sphere whose surface sits 100km
@@ -1297,8 +1245,6 @@ Resolv::DNS::Resource::LOC::TypeValue: Integer
 class Resolv::DNS::Resource::MINFO < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   # <!-- rdoc-file=lib/resolv.rb -->
   # Mailbox to use for error messages related to the mail list or mailbox.
   #
@@ -1328,8 +1274,6 @@ Resolv::DNS::Resource::MINFO::TypeValue: Integer
 #
 class Resolv::DNS::Resource::MX < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
-
-  public
 
   def encode_rdata: (Resolv::DNS::Message::MessageEncoder msg) -> void
 
@@ -1377,8 +1321,6 @@ Resolv::DNS::Resource::PTR::TypeValue: Integer
 #
 class Resolv::DNS::Resource::SOA < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
-
-  public
 
   def encode_rdata: (Resolv::DNS::Message::MessageEncoder msg) -> void
 
@@ -1440,8 +1382,6 @@ Resolv::DNS::Resource::SOA::TypeValue: Integer
 class Resolv::DNS::Resource::TXT < Resolv::DNS::Resource
   def self.decode_rdata: (Resolv::DNS::Message::MessageDecoder msg) -> instance
 
-  public
-
   # <!--
   #   rdoc-file=lib/resolv.rb
   #   - data()
@@ -1473,8 +1413,6 @@ Resolv::DNS::Resource::TXT::TypeValue: Integer
 # Resolv::Hosts is a hostname resolver that uses the system hosts file.
 #
 class Resolv::Hosts
-  public
-
   # <!--
   #   rdoc-file=lib/resolv.rb
   #   - each_address(name, &proc)
@@ -1549,8 +1487,6 @@ class Resolv::IPv4
   #
   def self.create: (String | instance arg) -> instance
 
-  public
-
   def ==: (instance other) -> bool
 
   # <!-- rdoc-file=lib/resolv.rb -->
@@ -1602,8 +1538,6 @@ class Resolv::IPv6
   # :   `arg` must match one of the IPv6::Regex* constants
   #
   def self.create: (String | instance arg) -> instance
-
-  public
 
   def ==: (instance other) -> bool
 
@@ -1688,8 +1622,6 @@ class Resolv::LOC::Alt
   #
   def self.create: (Resolv::LOC::Alt | String arg) -> instance
 
-  public
-
   def eql?: (Resolv::LOC::Alt other) -> bool
 
   # <!-- rdoc-file=lib/resolv.rb -->
@@ -1735,8 +1667,6 @@ class Resolv::LOC::Coord
   # :   `arg` must match the LOC::Coord::Regex constant
   #
   def self.create: (Resolv::LOC::Coord | String arg) -> instance
-
-  public
 
   def eql?: (Resolv::LOC::Coord other) -> bool
 
@@ -1787,8 +1717,6 @@ class Resolv::LOC::Size
   #
   def self.create: (Resolv::LOC::Size | String arg) -> instance
 
-  public
-
   def eql?: (Resolv::LOC::Size other) -> bool
 
   alias == eql?
@@ -1826,8 +1754,6 @@ Resolv::LOC::Size::Regex: Regexp
 # *   RFC 6762
 #
 class Resolv::MDNS < Resolv::DNS
-  public
-
   # <!--
   #   rdoc-file=lib/resolv.rb
   #   - each_address(name)

--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -101,8 +101,6 @@ module Singleton
   #
   def self.instance: () -> instance
 
-  public
-
   # <!--
   #   rdoc-file=lib/singleton.rb
   #   - _dump(depth = -1)

--- a/stdlib/socket/0/addrinfo.rbs
+++ b/stdlib/socket/0/addrinfo.rbs
@@ -110,8 +110,6 @@ class Addrinfo
   #
   def self.unix: (String path, ?Symbol socktype) -> Addrinfo
 
-  public
-
   # <!--
   #   rdoc-file=ext/socket/raddrinfo.c
   #   - addrinfo.afamily => integer

--- a/stdlib/socket/0/basic_socket.rbs
+++ b/stdlib/socket/0/basic_socket.rbs
@@ -41,8 +41,6 @@ class BasicSocket < IO
   #
   def self.for_fd: (Integer fileno) -> BasicSocket
 
-  public
-
   # <!--
   #   rdoc-file=ext/socket/basicsocket.c
   #   - basicsocket.close_read => nil

--- a/stdlib/socket/0/ip_socket.rbs
+++ b/stdlib/socket/0/ip_socket.rbs
@@ -15,8 +15,6 @@ class IPSocket < BasicSocket
   #
   def self.getaddress: (String host) -> String
 
-  public
-
   # <!--
   #   rdoc-file=ext/socket/ipsocket.c
   #   - ipsocket.addr([reverse_lookup]) => [address_family, port, hostname, numeric_address]

--- a/stdlib/socket/0/socket.rbs
+++ b/stdlib/socket/0/socket.rbs
@@ -752,8 +752,6 @@ class Socket < BasicSocket
   #
   def self.unpack_sockaddr_un: (String path) -> String
 
-  public
-
   # <!--
   #   rdoc-file=ext/socket/socket.c
   #   - socket.accept => [client_socket, client_addrinfo]
@@ -3730,8 +3728,6 @@ Socket::UDP_CORK: Integer
 # Socket::Ifaddr represents a result of getifaddrs() function.
 #
 class Socket::Ifaddr
-  public
-
   # <!--
   #   rdoc-file=ext/socket/ifaddr.c
   #   - ifaddr.addr => addrinfo
@@ -3805,8 +3801,6 @@ end
 # UDP/IP address information used by Socket.udp_server_loop.
 #
 class Socket::UDPSource
-  public
-
   def inspect: () -> String
 
   # <!-- rdoc-file=ext/socket/lib/socket.rb -->
@@ -3910,8 +3904,6 @@ class Socket::AncillaryData
   #     #=> #<Socket::AncillaryData: UNIX SOCKET RIGHTS 2>
   #
   def self.unix_rights: (IO fd) -> instance
-
-  public
 
   # <!--
   #   rdoc-file=ext/socket/ancdata.c

--- a/stdlib/socket/0/tcp_server.rbs
+++ b/stdlib/socket/0/tcp_server.rbs
@@ -27,8 +27,6 @@
 #     end
 #
 class TCPServer < TCPSocket
-  public
-
   # <!--
   #   rdoc-file=ext/socket/tcpserver.c
   #   - tcpserver.accept => tcpsocket

--- a/stdlib/socket/0/udp_socket.rbs
+++ b/stdlib/socket/0/udp_socket.rbs
@@ -2,8 +2,6 @@
 # UDPSocket represents a UDP/IP socket.
 #
 class UDPSocket < IPSocket
-  public
-
   # <!--
   #   rdoc-file=ext/socket/udpsocket.c
   #   - udpsocket.bind(host, port) #=> 0

--- a/stdlib/socket/0/unix_server.rbs
+++ b/stdlib/socket/0/unix_server.rbs
@@ -2,8 +2,6 @@
 # UNIXServer represents a UNIX domain stream server socket.
 #
 class UNIXServer < UNIXSocket
-  public
-
   # <!--
   #   rdoc-file=ext/socket/unixserver.c
   #   - unixserver.accept => unixsocket

--- a/stdlib/socket/0/unix_socket.rbs
+++ b/stdlib/socket/0/unix_socket.rbs
@@ -40,8 +40,6 @@ class UNIXSocket < BasicSocket
   #
   def self.socketpair: (?Symbol socktype, ?Integer protocol) -> [ instance, instance ]
 
-  public
-
   # <!--
   #   rdoc-file=ext/socket/unixsocket.c
   #   - unixsocket.addr => [address_family, unix_path]

--- a/stdlib/strscan/0/string_scanner.rbs
+++ b/stdlib/strscan/0/string_scanner.rbs
@@ -113,8 +113,6 @@ class StringScanner
   #
   def self.must_C_version: () -> self
 
-  public
-
   # <!-- rdoc-file=ext/strscan/strscan.c -->
   # Appends `str` to the string being scanned. This method does not affect scan
   # pointer.

--- a/stdlib/tempfile/0/tempfile.rbs
+++ b/stdlib/tempfile/0/tempfile.rbs
@@ -189,8 +189,6 @@ class Tempfile < File
   def self.open: (*untyped args, **untyped) -> Tempfile
                | [A] (*untyped args, **untyped) { (Tempfile) -> A } -> A
 
-  public
-
   # <!--
   #   rdoc-file=lib/tempfile.rb
   #   - close(unlink_now=false)
@@ -296,8 +294,6 @@ class Tempfile < File
   def unlink: () -> void
 
   class Remover
-    public
-
     def call: (*untyped args) -> void
 
     private

--- a/stdlib/zlib/0/deflate.rbs
+++ b/stdlib/zlib/0/deflate.rbs
@@ -98,8 +98,6 @@ module Zlib
     #
     def self.deflate: (string string, ?compression_level level) -> String
 
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - << string

--- a/stdlib/zlib/0/gzip_file.rbs
+++ b/stdlib/zlib/0/gzip_file.rbs
@@ -120,8 +120,6 @@ module Zlib
     #
     def self.wrap: (IO io, *untyped) { (instance gz) -> void } -> void
 
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - close()

--- a/stdlib/zlib/0/gzip_file/error.rbs
+++ b/stdlib/zlib/0/gzip_file/error.rbs
@@ -109,8 +109,6 @@ module Zlib
     # Base class of errors that occur when processing GZIP files.
     #
     class Error < Zlib::Error
-      public
-
       # <!-- rdoc-file=ext/zlib/zlib.c -->
       # input gzipped string
       #

--- a/stdlib/zlib/0/gzip_reader.rbs
+++ b/stdlib/zlib/0/gzip_reader.rbs
@@ -152,8 +152,6 @@ module Zlib
     def self.zcat: (IO io, **untyped) -> String
                  | (IO io, **untyped) { (String chunk) -> void } -> nil
 
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - each(*args)

--- a/stdlib/zlib/0/gzip_writer.rbs
+++ b/stdlib/zlib/0/gzip_writer.rbs
@@ -109,8 +109,6 @@ module Zlib
     #
     def self.open: (String filename) { (instance gz) -> void } -> instance
 
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - <<(p1)

--- a/stdlib/zlib/0/inflate.rbs
+++ b/stdlib/zlib/0/inflate.rbs
@@ -97,8 +97,6 @@ module Zlib
     #
     def self.inflate: (string string) -> String
 
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - <<(p1)

--- a/stdlib/zlib/0/zstream.rbs
+++ b/stdlib/zlib/0/zstream.rbs
@@ -126,8 +126,6 @@ module Zlib
   # *   #closed?
   #
   class ZStream
-    public
-
     # <!--
     #   rdoc-file=ext/zlib/zlib.c
     #   - adler()


### PR DESCRIPTION
Many cases are due to the following rules.(You can see example of rule on link)

- [RBS/Lint/UselessAccessModifier](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_lint.adoc#rbslintuselessaccessmodifier)
- [RBS/Layout/EmptyLines](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_layout.adoc#rbslayoutemptylines)
- [RBS/Layout/EmptyLinesAroundClassBody](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_layout.adoc#rbslayoutemptylinesaroundclassbody)
- [RBS/Layout/EmptyLinesAroundModuleBody
](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_layout.adoc#rbslayoutemptylinesaroundmodulebody)

Only open-uri has been changed according to the following rule.

- [RBS/Lint/AmbiguousOperatorPrecedence](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_lint.adoc#rbslintambiguousoperatorprecedence)