### PR TITLE
Optional type param restriction

### DIFF
--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -205,6 +205,21 @@ module RBS
           end
         end
       end
+
+      def self.validate(type_params)
+        optionals = type_params.filter {|param| param.default_type }
+
+        optional_param_names = optionals.map(&:name).sort
+
+        optionals.filter! do |param|
+          default_type = param.default_type or raise
+          optional_param_names.any? { default_type.free_variables.include?(_1) }
+        end
+
+        unless optionals.empty?
+          optionals
+        end
+      end
     end
   end
 end

--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -154,36 +154,54 @@ module RBS
       end
 
       def self.application(params, args)
-        subst = Substitution.new()
-
         if params.empty?
           return nil
         end
 
-        min_count = params.count { _1.default_type.nil? }
-        max_count = params.size
+        optional_params, required_params = params.partition {|param| param.default_type }
 
-        unless min_count <= args.size && args.size <= max_count
-          raise "Invalid type application: required type params=#{min_count}, optional type params=#{max_count - min_count}, given args=#{args.size}"
+        param_subst = Substitution.new()
+        app_subst = Substitution.new()
+
+        required_params.zip(args.take(required_params.size)).each do |param, arg|
+          arg ||= Types::Bases::Any.new(location: nil)
+          param_subst.add(from: param.name, to: arg)
+          app_subst.add(from: param.name, to: arg)
         end
 
-        params.zip(args).each do |param, arg|
+        optional_params.each do |param|
+          param_subst.add(from: param.name, to: Types::Bases::Any.new(location: nil))
+        end
+
+        optional_params.zip(args.drop(required_params.size)).each do |param, arg|
           if arg
-            subst.add(from: param.name, to: arg)
+            app_subst.add(from: param.name, to: arg)
           else
-            subst.add(from: param.name, to: param.default_type || raise)
+            param.default_type or raise
+            app_subst.add(from: param.name, to: param.default_type.sub(param_subst))
           end
         end
 
-        subst
+        app_subst
       end
 
       def self.normalize_args(params, args)
+        app = application(params, args) or return []
+
+        min_count = params.count { _1.default_type.nil? }
+        unless min_count <= args.size && args.size <= params.size
+          return args
+        end
+
         params.zip(args).filter_map do |param, arg|
           if arg
             arg
           else
-            param.default_type
+            if param.default_type
+              param.default_type.sub(app)
+            else
+              Types::Bases::Any.new(location: nil)
+            end
           end
         end
       end

--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -167,6 +167,8 @@ EOU
             end
           end
 
+          TypeParamDefaultReferenceError.check!(d.type_params)
+
           entry.decls.each do |d|
             d.decl.each_member do |member|
               case member
@@ -244,6 +246,8 @@ EOU
             end
           end
 
+          TypeParamDefaultReferenceError.check!(decl.decl.type_params)
+
           decl.decl.members.each do |member|
             case member
             when AST::Members::MethodDefinition
@@ -314,6 +318,8 @@ EOU
               @validator.validate_type(dt, context: nil)
             end
           end
+
+          TypeParamDefaultReferenceError.check!(decl.decl.type_params)
 
           no_self_type_validator(decl.decl.type)
           no_classish_type_validator(decl.decl.type)

--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -117,10 +117,6 @@ EOU
                   no_classish_type_validator(arg)
                   @validator.validate_type(arg, context: nil)
                 end
-
-                if super_entry = @env.normalized_class_entry(super_class.name)
-                  InvalidTypeApplicationError.check!(type_name: super_class.name, args: super_class.args, params: super_entry.type_params, location: super_class.location)
-                end
               end
             end
           when Environment::ModuleEntry

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -237,14 +237,8 @@ module RBS
         @ancestors = ancestors
       end
 
-      def apply(args, location:)
-        # Assume default types of type parameters are already added to `args`
-        InvalidTypeApplicationError.check!(
-          type_name: type_name,
-          args: args,
-          params: params.map { AST::TypeParam.new(name: _1, variance: :invariant, upper_bound: nil, location: nil, default_type: nil) },
-          location: location
-        )
+      def apply(args, env:, location:)
+        InvalidTypeApplicationError.check2!(env: env, type_name: type_name, args: args, location: location)
 
         subst = Substitution.build(params, args)
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -576,4 +576,23 @@ module RBS
       @location = location
     end
   end
+
+  class TypeParamDefaultReferenceError < DefinitionError
+    include DetailedMessageable
+
+    attr_reader :location
+
+    def initialize(type_param, location:)
+      super "#{Location.to_string(location)}: the default of #{type_param.name} cannot include optional type parameter"
+      @location = location
+    end
+
+    def self.check!(type_params)
+      if errors = AST::TypeParam.validate(type_params)
+        error = errors[0] or raise
+        error.default_type or raise
+        raise new(error, location: error.default_type.location)
+      end
+    end
+  end
 end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -88,6 +88,23 @@ module RBS
         raise new(type_name: type_name, args: args, params: params, location: location)
       end
     end
+
+    def self.check2!(env:, type_name:, args:, location:)
+      params =
+        case
+        when type_name.class?
+          decl = env.normalized_module_class_entry(type_name) or raise
+          decl.type_params
+        when type_name.interface?
+          env.interface_decls.fetch(type_name).decl.type_params
+        when type_name.alias?
+          env.type_alias_decls.fetch(type_name).decl.type_params
+        else
+          raise
+        end
+
+      check!(type_name: type_name, args: args, params: params, location: location)
+    end
   end
 
   class RecursiveAncestorError < DefinitionError

--- a/sig/definition.rbs
+++ b/sig/definition.rbs
@@ -109,7 +109,7 @@ module RBS
 
       def initialize: (type_name: TypeName, params: Array[Symbol], ancestors: Array[Ancestor::t]) -> void
 
-      def apply: (Array[Types::t], location: Location[untyped, untyped]?) -> Array[Ancestor::t]
+      def apply: (Array[Types::t], env: Environment, location: Location[untyped, untyped]?) -> Array[Ancestor::t]
     end
 
     class SingletonAncestors

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -66,6 +66,8 @@ module RBS
     def initialize: (type_name: TypeName, args: Array[Types::t], params: Array[AST::TypeParam], location: Location[untyped, untyped]?) -> void
 
     def self.check!: (type_name: TypeName, args: Array[Types::t], params: Array[AST::TypeParam], location: Location[untyped, untyped]?) -> void
+
+    def self.check2!: (env: Environment, type_name: TypeName, args: Array[Types::t], location: Location[untyped, untyped]?) -> void
   end
 
   class RecursiveAncestorError < DefinitionError

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -368,4 +368,14 @@ module RBS
 
     attr_reader location: Location[untyped, untyped]?
   end
+
+  class TypeParamDefaultReferenceError < BaseError
+    include DetailedMessageable
+
+    def initialize: (AST::TypeParam, location: Location[untyped, untyped]?) -> void
+
+    attr_reader location: Location[untyped, untyped]?
+
+    def self.check!: (Array[AST::TypeParam]) -> void
+  end
 end

--- a/sig/members.rbs
+++ b/sig/members.rbs
@@ -122,8 +122,7 @@ module RBS
         # include Array[String]
         # ^^^^^^^                keyword
         #         ^^^^^          name
-        #              ^         arg_open
-        #                     ^  arg_close
+        #              ^^^^^^^^  args
         #
         type loc = Location[:name | :keyword, :args]
 

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -75,7 +75,7 @@ module RBS
 
       def to_s: () -> String
 
-      # Returns an application with respect to type params` default
+      # Returns an application with respect to type params' default
       #
       def self.application: (Array[TypeParam], Array[Types::t]) -> Substitution?
 
@@ -95,10 +95,7 @@ module RBS
       # _Foo[String, Integer, untyped] # => _Foo[String, Integer, untyped]  (Keeping extra args)
       # ```
       #
-      # Note that it allows iinvalid arities.
-      #
-      # * Missing args will be omitted
-      # * Extra args will be keeped
+      # Note that it allows iinvalid arities, returning the `args` immediately.
       #
       def self.normalize_args: (Array[TypeParam], Array[Types::t]) -> Array[Types::t]
     end

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -75,6 +75,13 @@ module RBS
 
       def to_s: () -> String
 
+      # Validates TypeParams if it refers another optiional type params
+      #
+      # * Returns array of TypeParam objects that refers other optional type params
+      # * Returns `nil` if all type params are valid
+      #
+      def self.validate: (Array[TypeParam]) -> Array[TypeParam]?
+
       # Returns an application with respect to type params' default
       #
       def self.application: (Array[TypeParam], Array[Types::t]) -> Substitution?

--- a/test/rbs/ast/type_param_test.rb
+++ b/test/rbs/ast/type_param_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+class RBS::AST::TypeParamTest < Test::Unit::TestCase
+  include TestHelper
+
+  include RBS::AST
+
+  def parse_type(string, variables: [:A, :B, :C, :D, :E])
+    RBS::Parser.parse_type(string, variables: variables)
+  end
+
+  def test_application1
+    params = [
+      TypeParam.new(name: :A, variance: :inout, upper_bound: nil, location: nil),
+      TypeParam.new(name: :B, variance: :inout, upper_bound: nil, default_type: parse_type("::String"), location: nil),
+    ]
+
+    TypeParam.application(params, []).tap do |s|
+      assert_equal parse_type("untyped"), s.mapping[:A]
+      assert_equal parse_type("::String"), s.mapping[:B]
+    end
+
+    TypeParam.application(params, [parse_type("::Integer")]).tap do |s|
+      assert_equal parse_type("::Integer"), s.mapping[:A]
+      assert_equal parse_type("::String"), s.mapping[:B]
+    end
+
+    TypeParam.application(params, [parse_type("::Integer"), parse_type("::Symbol"), parse_type("bool")]).tap do |s|
+      assert_equal parse_type("::Integer"), s.mapping[:A]
+      assert_equal parse_type("::Symbol"), s.mapping[:B]
+    end
+  end
+
+  def test_application2
+    params = [
+      TypeParam.new(name: :A, variance: :inout, upper_bound: nil, location: nil),
+      TypeParam.new(name: :B, variance: :inout, upper_bound: nil, default_type: parse_type("::Array[A]"), location: nil),
+      TypeParam.new(name: :C, variance: :inout, upper_bound: nil, default_type: parse_type("::Array[B]"), location: nil),
+    ]
+
+    TypeParam.application(params, []).tap do |s|
+      assert_equal parse_type("untyped"), s.mapping[:A]
+      assert_equal parse_type("::Array[untyped]"), s.mapping[:B]
+      assert_equal parse_type("::Array[untyped]"), s.mapping[:C]
+    end
+
+    TypeParam.application(params, [parse_type("::Integer")]).tap do |s|
+      assert_equal parse_type("::Integer"), s.mapping[:A]
+      assert_equal parse_type("::Array[::Integer]"), s.mapping[:B]
+      assert_equal parse_type("::Array[untyped]"), s.mapping[:C]
+    end
+  end
+
+  def test_normalize_args
+    params = [
+      TypeParam.new(name: :A, variance: :inout, upper_bound: nil, location: nil),
+      TypeParam.new(name: :B, variance: :inout, upper_bound: nil, default_type: parse_type("::Array[A]"), location: nil),
+      TypeParam.new(name: :C, variance: :inout, upper_bound: nil, default_type: parse_type("::Array[B]"), location: nil),
+    ]
+
+    TypeParam.normalize_args(params, []).tap do |args|
+      assert_equal [], args.map(&:to_s)
+    end
+
+    TypeParam.normalize_args(params, [parse_type("::Integer")]).tap do |args|
+      assert_equal ["::Integer", "::Array[::Integer]", "::Array[::Array[::Integer]]"], args.map(&:to_s)
+    end
+  end
+end


### PR DESCRIPTION
Introduce another restriction to default types of generics type parameters. **default types cannot depend on optional type params.**

```rbs
# T is required type parameter.
# The default type of S depends on required type parameter => OK
# The default type of U depends on another optional type parameter S => Error
class Foo[T, S = T, U = S?]
end
```