### PR TITLE
stdlib: Add types for JSON.load_file and .load_file!

### DIFF
--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -980,6 +980,28 @@ module JSON
   #
   def self?.load: (string | _JsonReadableIO | _JsonRead source, ?Proc proc, ?json_options options) -> untyped
 
+  # <!--
+  #   rdoc-file=ext/json/lib/json/common.rb
+  #   - JSON.load_file(path, opts={}) -> object
+  # -->
+  # Calls:
+  #     parse(File.read(path), opts)
+  #
+  # See method #parse.
+  #
+  def self?.load_file: (string path, ?json_options opts) -> untyped
+
+  # <!--
+  #   rdoc-file=ext/json/lib/json/common.rb
+  #   - JSON.load_file!(path, opts = {})
+  # -->
+  # Calls:
+  #     JSON.parse!(File.read(path, opts))
+  #
+  # See method #parse!
+  #
+  def self?.load_file!: (string path, ?json_options opts) -> untyped
+
   # <!-- rdoc-file=ext/json/lib/json/common.rb -->
   # Sets or returns default options for the JSON.load method. Initially:
   #     opts = JSON.load_default_options

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -1,5 +1,6 @@
 require_relative "../test_helper"
 require "json"
+require "tempfile"
 
 class JsonToStr
   def initialize(value = "")
@@ -106,6 +107,26 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(JsonRead) -> 42", JSON, :load, JsonRead.new
     assert_send_type "(String, Proc) -> 42", JSON, :load, "42", proc { }
     assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", JSON, :load, "42", proc { }, { alllow_nan: true }
+  end
+
+  def test_load_file
+    Tempfile.create("json") do |f|
+      f.write '{}'
+      f.close
+
+      assert_send_type "(String) -> untyped", JSON, :load_file, f.path
+      assert_send_type "(String, Hash[untyped, untyped]) -> untyped", JSON, :load_file, f.path, { allow_nan: true }
+    end
+  end
+
+  def test_load_file!
+    Tempfile.create("json") do |f|
+      f.write '{}'
+      f.close
+
+      assert_send_type "(String) -> untyped", JSON, :load_file!, f.path
+      assert_send_type "(String, Hash[untyped, untyped]) -> untyped", JSON, :load_file!, f.path, { allow_nan: true }
+    end
   end
 
   def test_load_default_options


### PR DESCRIPTION
refs:

* https://rubydoc.info/gems/json/JSON.load_file
* https://github.com/ruby/ruby/blob/master/ext/json/lib/json/common.rb#L242-L262
* https://github.com/ruby/ruby/pull/3581
* https://github.com/flori/json/blob/v2.7.2/lib/json/common.rb#L242-L262
* https://github.com/flori/json/pull/387