### PR TITLE
Correct latest version number in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 1.8.0 (2024-09-30)
+## 3.6.0 (2024-09-30)
 
 Nothing changed since `3.6.0.pre.3`.
 


### PR DESCRIPTION
The `1.8.0` should be a `3.6.0` :)