### PR TITLE
stdlib: Make the block arguments of Kernel#proc untyped

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1209,7 +1209,7 @@ module Kernel : BasicObject
   # -->
   # Equivalent to Proc.new.
   #
-  def self?.proc: () { () -> untyped } -> Proc
+  def self?.proc: () { (?) -> untyped } -> Proc
 
   # <!--
   #   rdoc-file=proc.c

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -95,6 +95,11 @@ class KernelSingletonTest < Test::Unit::TestCase
     end
   end
 
+  def test_proc
+    assert_send_type "() { () -> untyped } -> Proc", Kernel, :proc do end
+    assert_send_type "() { () -> untyped } -> Proc", Kernel, :proc do |a, b| end
+  end
+
   def test_rand
     assert_send_type "() -> Float", Kernel, :rand
     assert_send_type "(0) -> Float", Kernel, :rand, 0


### PR DESCRIPTION
This changes the block argument of `Kernel#proc` to UntypedFunction. Then the arguments of the block become untyped instead of nil.

It allows users to override the type via comment annotation.

For example:

```
proc do |a, b, c|
  # @type var a: String
  # @type var b: Integer
  # @type var c: Symbol
end
```

I found this problem on the Steep repo.
https://github.com/soutaro/steep/blob/v1.8.0/lib/steep.rb#L169-L176