### PR TITLE
Apply RBS/Style/EmptyArgument

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,8 @@ RBS/Style:
   Exclude:
     - 'sig/**/*'
     - 'test/**/*'
+RBS/Style/EmptyArgument:
+  Enabled: true
 RBS/Style/InitializeReturnType:
   Enabled: true
 

--- a/core/dir.rbs
+++ b/core/dir.rbs
@@ -784,7 +784,7 @@ class Dir
   # caveats.
   #
   def chdir: () -> Integer
-           | [T] { () -> T } -> T
+           | [T] () { () -> T } -> T
 
   # <!--
   #   rdoc-file=dir.c

--- a/core/set.rbs
+++ b/core/set.rbs
@@ -629,5 +629,5 @@ module Enumerable[unchecked out Elem]
   # Needs to `require "set"` to use this method.
   #
   def to_set: () -> Set[Elem]
-            | [T] { (Elem) -> T } -> Set[T]
+            | [T] () { (Elem) -> T } -> Set[T]
 end

--- a/stdlib/did_you_mean/0/did_you_mean.rbs
+++ b/stdlib/did_you_mean/0/did_you_mean.rbs
@@ -243,7 +243,7 @@ module DidYouMean
     #   - requireables()
     # -->
     #
-    def self.requireables: -> Array[String]
+    def self.requireables: () -> Array[String]
 
     # <!--
     #   rdoc-file=lib/did_you_mean/spell_checkers/require_path_checker.rb


### PR DESCRIPTION
Use `()` when the argument is empty to unify the writing style.