### PR TITLE
Omit IOConsoleTest with Windows platform

### DIFF
--- a/test/stdlib/IO_console_test.rb
+++ b/test/stdlib/IO_console_test.rb
@@ -1,7 +1,6 @@
 require_relative "test_helper"
 require "io/console"
 require "io/console/size"
-require 'pty'
 
 class IOConsoleSingletonTest < Test::Unit::TestCase
   include TestHelper
@@ -34,8 +33,9 @@ class IOConsoleTest < Test::Unit::TestCase
   testing "::IO"
 
   private def helper
+    require 'pty'
     m, s = PTY.open
-  rescue RuntimeError
+  rescue RuntimeError, LoadError
     omit $!
   else
     yield m, s


### PR DESCRIPTION
`IOConsoleTest` couldn't work with Windows platform. We should omit them.

```
<internal:C:/Users/hsbt/DevDrive/github.com/ruby/ruby/lib/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- pty (LoadError)
        from <internal:C:/Users/hsbt/DevDrive/github.com/ruby/ruby/lib/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
        from test/stdlib/IO_console_test.rb:4:in '<top (required)>'
```