### PR TITLE
`CGI.acceht_charset` may be an `Encoding`

### DIFF
--- a/stdlib/cgi/0/core.rbs
+++ b/stdlib/cgi/0/core.rbs
@@ -360,7 +360,7 @@ class CGI
   # -->
   # Return the accept character set for all new CGI instances.
   #
-  def self.accept_charset: () -> String
+  def self.accept_charset: () -> encoding
 
   # <!--
   #   rdoc-file=lib/cgi/core.rb
@@ -368,7 +368,7 @@ class CGI
   # -->
   # Set the accept character set for all new CGI instances.
   #
-  def self.accept_charset=: (String accept_charset) -> String
+  def self.accept_charset=: (encoding accept_charset) -> encoding
 
   # <!--
   #   rdoc-file=lib/cgi/core.rb
@@ -385,7 +385,7 @@ class CGI
   # <!-- rdoc-file=lib/cgi/core.rb -->
   # Return the accept character set for this CGI instance.
   #
-  attr_reader accept_charset: String
+  attr_reader accept_charset: encoding
 
   # <!-- rdoc-file=lib/cgi/core.rb -->
   # This method is an alias for #http_header, when HTML5 tag maker is inactive.

--- a/test/stdlib/CGI_test.rb
+++ b/test/stdlib/CGI_test.rb
@@ -22,13 +22,15 @@ class CGISingletonTest < Test::Unit::TestCase
   end
 
   def test_accept_charset
-    assert_send_type  "() -> ::String",
+    assert_send_type  "() -> ::encoding",
                       CGI, :accept_charset
   end
 
   def test_accept_charset=
     assert_send_type  "(::String accept_charset) -> ::String",
                       CGI, :accept_charset=, 'utf-8'
+    assert_send_type  "(::Encoding accept_charset) -> ::Encoding",
+                      CGI, :accept_charset=, Encoding::UTF_8
   end
 
   def test_parse


### PR DESCRIPTION
Requiring `cgi/util` before `cgi` itself sets an `Encoding` to `CGI.accept_charset`.