### PR TITLE
Overload annotations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rbs (3.6.1)
+    rbs (3.7.0.dev.0)
       logger
 
 PATH
@@ -38,7 +38,6 @@ GEM
     digest (3.1.1)
     drb (2.2.1)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-darwin)
     fileutils (1.7.2)
     goodcheck (3.1.0)
       marcel (>= 1.0, < 2.0)
@@ -120,7 +119,7 @@ GEM
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
     stackprof (0.2.26)
-    steep (1.8.0.pre.2)
+    steep (1.8.0)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -131,7 +130,7 @@ GEM
       logger (>= 1.3.0)
       parser (>= 3.1)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.6.0.pre)
+      rbs (~> 3.6.0)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 4)

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -28,12 +28,18 @@ module RBS
         attr_reader :member
         attr_reader :defined_in
         attr_reader :implemented_in
+        attr_reader :member_annotations
+        attr_reader :overload_annotations
+        attr_reader :annotations
 
-        def initialize(type:, member:, defined_in:, implemented_in:)
+        def initialize(type:, member:, defined_in:, implemented_in:, overload_annotations: [])
           @type = type
           @member = member
           @defined_in = defined_in
           @implemented_in = implemented_in
+          @member_annotations = member.annotations
+          @overload_annotations = overload_annotations
+          @annotations = member.annotations + overload_annotations
         end
 
         def ==(other)
@@ -54,12 +60,8 @@ module RBS
           member.comment
         end
 
-        def annotations
-          member.annotations
-        end
-
         def update(type: self.type, member: self.member, defined_in: self.defined_in, implemented_in: self.implemented_in)
-          TypeDef.new(type: type, member: member, defined_in: defined_in, implemented_in: implemented_in)
+          TypeDef.new(type: type, member: member, defined_in: defined_in, implemented_in: implemented_in, overload_annotations: overload_annotations)
         end
 
         def overload?
@@ -82,7 +84,7 @@ module RBS
         @super_method = super_method
         @defs = defs
         @accessibility = accessibility
-        @extra_annotations = annotations
+        @extra_annotations = []
         @alias_of = alias_of
       end
 
@@ -124,7 +126,7 @@ module RBS
       end
 
       def annotations
-        @annotations ||= @extra_annotations + defs.flat_map {|d| d.annotations }
+        @annotations ||= defs.flat_map {|d| d.member_annotations }
       end
 
       def members

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -386,7 +386,8 @@ module RBS
                       type: method_type,
                       member: initialize_def.member,
                       defined_in: initialize_def.defined_in,
-                      implemented_in: initialize_def.implemented_in
+                      implemented_in: initialize_def.implemented_in,
+                      overload_annotations: initialize_def.overload_annotations
                     )
                   end,
                   accessibility: :public,
@@ -641,7 +642,8 @@ module RBS
             type: subst.empty? ? overload.method_type : overload.method_type.sub(subst),
             member: original,
             defined_in: defined_in,
-            implemented_in: implemented_in
+            implemented_in: implemented_in,
+            overload_annotations: overload.annotations
           )
         end
 
@@ -750,7 +752,8 @@ module RBS
             type: subst.empty? ? overload.method_type : overload.method_type.sub(subst),
             member: overloading_def,
             defined_in: defined_in,
-            implemented_in: implemented_in
+            implemented_in: implemented_in,
+            overload_annotations: overload.annotations
           )
 
           method_definition.defs.unshift(type_def)

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "3.6.1"
+  VERSION = "3.7.0.dev.0"
 end

--- a/sig/definition.rbs
+++ b/sig/definition.rbs
@@ -21,11 +21,18 @@ module RBS
         attr_reader defined_in: TypeName
         attr_reader implemented_in: TypeName?
 
-        def initialize: (type: MethodType, member: method_member, defined_in: TypeName, implemented_in: TypeName?) -> void
+        # Annotations given to `#member`
+        attr_reader member_annotations: Array[AST::Annotation]
+
+        # Annotations given to the overload associated to the method type
+        attr_reader overload_annotations: Array[AST::Annotation]
+
+        # Concatnation of `member_annotations` and `overload_annotations`
+        attr_reader annotations: Array[AST::Annotation]
+
+        def initialize: (type: MethodType, member: method_member, defined_in: TypeName, implemented_in: TypeName?, ?overload_annotations: Array[AST::Annotation]) -> void
 
         def comment: () -> AST::Comment?
-
-        def annotations: () -> Array[AST::Annotation]
 
         def update: (?type: MethodType, ?member: method_member, ?defined_in: TypeName, ?implemented_in: TypeName?) -> TypeDef
 
@@ -35,15 +42,23 @@ module RBS
       attr_reader super_method: Method?
       attr_reader defs: Array[TypeDef]
       attr_reader accessibility: accessibility
-      attr_reader extra_annotations: Array[AST::Annotation]
+
       attr_reader defined_in: TypeName?
       attr_reader implemented_in: TypeName?
       attr_reader method_types: Array[MethodType]
       attr_reader comments: Array[AST::Comment]
-      attr_reader annotations: Array[AST::Annotation]
+
       attr_reader members: Array[method_member]
       attr_reader alias_of: Method?
 
+      # Unused, always returns empty array
+      attr_reader extra_annotations: Array[AST::Annotation]
+
+      # Union of annotations given to `defs`, not contains annotations given to each overload
+      attr_reader annotations: Array[AST::Annotation]
+
+      # Note that the annotations given through `annotations:` keyword is ignored.
+      #
       def initialize: (super_method: Method?,
                        defs: Array[TypeDef],
                        accessibility: accessibility,

--- a/test/stdlib/PP_test.rb
+++ b/test/stdlib/PP_test.rb
@@ -22,7 +22,7 @@ class PPSingletonTest < Test::Unit::TestCase
                      PP, :width_for, Object.new
     assert_send_type "(untyped out) -> ::Integer",
                      PP, :width_for, $stdout
-   end
+  end
 
   def test_singleline_pp
     assert_send_type "(::PP::_PrettyPrint obj, ?::PP::_LeftShift out) -> untyped",


### PR DESCRIPTION
Sometimes we need annotation of each overload, not the `def` syntax.