### PR TITLE
Suppress `inline` is not at beginning of declaration for melt_array

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -54,7 +54,7 @@ typedef struct {
 
 static VALUE EMPTY_ARRAY;
 
-static void inline melt_array(VALUE *array) {
+static inline void melt_array(VALUE *array) {
   if (*array == EMPTY_ARRAY) {
     *array = rb_ary_new();
   }


### PR DESCRIPTION
function

When building RBS on Ubuntu 22.04 and GCC 11.4.0, the following warning appeared.
And this change has suppressed warning.

```
+ bundle exec rake compile
mkdir -p tmp/x86_64-linux/rbs_extension/3.4.0
cd tmp/x86_64-linux/rbs_extension/3.4.0
/home/sh/.rbenv/versions/ruby-dev/bin/ruby -I. ../../../../ext/rbs_extension/extconf.rb
checking for whether -std=gnu99 is accepted as CFLAGS... yes
creating Makefile
cd -
cd tmp/x86_64-linux/rbs_extension/3.4.0
/usr/bin/gmake
compiling ../../../../ext/rbs_extension/constants.c
compiling ../../../../ext/rbs_extension/lexer.c
compiling ../../../../ext/rbs_extension/lexstate.c
compiling ../../../../ext/rbs_extension/location.c
compiling ../../../../ext/rbs_extension/main.c
compiling ../../../../ext/rbs_extension/parser.c
../../../../ext/rbs_extension/parser.c:57:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
   57 | static void inline melt_array(VALUE *array) {
      | ^~~~~~
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
compiling ../../../../ext/rbs_extension/parserstate.c
compiling ../../../../ext/rbs_extension/ruby_objs.c
compiling ../../../../ext/rbs_extension/unescape.c
linking shared-object rbs_extension.so
cd -
mkdir -p tmp/x86_64-linux/stage/lib
/usr/bin/gmake install sitearchdir=../../../../lib sitelibdir=../../../../lib target_prefix=
/usr/bin/install -c -m 0755 rbs_extension.so ../../../../lib
cp tmp/x86_64-linux/rbs_extension/3.4.0/rbs_extension.so tmp/x86_64-linux/stage/lib/rbs_extension.so
+ type re2c
+ echo '🚨 Cannot find re2c, which is required to generate lexer. Install the tool to change the lexer.'
🚨 Cannot find re2c, which is required to generate lexer. Install the tool to change the lexer.

```