### PR TITLE
Suppress -Wold-style-declaration

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -54,7 +54,7 @@ typedef struct {
 
 static VALUE EMPTY_ARRAY;
 
-static void inline melt_array(VALUE *array) {
+static inline void melt_array(VALUE *array) {
   if (*array == EMPTY_ARRAY) {
     *array = rb_ary_new();
   }


### PR DESCRIPTION
Fixes:

```
../../../../../../.bundle/gems/rbs-3.6.1/ext/rbs_extension/parser.c:57:1: warning: ‘inline’ is not at beginning of declaration [-Wold-style-declaration]
   57 | static void inline melt_array(VALUE *array) {
      | ^~~~~~
```