### PR TITLE
Remove unused `rbs_unescape_string` declaration

### DIFF
--- a/ext/rbs_extension/rbs_extension.h
+++ b/ext/rbs_extension/rbs_extension.h
@@ -10,14 +10,6 @@
 #include "ruby_objs.h"
 
 /**
- * Unescape escape sequences in the given string inplace:
- *
- *   '\\n' => "\n"
- *
- * */
-void rbs_unescape_string(VALUE string, bool dq_string);
-
-/**
  * Receives `parserstate` and `range`, which represents a string token or symbol token, and returns a string VALUE.
  *
  *    Input token | Output string


### PR DESCRIPTION
Seems to be a leftover of #1685.

See the implementation removal in https://github.com/ruby/rbs/commit/445716229d3d9b98d62d2e1e9d51c3c5ea89961d.