### PR TITLE
Add `chomp` to  `IO#readline` and  `IO#readlines`

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1638,7 +1638,7 @@ class IO < Object
   # Optional keyword argument `chomp` specifies whether line separators are to be
   # omitted.
   #
-  def readline: (?String sep, ?Integer limit) -> String
+  def readline: (?String sep, ?Integer limit, ?chomp: boolish) -> String
 
   # <!--
   #   rdoc-file=io.c

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1701,7 +1701,7 @@ class IO < Object
   #     # => ["First line", "Second line", "", "Fourth line", "Fifth line"]
   #     f.close
   #
-  def readlines: (?String sep, ?Integer limit) -> ::Array[String]
+  def readlines: (?String sep, ?Integer limit, ?chomp: boolish) -> ::Array[String]
 
   # <!--
   #   rdoc-file=io.c

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -382,6 +382,22 @@ class IOInstanceTest < Test::Unit::TestCase
                        io, :gets, nil, chomp: true
     end
   end
+
+  def test_readlines
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
+      assert_send_type '() -> Array[String]',
+                       io, :readlines
+
+      assert_send_type '(String, Integer) -> Array[String]',
+                       io, :readlines, "\n", 100
+
+      assert_send_type '(chomp: bool) -> Array[String]',
+                       io, :readlines, chomp: true
+
+      assert_send_type '(String, Integer, chomp: bool) -> Array[String]',
+                       io, :readlines, "\n", 100, chomp: true
+    end
+  end
 end
 
 class IOWaitTest < Test::Unit::TestCase

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -398,6 +398,22 @@ class IOInstanceTest < Test::Unit::TestCase
                        io, :readlines, "\n", 100, chomp: true
     end
   end
+
+  def test_readline
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
+      assert_send_type '() -> String',
+                       io, :readline
+
+      assert_send_type '(String, Integer) -> String',
+                       io, :readline, "\n", 100
+
+      assert_send_type '(chomp: bool) -> String',
+                       io, :readline, chomp: true
+
+      assert_send_type '(String, Integer, chomp: bool) -> String',
+                       io, :readline, "\n", 100, chomp: true
+    end
+  end
 end
 
 class IOWaitTest < Test::Unit::TestCase


### PR DESCRIPTION
`IO.readlines` supports `chomp` argument and signature exists.

https://github.com/ruby/rbs/blob/745943bc0b28351018fc0f0257fc0f4d522b7a15/core/io.rbs#L2764-L2766

https://github.com/ruby/rbs/blob/745943bc0b28351018fc0f0257fc0f4d522b7a15/core/io.rbs#L2813

`IO#readline` and `IO#readlines` likewise support the `chomp` argument.

https://github.com/ruby/rbs/blob/745943bc0b28351018fc0f0257fc0f4d522b7a15/core/io.rbs#L1632-L1634

https://github.com/ruby/rbs/blob/745943bc0b28351018fc0f0257fc0f4d522b7a15/core/io.rbs#L1645-L1647

But this didn't exist in `io.rbs`, so I added.