### PR TITLE
Proposal: Data (and struct) syntax

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1747,6 +1747,7 @@ VALUE parse_member_def(parserstate *state, bool instance_only, bool accept_overl
 
 /**
  * class_instance_name ::= {} <class_name>
+ *                       | {} Data `[` kwarg args `]`
  *                       | {} class_name `[` type args <`]`>
  *
  * @param kind
@@ -1756,7 +1757,13 @@ void class_instance_name(parserstate *state, TypeNameKind kind, VALUE *name, VAL
 
   *name = parse_type_name(state, kind, name_range);
 
-  if (state->next_token.type == pLBRACKET) {
+  if (CLASS_OF(*name) == RBS_TypeName && rb_funcall(*name, rb_intern("data?"), 0) == Qtrue) {
+    parser_advance_assert(state, pLPAREN);
+    args_range->start = state->current_token.range.start;
+    *args = parse_record_attributes(state);
+    parser_advance_assert(state, pRPAREN);
+    args_range->end = state->current_token.range.end;
+  } else if (state->next_token.type == pLBRACKET) {
     parser_advance(state);
     args_range->start = state->current_token.range.start;
     parse_type_list(state, pRBRACKET, args);

--- a/ext/rbs_extension/ruby_objs.c
+++ b/ext/rbs_extension/ruby_objs.c
@@ -3,7 +3,7 @@
 #ifdef RB_PASS_KEYWORDS
   // Ruby 2.7 or later
   #define CLASS_NEW_INSTANCE(klass, argc, argv)\
-          rb_class_new_instance_kw(argc, argv, klass, RB_PASS_KEYWORDS)
+          rb_respond_to(klass, rb_intern("new")) ? rb_funcallv_kw(klass, rb_intern("new"), argc, argv, RB_PASS_KEYWORDS) : rb_class_new_instance_kw(argc, argv, klass, RB_PASS_KEYWORDS)
 #else
   // Ruby 2.6
   #define CLASS_NEW_INSTANCE(receiver, argc, argv)\

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -81,6 +81,141 @@ module RBS
               location: location
             }.to_json(state)
           end
+
+          def self.new(name: , args:, location:)
+
+            return super unless name.data?
+
+            superklass = super(name: name, args: [], location: location)
+
+            args.transform_values! do |(type, required)|
+              required ? type : Types::Optional.new(type: type, location: type.location)
+            end
+
+            # attribute readers
+            members = args.map do |k, type|
+              Members::AttrReader.new(
+                name: k,
+                type: type,
+                ivar_name: :"@#{type}",
+                kind: :instance,
+                location: location,
+                comment: nil,
+                annotations: nil
+              )
+            end
+
+            # initialize
+            members << Members::MethodDefinition.new(
+              name: :initialize,
+              kind: :instance,
+              location: location,
+              overloading: false,
+              comment: nil,
+              annotations: nil,
+              visibility: nil,
+              overloads: [
+                Members::MethodDefinition::Overload.new(
+                  method_type: MethodType.new(
+                    type_params: [],
+                    type: Types::Function.new(
+                      required_keywords: args.to_h { |k, type|
+                        [
+                          k,
+                          # set param
+                          Types::Function::Param.new(
+                            name: nil,
+                            type: type,
+                            location: location
+                          )
+                        ]
+                      },
+                      required_positionals: [],
+                      optional_keywords: {},
+                      optional_positionals: [],
+                      rest_keywords: nil,
+                      rest_positionals: nil,
+                      trailing_positionals: [],
+                      return_type: RBS::Types::Bases::Void.new(location: location),
+                    ),
+                    location: location,
+                    block: nil,
+                  ),
+                  annotations: []
+                ),
+                Members::MethodDefinition::Overload.new(
+                  method_type: MethodType.new(
+                    type_params: [],
+                    type: Types::Function.new(
+                      required_positionals: args.map { |k, type|
+                        # set param
+                        Types::Function::Param.new(
+                          name: k,
+                          type: type,
+                          location: location
+                        )
+                      },
+                      required_keywords: [],
+                      optional_keywords: {},
+                      optional_positionals: [],
+                      rest_keywords: nil,
+                      rest_positionals: nil,
+                      trailing_positionals: [],
+                      return_type: RBS::Types::Bases::Void.new(location: location),
+                    ),
+                    location: location,
+                    block: nil,
+                  ),
+                  annotations: []
+                )
+              ]
+            )
+
+            # members
+            members << Members::MethodDefinition.new(
+              name: :members,
+              kind: :instance,
+              location: location,
+              overloading: false,
+              comment: nil,
+              annotations: nil,
+              visibility: nil,
+              overloads: [
+                Members::MethodDefinition::Overload.new(
+                  method_type: MethodType.new(
+                    type_params: [],
+                    type: Types::Function.new(
+                      required_keywords: {},
+                      required_positionals: [],
+                      optional_keywords: {},
+                      optional_positionals: [],
+                      rest_keywords: nil,
+                      rest_positionals: nil,
+                      trailing_positionals: [],
+                      return_type: RBS::Types::ClassInstance.new(
+                        name: BuiltinNames::Array,
+                        args: [RBS::Types::ClassInstance.new(name: BuiltinNames::Symbol, args: [], location: location)],
+                        location: location
+                      ),
+                    ),
+                    location: location,
+                    block: nil,
+                  ),
+                  annotations: []
+                )
+              ]
+            )
+
+            Class.new(
+              name: nil,
+              type_params: nil,
+              super_class: superklass,
+              annotations: nil,
+              comment: nil,
+              location: location,
+              members: members
+            )
+          end
         end
 
         include NestedDeclarationHelper

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -52,6 +52,10 @@ module RBS
       kind == :alias
     end
 
+    def data?
+      class? && namespace.empty? && name == :Data
+    end
+
     def absolute!
       self.class.new(namespace: namespace.absolute!, name: name)
     end

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -428,6 +428,72 @@ end
     end
   end
 
+  def test_data_class_decl
+    RBS::Parser.parse_signature(buffer(<<-RBS)).tap do |_, _, decls|
+      class Foo < Data(a: Integer)
+      end
+          RBS
+      decls[0].tap do |decl|
+        assert_instance_of RBS::AST::Declarations::Class, decl
+        assert_equal TypeName("Foo"), decl.name
+        assert_predicate decl.type_params, :empty?
+        assert_nil decl.super_class.name
+        assert_equal TypeName("Data"), decl.super_class.superclass.name
+
+        assert_equal 8, decl.members.size
+
+        decl.members[0].tap do |member|
+          assert_instance_of RBS::AST::Members::AttrReader, member
+          assert_equal :instance, member.kind
+          assert_equal :a, member.name
+          assert_equal "Integer", member.type.to_s
+        end
+
+        decl.members[1].tap do |member|
+          assert_instance_of RBS::AST::Members::MethodDefinition, member
+          assert_equal :method, member.kind
+          assert_equal :initialize, member.name
+          assert_equal ["(::Integer) -> void | (id: ::Integer) -> void"], member.method_types.map(&:to_s)
+        end
+
+        decl.members[2].tap do |member|
+          assert_instance_of RBS::AST::Members::MethodDefinition, member
+          assert_equal :method, member.kind
+          assert_equal :members, member.name
+          assert_equal ["() -> Array[Symbol]"], member.method_types.map(&:to_s)
+        end
+
+        decl.members[3].tap do |member|
+          assert_instance_of RBS::AST::Members::MethodDefinition, member
+          assert_equal :method, member.kind
+          assert_equal :deconstruct, member.name
+          assert_equal ["() -> [Integer]"], member.method_types.map(&:to_s)
+        end
+
+        decl.members[4].tap do |member|
+          assert_instance_of RBS::AST::Members::MethodDefinition, member
+          assert_equal :method, member.kind
+          assert_equal :deconstruct_keys, member.name
+          assert_equal ["(nil) -> {a: Integer} | (Array(Symbol)) -> Hash[untyped]"], member.method_types.map(&:to_s)
+        end
+
+        decl.members[5].tap do |member|
+          assert_instance_of RBS::AST::Members::MethodDefinition, member
+          assert_equal :method, member.kind
+          assert_equal :with, member.name
+          assert_equal ["(?a: Integer) -> Foo"], member.method_types.map(&:to_s)
+        end
+      end
+
+      decls[1].tap do |decl|
+        # as funcall: Foo[1]
+        assert_instance_of RBS::Types::UntypedFunction, decl.block.type
+        assert_equal TypeName("Foo"), decl.name
+          assert_equal ["(::Integer a) -> Foo |(a: ::Integer) -> Foo"], member.method_types.map(&:to_s)
+      end
+    end
+  end
+
   def test_parse_type
     assert_equal "hello", RBS::Parser.parse_type(buffer('"hello"')).literal
     assert_equal "hello", RBS::Parser.parse_type(buffer("'hello'")).literal

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -438,59 +438,68 @@ end
         assert_equal TypeName("Foo"), decl.name
         assert_predicate decl.type_params, :empty?
         assert_nil decl.super_class.name
-        assert_equal TypeName("Data"), decl.super_class.superclass.name
+        assert_equal TypeName("Data"), decl.super_class.super_class.name
 
-        assert_equal 8, decl.members.size
+        members = decl.super_class.members
 
-        decl.members[0].tap do |member|
+        # assert_equal 8, members.size
+
+        members[0].tap do |member|
           assert_instance_of RBS::AST::Members::AttrReader, member
           assert_equal :instance, member.kind
           assert_equal :a, member.name
           assert_equal "Integer", member.type.to_s
         end
 
-        decl.members[1].tap do |member|
+        members[1].tap do |member|
           assert_instance_of RBS::AST::Members::MethodDefinition, member
-          assert_equal :method, member.kind
+          assert_equal :instance, member.kind
           assert_equal :initialize, member.name
-          assert_equal ["(::Integer) -> void | (id: ::Integer) -> void"], member.method_types.map(&:to_s)
+          assert_equal 2, member.overloads.size
+          assert_equal "(a: Integer) -> void", member.overloads[0].method_type.to_s
+          assert_equal"(Integer a) -> void", member.overloads[1].method_type.to_s
         end
 
-        decl.members[2].tap do |member|
+        members[2].tap do |member|
           assert_instance_of RBS::AST::Members::MethodDefinition, member
-          assert_equal :method, member.kind
+          assert_equal :instance, member.kind
           assert_equal :members, member.name
-          assert_equal ["() -> Array[Symbol]"], member.method_types.map(&:to_s)
+          assert_equal 1, member.overloads.size
+          assert_equal "() -> ::Array[::Symbol]", member.overloads[0].method_type.to_s
         end
 
-        decl.members[3].tap do |member|
-          assert_instance_of RBS::AST::Members::MethodDefinition, member
-          assert_equal :method, member.kind
-          assert_equal :deconstruct, member.name
-          assert_equal ["() -> [Integer]"], member.method_types.map(&:to_s)
-        end
+        # members[3].tap do |member|
+        #   assert_instance_of RBS::AST::Members::MethodDefinition, member
+        #   assert_equal :method, member.kind
+        #   assert_equal :deconstruct, member.name
+        #   assert_equal 1, member.overloads.size
+        #   assert_equal "() -> [Integer]", member.overloads[0].method_type.to_s
+        # end
 
-        decl.members[4].tap do |member|
-          assert_instance_of RBS::AST::Members::MethodDefinition, member
-          assert_equal :method, member.kind
-          assert_equal :deconstruct_keys, member.name
-          assert_equal ["(nil) -> {a: Integer} | (Array(Symbol)) -> Hash[untyped]"], member.method_types.map(&:to_s)
-        end
+        # members[4].tap do |member|
+        #   assert_instance_of RBS::AST::Members::MethodDefinition, member
+        #   assert_equal :method, member.kind
+        #   assert_equal :deconstruct_keys, member.name
+        #   assert_equal 2, member.overloads.size
+        #   assert_equal "(nil) -> {a: Integer}", member.overloads[0].method_type.to_s
+        #   assert_equal"(Array(Symbol)) -> Hash[untyped]", member.overloads[1].method_type.to_s
+        # end
 
-        decl.members[5].tap do |member|
-          assert_instance_of RBS::AST::Members::MethodDefinition, member
-          assert_equal :method, member.kind
-          assert_equal :with, member.name
-          assert_equal ["(?a: Integer) -> Foo"], member.method_types.map(&:to_s)
-        end
+        # members[5].tap do |member|
+        #   assert_instance_of RBS::AST::Members::MethodDefinition, member
+        #   assert_equal :method, member.kind
+        #   assert_equal :with, member.name
+        #   assert_equal 1, member.overloads.size
+        #   assert_equal "(?a: Integer) -> Foo", member.overloads[0].method_type.to_s
+        # end
       end
 
-      decls[1].tap do |decl|
-        # as funcall: Foo[1]
-        assert_instance_of RBS::Types::UntypedFunction, decl.block.type
-        assert_equal TypeName("Foo"), decl.name
-          assert_equal ["(::Integer a) -> Foo |(a: ::Integer) -> Foo"], member.method_types.map(&:to_s)
-      end
+      # decls[1].tap do |decl|
+      #   # as funcall: Foo[1]
+      #   assert_instance_of RBS::Types::UntypedFunction, decl.block.type
+      #   assert_equal TypeName("Foo"), decl.name
+      #     assert_equal ["(::Integer a) -> Foo |(a: ::Integer) -> Foo"], member.method_types.map(&:to_s)
+      # end
     end
   end
 


### PR DESCRIPTION
This is a proposal on how to solve the `Data` and `Struct` usage, which currently has to be hand-stitched and is often times incomplete (lack of `#members`, for example). Essentially it boils down to this:

```rbs
class A < Data(a: Integer, b: String)
end
```

The generated type will have the corresponding attribute readers, correct initiallize signatures, `#members`, and all that, as well as correct class innheritance hierarchy (anonymous dynamic class in between `A` and `Data` with all the aforementioned methods).

Implementation-wise, this patch reuses code from record attibutes to parse the class members, and provides an exceptional path for classes inheriting from `Data` (a similar solution could be built for `Struct`).

I've left this purposedly raw and incomplete to get some early feedback, before I go too far on an unwanted path. 

cc @soutaro 