### PR TITLE
stdlib: Add types for base64digest of openssl

### DIFF
--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -3665,6 +3665,23 @@ module OpenSSL
     #
     def self.hexdigest: (String | Digest algo, String key, String data) -> String
 
+    # <!--
+    #   rdoc-file=ext/openssl/lib/openssl/hmac.rb
+    #   - HMAC.base64digest(digest, key, data) -> aString
+    # -->
+    # Returns the authentication code as a Base64-encoded string. The *digest*
+    # parameter specifies the digest algorithm to use. This may be a String
+    # representing the algorithm name or an instance of OpenSSL::Digest.
+    #
+    # ### Example
+    #     key = 'key'
+    #     data = 'The quick brown fox jumps over the lazy dog'
+    #
+    #     hmac = OpenSSL::HMAC.base64digest('SHA1', key, data)
+    #     #=> "3nybhbi3iqa8ino29wqQcBydtNk="
+    #
+    def self.base64digest: (String | Digest algo, String key, String data) -> String
+
     # <!-- rdoc-file=ext/openssl/ossl_hmac.c -->
     # Returns *hmac* updated with the message to be authenticated. Can be called
     # repeatedly with chunks of the message.
@@ -3711,6 +3728,14 @@ module OpenSSL
     # string.
     #
     def hexdigest: () -> String
+
+    # <!--
+    #   rdoc-file=ext/openssl/lib/openssl/hmac.rb
+    #   - hmac.base64digest -> string
+    # -->
+    # Returns the authentication code an a Base64-encoded string.
+    #
+    def base64digest: () -> String
 
     # <!-- rdoc-file=ext/openssl/lib/openssl/hmac.rb -->
     # Returns the authentication code as a hex-encoded string. The *digest*

--- a/test/stdlib/OpenSSL_test.rb
+++ b/test/stdlib/OpenSSL_test.rb
@@ -525,6 +525,11 @@ class OpenSSLHMACSingletonTest < Test::Unit::TestCase
     assert_send_type "(String, String, String) -> String",
       OpenSSL::HMAC, :hexdigest, "SHA256", "key", "data"
   end
+
+  def test_base64digest
+    assert_send_type "(String, String, String) -> String",
+      OpenSSL::HMAC, :base64digest, "SHA256", "key", "data"
+  end
 end
 
 class OpenSSLHMACTest < Test::Unit::TestCase
@@ -540,6 +545,11 @@ class OpenSSLHMACTest < Test::Unit::TestCase
   def test_hexdigest
     assert_send_type "() -> String",
       hmac, :hexdigest
+  end
+
+  def test_base64digest
+    assert_send_type "() -> String",
+      hmac, :base64digest
   end
 
   def test_reset


### PR DESCRIPTION
refs:
 - https://github.com/ruby/openssl/blob/bd647c3b05513fe8782d8246b9b7a03381b67eaf/lib/openssl/hmac.rb#L13-L19
 - https://docs.ruby-lang.org/en/master/OpenSSL/HMAC.html#method-i-base64digest
 - https://github.com/ruby/openssl/blob/bd647c3b05513fe8782d8246b9b7a03381b67eaf/lib/openssl/hmac.rb#L60-L75
 - https://docs.ruby-lang.org/en/master/OpenSSL/HMAC.html#method-c-base64digest