### PR TITLE
Skip `rbs` gem validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     abbrev (0.1.2)
-    activesupport (7.2.1)
+    activesupport (8.0.0)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -24,10 +25,12 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
     base64 (0.2.0)
+    benchmark (0.4.0)
     benchmark-ips (2.14.0)
     bigdecimal (3.1.8)
     concurrent-ruby (1.3.4)
@@ -117,9 +120,9 @@ GEM
     rubocop-rubycw (0.1.6)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
-    securerandom (0.3.1)
+    securerandom (0.3.2)
     stackprof (0.2.26)
-    steep (1.8.0)
+    steep (1.8.3)
       activesupport (>= 5.1)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
@@ -146,6 +149,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
+    uri (1.0.2)
     zlib (3.1.1)
 
 PLATFORMS

--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,12 @@ task :validate => :compile do
   # Skip RBS validation because Ruby CI runs without rubygems
   case skip_rbs_validation = ENV["SKIP_RBS_VALIDATION"]
   when nil
-    libs << "rbs"
+    begin
+      Gem::Specification.find_by_name("rbs")
+      libs << "rbs"
+    rescue Gem::MissingSpecError
+      STDERR.puts "🚨🚨🚨🚨 Skipping `rbs` gem because it's not found"
+    end
   when "true"
     # Skip
   else
@@ -90,7 +95,7 @@ task :stdlib_test => :compile do
   if ENV["RANDOMIZE_STDLIB_TEST_ORDER"] == "true"
     test_files.shuffle!
   end
-  
+
   sh "#{ruby} -Ilib #{bin}/test_runner.rb #{test_files.join(' ')}"
   # TODO: Ractor tests need to be run in a separate process
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/Ractor_test.rb"


### PR DESCRIPTION
I'm not sure the reason exactly, but `rbs validate` with `rbs` fails because `Gem::Specification.find_by_name('rbs')` doesn't work with `gemspec` source with extensions.

```
/Users/soutaro/Developer/rbs/lib/rbs/environment_loader.rb:133:in `block in each_dir': Cannot find type definitions for library: rbs ([nil]) (RBS::EnvironmentLoader::UnknownLibraryError)
```

We can reproduce the problem with `irb`.

```
$ bundle exec irb
Ignoring rbs-3.7.0.dev.0 because its extensions are not built. Try: gem pristine rbs --version 3.7.0.dev.0
irb(main):001> Gem::Specification.find_by_name("rbs")
/Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/3.3.0/rubygems/dependency.rb:303:in `to_specs': Could not find 'rbs' (>= 0) - did find: [rbs-3.7.0.dev.0] (Gem::MissingSpecVersionError)
Checked in 'GEM_PATH=/Users/soutaro/.local/share/gem/ruby/3.3.0:/Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0' , execute `gem env` for more information
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/3.3.0/rubygems/dependency.rb:313:in `to_spec'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/3.3.0/rubygems/specification.rb:962:in `find_by_name'
	from (irb):1:in `<main>'
	from <internal:kernel>:187:in `loop'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/irb-1.13.1/exe/irb:9:in `<top (required)>'
	from /Users/soutaro/.rbenv/versions/3.3.6/bin/irb:25:in `load'
	from /Users/soutaro/.rbenv/versions/3.3.6/bin/irb:25:in `<top (required)>'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in `load'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:58:in `kernel_load'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/cli/exec.rb:23:in `run'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/cli.rb:455:in `exec'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/cli.rb:35:in `dispatch'
	from /Users/soutaro/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/bundler-2.5.16/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
	... 6 levels...
```

I think it's a bug of rubygems (or bundler)...