### PR TITLE
fix for inherited not supporting subclassing

### DIFF
--- a/core/class.rbs
+++ b/core/class.rbs
@@ -149,7 +149,7 @@ class Class < Module
   #     New subclass: Bar
   #     New subclass: Baz
   #
-  def inherited: (Class arg0) -> untyped
+  def inherited: (instance arg0) -> untyped
 
   # <!--
   #   rdoc-file=object.c


### PR DESCRIPTION
the arg of inherited is a subclass of the current class, not (just) a ::Class.


There's also a similar limitation in `Kernel#class` definition, where `def class: () -> Class` should map out to something more useful, i.e. `def class: () -> instance_class`, but that would require support for a new keyword, and there may be other limitations? 

