### PR TITLE
Make it usable even for stdlib if rubygems is available

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -7,6 +7,7 @@ module RBS
         DEPRECATED_STDLIBS = [
           ['mutex_m', '0.3.0']
         ]
+        ALMUNI_STDLIBS = []
 
         class GemfileLockMismatchError < StandardError
           def initialize(expected:, actual:)
@@ -135,6 +136,11 @@ module RBS
 
               begin
                 locked[:source].dependencies_of(locked[:name], locked[:version])&.each do |dep|
+                  next if ALMUNI_STDLIBS.include?(dep["name"])
+                  unless Sources::Stdlib.instance.has?(dep["name"], nil)
+                    RBS.logger.warn "`#{dep["name"]}` has been specified in #{locked[:name]}/#{locked[:version]}/manifest.yaml. However, only stdlib gem can be specified here."
+                    next
+                  end
                   assign_by(name: dep["name"], version: nil, from_gem: name)
                 end
               rescue
@@ -178,6 +184,11 @@ module RBS
 
           if deps = source.dependencies_of(name, "0")
             deps.each do |dep|
+              next if ALMUNI_STDLIBS.include?(dep["name"])
+              unless Sources::Stdlib.instance.has?(dep["name"], nil)
+                RBS.logger.warn "`#{dep["name"]}` has been specified in #{name}/0/manifest.yaml. However, only stdlib gem can be specified here."
+                next
+              end
               assign_by(name: dep["name"], version: nil, from_gem: name)
             end
           end

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -4,6 +4,10 @@ module RBS
   module Collection
     class Config
       class LockfileGenerator
+        DEPRECATED_STDLIBS = [
+          ['mutex_m', '0.3.0']
+        ]
+
         class GemfileLockMismatchError < StandardError
           def initialize(expected:, actual:)
             @expected = expected
@@ -160,6 +164,9 @@ module RBS
             RBS.logger.warn msg
 
             return
+          end
+          if deprecated = DEPRECATED_STDLIBS.find { |n, v| n == name }
+            RBS.logger.warn "`#{deprecated[0]}` in rbs/stdlib is deprecated. Please install gem v#{deprecated[1]} or over instead."
           end
 
           source = Sources::Stdlib.instance

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -2,6 +2,8 @@ module RBS
   module Collection
     class Config
       class LockfileGenerator
+        DEPRECATED_STDLIBS: Array[[String, String]]
+
         class GemfileLockMismatchError < StandardError
           @expected: Pathname
 

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -45,6 +45,9 @@ module RBS
 
         def assign_stdlib: (name: String, from_gem: String?) -> void
 
+        def assign_by: (name: String, version: String?, from_gem: String?) -> void
+
+        def assign_by_source: (source: Sources::t?, name: String, version: String?, from_gem: String?) -> void
         # Find a source of a gem from ones registered in `config.sources`
         #
         # Returns `nil` if no source contains the definition of the gem.

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -3,6 +3,7 @@ module RBS
     class Config
       class LockfileGenerator
         DEPRECATED_STDLIBS: Array[[String, String]]
+        ALMUNI_STDLIBS: Array[String]
 
         class GemfileLockMismatchError < StandardError
           @expected: Pathname


### PR DESCRIPTION
ref: https://github.com/ruby/mutex_m/pull/20

mutex_m v0.3.0 has been released. ([link](https://github.com/ruby/mutex_m/releases/tag/v0.3.0))
However, even if this gem is installed, there are limited situations where the signature can be used.

This fix allows gem signatures to be used in the above two situations as long as the gem is installed.


## Before

- Write `mutex_m` in rbs_collection.yaml
    - ❌ Always stdlib is selected.
- Find `mutex_m` in manifest.yaml
    - ❌ Always stdlib is selected.
- Find `mutex_m` in Gemfile.lock
    - ✅ Rubygems is selected.

## After

- Write `mutex_m` in rbs_collection.yaml
    - ✅ Rubygems is selected if gem was installed.
    - ✅ Stdlib is selected if gem was not installed.
- Find `mutex_m` in manifest.yaml
    - ✅ Rubygems is selected if gem was installed.
    - ✅ Stdlib is selected if gem was not installed.
- Find `mutex_m` in Gemfile.lock
    - ✅ Rubygems is selected.


⚠️ Assume that `source` is not specified in rbs_collection.yaml.