### PR TITLE
Bundle update json 2.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       strong_json (>= 1.1, < 2.2)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    json (2.7.2)
+    json (2.8.2)
     json-schema (5.0.0)
       addressable (~> 2.8)
     language_server-protocol (3.17.0.3)

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -714,7 +714,7 @@ module JSON
   #
   def self.create_id=: (_ToS create_id) -> _ToS
 
-  def self.deep_const_get: (_ToS path) -> untyped
+  def self.deep_const_get: (interned path) -> untyped
 
   # <!--
   #   rdoc-file=ext/json/lib/json/common.rb

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -48,8 +48,9 @@ class JSONSingletonTest < Test::Unit::TestCase
   end
 
   def test_deep_const_get
-    assert_send_type "(String) -> String", JSON, :deep_const_get, "File::SEPARATOR"
-    assert_send_type "(_ToS) -> String", JSON, :deep_const_get, JsonToS.new("File::SEPARATOR")
+    with_interned("File") do |val|
+      assert_send_type "(interned) -> singleton(File)", JSON, :deep_const_get, val
+    end
   end
 
   def test_dump


### PR DESCRIPTION
ref: https://github.com/ruby/json/pull/644

The implementation of `JSON.deep_const_get` has changed and `_ToS` is no longer appropriate.