### PR TITLE
Remove the dependency to activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'tempfile'
 gem "rdoc"
 gem "fileutils"
 gem "raap"
-gem "activesupport"
 
 group :libs do
   # Libraries required for stdlib test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,6 @@ PLATFORMS
 
 DEPENDENCIES
   abbrev
-  activesupport
   base64
   benchmark-ips
   bigdecimal

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -4,9 +4,6 @@ require "erb"
 require "fileutils"
 require "yaml"
 
-require "active_support"
-require "active_support/core_ext/string/inflections"
-
 module RBS
   class Template
     class Field
@@ -48,12 +45,12 @@ module RBS
 
       def initialize(yaml)
         @ruby_full_name = yaml["name"]
-        @ruby_class_name = @ruby_full_name.demodulize
+        @ruby_class_name = @ruby_full_name[/[^:]+\z/] # demodulize-like
+        name = @ruby_full_name.gsub("::", "_")
+        name = name.gsub(/(^)?(_)?([A-Z](?:[A-Z]*(?=[A-Z_])|[a-z0-9]*))/) { ($1 || $2 || "_") + $3.downcase } # underscore-like
         @c_function_name = if @ruby_full_name =~ /^RBS::Types/
-          name = @ruby_full_name.gsub("::", "_").underscore
           name.gsub("_types_", "_")
         else
-          name = @ruby_full_name.gsub("::", "_").underscore
           name.gsub("_declarations_", "_decl_")
         end
         @c_constant_name = @ruby_full_name.gsub("::", "_")

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -47,12 +47,9 @@ module RBS
         @ruby_full_name = yaml["name"]
         @ruby_class_name = @ruby_full_name[/[^:]+\z/] # demodulize-like
         name = @ruby_full_name.gsub("::", "_")
-        name = name.gsub(/(^)?(_)?([A-Z](?:[A-Z]*(?=[A-Z_])|[a-z0-9]*))/) { ($1 || $2 || "_") + $3.downcase } # underscore-like
-        @c_function_name = if @ruby_full_name =~ /^RBS::Types/
-          name.gsub("_types_", "_")
-        else
-          name.gsub("_declarations_", "_decl_")
-        end
+        @c_function_name = name.gsub(/(^)?(_)?([A-Z](?:[A-Z]*(?=[A-Z_])|[a-z0-9]*))/) { ($1 || $2 || "_") + $3.downcase } # underscore-like
+        @c_function_name.gsub!(/^rbs_types_/, 'rbs_')
+        @c_function_name.gsub!(/^rbs_ast_declarations_/, 'rbs_ast_decl_')
         @c_constant_name = @ruby_full_name.gsub("::", "_")
         @c_parent_constant_name = @ruby_full_name.split("::")[0..-2].join("::").gsub("::", "_")
 


### PR DESCRIPTION
... by replacing `demodulize` and `underscore` with hand-written regexps.