### PR TITLE
add correct base class to OpenSSL::Digest

### DIFF
--- a/stdlib/openssl/0/manifest.yaml
+++ b/stdlib/openssl/0/manifest.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - name: socket
+  - name: digest

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -3164,7 +3164,7 @@ module OpenSSL
   #     sha256.reset
   #     digest2 = sha256.digest(data2)
   #
-  class Digest
+  class Digest < ::Digest::Class
     # <!--
     #   rdoc-file=ext/openssl/lib/openssl/digest.rb
     #   - digest(name, data)


### PR DESCRIPTION
some method definitions, like OpenSSL::Digest#file, are missing otherwise