### PR TITLE
Reduce object allocation for record type

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -521,13 +521,20 @@ module RBS
       def initialize(all_fields: nil, fields: nil, location:)
         case
         when fields && all_fields.nil?
-          @all_fields = fields.map { |k, v| [k, [v, true]] }.to_h
+          @all_fields = fields.transform_values { |v| [v, true] }
           @fields = fields
           @optional_fields = {}
         when all_fields && fields.nil?
           @all_fields = all_fields
-          @fields = all_fields.filter_map { |k, (v, required)| [k, v] if required }.to_h
-          @optional_fields = all_fields.filter_map { |k, (v, required)| [k, v] unless required }.to_h
+          @fields = {}
+          @optional_fields = {}
+          all_fields.each do |(k, (v, required))|
+            if required
+              @fields[k] = v
+            else
+              @optional_fields[k] = v
+            end
+          end
         else
           raise ArgumentError, "only one of `:fields` or `:all_fields` is requireds"
         end


### PR DESCRIPTION
## Repro

```rb
# Gemfile
source "https://rubygems.org"
gem 'aws-sdk-quicksight' # It has many record types
```

```
$ bundle exec rbs collection init
$ bundle exec rbs collection install
```

```rb
# t.rb
require 'rbs'
require 'rbs/cli'
require 'memory_profiler'
report = MemoryProfiler.report do
  loader = RBS::CLI::LibraryOptions.new.loader
  env = RBS::Environment.from_loader(loader)
  env.resolve_type_names
end
report.pretty_print
```

## Before

```
Total allocated: 593146847 bytes (6288468 objects)
Total retained:  239940 bytes (3582 objects)
...
allocated memory by location
-----------------------------------
 301030072  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:20
  53040880  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:529
  42449400  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:680
  36932720  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:530
  24652000  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:596
  24599520  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:374
  19889959  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/environment_loader.rb:164
```

## After

```
Total allocated: 555155855 bytes (5427912 objects)
Total retained:  239940 bytes (3582 objects)
...
allocated memory by location
-----------------------------------
 301030072  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/parser_aux.rb:20
  42449400  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:687
  24652000  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:603
  24599520  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:374
  19980288  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:529
  19889959  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/environment_loader.rb:164
  19721600  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:530
```