### PR TITLE
Deprecate `Kernel#Namespace`

### DIFF
--- a/bin/query-rdoc
+++ b/bin/query-rdoc
@@ -28,17 +28,17 @@ source.load()
 
 case
 when match = name.match(/(?<constant_name>[^#]+)#(?<method_name>.+)/)
-  type_name = TypeName(match[:constant_name] || raise)
+  type_name = RBS::TypeName.parse(match[:constant_name] || raise)
   instance_method = (match[:method_name] or raise).to_sym
 
   doc = annotator.doc_for_method(type_name, instance_method: instance_method, tester: tester)
 when match = name.match(/(?<constant_name>[^#]+)\.(?<method_name>.+)/)
-  type_name = TypeName(match[:constant_name] || raise)
+  type_name = RBS::TypeName.parse(match[:constant_name] || raise)
   singleton_method = (match[:method_name] or raise).to_sym
 
   doc = annotator.doc_for_method(type_name, singleton_method: singleton_method, tester: tester)
 else
-  type_name = TypeName(name)
+  type_name = RBS::TypeName.parse(name)
 
   doc = annotator.doc_for_class(type_name, tester: tester) || annotator.doc_for_constant(type_name, tester: tester)
 end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ The `#build_singleton` calculates the type of `.new` methods based on the defini
 `DefinitionBuilder#expand_alias` and its variants provide one step *unfold* operation of type aliases.
 
 ```ruby
-builder.expand_alias2(TypeName("::int"), []) # => returns `::Integer | ::_ToInt`
+builder.expand_alias2(RBS::TypeName.parse("::int"), []) # => returns `::Integer | ::_ToInt`
 ```
 
 We don't have *normalize* operation for type aliases, because RBS allows recursive type alias definition, which cannot be *fully* unfolded.

--- a/lib/rbs/annotate/annotations.rb
+++ b/lib/rbs/annotate/annotations.rb
@@ -93,7 +93,7 @@ module RBS
           case
           when match = source.match(/(?<constant_name>[^#]+)#(?<method_name>.+)/)
             [
-              TypeName(match[:constant_name] || raise),
+              TypeName.parse(match[:constant_name] || raise),
               [
                 false,
                 (match[:method_name] or raise).to_sym
@@ -101,7 +101,7 @@ module RBS
             ]
           when match = source.match(/(?<constant_name>[^#]+)\.(?<method_name>.+)/)
             [
-              TypeName(match[:constant_name] || raise),
+              TypeName.parse(match[:constant_name] || raise),
               [
                 true,
                 (match[:method_name] or raise).to_sym
@@ -109,7 +109,7 @@ module RBS
             ]
           else
             [
-              TypeName(source),
+              TypeName.parse(source),
               nil
             ]
           end

--- a/lib/rbs/annotate/rdoc_source.rb
+++ b/lib/rbs/annotate/rdoc_source.rb
@@ -70,7 +70,7 @@ module RBS
       def find_const(const_name)
         namespace =
           if const_name.namespace.empty?
-            TypeName("::Object")
+            TypeName.parse("::Object")
           else
             const_name.namespace.to_type_name
           end

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -288,7 +288,7 @@ EOU
       env = Environment.from_loader(loader).resolve_type_names
 
       builder = DefinitionBuilder::AncestorBuilder.new(env: env)
-      type_name = TypeName(args[0]).absolute!
+      type_name = TypeName.parse(args[0]).absolute!
 
       case env.constant_entry(type_name)
       when Environment::ClassEntry, Environment::ModuleEntry, Environment::ClassAliasEntry, Environment::ModuleAliasEntry
@@ -353,7 +353,7 @@ EOU
       env = Environment.from_loader(loader).resolve_type_names
 
       builder = DefinitionBuilder.new(env: env)
-      type_name = TypeName(args[0]).absolute!
+      type_name = TypeName.parse(args[0]).absolute!
 
       if env.module_name?(type_name)
         definition = case kind
@@ -406,7 +406,7 @@ EOU
       env = Environment.from_loader(loader).resolve_type_names
 
       builder = DefinitionBuilder.new(env: env)
-      type_name = TypeName(args[0]).absolute!
+      type_name = TypeName.parse(args[0]).absolute!
       method_name = args[1].to_sym
 
       unless env.module_name?(type_name)
@@ -479,9 +479,9 @@ EOU
       builder = DefinitionBuilder.new(env: env)
       resolver = Resolver::ConstantResolver.new(builder: builder)
 
-      resolver_context = context ? [nil, TypeName(context).absolute!] : nil #: Resolver::context
+      resolver_context = context ? [nil, TypeName.parse(context).absolute!] : nil #: Resolver::context
       stdout.puts "Context: #{context}"
-      const_name = TypeName(args[0])
+      const_name = TypeName.parse(args[0])
       stdout.puts "Constant name: #{const_name}"
 
       if const_name.absolute?

--- a/lib/rbs/cli/diff.rb
+++ b/lib/rbs/cli/diff.rb
@@ -46,7 +46,7 @@ module RBS
         end
 
         @diff = RBS::Diff.new(
-          type_name: TypeName(type_name).absolute!,
+          type_name: TypeName.parse(type_name).absolute!,
           library_options: library_options,
           after_path: after_path,
           before_path: before_path,

--- a/lib/rbs/namespace.rb
+++ b/lib/rbs/namespace.rb
@@ -119,6 +119,7 @@ end
 
 module Kernel
   def Namespace(name)
+    warn "Kernel#Namespace() is deprecated. Use RBS::Namespace.parse instead.", category: :deprecated
     RBS::Namespace.parse(name)
   end
 end

--- a/lib/rbs/prototype/rb.rb
+++ b/lib/rbs/prototype/rb.rb
@@ -722,9 +722,9 @@ module RBS
         when :FLOAT
           BuiltinNames::Float.instance_type
         when :RATIONAL
-          Types::ClassInstance.new(name: TypeName("::Rational"), args: [], location: nil)
+          Types::ClassInstance.new(name: TypeName.parse("::Rational"), args: [], location: nil)
         when :IMAGINARY
-          Types::ClassInstance.new(name: TypeName("::Complex"), args: [], location: nil)
+          Types::ClassInstance.new(name: TypeName.parse("::Complex"), args: [], location: nil)
         when :LIT
           case node.children[0]
           when Symbol

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -449,9 +449,9 @@ module RBS
                      location: nil
                    )
                  when ARGF
-                   Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ARGFClass"), args: [], location: nil)
+                   Types::ClassInstance.new(name: TypeName.parse("::RBS::Unnamed::ARGFClass"), args: [], location: nil)
                  when ENV
-                   Types::ClassInstance.new(name: TypeName("::RBS::Unnamed::ENVClass"), args: [], location: nil)
+                   Types::ClassInstance.new(name: TypeName.parse("::RBS::Unnamed::ENVClass"), args: [], location: nil)
                  else
                    value_type_name = to_type_name(const_name!(Reflection.object_class(value)), full_name: true).absolute!
                    args = type_args(value_type_name)

--- a/lib/rbs/prototype/runtime/value_object_generator.rb
+++ b/lib/rbs/prototype/runtime/value_object_generator.rb
@@ -102,7 +102,7 @@ module RBS
         CAN_CALL_KEYWORD_INIT_P = Struct.new(:tmp).respond_to?(:keyword_init?)
 
         def build_super_class
-          AST::Declarations::Class::Super.new(name: TypeName("::Struct"), args: [untyped], location: nil)
+          AST::Declarations::Class::Super.new(name: TypeName.parse("::Struct"), args: [untyped], location: nil)
         end
 
         def add_decl_members(decl)
@@ -223,7 +223,7 @@ module RBS
         private
 
         def build_super_class
-          AST::Declarations::Class::Super.new(name: TypeName("::Data"), args: [], location: nil)
+          AST::Declarations::Class::Super.new(name: TypeName.parse("::Data"), args: [], location: nil)
         end
 
         def add_decl_members(decl)

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -86,19 +86,24 @@ module RBS
         )
       end
     end
+    
+    def self.parse(string)
+      absolute = string.start_with?("::")
+
+      *path, name = string.delete_prefix("::").split("::").map(&:to_sym)
+      raise unless name
+
+      TypeName.new(
+        name: name,
+        namespace: RBS::Namespace.new(path: path, absolute: absolute)
+      )
+    end
   end
 end
 
 module Kernel
   def TypeName(string)
-    absolute = string.start_with?("::")
-
-    *path, name = string.delete_prefix("::").split("::").map(&:to_sym)
-    raise unless name
-
-    RBS::TypeName.new(
-      name: name,
-      namespace: RBS::Namespace.new(path: path, absolute: absolute)
-    )
+    warn "Kernel#TypeName() is deprecated. Use RBS::TypeName.parse instead.", category: :deprecated
+    RBS::TypeName.parse(string)
   end
 end

--- a/lib/rbs/unit_test/type_assertions.rb
+++ b/lib/rbs/unit_test/type_assertions.rb
@@ -271,7 +271,7 @@ module RBS
 
         assert typecheck.value(constant, value_type), "`#{constant_name}` (#{constant.inspect}) must be compatible with given type `#{value_type}`"
 
-        type_name = TypeName(constant_name).absolute!
+        type_name = TypeName.parse(constant_name).absolute!
         definition = env.constant_entry(type_name)
         assert definition, "Cannot find RBS type definition of `#{constant_name}`"
 

--- a/sig/ancestor_graph.rbs
+++ b/sig/ancestor_graph.rbs
@@ -4,11 +4,11 @@ module RBS
   # ```ruby
   # graph = AncestorGraph.new(env: env, ancestor_builder: ancestor_builder)
   #
-  # graph.each_parent(AncestorGraph::InstanceNode.new(type_name: TypeName("::Object")))
-  # graph.each_ancestor(AncestorGraph::InstanceNode.new(type_name: TypeName("::Object")))
+  # graph.each_parent(AncestorGraph::InstanceNode.new(type_name: TypeName.parse("::Object")))
+  # graph.each_ancestor(AncestorGraph::InstanceNode.new(type_name: TypeName.parse("::Object")))
   #
-  # graph.each_child(AncestorGraph::InstanceNode.new(type_name: TypeName("::Object")))
-  # graph.each_descendant(AncestorGraph::InstanceNode.new(type_name: TypeName("::Object")))
+  # graph.each_child(AncestorGraph::InstanceNode.new(type_name: TypeName.parse("::Object")))
+  # graph.each_descendant(AncestorGraph::InstanceNode.new(type_name: TypeName.parse("::Object")))
   # ```
   #
   # Note that the class works for class/module declarations.

--- a/sig/namespace.rbs
+++ b/sig/namespace.rbs
@@ -141,7 +141,6 @@ module RBS
 end
 
 module Kernel
-  # Parses given string and returns Namespace.
-  #
-  def Namespace: (String) -> RBS::Namespace
+  # Deprecated: Use `RBS::Namespace.parse` instead
+  %a{steep:deprecated} def Namespace: (String) -> RBS::Namespace
 end

--- a/sig/resolver/constant_resolver.rbs
+++ b/sig/resolver/constant_resolver.rbs
@@ -6,8 +6,8 @@ module RBS
       # ```rb
       # table = RBS::ConstantResolver::Table.new(env)
       #
-      # table.children(TypeName("::Object"))                # -> { ... }  Returns a hash of name and constants.
-      # table.children(TypeName("::File::PATH_SEPARATOR"))  # -> nil      Returns nil because the constant is not a module.
+      # table.children(TypeName.parse("::Object"))                # -> { ... }  Returns a hash of name and constants.
+      # table.children(TypeName.parse("::File::PATH_SEPARATOR"))  # -> nil      Returns nil because the constant is not a module.
       #
       # table.toplevel                                      # -> { ... }  Returns a hash of top level constants.
       # ```

--- a/sig/resolver/context.rbs
+++ b/sig/resolver/context.rbs
@@ -9,7 +9,7 @@ module RBS
     #
     # Note that the `TypeName` must be an absolute type name.
     #
-    # The following Ruby code has context of `[[nil, TypeName("::Foo")], false]` where
+    # The following Ruby code has context of `[[nil, TypeName.parse("::Foo")], false]` where
     #
     # * `Foo` is a class defined in RBS file
     # * `Bar` is not defined in RBS files

--- a/sig/type_alias_regularity.rbs
+++ b/sig/type_alias_regularity.rbs
@@ -20,9 +20,9 @@ module RBS
   # ```rb
   # validator = RBS::TypeAliasRegularity.validate(env: env)
   #
-  # validator.nonregular?(TypeName("::foo"))    # => nil
-  # validator.nonregular?(TypeName("::bar"))    # => nil
-  # validator.nonregular?(TypeName("::baz"))    # => TypeAliasRegularity::Diagnostic
+  # validator.nonregular?(TypeName.parse("::foo"))    # => nil
+  # validator.nonregular?(TypeName.parse("::bar"))    # => nil
+  # validator.nonregular?(TypeName.parse("::baz"))    # => TypeAliasRegularity::Diagnostic
   # ```
   #
   # A special case is when the type argument is `untyped`.
@@ -51,8 +51,8 @@ module RBS
     # The type `t` is nonregular because it contains `t[T?]` on it's right hand side.
     #
     # ```
-    # diagnostic = validator.nonregular?(TypeName("::t"))
-    # diagnostic.type_name         # => TypeName("::t")
+    # diagnostic = validator.nonregular?(TypeName.parse("::t"))
+    # diagnostic.type_name         # => TypeName.parse("::t")
     # diagnostic.nonregular_type   # => t[T?]
     # ```
     #

--- a/sig/typename.rbs
+++ b/sig/typename.rbs
@@ -57,9 +57,9 @@ module RBS
     # Returns a new type name with a namespace appended to given namespace.
     #
     # ```rb
-    # TypeName("Hello").with_prefix(Namespace("World"))           # => World::Hello
-    # TypeName("Foo::Bar").with_prefix(Namespace("::Hello"))      # => ::Hello::Foo::Bar
-    # TypeName("::A::B").with_prefix(Namespace("C"))              # => ::A::B
+    # TypeName.parse("Hello").with_prefix(Namespace("World"))           # => World::Hello
+    # TypeName.parse("Foo::Bar").with_prefix(Namespace("::Hello"))      # => ::Hello::Foo::Bar
+    # TypeName.parse("::A::B").with_prefix(Namespace("C"))              # => ::A::B
     # ```
     #
     def with_prefix: (Namespace namespace) -> TypeName
@@ -67,10 +67,13 @@ module RBS
     def +: (TypeName) -> TypeName
 
     def split: () -> Array[Symbol]
+
+    # Returns type name with given string representation.
+    def self.parse: (String name) -> RBS::TypeName
   end
 end
 
 module Kernel
-  # Returns type name with given string representation.
-  def TypeName: (String name) -> RBS::TypeName
+  # Deprecated: Use `RBS::TypeName.parse` instead
+  %a{steep:deprecated} def TypeName: (String name) -> RBS::TypeName
 end

--- a/sig/use_map.rbs
+++ b/sig/use_map.rbs
@@ -3,7 +3,7 @@ module RBS
     # ```rb
     # map = UseMap.build(environment)
     #
-    # map.resolve?(TypeName("TN"))   # => nil or resolved type name
+    # map.resolve?(TypeName.parse("TN"))   # => nil or resolved type name
     # ```
     #
     class UseMap

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -340,13 +340,13 @@ EOF
           assert_equal 5, a.ancestors.size
           a.ancestors[0].tap do |ancestor|
             assert_instance_of Ancestor::Instance, ancestor
-            assert_equal TypeName("::Foo"), ancestor.name
+            assert_equal RBS::TypeName.parse("::Foo"), ancestor.name
             assert_equal [Types::Variable.build(:X)], ancestor.args
             assert_nil ancestor.source
           end
           a.ancestors[1].tap do |ancestor|
             assert_instance_of Ancestor::Instance, ancestor
-            assert_equal TypeName("::Bar"), ancestor.name
+            assert_equal RBS::TypeName.parse("::Bar"), ancestor.name
             assert_equal [Types::Variable.build(:X), parse_type("::String")], ancestor.args
             assert_instance_of AST::Members::Include, ancestor.source
           end

--- a/test/rbs/ancestor_graph_test.rb
+++ b/test/rbs/ancestor_graph_test.rb
@@ -9,7 +9,7 @@ class RBS::AncestorGraphTest < Test::Unit::TestCase
 
   def InstanceNode(name)
     if name.is_a?(String)
-      name = TypeName(name)
+      name = RBS::TypeName.parse(name)
     end
 
     AncestorGraph::InstanceNode.new(type_name: name)
@@ -17,7 +17,7 @@ class RBS::AncestorGraphTest < Test::Unit::TestCase
 
   def SingletonNode(name)
     if name.is_a?(String)
-      name = TypeName(name)
+      name = RBS::TypeName.parse(name)
     end
 
     AncestorGraph::SingletonNode.new(type_name: name)

--- a/test/rbs/annotate/annotations_test.rb
+++ b/test/rbs/annotate/annotations_test.rb
@@ -35,7 +35,7 @@ class RBS::Annotate::AnnotationsTest < Test::Unit::TestCase
     RBS::Annotate::Annotations.parse(an("annotate:rdoc:copy:Bar#baz")).tap do |a|
       assert_instance_of RBS::Annotate::Annotations::Copy, a
 
-      assert_equal TypeName("Bar"), a.type_name
+      assert_equal RBS::TypeName.parse("Bar"), a.type_name
       refute_predicate a, :singleton?
       assert_equal :baz, a.method_name
     end
@@ -43,7 +43,7 @@ class RBS::Annotate::AnnotationsTest < Test::Unit::TestCase
     RBS::Annotate::Annotations.parse(an("annotate:rdoc:copy:Bar.baz")).tap do |a|
       assert_instance_of RBS::Annotate::Annotations::Copy, a
 
-      assert_equal TypeName("Bar"), a.type_name
+      assert_equal RBS::TypeName.parse("Bar"), a.type_name
       assert_predicate a, :singleton?
       assert_equal :baz, a.method_name
     end
@@ -51,7 +51,7 @@ class RBS::Annotate::AnnotationsTest < Test::Unit::TestCase
     RBS::Annotate::Annotations.parse(an("annotate:rdoc:copy:Bar")).tap do |a|
       assert_instance_of RBS::Annotate::Annotations::Copy, a
 
-      assert_equal TypeName("Bar"), a.type_name
+      assert_equal RBS::TypeName.parse("Bar"), a.type_name
       refute_predicate a, :singleton?
       assert_nil a.method_name
     end

--- a/test/rbs/annotate/rdoc_annotator_test.rb
+++ b/test/rbs/annotate/rdoc_annotator_test.rb
@@ -79,7 +79,7 @@ This is another doc for CLI.
       TEXT
 
       decl.members[0].tap do |decl|
-        annotator.annotate_class(decl, outer: [TypeName("CLI").to_namespace])
+        annotator.annotate_class(decl, outer: [RBS::TypeName.parse("CLI").to_namespace])
 
         assert_equal <<-TEXT, decl.comment.string
 <!-- rdoc-file=lib/helper.rb -->
@@ -113,7 +113,7 @@ end
 
     annotator = RBS::Annotate::RDocAnnotator.new(source: source)
 
-    assert_equal <<-TEXT, annotator.doc_for_method(TypeName("Foo"), instance_method: :m1, tester: tester)
+    assert_equal <<-TEXT, annotator.doc_for_method(RBS::TypeName.parse("Foo"), instance_method: :m1, tester: tester)
 <!--
   rdoc-file=lib/cli.rb
   - m1()
@@ -122,25 +122,25 @@ Doc for m1
 
     TEXT
 
-    assert_equal <<-TEXT, annotator.doc_for_method(TypeName("Foo"), instance_method: :m2, tester: tester)
+    assert_equal <<-TEXT, annotator.doc_for_method(RBS::TypeName.parse("Foo"), instance_method: :m2, tester: tester)
 <!-- rdoc-file=lib/cli.rb -->
 Doc for m2
 
     TEXT
 
-    assert_equal <<-TEXT, annotator.doc_for_method(TypeName("Foo"), instance_method: :m3, tester: tester)
+    assert_equal <<-TEXT, annotator.doc_for_method(RBS::TypeName.parse("Foo"), instance_method: :m3, tester: tester)
 <!-- rdoc-file=lib/cli.rb -->
 Doc for m3
 
     TEXT
 
-    assert_equal <<-TEXT, annotator.doc_for_method(TypeName("Foo"), instance_method: :m3=, tester: tester)
+    assert_equal <<-TEXT, annotator.doc_for_method(RBS::TypeName.parse("Foo"), instance_method: :m3=, tester: tester)
 <!-- rdoc-file=lib/cli.rb -->
 Doc for m3
 
     TEXT
 
-    assert_nil annotator.doc_for_method(TypeName("Foo"), instance_method: :m4=, tester: tester)
+    assert_nil annotator.doc_for_method(RBS::TypeName.parse("Foo"), instance_method: :m4=, tester: tester)
   end
 
   def assert_annotated_decls(expected, decls)

--- a/test/rbs/annotate/rdoc_source_test.rb
+++ b/test/rbs/annotate/rdoc_source_test.rb
@@ -49,9 +49,9 @@ end
       }
     )
 
-    assert_nil source.find_class(TypeName("Hello0"))
+    assert_nil source.find_class(RBS::TypeName.parse("Hello0"))
 
-    source.find_class(TypeName("Hello1")).tap do |klss|
+    source.find_class(RBS::TypeName.parse("Hello1")).tap do |klss|
       assert_instance_of Array, klss
 
       assert_equal 1, klss.size
@@ -64,7 +64,7 @@ end
       end
     end
 
-    source.find_class(TypeName("Hello2")).tap do |klss|
+    source.find_class(RBS::TypeName.parse("Hello2")).tap do |klss|
       assert_instance_of Array, klss
 
       assert_equal 1, klss.size
@@ -76,7 +76,7 @@ end
       end
     end
 
-    source.find_class(TypeName("Hello3")).tap do |klss|
+    source.find_class(RBS::TypeName.parse("Hello3")).tap do |klss|
       assert_instance_of Array, klss
 
       assert_equal 1, klss.size
@@ -105,7 +105,7 @@ end
       }
     )
 
-    source.find_const(TypeName("FOO")).tap do |consts|
+    source.find_const(RBS::TypeName.parse("FOO")).tap do |consts|
       assert_instance_of Array, consts
 
       assert_equal 1, consts.size
@@ -115,7 +115,7 @@ end
       end
     end
 
-    source.find_const(TypeName("Hello::VERSION")).tap do |consts|
+    source.find_const(RBS::TypeName.parse("Hello::VERSION")).tap do |consts|
       assert_instance_of Array, consts
 
       assert_equal 1, consts.size
@@ -125,9 +125,9 @@ end
       end
     end
 
-    assert_nil source.find_const(TypeName("Hello::World"))
+    assert_nil source.find_const(RBS::TypeName.parse("Hello::World"))
 
-    assert_nil source.find_const(TypeName("Hello"))
+    assert_nil source.find_const(RBS::TypeName.parse("Hello"))
   end
 
   def test_load_method
@@ -153,7 +153,7 @@ end
       }
     )
 
-    source.find_method(TypeName("Foo"), instance_method: :m1).tap do |ms|
+    source.find_method(RBS::TypeName.parse("Foo"), instance_method: :m1).tap do |ms|
       assert_equal 1, ms.size
 
       ms[0].tap do |m|
@@ -162,7 +162,7 @@ end
       end
     end
 
-    source.find_method(TypeName("Foo"), instance_method: :m2).tap do |ms|
+    source.find_method(RBS::TypeName.parse("Foo"), instance_method: :m2).tap do |ms|
       assert_equal 1, ms.size
 
       ms[0].tap do |m|
@@ -172,9 +172,9 @@ end
       end
     end
 
-    assert_nil source.find_method(TypeName("Foo"), instance_method: :m3)
+    assert_nil source.find_method(RBS::TypeName.parse("Foo"), instance_method: :m3)
 
-    source.find_method(TypeName("Foo"), singleton_method: :m4).tap do |ms|
+    source.find_method(RBS::TypeName.parse("Foo"), singleton_method: :m4).tap do |ms|
       assert_equal 1, ms.size
 
       ms[0].tap do |m|
@@ -183,7 +183,7 @@ end
       end
     end
 
-    source.find_method(TypeName("Foo"), singleton_method: :m5).tap do |ms|
+    source.find_method(RBS::TypeName.parse("Foo"), singleton_method: :m5).tap do |ms|
       assert_equal 1, ms.size
 
       ms[0].tap do |m|
@@ -213,7 +213,7 @@ end
       }
     )
 
-    source.find_attribute(TypeName("Foo"), :foo, singleton: false).tap do |attrs|
+    source.find_attribute(RBS::TypeName.parse("Foo"), :foo, singleton: false).tap do |attrs|
       assert_equal 1, attrs.size
 
       attrs[0].tap do |attr|
@@ -223,7 +223,7 @@ end
       end
     end
 
-    source.find_attribute(TypeName("Foo"), :bar, singleton: false).tap do |attrs|
+    source.find_attribute(RBS::TypeName.parse("Foo"), :bar, singleton: false).tap do |attrs|
       assert_equal 1, attrs.size
 
       attrs[0].tap do |attr|
@@ -233,7 +233,7 @@ end
       end
     end
 
-    source.find_attribute(TypeName("Foo"), :baz, singleton: false).tap do |attrs|
+    source.find_attribute(RBS::TypeName.parse("Foo"), :baz, singleton: false).tap do |attrs|
       assert_equal 1, attrs.size
 
       attrs[0].tap do |attr|

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -341,7 +341,7 @@ EOF
           assert_operator Set[:get], :subset?, Set.new(definition.methods.keys)
           assert_method_definition definition.methods[:get], ["(::Integer) -> ::String", "() -> ::String"], accessibility: :public
 
-          assert definition.methods[:get].defs.all? {|td| td.implemented_in == TypeName("::M2") }
+          assert definition.methods[:get].defs.all? {|td| td.implemented_in == RBS::TypeName.parse("::M2") }
         end
       end
     end
@@ -923,11 +923,11 @@ EOF
       manager.build do |env|
         builder = DefinitionBuilder.new(env: env)
 
-        builder.build_instance(TypeName("::Hello")).tap do |definition|
+        builder.build_instance(RBS::TypeName.parse("::Hello")).tap do |definition|
           assert_equal ["(instance) -> class"], definition.methods[:foo].method_types.map(&:to_s)
         end
 
-        builder.build_singleton(TypeName("::Hello")).tap do |definition|
+        builder.build_singleton(RBS::TypeName.parse("::Hello")).tap do |definition|
           assert_equal ["(instance) -> class"], definition.methods[:foo].method_types.map(&:to_s)
         end
       end
@@ -2326,12 +2326,12 @@ end
         env.add_signature(buffer: buf, directives: dirs, decls: decls)
       end
       definition_builder = RBS::DefinitionBuilder.new(env: env.resolve_type_names)
-      definition_builder.build_instance(TypeName("::Foo")).tap do |defn|
+      definition_builder.build_instance(RBS::TypeName.parse("::Foo")).tap do |defn|
         defn.methods[:request].tap do |m|
           assert_equal ["(::interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped"], m.method_types.map(&:to_s)
         end
       end
-      definition_builder.build_instance(TypeName("::Mod")).tap do |defn|
+      definition_builder.build_instance(RBS::TypeName.parse("::Mod")).tap do |defn|
         defn.methods[:request].tap do |m|
           assert_equal ["(::interned name, *untyped, **untyped) ?{ (?) -> untyped } -> untyped"], m.method_types.map(&:to_s)
         end
@@ -2573,23 +2573,23 @@ end
           assert_instance_of Definition, definition
 
           definition.methods[:b].tap do |method|
-            assert_equal [TypeName("::B")], method.defs.map(&:defined_in)
-            assert_equal [TypeName("::B")], method.defs.map(&:implemented_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:defined_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:implemented_in)
           end
 
           definition.methods[:c].tap do |method|
-            assert_equal [TypeName("::B")], method.defs.map(&:defined_in)
-            assert_equal [TypeName("::B")], method.defs.map(&:implemented_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:defined_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:implemented_in)
           end
 
           definition.methods[:d].tap do |method|
-            assert_equal [TypeName("::B")], method.defs.map(&:defined_in)
-            assert_equal [TypeName("::B")], method.defs.map(&:implemented_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:defined_in)
+            assert_equal [RBS::TypeName.parse("::B")], method.defs.map(&:implemented_in)
           end
 
           definition.methods[:__id__].tap do |method|
-            assert_equal [TypeName("::B"), TypeName("::Object")], method.defs.map(&:defined_in)
-            assert_equal [TypeName("::B"), TypeName("::B")], method.defs.map(&:implemented_in)
+            assert_equal [RBS::TypeName.parse("::B"), RBS::TypeName.parse("::Object")], method.defs.map(&:defined_in)
+            assert_equal [RBS::TypeName.parse("::B"), RBS::TypeName.parse("::B")], method.defs.map(&:implemented_in)
           end
         end
       end
@@ -2615,8 +2615,8 @@ end
           assert_instance_of Definition, definition
 
           definition.methods[:f].tap do |method|
-            assert_equal [TypeName("::A"), TypeName("::M")], method.defs.map(&:defined_in)
-            assert_equal [TypeName("::A"), TypeName("::A")], method.defs.map(&:implemented_in)
+            assert_equal [RBS::TypeName.parse("::A"), RBS::TypeName.parse("::M")], method.defs.map(&:defined_in)
+            assert_equal [RBS::TypeName.parse("::A"), RBS::TypeName.parse("::A")], method.defs.map(&:implemented_in)
           end
         end
       end

--- a/test/rbs/diff_test.rb
+++ b/test/rbs/diff_test.rb
@@ -55,7 +55,7 @@ class RBS::DiffTest < Test::Unit::TestCase
       RBS
 
       diff = Diff.new(
-        type_name: TypeName("::Foo"),
+        type_name: RBS::TypeName.parse("::Foo"),
         library_options: RBS::CLI::LibraryOptions.new,
         before_path: [dir1],
         after_path: [dir2],
@@ -118,7 +118,7 @@ class RBS::DiffTest < Test::Unit::TestCase
       RBS
 
       diff = Diff.new(
-        type_name: TypeName("::Foo"),
+        type_name: RBS::TypeName.parse("::Foo"),
         library_options: RBS::CLI::LibraryOptions.new,
         before_path: [dir1],
         after_path: [dir2],
@@ -167,7 +167,7 @@ class RBS::DiffTest < Test::Unit::TestCase
       RBS
 
       diff = Diff.new(
-        type_name: TypeName("::Pathname"),
+        type_name: RBS::TypeName.parse("::Pathname"),
         library_options: RBS::CLI::LibraryOptions.new,
         before_path: [dir1],
         after_path: [dir2],
@@ -200,7 +200,7 @@ class RBS::DiffTest < Test::Unit::TestCase
       RBS
 
       diff = Diff.new(
-        type_name: TypeName("::Foo"),
+        type_name: RBS::TypeName.parse("::Foo"),
         library_options: RBS::CLI::LibraryOptions.new,
         before_path: [dir1],
         after_path: [dir2],

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -64,9 +64,9 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Person")
-      assert_operator env.class_decls, :key?, TypeName("::PeopleController")
-      assert_operator env.class_decls, :key?, TypeName("::Person::Internal")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Person")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::PeopleController")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Person::Internal")
     end
   end
 
@@ -78,7 +78,7 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::URI")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::URI")
     end
   end
 
@@ -91,7 +91,7 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Gem")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Gem")
       assert io.string.include?('`rubygems` has been moved to core library')
     end
   ensure
@@ -115,9 +115,9 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Person")
-      assert_operator env.class_decls, :key?, TypeName("::PeopleController")
-      refute_operator env.class_decls, :key?, TypeName("::Person::Internal")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Person")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::PeopleController")
+      refute_operator env.class_decls, :key?, RBS::TypeName.parse("::Person::Internal")
     end
   end
 
@@ -145,7 +145,7 @@ end
       env = Environment.new
       loaded = loader.load(env: env)
 
-      assert_equal 1, loaded.count {|decl, _, _| decl.respond_to?(:name) && decl.name == TypeName("Person") }
+      assert_equal 1, loaded.count {|decl, _, _| decl.respond_to?(:name) && decl.name == RBS::TypeName.parse("Person") }
     end
   end
 
@@ -161,7 +161,7 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Amber")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Amber")
     end
   end
 
@@ -190,9 +190,9 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::Psych")
-      assert_operator env.class_decls, :key?, TypeName("::DBM")
-      assert_operator env.class_decls, :key?, TypeName("::PStore")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Psych")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::DBM")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::PStore")
     end
   end
 
@@ -235,8 +235,8 @@ end
       env = Environment.new
       loader.load(env: env)
 
-      assert_operator env.class_decls, :key?, TypeName("::AST")
-      assert_operator env.class_decls, :key?, TypeName("::Rainbow")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::AST")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::Rainbow")
       assert repo.dirs.include? lock.fullpath
     end
   end

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -65,7 +65,7 @@ EOF
       env << decl
     end
 
-    env.class_alias_decls[TypeName("::RBS::Kernel")].tap do |decl|
+    env.class_alias_decls[RBS::TypeName.parse("::RBS::Kernel")].tap do |decl|
       assert_instance_of Environment::ModuleAliasEntry, decl
     end
   end
@@ -462,8 +462,8 @@ end
     env.add_signature(buffer: buf, directives: dirs, decls: decls)
 
     env.resolve_type_names.tap do |env|
-      class_decl = env.class_decls[TypeName("::A::B")]
-      assert_equal TypeName("::A::C"), class_decl.primary.decl.super_class.name
+      class_decl = env.class_decls[RBS::TypeName.parse("::A::B")]
+      assert_equal RBS::TypeName.parse("::A::C"), class_decl.primary.decl.super_class.name
     end
   end
 
@@ -543,10 +543,10 @@ end
     env.add_signature(buffer: buf, directives: dirs, decls: decls)
 
     env.resolve_type_names.tap do |env|
-      class_decl = env.class_decls[TypeName("::Foo")]
-      assert_equal TypeName("::Object"), class_decl.primary.decl.super_class.name
+      class_decl = env.class_decls[RBS::TypeName.parse("::Foo")]
+      assert_equal RBS::TypeName.parse("::Object"), class_decl.primary.decl.super_class.name
 
-      assert_operator env.class_decls, :key?, TypeName("::OB")
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::OB")
     end
   end
 end

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -101,7 +101,7 @@ class RBS::ParserTest < Test::Unit::TestCase
 
       decls[0].tap do |decl|
         assert_instance_of RBS::AST::Declarations::Module, decl
-        assert_equal TypeName("Foo"), decl.name
+        assert_equal RBS::TypeName.parse("Foo"), decl.name
 
         assert_equal "module", decl.location[:keyword].source
         assert_equal "Foo", decl.location[:name].source
@@ -386,7 +386,7 @@ class RBS::ParserTest < Test::Unit::TestCase
 
       decls[0].tap do |decl|
         assert_instance_of RBS::AST::Declarations::Class, decl
-        assert_equal TypeName("Foo"), decl.name
+        assert_equal RBS::TypeName.parse("Foo"), decl.name
         assert_predicate decl.type_params, :empty?
         assert_nil decl.super_class
       end
@@ -399,9 +399,9 @@ class RBS::ParserTest < Test::Unit::TestCase
 
       decls[0].tap do |decl|
         assert_instance_of RBS::AST::Declarations::Class, decl
-        assert_equal TypeName("Foo"), decl.name
+        assert_equal RBS::TypeName.parse("Foo"), decl.name
         assert_equal [:A], decl.type_params.each.map(&:name)
-        assert_equal TypeName("Bar"), decl.super_class.name
+        assert_equal RBS::TypeName.parse("Bar"), decl.super_class.name
       end
     end
   end

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -1040,10 +1040,10 @@ end
   def test_const_to_name
     parser = RBS::Prototype::RB.new
     [
-      ["self", TypeName("::Foo")],
-      ["Bar", TypeName("Bar")],
-      ["::Bar", TypeName("::Bar")],
-      ["Bar::Baz", TypeName("Bar::Baz")],
+      ["self", RBS::TypeName.parse("::Foo")],
+      ["Bar", RBS::TypeName.parse("Bar")],
+      ["::Bar", RBS::TypeName.parse("::Bar")],
+      ["Bar::Baz", RBS::TypeName.parse("Bar::Baz")],
       ["obj::Baz", nil],
     ].each do |rb, name|
       node = RubyVM::AbstractSyntaxTree.parse("_ = #{rb}").children[2]

--- a/test/rbs/resolver/constant_resolver_test.rb
+++ b/test/rbs/resolver/constant_resolver_test.rb
@@ -21,19 +21,19 @@ EOF
 
         assert table.toplevel.key?(:M1)
 
-        table.children(TypeName("::M1")).tap do |children|
+        table.children(RBS::TypeName.parse("::M1")).tap do |children|
           assert_equal [:C1, :D], children.keys.sort
 
-          assert_equal TypeName("::M1::C1"), children[:C1].name
+          assert_equal RBS::TypeName.parse("::M1::C1"), children[:C1].name
           assert_equal parse_type("singleton(::M1::C1)"), children[:C1].type
 
-          assert_equal TypeName("::M1::D"), children[:D].name
+          assert_equal RBS::TypeName.parse("::M1::D"), children[:D].name
           assert_equal parse_type("::String"), children[:D].type
         end
 
-        assert_equal [:D], table.children(TypeName("::M1::C1")).keys
+        assert_equal [:D], table.children(RBS::TypeName.parse("::M1::C1")).keys
 
-        assert_nil table.children(TypeName("::M1::C1::D"))
+        assert_nil table.children(RBS::TypeName.parse("::M1::C1::D"))
       end
     end
   end
@@ -77,7 +77,7 @@ EOF
         resolver = Resolver::ConstantResolver.new(builder: builder)
         Namespace.parse("::Foo")
 
-        resolver.resolve(:Name, context: [nil, TypeName("::Foo")]).tap do |constant|
+        resolver.resolve(:Name, context: [nil, RBS::TypeName.parse("::Foo")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Foo::Name", constant.name.to_s
           assert_equal '"Foo::Name"', constant.type.to_s
@@ -108,12 +108,12 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:Bar, context: [nil, TypeName("::Foo")]).tap do |constant|
+        resolver.resolve(:Bar, context: [nil, RBS::TypeName.parse("::Foo")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Foo::Bar", constant.name.to_s
         end
 
-        resolver.resolve(:Bar, context: [nil, TypeName("::Foo::Bar")]).tap do |constant|
+        resolver.resolve(:Bar, context: [nil, RBS::TypeName.parse("::Foo::Bar")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Foo::Bar", constant.name.to_s
         end
@@ -140,7 +140,7 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:X, context: [[nil, TypeName("::Foo")], TypeName("::Foo::Bar::Baz")]).tap do |constant|
+        resolver.resolve(:X, context: [[nil, RBS::TypeName.parse("::Foo")], RBS::TypeName.parse("::Foo::Bar::Baz")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::X", constant.name.to_s
           assert_equal '"::X"', constant.type.to_s
@@ -170,13 +170,13 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:MAX, context: [nil, TypeName("::Child")]).tap do |constant|
+        resolver.resolve(:MAX, context: [nil, RBS::TypeName.parse("::Child")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Parent::MAX", constant.name.to_s
           assert_equal "10000", constant.type.to_s
         end
 
-        resolver.resolve(:MIN, context: [nil, TypeName("::Child")]).tap do |constant|
+        resolver.resolve(:MIN, context: [nil, RBS::TypeName.parse("::Child")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Mix::MIN", constant.name.to_s
           assert_equal '0', constant.type.to_s
@@ -207,12 +207,12 @@ EOF
           assert_equal "::Object::FOO", constant.name.to_s
         end
 
-        resolver.resolve(:FOO, context: [nil, TypeName("::C")]).tap do |constant|
+        resolver.resolve(:FOO, context: [nil, RBS::TypeName.parse("::C")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Object::FOO", constant.name.to_s
         end
 
-        resolver.resolve(:FOO, context: [nil, TypeName("::M")]).tap do |constant|
+        resolver.resolve(:FOO, context: [nil, RBS::TypeName.parse("::M")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Object::FOO", constant.name.to_s
         end
@@ -241,13 +241,13 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:Set, context: [[nil, TypeName("::Foo")], TypeName("::Foo::Bar")]).tap do |constant|
+        resolver.resolve(:Set, context: [[nil, RBS::TypeName.parse("::Foo")], RBS::TypeName.parse("::Foo::Bar")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Set", constant.name.to_s
           assert_equal 'singleton(::Set)', constant.type.to_s
         end
 
-        resolver.resolve(:X, context: [[nil, TypeName("::Foo")], TypeName("::Foo::Bar")]).tap do |constant|
+        resolver.resolve(:X, context: [[nil, RBS::TypeName.parse("::Foo")], RBS::TypeName.parse("::Foo::Bar")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Baz::X", constant.name.to_s
           assert_equal '::Integer', constant.type.to_s
@@ -271,7 +271,7 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:BAZ, context: [nil, TypeName("::Foo")]).tap do |constant|
+        resolver.resolve(:BAZ, context: [nil, RBS::TypeName.parse("::Foo")]).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::BAZ", constant.name.to_s
         end
@@ -293,7 +293,7 @@ EOF
 
         resolver.resolve(
           :Foo,
-          context: [nil, TypeName("::Foo")],
+          context: [nil, RBS::TypeName.parse("::Foo")],
         ).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Foo", constant.name.to_s
@@ -318,21 +318,21 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve_child(TypeName("::Stuff"), :ONE).tap do |constant|
+        resolver.resolve_child(RBS::TypeName.parse("::Stuff"), :ONE).tap do |constant|
           assert_nil constant
         end
 
-        resolver.resolve_child(TypeName("::Stuff"), :TWO).tap do |constant|
+        resolver.resolve_child(RBS::TypeName.parse("::Stuff"), :TWO).tap do |constant|
           assert_nil constant
         end
 
-        resolver.resolve_child(TypeName("::Stuff"), :THREE).tap do |constant|
+        resolver.resolve_child(RBS::TypeName.parse("::Stuff"), :THREE).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::Kernel::THREE", constant.name.to_s
           assert_equal "3", constant.type.to_s
         end
 
-        resolver.resolve_child(TypeName("::Stuff"), :FOUR).tap do |constant|
+        resolver.resolve_child(RBS::TypeName.parse("::Stuff"), :FOUR).tap do |constant|
           assert_instance_of Constant, constant
           assert_equal "::BasicObject::FOUR", constant.name.to_s
           assert_equal "4", constant.type.to_s
@@ -357,7 +357,7 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:CONST, context: [nil, TypeName("::Bar")]).tap do |constant|
+        resolver.resolve(:CONST, context: [nil, RBS::TypeName.parse("::Bar")]).tap do |constant|
           assert_equal "::Foo::CONST", constant.name.to_s
         end
       end
@@ -377,7 +377,7 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.resolve(:CONST, context: [nil, TypeName("::String")]).tap do |constant|
+        resolver.resolve(:CONST, context: [nil, RBS::TypeName.parse("::String")]).tap do |constant|
           assert_equal "::CONST", constant.name.to_s
         end
       end
@@ -416,7 +416,7 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.constants([[nil, TypeName("::M")], TypeName("::M::M2")]).tap do |constants|
+        resolver.constants([[nil, RBS::TypeName.parse("::M")], RBS::TypeName.parse("::M::M2")]).tap do |constants|
           assert constants.key?(:Hello)
         end
       end
@@ -438,11 +438,11 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         resolver = Resolver::ConstantResolver.new(builder: builder)
 
-        resolver.constants([nil, TypeName("::M3")]).tap do |constants|
+        resolver.constants([nil, RBS::TypeName.parse("::M3")]).tap do |constants|
           assert constants.key?(:M2)
         end
 
-        resolver.constants([nil, TypeName("::M3")]).tap do |constants|
+        resolver.constants([nil, RBS::TypeName.parse("::M3")]).tap do |constants|
           assert constants.key?(:M3)
         end
       end

--- a/test/rbs/resolver/type_name_resolver_test.rb
+++ b/test/rbs/resolver/type_name_resolver_test.rb
@@ -30,14 +30,14 @@ EOF
         assert_nil resolver.resolve(type_name("Baz"), context: nil)
 
         assert_equal type_name("::Foo"),
-                     resolver.resolve(type_name("Foo"), context: [nil, TypeName("::Foo")])
+                     resolver.resolve(type_name("Foo"), context: [nil, RBS::TypeName.parse("::Foo")])
         assert_equal type_name("::Foo::Bar"),
-                     resolver.resolve(type_name("Bar"), context: [nil, TypeName("::Foo")])
+                     resolver.resolve(type_name("Bar"), context: [nil, RBS::TypeName.parse("::Foo")])
         assert_equal type_name("::Foo::Bar::Baz"),
-                     resolver.resolve(type_name("Bar::Baz"), context: [nil, TypeName("::Foo")])
+                     resolver.resolve(type_name("Bar::Baz"), context: [nil, RBS::TypeName.parse("::Foo")])
 
         assert_equal type_name("::Bar"),
-                     resolver.resolve(type_name("Bar"), context: [nil, TypeName("::Foo::Bar::Baz")])
+                     resolver.resolve(type_name("Bar"), context: [nil, RBS::TypeName.parse("::Foo::Bar::Baz")])
       end
     end
   end
@@ -56,7 +56,7 @@ EOF
       manager.build do |env|
         resolver = Resolver::TypeNameResolver.new(env)
 
-        assert_nil resolver.resolve(type_name("Foo::Bar"), context: [[nil, TypeName("::Foo")], TypeName("::Foo::Foo")])
+        assert_nil resolver.resolve(type_name("Foo::Bar"), context: [[nil, RBS::TypeName.parse("::Foo")], RBS::TypeName.parse("::Foo::Foo")])
       end
     end
   end
@@ -74,7 +74,7 @@ EOF
         resolver = Resolver::TypeNameResolver.new(env)
 
         assert_equal type_name("::X::X"),
-                     resolver.resolve(type_name("X"), context: [nil, TypeName("::X")])
+                     resolver.resolve(type_name("X"), context: [nil, RBS::TypeName.parse("::X")])
       end
     end
   end
@@ -97,14 +97,14 @@ EOF
 
         assert_equal type_name("::X::Y::Y"),
                      resolver.resolve(type_name("Y"),
-                                      context: [[nil, TypeName("::X::Y")], TypeName("::X::Y::Z")])
+                                      context: [[nil, RBS::TypeName.parse("::X::Y")], RBS::TypeName.parse("::X::Y::Z")])
 
         assert_nil resolver.resolve(type_name("Y::Z"),
-                                    context: [[nil, TypeName("::X::Y")], TypeName("::X::Y::Z")])
+                                    context: [[nil, RBS::TypeName.parse("::X::Y")], RBS::TypeName.parse("::X::Y::Z")])
 
         assert_equal type_name("::X::Y::Z"),
                      resolver.resolve(type_name("Y::Z"),
-                                      context: [[nil, TypeName("::X")], TypeName("::X::Y::Z")])
+                                      context: [[nil, RBS::TypeName.parse("::X")], RBS::TypeName.parse("::X::Y::Z")])
       end
     end
   end
@@ -122,9 +122,9 @@ EOF
         resolver = Resolver::TypeNameResolver.new(env)
 
         assert_equal type_name("::MyObject::name"),
-                     resolver.resolve(type_name("name"), context: [nil, TypeName("::MyObject")])
+                     resolver.resolve(type_name("name"), context: [nil, RBS::TypeName.parse("::MyObject")])
         assert_equal type_name("::MyObject::name2"),
-                     resolver.resolve(type_name("name2"), context: [nil, TypeName("::MyObject")])
+                     resolver.resolve(type_name("name2"), context: [nil, RBS::TypeName.parse("::MyObject")])
       end
     end
   end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -2153,7 +2153,7 @@ end
         end
 
         use.clauses[1].tap do |clause|
-          assert_equal Namespace("RBS::AST::Declarations::"), clause.namespace
+          assert_equal RBS::Namespace.parse("RBS::AST::Declarations::"), clause.namespace
           assert_equal "RBS::AST::Declarations::", clause.location[:namespace].source
           assert_equal "*", clause.location[:star].source
         end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -43,7 +43,7 @@ RBS
       type_decl = decls[0]
 
       assert_instance_of Declarations::TypeAlias, type_decl
-      assert_equal TypeName("optional"), type_decl.name
+      assert_equal RBS::TypeName.parse("optional"), type_decl.name
       assert_equal [:A], type_decl.type_params.each.map(&:name)
       assert_equal parse_type("A?", variables: [:A]), type_decl.type
       assert_equal "[A]", type_decl.location[:type_params].source
@@ -56,7 +56,7 @@ end
 RBS
       decls[0].members[0].tap do |type_decl|
         assert_instance_of Declarations::TypeAlias, type_decl
-        assert_equal TypeName("bar"), type_decl.name
+        assert_equal RBS::TypeName.parse("bar"), type_decl.name
         assert_equal [], type_decl.type_params.each.map(&:name)
         assert_instance_of Types::ClassInstance, type_decl.type
         assert_nil type_decl.location[:type_params]
@@ -1328,15 +1328,15 @@ module Baz::Baz: Object
 end
 EOF
       decls[0].tap do |decl|
-        assert_equal TypeName("Foo"), decl.name
+        assert_equal RBS::TypeName.parse("Foo"), decl.name
       end
 
       decls[1].tap do |decl|
-        assert_equal TypeName("::Bar"), decl.name
+        assert_equal RBS::TypeName.parse("::Bar"), decl.name
       end
 
       decls[2].tap do |decl|
-        assert_equal TypeName("Baz::Baz"), decl.name
+        assert_equal RBS::TypeName.parse("Baz::Baz"), decl.name
       end
     end
   end
@@ -2086,8 +2086,8 @@ end
       decls[0].tap do |decl|
         assert_instance_of Declarations::ModuleAlias, decl
 
-        assert_equal TypeName("RBS::Kernel"), decl.new_name
-        assert_equal TypeName("Kernel"), decl.old_name
+        assert_equal RBS::TypeName.parse("RBS::Kernel"), decl.new_name
+        assert_equal RBS::TypeName.parse("Kernel"), decl.old_name
         assert_equal "module", decl.location[:keyword].source
         assert_equal "RBS::Kernel", decl.location[:new_name].source
         assert_equal "=", decl.location[:eq].source
@@ -2104,8 +2104,8 @@ end
       decls[0].tap do |decl|
         assert_instance_of Declarations::ClassAlias, decl
 
-        assert_equal TypeName("RBS::Object"), decl.new_name
-        assert_equal TypeName("Object"), decl.old_name
+        assert_equal RBS::TypeName.parse("RBS::Object"), decl.new_name
+        assert_equal RBS::TypeName.parse("Object"), decl.old_name
         assert_equal "class", decl.location[:keyword].source
         assert_equal "RBS::Object", decl.location[:new_name].source
         assert_equal "=", decl.location[:eq].source
@@ -2132,7 +2132,7 @@ end
         assert_equal 1, use.clauses.size
 
         use.clauses[0].tap do |clause|
-          assert_equal TypeName("RBS::Namespace"), clause.type_name
+          assert_equal RBS::TypeName.parse("RBS::Namespace"), clause.type_name
           assert_equal :NS, clause.new_name
           assert_equal "RBS::Namespace as NS", clause.location.source
           assert_equal "RBS::Namespace", clause.location[:type_name].source
@@ -2145,7 +2145,7 @@ end
         assert_equal 2, use.clauses.size
 
         use.clauses[0].tap do |clause|
-          assert_equal TypeName("RBS::TypeName"), clause.type_name
+          assert_equal RBS::TypeName.parse("RBS::TypeName"), clause.type_name
           assert_nil clause.new_name
           assert_equal "RBS::TypeName", clause.location[:type_name].source
           assert_nil clause.location[:keyword]

--- a/test/rbs/type_alias_dependency_test.rb
+++ b/test/rbs/type_alias_dependency_test.rb
@@ -19,9 +19,9 @@ type baz = bar | foo | Integer
         alias_dependency = TypeAliasDependency.new(env: env)
         alias_dependency.transitive_closure()
 
-        assert_equal Set[], alias_dependency.direct_dependencies[TypeName("::foo")]
-        assert_equal Set[TypeName("::foo")], alias_dependency.direct_dependencies[TypeName("::bar")]
-        assert_equal Set[TypeName("::foo"), TypeName("::bar")], alias_dependency.direct_dependencies[TypeName("::baz")]
+        assert_equal Set[], alias_dependency.direct_dependencies[RBS::TypeName.parse("::foo")]
+        assert_equal Set[RBS::TypeName.parse("::foo")], alias_dependency.direct_dependencies[RBS::TypeName.parse("::bar")]
+        assert_equal Set[RBS::TypeName.parse("::foo"), RBS::TypeName.parse("::bar")], alias_dependency.direct_dependencies[RBS::TypeName.parse("::baz")]
       end
     end
   end
@@ -44,19 +44,19 @@ type Foo::baz = Bar::bar | String
         alias_dependency = TypeAliasDependency.new(env: env)
         alias_dependency.transitive_closure()
 
-        assert_equal Set[], alias_dependency.direct_dependencies_of(TypeName("::Foo::foo"))
-        assert_equal Set[], alias_dependency.direct_dependencies_of(TypeName("::Bar::foo"))
-        assert_equal Set[TypeName("::Foo::foo")], alias_dependency.direct_dependencies_of(TypeName("::Foo::bar"))
-        assert_equal Set[TypeName("::Foo::foo")], alias_dependency.direct_dependencies_of(TypeName("::Bar::bar"))
-        assert_equal Set[TypeName("::Foo::bar")], alias_dependency.direct_dependencies_of(TypeName("::Foo::baz"))
-        assert_equal Set[TypeName("::Foo::bar")], alias_dependency.direct_dependencies_of(TypeName("::Bar::baz"))
+        assert_equal Set[], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Foo::foo"))
+        assert_equal Set[], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Bar::foo"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo")], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Foo::bar"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo")], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Bar::bar"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::bar")], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Foo::baz"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::bar")], alias_dependency.direct_dependencies_of(RBS::TypeName.parse("::Bar::baz"))
 
-        assert_equal Set[], alias_dependency.dependencies_of(TypeName("::Foo::foo"))
-        assert_equal Set[], alias_dependency.dependencies_of(TypeName("::Bar::foo"))
-        assert_equal Set[TypeName("::Foo::foo")], alias_dependency.dependencies_of(TypeName("::Foo::bar"))
-        assert_equal Set[TypeName("::Foo::foo")], alias_dependency.dependencies_of(TypeName("::Bar::bar"))
-        assert_equal Set[TypeName("::Foo::foo"), TypeName("::Foo::bar")], alias_dependency.dependencies_of(TypeName("::Foo::baz"))
-        assert_equal Set[TypeName("::Foo::foo"), TypeName("::Foo::bar")], alias_dependency.dependencies_of(TypeName("::Bar::baz"))
+        assert_equal Set[], alias_dependency.dependencies_of(RBS::TypeName.parse("::Foo::foo"))
+        assert_equal Set[], alias_dependency.dependencies_of(RBS::TypeName.parse("::Bar::foo"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo")], alias_dependency.dependencies_of(RBS::TypeName.parse("::Foo::bar"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo")], alias_dependency.dependencies_of(RBS::TypeName.parse("::Bar::bar"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo"), RBS::TypeName.parse("::Foo::bar")], alias_dependency.dependencies_of(RBS::TypeName.parse("::Foo::baz"))
+        assert_equal Set[RBS::TypeName.parse("::Foo::foo"), RBS::TypeName.parse("::Foo::bar")], alias_dependency.dependencies_of(RBS::TypeName.parse("::Bar::baz"))
       end
     end
   end

--- a/test/rbs/type_alias_regulartiry_test.rb
+++ b/test/rbs/type_alias_regulartiry_test.rb
@@ -19,13 +19,13 @@ type baz[T] = baz[bar[T]]
       manager.build do |env|
         validator = TypeAliasRegularity.validate(env: env)
 
-        refute_operator validator, :nonregular?, TypeName("::foo")
-        refute_operator validator, :nonregular?, TypeName("::bar")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::foo")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::bar")
 
-        assert_operator validator, :nonregular?, TypeName("::baz")
+        assert_operator validator, :nonregular?, RBS::TypeName.parse("::baz")
         assert_equal(
           parse_type("::baz[::bar[T]]", variables: [:T]),
-          validator.nonregular?(TypeName("::baz")).nonregular_type
+          validator.nonregular?(RBS::TypeName.parse("::baz")).nonregular_type
         )
       end
     end
@@ -44,10 +44,10 @@ type baz[T] = foo[Array[T]]
       manager.build do |env|
         validator = TypeAliasRegularity.validate(env: env)
 
-        assert_operator validator, :nonregular?, TypeName("::foo")
+        assert_operator validator, :nonregular?, RBS::TypeName.parse("::foo")
         assert_equal(
           parse_type("::foo[Array[::String | T]]", variables: [:T]),
-          validator.nonregular?(TypeName("::foo")).nonregular_type
+          validator.nonregular?(RBS::TypeName.parse("::foo")).nonregular_type
         )
       end
     end
@@ -73,17 +73,17 @@ type Foo::baz[T] = Bar::baz[Foo::bar[T]]
       manager.build do |env|
         validator = TypeAliasRegularity.validate(env: env)
 
-        refute_operator validator, :nonregular?, TypeName("::Foo::foo")
-        refute_operator validator, :nonregular?, TypeName("::Bar::foo")
-        refute_operator validator, :nonregular?, TypeName("::Foo::bar")
-        refute_operator validator, :nonregular?, TypeName("::Bar::bar")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::Foo::foo")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::Bar::foo")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::Foo::bar")
+        refute_operator validator, :nonregular?, RBS::TypeName.parse("::Bar::bar")
 
-        assert_operator validator, :nonregular?, TypeName("::Foo::baz")
-        assert_operator validator, :nonregular?, TypeName("::Bar::baz")
+        assert_operator validator, :nonregular?, RBS::TypeName.parse("::Foo::baz")
+        assert_operator validator, :nonregular?, RBS::TypeName.parse("::Bar::baz")
 
         assert_equal(
           parse_type("::Bar::baz[::Foo::bar[T]]", variables: [:T]),
-          validator.nonregular?(TypeName("::Foo::baz")).nonregular_type
+          validator.nonregular?(RBS::TypeName.parse("::Foo::baz")).nonregular_type
         )
       end
     end

--- a/test/rbs/use_map_test.rb
+++ b/test/rbs/use_map_test.rb
@@ -12,42 +12,42 @@ class RBS::Environment::UseMapTest < Test::Unit::TestCase
     super
 
     table = UseMap::Table.new()
-    table.known_types << TypeName("::Foo")
-    table.known_types << TypeName("::Foo::M")
-    table.known_types << TypeName("::Foo::_I")
-    table.known_types << TypeName("::Foo::a")
+    table.known_types << RBS::TypeName.parse("::Foo")
+    table.known_types << RBS::TypeName.parse("::Foo::M")
+    table.known_types << RBS::TypeName.parse("::Foo::_I")
+    table.known_types << RBS::TypeName.parse("::Foo::a")
     table.compute_children()
 
     @map = UseMap.new(table: table)
   end
 
   def test_import_single_clause
-    map.build_map(Use::SingleClause.new(type_name: TypeName("Foo::M"), new_name: nil, location: nil))
-    map.build_map(Use::SingleClause.new(type_name: TypeName("Foo::_I"), new_name: :_FooI, location: nil))
-    map.build_map(Use::SingleClause.new(type_name: TypeName("Foo::a"), new_name: :af, location: nil))
+    map.build_map(Use::SingleClause.new(type_name: RBS::TypeName.parse("Foo::M"), new_name: nil, location: nil))
+    map.build_map(Use::SingleClause.new(type_name: RBS::TypeName.parse("Foo::_I"), new_name: :_FooI, location: nil))
+    map.build_map(Use::SingleClause.new(type_name: RBS::TypeName.parse("Foo::a"), new_name: :af, location: nil))
 
-    assert_equal TypeName("::Foo::M"), map.resolve?(TypeName("M"))
-    assert_equal TypeName("::Foo::_I"), map.resolve?(TypeName("_FooI"))
-    assert_equal TypeName("::Foo::a"), map.resolve?(TypeName("af"))
+    assert_equal RBS::TypeName.parse("::Foo::M"), map.resolve?(RBS::TypeName.parse("M"))
+    assert_equal RBS::TypeName.parse("::Foo::_I"), map.resolve?(RBS::TypeName.parse("_FooI"))
+    assert_equal RBS::TypeName.parse("::Foo::a"), map.resolve?(RBS::TypeName.parse("af"))
 
-    assert_nil map.resolve?(TypeName("::M"))
-    assert_nil map.resolve?(TypeName("::_FooI"))
-    assert_nil map.resolve?(TypeName("::af"))
+    assert_nil map.resolve?(RBS::TypeName.parse("::M"))
+    assert_nil map.resolve?(RBS::TypeName.parse("::_FooI"))
+    assert_nil map.resolve?(RBS::TypeName.parse("::af"))
   end
 
   def test_import_wildcard_clause
     map.build_map(Use::WildcardClause.new(namespace: RBS::Namespace.parse("Foo::"), location: nil))
 
-    assert_equal TypeName("::Foo::M"), map.resolve?(TypeName("M"))
-    assert_equal TypeName("::Foo::_I"), map.resolve?(TypeName("_I"))
-    assert_equal TypeName("::Foo::a"), map.resolve?(TypeName("a"))
+    assert_equal RBS::TypeName.parse("::Foo::M"), map.resolve?(RBS::TypeName.parse("M"))
+    assert_equal RBS::TypeName.parse("::Foo::_I"), map.resolve?(RBS::TypeName.parse("_I"))
+    assert_equal RBS::TypeName.parse("::Foo::a"), map.resolve?(RBS::TypeName.parse("a"))
   end
 
   def test_resolve_namespace
-    map.build_map(Use::SingleClause.new(type_name: TypeName("Foo"), new_name: :Bar, location: nil))
+    map.build_map(Use::SingleClause.new(type_name: RBS::TypeName.parse("Foo"), new_name: :Bar, location: nil))
 
-    assert_equal TypeName("::Foo::M"), map.resolve?(TypeName("Bar::M"))
-    assert_equal TypeName("::Foo::_I"), map.resolve?(TypeName("Bar::_I"))
-    assert_equal TypeName("::Foo::a"), map.resolve?(TypeName("Bar::a"))
+    assert_equal RBS::TypeName.parse("::Foo::M"), map.resolve?(RBS::TypeName.parse("Bar::M"))
+    assert_equal RBS::TypeName.parse("::Foo::_I"), map.resolve?(RBS::TypeName.parse("Bar::_I"))
+    assert_equal RBS::TypeName.parse("::Foo::a"), map.resolve?(RBS::TypeName.parse("Bar::a"))
   end
 end

--- a/test/rbs/use_map_test.rb
+++ b/test/rbs/use_map_test.rb
@@ -36,7 +36,7 @@ class RBS::Environment::UseMapTest < Test::Unit::TestCase
   end
 
   def test_import_wildcard_clause
-    map.build_map(Use::WildcardClause.new(namespace: Namespace("Foo::"), location: nil))
+    map.build_map(Use::WildcardClause.new(namespace: RBS::Namespace.parse("Foo::"), location: nil))
 
     assert_equal TypeName("::Foo::M"), map.resolve?(TypeName("M"))
     assert_equal TypeName("::Foo::_I"), map.resolve?(TypeName("_I"))

--- a/test/rbs/variance_calculator_test.rb
+++ b/test/rbs/variance_calculator_test.rb
@@ -78,19 +78,19 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         calculator = VarianceCalculator.new(builder: builder)
 
-        calculator.in_type_alias(name: TypeName("::a")).tap do |result|
+        calculator.in_type_alias(name: RBS::TypeName.parse("::a")).tap do |result|
           assert_equal({ T: :covariant }, result.result)
         end
 
-        calculator.in_type_alias(name: TypeName("::b")).tap do |result|
+        calculator.in_type_alias(name: RBS::TypeName.parse("::b")).tap do |result|
           assert_equal({ T: :contravariant, S: :covariant }, result.result)
         end
 
-        calculator.in_type_alias(name: TypeName("::c")).tap do |result|
+        calculator.in_type_alias(name: RBS::TypeName.parse("::c")).tap do |result|
           assert_equal({ T: :contravariant, S: :covariant }, result.result)
         end
 
-        calculator.in_type_alias(name: TypeName("::d")).tap do |result|
+        calculator.in_type_alias(name: RBS::TypeName.parse("::d")).tap do |result|
           assert_equal({ T: :invariant }, result.result)
         end
       end
@@ -135,8 +135,8 @@ EOF
         builder = DefinitionBuilder.new(env: env)
         calculator = VarianceCalculator.new(builder: builder)
 
-        calculator.in_type_alias(name: TypeName("::Foo::foo"))
-        calculator.in_type_alias(name: TypeName("::Foo::bar"))
+        calculator.in_type_alias(name: RBS::TypeName.parse("::Foo::foo"))
+        calculator.in_type_alias(name: RBS::TypeName.parse("::Foo::bar"))
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -238,7 +238,7 @@ SIG
     end
 
     def no_argument_error?(method_name)
-      method = @builder.build_interface(TypeName(@interface)).methods[method_name]
+      method = @builder.build_interface(RBS::TypeName.parse(@interface)).methods[method_name]
       method.defs.any? do |type_def|
         type_def.member.overloads.all? do |overload|
           fun = overload.method_type.type

--- a/test/validator_test.rb
+++ b/test/validator_test.rb
@@ -175,7 +175,7 @@ type bar[T < _Foo[S], S < _Bar[T]] = nil
           validator.validate_type_alias(entry: env.type_alias_decls[type_name("::bar")])
         end
 
-        assert_equal error.type_name, TypeName("::bar")
+        assert_equal error.type_name, RBS::TypeName.parse("::bar")
         assert_equal "[T < _Foo[S], S < _Bar[T]]", error.location.source
         assert_equal <<~DETAILED_MESSAGE, error.detailed_message if Exception.method_defined?(:detailed_message)
           #{error.message} (RBS::CyclicTypeParameterBound)
@@ -242,7 +242,7 @@ class Baz = Baz
         resolver = RBS::Resolver::TypeNameResolver.new(env)
         validator = RBS::Validator.new(env: env, resolver: resolver)
 
-        env.class_alias_decls[TypeName("::Foo")].tap do |entry|
+        env.class_alias_decls[RBS::TypeName.parse("::Foo")].tap do |entry|
           assert_raises RBS::InconsistentClassModuleAliasError do
             validator.validate_class_alias(entry: entry)
           end.tap do |error|
@@ -255,13 +255,13 @@ class Baz = Baz
           end
         end
 
-        env.class_alias_decls[TypeName("::Bar")].tap do |entry|
+        env.class_alias_decls[RBS::TypeName.parse("::Bar")].tap do |entry|
           assert_raises RBS::NoTypeFoundError do
             validator.validate_class_alias(entry: entry)
           end
         end
 
-        env.class_alias_decls[TypeName("::Baz")].tap do |entry|
+        env.class_alias_decls[RBS::TypeName.parse("::Baz")].tap do |entry|
           assert_raises RBS::CyclicClassAliasDefinitionError do
             validator.validate_class_alias(entry: entry)
           end.tap do |error|
@@ -361,7 +361,7 @@ type Foo::list[T < Baz] = nil | [T, Bar::list[T]]
         resolver = RBS::Resolver::TypeNameResolver.new(env)
         validator = RBS::Validator.new(env: env, resolver: resolver)
 
-        validator.validate_type_alias(entry: env.type_alias_decls[TypeName("::Foo::list")])
+        validator.validate_type_alias(entry: env.type_alias_decls[RBS::TypeName.parse("::Foo::list")])
       end
     end
   end


### PR DESCRIPTION
The **Namespace** functionality will be added in Ruby4. https://bugs.ruby-lang.org/issues/19744
If added, `Namespace()` is likely to create confusion.

I propose that we deprecate it now.