### PR TITLE
Avoid double name resolution

### DIFF
--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -52,7 +52,7 @@ module RBS
         loader = options.loader()
         @env = Environment.from_loader(loader).resolve_type_names
         @builder = DefinitionBuilder.new(env: @env)
-        @validator = Validator.new(env: @env, resolver: Resolver::TypeNameResolver.new(@env))
+        @validator = Validator.new(env: @env)
         exit_error = false
         limit = nil #: Integer?
         OptionParser.new do |opts|

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -13,7 +13,7 @@ module RBS
     end
 
     def absolute_type(type, context:, &block)
-      return type unless @resolver
+      return type unless resolver
 
       type.map_type_name do |type_name, _, type|
         resolver.resolve(type_name, context: context) || (block ? yield(type) : type_name)

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -6,13 +6,15 @@ module RBS
     attr_reader :resolver
     attr_reader :definition_builder
 
-    def initialize(env:, resolver:)
+    def initialize(env:, resolver: nil)
       @env = env
       @resolver = resolver
       @definition_builder = DefinitionBuilder.new(env: env)
     end
 
     def absolute_type(type, context:, &block)
+      return type unless @resolver
+
       type.map_type_name do |type_name, _, type|
         resolver.resolve(type_name, context: context) || (block ? yield(type) : type_name)
       end

--- a/sig/validator.rbs
+++ b/sig/validator.rbs
@@ -2,7 +2,7 @@ module RBS
   class Validator
     attr_reader env: Environment
 
-    attr_reader resolver: Resolver::TypeNameResolver
+    attr_reader resolver: Resolver::TypeNameResolver?
 
     attr_reader definition_builder: DefinitionBuilder
 
@@ -10,7 +10,7 @@ module RBS
 
     attr_reader type_alias_regularity: TypeAliasRegularity
 
-    def initialize: (env: Environment, resolver: Resolver::TypeNameResolver) -> void
+    def initialize: (env: Environment, ?resolver: Resolver::TypeNameResolver?) -> void
 
     # Validates the presence of type names and type application arity match.
     #


### PR DESCRIPTION
The `rbs validate` command does double name resolution.
The env that executed `resolve_type_names` should have completed all name resolution, so name resolution within the validator should not be necessary.

## Repro

rbs 1a3ab85f
ruby 3.3.6

```rb
# Gemfile
source "https://rubygems.org"
gem 'rbs'
gem 'memory_profiler'
gem 'aws-sdk-s3'
gem 'aws-sdk-sqs'
gem 'aws-sdk-ec2'
gem 'aws-sdk-quicksight'
```

```
$ bundle install
$ bundle exec rbs collection init
$ bundle exec rbs collection install
```

```rb
# t.rb
require 'rbs'
require 'rbs/cli'
require 'memory_profiler'

options = RBS::CLI::LibraryOptions.new
validate = RBS::CLI::Validate.new(args: [], options: options)
report = MemoryProfiler.report do
  validate.run
end
report.pretty_print
```

## Before

```
$ time bundle exec rbs validate
bundle exec rbs validate  9.95s user 0.44s system 98% cpu 10.505 total
```

```
$ time bundle exec ruby t.rb
Total allocated: 1434079736 bytes (13515513 objects)
Total retained:  239405736 bytes (2371893 objects)
...
allocated memory by location
-----------------------------------
 118300680  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:687
 115440840  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:374
  87703808  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/definition.rb:301
  71837200  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:603
  62730720  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:368
  46641112  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:604
  46364040  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:661
```

## After

```
$ time bundle exec rbs validate
bundle exec rbs validate  7.16s user 0.33s system 97% cpu 7.690 total
```

```
$ time bundle exec ruby t.rb
Total allocated: 947277720 bytes (8836729 objects)
Total retained:  239405736 bytes (2371893 objects)
...
allocated memory by location
-----------------------------------
  87703808  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/definition.rb:301
  62730720  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:368
  46364040  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:661
  35529720  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/definition_builder.rb:323
  25566480  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/namespace.rb:90
  25244000  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:571
  23562000  /Users/yuki.kurihara/src/github.com/ksss/rbs/lib/rbs/types.rb:1085

```
