### PR TITLE
Un-hardcode repo name in test suite

### DIFF
--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -252,9 +252,9 @@ singleton(::BasicObject)
       assert_includes stdout.string, 'accessibility: public'
       assert_includes stdout.string, 'types:'
       assert_includes stdout.string, '  () -> ::Enumerator[self, untyped]'
-      assert_includes stdout.string, 'rbs/core/kernel.rbs'
+      assert_includes stdout.string, 'core/kernel.rbs'
       assert_includes stdout.string, '| [T] () { (self) -> T } -> T'
-      assert_includes stdout.string, 'rbs/core/kernel.rbs'
+      assert_includes stdout.string, 'core/kernel.rbs'
     end
 
     Dir.mktmpdir do |dir|
@@ -855,8 +855,8 @@ singleton(::BasicObject)
   def test_paths
     with_cli do |cli|
       cli.run(%w(-r pathname -I no-such-dir paths))
-      assert_match %r{/rbs/core \(dir, core\)$}, stdout.string
-      assert_match %r{/rbs/stdlib/pathname/0 \(dir, library, name=pathname\)$}, stdout.string
+      assert_match %r{/core \(dir, core\)$}, stdout.string
+      assert_match %r{/stdlib/pathname/0 \(dir, library, name=pathname\)$}, stdout.string
       assert_match %r{^no-such-dir \(absent\)$}, stdout.string
     end
   end
@@ -866,7 +866,7 @@ singleton(::BasicObject)
 
     with_cli do |cli|
       cli.run(%w(-r rbs-amber paths))
-      assert_match %r{/rbs/core \(dir, core\)$}, stdout.string
+      assert_match %r{/core \(dir, core\)$}, stdout.string
       assert_match %r{/sig \(dir, library, name=rbs-amber\)$}, stdout.string
     end
   end

--- a/test/rbs/collection/installer_test.rb
+++ b/test/rbs/collection/installer_test.rb
@@ -105,7 +105,7 @@ class RBS::Collection::InstallerTest < Test::Unit::TestCase
 
       assert dest.directory?
       assert dest.glob('*').empty? # because rubygems installer does nothing
-      assert_match(%r!Using rbs-amber:1.0.0 \(.+/rbs/test/assets/test-gem/sig\)!, stdout.string)
+      assert_match(%r!Using rbs-amber:1.0.0 \(.+/test/assets/test-gem/sig\)!, stdout.string)
       assert_match("It's done! 1 gems' RBSs now installed.", stdout.string)
     end
   end

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -94,7 +94,7 @@ RUBY
 
   def test_test_target
     output = refute_test_success(other_env: { "RBS_TEST_TARGET" => nil })
-    assert_match "rbs/test/setup handles the following environment variables:", output
+    assert_match "test/setup handles the following environment variables:", output
   end
 
   def test_no_test_install


### PR DESCRIPTION
These tests inadvertently require that the devs working on RBS have it checked out in a folder called `rbs`.

This becomes an issue if a dev wants to check out the RBS repo under a different name, such as to check out multiple worktrees at a time.

```sh
git worktree add ../rbs1
git worktree add ../rbs1
```