### PR TITLE
Designated initializers

### DIFF
--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -57,15 +57,10 @@ static void check_children_cap(rbs_loc *loc) {
 }
 
 void rbs_loc_add_required_child(rbs_loc *loc, ID name, range r) {
-  check_children_cap(loc);
+  rbs_loc_add_optional_child(loc, name, r);
 
-  unsigned short i = loc->children->len++;
-  loc->children->entries[i] = (rbs_loc_entry) {
-    .name = name,
-    .rg = rbs_new_loc_range(r),
-  };
-
-  loc->children->required_p |= 1 << i;
+  unsigned short last_index = loc->children->len - 1;
+  loc->children->required_p |= 1 << last_index;
 }
 
 void rbs_loc_add_optional_child(rbs_loc *loc, ID name, range r) {

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -604,13 +604,15 @@ static VALUE parse_optional(parserstate *state) {
 }
 
 static void initialize_method_params(method_params *params){
-  params->required_positionals = EMPTY_ARRAY;
-  params->optional_positionals = EMPTY_ARRAY;
-  params->rest_positionals = Qnil;
-  params->trailing_positionals = EMPTY_ARRAY;
-  params->required_keywords = rb_hash_new();
-  params->optional_keywords = rb_hash_new();
-  params->rest_keywords = Qnil;
+  *params = (method_params) {
+    .required_positionals = EMPTY_ARRAY,
+    .optional_positionals = EMPTY_ARRAY,
+    .rest_positionals = Qnil,
+    .trailing_positionals = EMPTY_ARRAY,
+    .required_keywords = rb_hash_new(),
+    .optional_keywords = rb_hash_new(),
+    .rest_keywords = Qnil,
+  };
 }
 
 /*
@@ -1566,8 +1568,6 @@ static InstanceSingletonKind parse_instance_singleton_kind(parserstate *state, b
       parser_advance(state);
       parser_advance(state);
       kind = SINGLETON_KIND;
-      rg->start = self_range.start;
-      rg->end = state->current_token.range.end;
     } else if (
       state->next_token2.type == pQUESTION
     && state->next_token.range.end.char_pos == state->next_token2.range.start.char_pos
@@ -1577,9 +1577,12 @@ static InstanceSingletonKind parse_instance_singleton_kind(parserstate *state, b
       parser_advance(state);
       parser_advance(state);
       kind = INSTANCE_SINGLETON_KIND;
-      rg->start = self_range.start;
-      rg->end = state->current_token.range.end;
     }
+
+    *rg = (range) {
+      .start = self_range.start,
+      .end = state->current_token.range.end,
+    };
   } else {
     *rg = NULL_RANGE;
   }
@@ -2692,8 +2695,10 @@ static VALUE parse_namespace(parserstate *state, range *rg) {
   bool is_absolute = false;
 
   if (state->next_token.type == pCOLON2) {
-    rg->start = state->next_token.range.start;
-    rg->end = state->next_token.range.end;
+    *rg = (range) {
+      .start = state->next_token.range.start,
+      .end = state->next_token.range.end,
+    };
     is_absolute = true;
 
     parser_advance(state);


### PR DESCRIPTION
This PR changes several repeated assignments with [C99 designated initializers](https://en.cppreference.com/w/c/language/struct_initialization).

We're already requiring C99 (well, the GNU dialect of it), so there shouldn't be any compiler versioning concerns:

https://github.com/ruby/rbs/blob/4077aae170a816e4adc6df0549d84d13863ccd71/ext/rbs_extension/extconf.rb#L13

These have 3 benefits:

1. In some places they can replace a `calloc`, since they automatically zero-out any fields that that weren't explicitly set.
2. They have better IDE auto-completions to help remember to set all fields.
3. As a combination of 1 and 2, using these now will help us land our large C API changes on top.