### PR TITLE
Fix typo in `instance` usage example

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -291,7 +291,7 @@ class Foo
 
   def foo: () -> instance
 
-  @@foos: Array[instances]
+  @@foos: Array[instance]
 
   include Enumerable[class]
 end


### PR DESCRIPTION
I believe what we want an `Array[instance]`?