### PR TITLE
`IO#each_line` and `Kernel#readlines` accept `chomp: true`

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -3104,8 +3104,8 @@ class IO < Object
   #
   # Returns an Enumerator if no block is given.
   #
-  def each_line: (?String sep, ?Integer limit) { (String line) -> void } -> self
-               | (?String sep, ?Integer limit) -> ::Enumerator[String, self]
+  def each_line: (?string sep, ?int limit, ?chomp: boolish) { (String line) -> void } -> self
+               | (?string sep, ?int limit, ?chomp: boolish) -> ::Enumerator[String, self]
 
   # <!--
   #   rdoc-file=io.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1499,7 +1499,7 @@ module Kernel : BasicObject
   # Optional keyword arguments `enc_opts` specify encoding options; see [Encoding
   # options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self?.readlines: (?String arg0, ?Integer arg1) -> ::Array[String]
+  def self?.readlines: (?string sep, ?int limit, ?chomp: boolish) -> ::Array[String]
 
   # <!--
   #   rdoc-file=lib/rubygems/core_ext/kernel_require.rb

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -231,6 +231,39 @@ class IOInstanceTest < Test::Unit::TestCase
     end
   end
 
+  def test_each_line
+    IO.open(IO.sysopen(File.expand_path(__FILE__)), path: "foo") do |io|
+      assert_send_type(
+        "() -> Enumerator[String, IO]",
+        io, :each_line
+      )
+    end
+
+    IO.open(IO.sysopen(File.expand_path(__FILE__)), path: "foo") do |io|
+      assert_send_type(
+        "() { (String) -> void } -> void",
+        io, :each_line, &->(_x) { }
+      )
+    end
+
+    IO.open(IO.sysopen(File.expand_path(__FILE__)), path: "foo") do |io|
+      with_string("\n") do |sep|
+        with_int(3) do |limit|
+          with_boolish() do |chomp|
+            assert_send_type(
+              "(string, int, chomp: boolish) -> Enumerator[String, IO]",
+              io, :each_line, sep, limit, chomp: chomp
+            )
+            assert_send_type(
+              "(string, int, chomp: boolish) { (String) -> void } -> void",
+              io, :each_line, sep, limit, chomp: chomp, &->(_x) { }
+            )
+            end
+        end
+      end
+    end
+  end
+
   def test_path
     IO.open(IO.sysopen(File.expand_path(__FILE__)), path: "foo") do |io|
       assert_send_type(


### PR DESCRIPTION
* Help wanted: testing
  * Broken Windows Theory: We don’t need to test those because `IO` and `Kernel` don’t have complete test coverage.