### PR TITLE
Dir.mktmpdir and File.join accept Pathname

### DIFF
--- a/core/file.rbs
+++ b/core/file.rbs
@@ -1314,7 +1314,7 @@ class File < IO
   #
   #     File.join("usr", "mail", "gumby")   #=> "usr/mail/gumby"
   #
-  def self.join: (*string) -> String
+  def self.join: (*path) -> String
 
   # <!--
   #   rdoc-file=file.c

--- a/stdlib/tmpdir/0/tmpdir.rbs
+++ b/stdlib/tmpdir/0/tmpdir.rbs
@@ -64,6 +64,6 @@ class Dir
   #       FileUtils.remove_entry dir
   #     end
   #
-  def self.mktmpdir: (?String | [ String, String ] | nil, ?String?, ?max_try: Integer?) -> String
-                   | [X] (?String | [ String, String ] | nil, ?String?, ?max_try: Integer?) { (String) -> X } -> X
+  def self.mktmpdir: (?string | [ string, string ] | nil, ?path?, ?max_try: Integer?) -> String
+                   | [X] (?string | [string, string ] | nil, ?path?, ?max_try: Integer?) { (String) -> X } -> X
 end

--- a/test/stdlib/Dir_tmpdir_test.rb
+++ b/test/stdlib/Dir_tmpdir_test.rb
@@ -1,23 +1,82 @@
 require_relative "test_helper"
-require "tmpdir"
 
-class Dir_tmpdirTest < StdlibTest
-  target Dir
+class Tmpdir_Dir_SingletonTest < Test::Unit::TestCase
+  include TestHelper
+
   library "tmpdir"
+  testing "singleton(Dir)"
 
   def test_tmpdir
-    Dir.tmpdir()
+    assert_send_type(
+      "() -> String",
+      Dir, :mktmpdir
+    )
   end
 
   def test_mktmpdir
-    Dir.mktmpdir()
-    Dir.mktmpdir(["foo", "bar"])
-    Dir.mktmpdir("foo", Dir.tmpdir, max_try: 3)
-    Dir.mktmpdir(nil, nil, max_try: nil)
+    assert_send_type(
+      "() -> String",
+      Dir, :mktmpdir
+    )
+    assert_send_type(
+      "() { (String) -> Integer} -> Integer",
+      Dir, :mktmpdir, &->(s) { s.size }
+    )
 
-    Dir.mktmpdir() {}
-    Dir.mktmpdir(["foo", "bar"]) {}
-    Dir.mktmpdir("foo", Dir.tmpdir, max_try: 3) {}
-    Dir.mktmpdir(nil, nil, max_try: nil) {}
+    assert_send_type(
+      "(max_try: Integer) -> String",
+      Dir, :mktmpdir, max_try: 1
+    )
+    assert_send_type(
+      "(max_try: Integer) { (String) -> Integer } -> Integer",
+      Dir, :mktmpdir, max_try: 1, &->(s) { s.size}
+    )
+
+    with_string("foo") do |foo|
+      assert_send_type(
+        "(string) -> String",
+        Dir, :mktmpdir, foo
+      )
+      assert_send_type(
+        "(string) { (String) -> Integer } -> Integer",
+        Dir, :mktmpdir, foo, &->(x) { x.size }
+      )
+    end
+
+    assert_send_type(
+      "(nil) -> String",
+      Dir, :mktmpdir, nil
+    )
+    assert_send_type(
+      "(nil) { (String) -> Integer } -> Integer",
+      Dir, :mktmpdir, nil, &->(x) { x.size }
+    )
+
+    with_string("foo") do |foo|
+      with_string("bar") do |bar|
+        assert_send_type(
+          "([string, string]) -> String",
+          Dir, :mktmpdir, [foo, bar]
+        )
+        assert_send_type(
+          "([string, string]) { (String) -> Integer } -> Integer",
+          Dir, :mktmpdir, [foo, bar], &->(s) { s.size }
+        )
+      end
+    end
+
+    with_string("foo") do |foo|
+      with(Dir.tmpdir, Pathname(Dir.tmpdir)) do |bar|
+        assert_send_type(
+          "(string, path) -> String",
+          Dir, :mktmpdir, foo, bar
+        )
+
+        assert_send_type(
+          "(string, path) { (String) -> Integer } -> Integer",
+          Dir, :mktmpdir, foo, bar, &->(s) { s.size }
+        )
+      end
+    end
   end
 end

--- a/test/stdlib/File_test.rb
+++ b/test/stdlib/File_test.rb
@@ -353,12 +353,16 @@ class FileSingletonTest < Test::Unit::TestCase
   end
 
   def test_join
-    assert_send_type "(String) -> String",
-                     File, :join, "foo"
-    assert_send_type "(ToStr) -> String",
-                     File, :join, ToStr.new("foo")
-    assert_send_type "(String, String) -> String",
-                     File, :join, "foo", "bar"
+    with_path("foo") do |str|
+      assert_send_type(
+        "(path) -> String",
+        File, :join, str
+      )
+      assert_send_type(
+        "(path, path) -> String",
+        File, :join, str, str
+      )
+    end
   end
 
   def test_lchown


### PR DESCRIPTION
`File.join` uses `FilePathStringValue`, so it accepts `Pathname`.

https://github.com/ruby/ruby/blob/7c2660b34774c017accff8a7d78371c2f368b9dc/file.c#L5160

`Dir.mktmpdir` uses `File.join` internally, so it also accepts `Pathname` as parent.
And it use `String.try_convert` for `prefix_suffix`, so they accept `string` instead of `String`.

https://github.com/ruby/ruby/blob/923f831804b8bc26bf0412b932791d9090ff8ac4/lib/tmpdir.rb#L159-L165