### PR TITLE
Extract out usages of Ruby IDs

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -4,10 +4,11 @@ $INCFLAGS << " -I$(top_srcdir)" if $extmk
 $INCFLAGS << " -I$(srcdir)/../../include"
 
 $VPATH << "$(srcdir)/../../src"
+$VPATH << "$(srcdir)/../../src/util"
 $VPATH << "$(srcdir)/ext/rbs_extension"
 
 root_dir = File.expand_path('../../../', __FILE__)
-$srcs = Dir.glob("#{root_dir}/src/*.c") +
+$srcs = Dir.glob("#{root_dir}/src/**/*.c") +
         Dir.glob("#{root_dir}/ext/rbs_extension/*.c")
 
 append_cflags ['-std=gnu99']

--- a/ext/rbs_extension/location.c
+++ b/ext/rbs_extension/location.c
@@ -56,14 +56,14 @@ static void check_children_cap(rbs_loc *loc) {
   }
 }
 
-void rbs_loc_add_required_child(rbs_loc *loc, ID name, range r) {
+void rbs_loc_add_required_child(rbs_loc *loc, rbs_constant_id_t name, range r) {
   rbs_loc_add_optional_child(loc, name, r);
 
   unsigned short last_index = loc->children->len - 1;
   loc->children->required_p |= 1 << last_index;
 }
 
-void rbs_loc_add_optional_child(rbs_loc *loc, ID name, range r) {
+void rbs_loc_add_optional_child(rbs_loc *loc, rbs_constant_id_t name, range r) {
   check_children_cap(loc);
 
   unsigned short i = loc->children->len++;
@@ -168,6 +168,12 @@ static VALUE location_end_pos(VALUE self) {
   return INT2FIX(loc->rg.end);
 }
 
+static rbs_constant_id_t rbs_find_constant_id_from_ruby_symbol(VALUE symbol) {
+  VALUE name = rb_sym2str(symbol);
+
+  return rbs_constant_pool_find(RBS_GLOBAL_CONSTANT_POOL, (const uint8_t *) RSTRING_PTR(name), RSTRING_LEN(name));
+}
+
 static VALUE location_add_required_child(VALUE self, VALUE name, VALUE start, VALUE end) {
   rbs_loc *loc = rbs_check_location(self);
 
@@ -175,7 +181,7 @@ static VALUE location_add_required_child(VALUE self, VALUE name, VALUE start, VA
   rg.start = rbs_loc_position(FIX2INT(start));
   rg.end = rbs_loc_position(FIX2INT(end));
 
-  rbs_loc_add_required_child(loc, SYM2ID(name), rg);
+  rbs_loc_add_required_child(loc, rbs_find_constant_id_from_ruby_symbol(name), rg);
 
   return Qnil;
 }
@@ -187,7 +193,7 @@ static VALUE location_add_optional_child(VALUE self, VALUE name, VALUE start, VA
   rg.start = rbs_loc_position(FIX2INT(start));
   rg.end = rbs_loc_position(FIX2INT(end));
 
-  rbs_loc_add_optional_child(loc, SYM2ID(name), rg);
+  rbs_loc_add_optional_child(loc, rbs_find_constant_id_from_ruby_symbol(name), rg);
 
   return Qnil;
 }
@@ -195,7 +201,7 @@ static VALUE location_add_optional_child(VALUE self, VALUE name, VALUE start, VA
 static VALUE location_add_optional_no_child(VALUE self, VALUE name) {
   rbs_loc *loc = rbs_check_location(self);
 
-  rbs_loc_add_optional_child(loc, SYM2ID(name), NULL_RANGE);
+  rbs_loc_add_optional_child(loc, rbs_find_constant_id_from_ruby_symbol(name), NULL_RANGE);
 
   return Qnil;
 }
@@ -221,9 +227,9 @@ static VALUE rbs_new_location_from_loc_range(VALUE buffer, rbs_loc_range rg) {
 static VALUE location_aref(VALUE self, VALUE name) {
   rbs_loc *loc = rbs_check_location(self);
 
-  ID id = SYM2ID(name);
+  rbs_constant_id_t id = rbs_find_constant_id_from_ruby_symbol(name);
 
-  if (loc->children != NULL) {
+  if (loc->children != NULL && id != RBS_CONSTANT_ID_UNSET) {
     for (unsigned short i = 0; i < loc->children->len; i++) {
       if (loc->children->entries[i].name == id) {
         rbs_loc_range result = loc->children->entries[i].rg;
@@ -241,6 +247,11 @@ static VALUE location_aref(VALUE self, VALUE name) {
   rb_raise(rb_eRuntimeError, "Unknown child name given: %s", RSTRING_PTR(string));
 }
 
+static VALUE rbs_constant_to_ruby_symbol(rbs_constant_t *constant) {
+  // Casts back the Ruby Symbol that was inserted by `rbs_constant_pool_insert_constant()`.
+  return (VALUE) constant;
+}
+
 static VALUE location_optional_keys(VALUE self) {
   VALUE keys = rb_ary_new();
 
@@ -252,8 +263,9 @@ static VALUE location_optional_keys(VALUE self) {
 
   for (unsigned short i = 0; i < children->len; i++) {
     if (RBS_LOC_OPTIONAL_P(loc, i)) {
-      rb_ary_push(keys, ID2SYM(children->entries[i].name));
-
+      rbs_constant_t *key_id = rbs_constant_pool_id_to_constant(RBS_GLOBAL_CONSTANT_POOL, children->entries[i].name);
+      VALUE key_sym = rbs_constant_to_ruby_symbol(key_id);
+      rb_ary_push(keys, key_sym);
     }
   }
 
@@ -271,7 +283,9 @@ static VALUE location_required_keys(VALUE self) {
 
   for (unsigned short i = 0; i < children->len; i++) {
     if (RBS_LOC_REQUIRED_P(loc, i)) {
-      rb_ary_push(keys, ID2SYM(children->entries[i].name));
+      rbs_constant_t *key_id = rbs_constant_pool_id_to_constant(RBS_GLOBAL_CONSTANT_POOL, children->entries[i].name);
+      VALUE key_sym = rbs_constant_to_ruby_symbol(key_id);
+      rb_ary_push(keys, key_sym);
     }
   }
 

--- a/ext/rbs_extension/location.h
+++ b/ext/rbs_extension/location.h
@@ -3,6 +3,7 @@
 
 #include "ruby.h"
 #include "lexer.h"
+#include "rbs/util/rbs_constant_pool.h"
 
 /**
  * RBS::Location class
@@ -15,7 +16,7 @@ typedef struct {
 } rbs_loc_range;
 
 typedef struct {
-  ID name;
+  rbs_constant_id_t name;
   rbs_loc_range rg;
 } rbs_loc_entry;
 
@@ -58,14 +59,14 @@ void rbs_loc_alloc_children(rbs_loc *loc, unsigned short cap);
  *
  * Allocate memory for children with rbs_loc_alloc_children before calling this function.
  * */
-void rbs_loc_add_required_child(rbs_loc *loc, ID name, range r);
+void rbs_loc_add_required_child(rbs_loc *loc, rbs_constant_id_t name, range r);
 
 /**
  * Add an optional child range with given name.
  *
  * Allocate memory for children with rbs_loc_alloc_children before calling this function.
  * */
-void rbs_loc_add_optional_child(rbs_loc *loc, ID name, range r);
+void rbs_loc_add_optional_child(rbs_loc *loc, rbs_constant_id_t name, range r);
 
 /**
  * Returns RBS::Location object with start/end positions.

--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -1,12 +1,23 @@
 #include "rbs_extension.h"
+#include "rbs/util/rbs_constant_pool.h"
+
+#include "ruby/vm.h"
+
+static
+void Deinit_rbs_extension(ruby_vm_t *_) {
+  rbs_constant_pool_free(RBS_GLOBAL_CONSTANT_POOL);
+}
 
 void
 Init_rbs_extension(void)
 {
 #ifdef HAVE_RB_EXT_RACTOR_SAFE
   rb_ext_ractor_safe(true);
-#endif  
+#endif
   rbs__init_constants();
   rbs__init_location();
   rbs__init_parser();
+
+  rbs_constant_pool_init(RBS_GLOBAL_CONSTANT_POOL, 0);
+  ruby_vm_at_exit(Deinit_rbs_extension);
 }

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1,4 +1,12 @@
 #include "rbs_extension.h"
+#include "rbs/util/rbs_constant_pool.h"
+
+#define INTERN(str)                  \
+  rbs_constant_pool_insert_constant( \
+    RBS_GLOBAL_CONSTANT_POOL,        \
+    (const uint8_t *) str,           \
+    strlen(str)                      \
+  )
 
 #define INTERN_TOKEN(parserstate, tok) \
   rb_intern3(\
@@ -277,7 +285,7 @@ static VALUE parse_function_param(parserstate *state) {
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 1);
-    rbs_loc_add_optional_child(loc, rb_intern("name"), NULL_RANGE);
+    rbs_loc_add_optional_child(loc, INTERN("name"), NULL_RANGE);
 
     return rbs_function_param(type, Qnil, location);
   } else {
@@ -302,7 +310,7 @@ static VALUE parse_function_param(parserstate *state) {
     VALUE location = rbs_new_location(state->buffer, param_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 1);
-    rbs_loc_add_optional_child(loc, rb_intern("name"), name_range);
+    rbs_loc_add_optional_child(loc, INTERN("name"), name_range);
 
     return rbs_function_param(type, name, location);
   }
@@ -902,8 +910,8 @@ static VALUE parse_instance_type(parserstate *state, bool parse_alias) {
     VALUE location = rbs_new_location(state->buffer, type_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 2);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_optional_child(loc, INTERN("args"), args_range);
 
     if (kind == CLASS_NAME) {
       return rbs_class_instance(typename, types, location);
@@ -936,7 +944,7 @@ static VALUE parse_singleton_type(parserstate *state) {
   VALUE location = rbs_new_location(state->buffer, type_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 1);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
 
   return rbs_class_singleton(typename, location);
 }
@@ -1221,11 +1229,11 @@ static VALUE parse_type_params(parserstate *state, range *rg, bool module_type_p
       VALUE location = rbs_new_location(state->buffer, param_range);
       rbs_loc *loc = rbs_check_location(location);
       rbs_loc_alloc_children(loc, 5);
-      rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-      rbs_loc_add_optional_child(loc, rb_intern("variance"), variance_range);
-      rbs_loc_add_optional_child(loc, rb_intern("unchecked"), unchecked_range);
-      rbs_loc_add_optional_child(loc, rb_intern("upper_bound"), upper_bound_range);
-      rbs_loc_add_optional_child(loc, rb_intern("default"), default_type_range);
+      rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+      rbs_loc_add_optional_child(loc, INTERN("variance"), variance_range);
+      rbs_loc_add_optional_child(loc, INTERN("unchecked"), unchecked_range);
+      rbs_loc_add_optional_child(loc, INTERN("upper_bound"), upper_bound_range);
+      rbs_loc_add_optional_child(loc, INTERN("default"), default_type_range);
 
       VALUE param = rbs_ast_type_param(name, variance, upper_bound, default_type, location);
 
@@ -1288,8 +1296,8 @@ VALUE parse_method_type(parserstate *state) {
   VALUE location = rbs_new_location(state->buffer, rg);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 2);
-  rbs_loc_add_required_child(loc, rb_intern("type"), type_range);
-  rbs_loc_add_optional_child(loc, rb_intern("type_params"), params_range);
+  rbs_loc_add_required_child(loc, INTERN("type"), type_range);
+  rbs_loc_add_optional_child(loc, INTERN("type_params"), params_range);
 
   return rbs_method_type(
     type_params,
@@ -1319,8 +1327,8 @@ static VALUE parse_global_decl(parserstate *state) {
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 2);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
 
   return rbs_ast_decl_global(typename, type, location, comment);
 }
@@ -1346,8 +1354,8 @@ static VALUE parse_const_decl(parserstate *state) {
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 2);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
 
   return rbs_ast_decl_constant(typename, type, location, comment);
 }
@@ -1381,10 +1389,10 @@ static VALUE parse_type_decl(parserstate *state, position comment_pos, VALUE ann
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 4);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_optional_child(loc, rb_intern("type_params"), params_range);
-  rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_optional_child(loc, INTERN("type_params"), params_range);
+  rbs_loc_add_required_child(loc, INTERN("eq"), eq_range);
 
   parser_pop_typevar_table(state);
 
@@ -1726,11 +1734,11 @@ static VALUE parse_member_def(parserstate *state, bool instance_only, bool accep
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 5);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_optional_child(loc, rb_intern("kind"), kind_range);
-  rbs_loc_add_optional_child(loc, rb_intern("overloading"), overloading_range);
-  rbs_loc_add_optional_child(loc, rb_intern("visibility"), visibility_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_optional_child(loc, INTERN("kind"), kind_range);
+  rbs_loc_add_optional_child(loc, INTERN("overloading"), overloading_range);
+  rbs_loc_add_optional_child(loc, INTERN("visibility"), visibility_range);
 
   return rbs_ast_members_method_definition(
     name,
@@ -1826,9 +1834,9 @@ static VALUE parse_mixin_member(parserstate *state, bool from_interface, positio
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 3);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_optional_child(loc, INTERN("args"), args_range);
 
   VALUE comment = get_comment(state, comment_pos.line);
   switch (type)
@@ -1889,11 +1897,11 @@ static VALUE parse_alias_member(parserstate *state, bool instance_only, position
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 5);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("new_name"), new_name_range);
-  rbs_loc_add_required_child(loc, rb_intern("old_name"), old_name_range);
-  rbs_loc_add_optional_child(loc, rb_intern("new_kind"), new_kind_range);
-  rbs_loc_add_optional_child(loc, rb_intern("old_kind"), old_kind_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("new_name"), new_name_range);
+  rbs_loc_add_required_child(loc, INTERN("old_name"), old_name_range);
+  rbs_loc_add_optional_child(loc, INTERN("new_kind"), new_kind_range);
+  rbs_loc_add_optional_child(loc, INTERN("old_kind"), old_kind_range);
 
   return rbs_ast_members_alias(
     new_name,
@@ -1939,9 +1947,9 @@ static VALUE parse_variable_member(parserstate *state, position comment_pos, VAL
     VALUE location = rbs_new_location(state->buffer, member_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 3);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
-    rbs_loc_add_optional_child(loc, rb_intern("kind"), NULL_RANGE);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
+    rbs_loc_add_optional_child(loc, INTERN("kind"), NULL_RANGE);
 
     return rbs_ast_members_instance_variable(name, type, location, comment);
   }
@@ -1960,9 +1968,9 @@ static VALUE parse_variable_member(parserstate *state, position comment_pos, VAL
     VALUE location = rbs_new_location(state->buffer, member_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 3);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
-    rbs_loc_add_optional_child(loc, rb_intern("kind"), NULL_RANGE);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
+    rbs_loc_add_optional_child(loc, INTERN("kind"), NULL_RANGE);
 
     return rbs_ast_members_class_variable(name, type, location, comment);
   }
@@ -1989,9 +1997,9 @@ static VALUE parse_variable_member(parserstate *state, position comment_pos, VAL
     VALUE location = rbs_new_location(state->buffer, member_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 3);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
-    rbs_loc_add_optional_child(loc, rb_intern("kind"), kind_range);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
+    rbs_loc_add_optional_child(loc, INTERN("kind"), kind_range);
 
     return rbs_ast_members_class_instance_variable(name, type, location, comment);
   }
@@ -2109,13 +2117,13 @@ static VALUE parse_attribute_member(parserstate *state, position comment_pos, VA
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 7);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("colon"), colon_range);
-  rbs_loc_add_optional_child(loc, rb_intern("kind"), kind_range);
-  rbs_loc_add_optional_child(loc, rb_intern("ivar"), ivar_range);
-  rbs_loc_add_optional_child(loc, rb_intern("ivar_name"), ivar_name_range);
-  rbs_loc_add_optional_child(loc, rb_intern("visibility"), visibility_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("colon"), colon_range);
+  rbs_loc_add_optional_child(loc, INTERN("kind"), kind_range);
+  rbs_loc_add_optional_child(loc, INTERN("ivar"), ivar_range);
+  rbs_loc_add_optional_child(loc, INTERN("ivar_name"), ivar_name_range);
+  rbs_loc_add_optional_child(loc, INTERN("visibility"), visibility_range);
 
   switch (attr_type)
   {
@@ -2211,10 +2219,10 @@ static VALUE parse_interface_decl(parserstate *state, position comment_pos, VALU
   VALUE location = rbs_new_location(state->buffer, member_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 4);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
-  rbs_loc_add_optional_child(loc, rb_intern("type_params"), type_params_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("end"), end_range);
+  rbs_loc_add_optional_child(loc, INTERN("type_params"), type_params_range);
 
   return rbs_ast_decl_interface(
     name,
@@ -2255,8 +2263,8 @@ static void parse_module_self_types(parserstate *state, VALUE *array) {
     VALUE location = rbs_new_location(state->buffer, self_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 2);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_optional_child(loc, INTERN("args"), args_range);
 
     VALUE self_type = rbs_ast_decl_module_self(module_name, args, location);
     melt_array(array);
@@ -2397,12 +2405,12 @@ static VALUE parse_module_decl0(parserstate *state, range keyword_range, VALUE m
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 6);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
-  rbs_loc_add_optional_child(loc, rb_intern("type_params"), type_params_range);
-  rbs_loc_add_optional_child(loc, rb_intern("colon"), colon_range);
-  rbs_loc_add_optional_child(loc, rb_intern("self_types"), self_types_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("end"), end_range);
+  rbs_loc_add_optional_child(loc, INTERN("type_params"), type_params_range);
+  rbs_loc_add_optional_child(loc, INTERN("colon"), colon_range);
+  rbs_loc_add_optional_child(loc, INTERN("self_types"), self_types_range);
 
   parser_pop_typevar_table(state);
 
@@ -2448,10 +2456,10 @@ static VALUE parse_module_decl(parserstate *state, position comment_pos, VALUE a
     VALUE location = rbs_new_location(state->buffer, decl_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 4);
-    rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-    rbs_loc_add_required_child(loc, rb_intern("new_name"), module_name_range);
-    rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
-    rbs_loc_add_optional_child(loc, rb_intern("old_name"), old_name_range);
+    rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+    rbs_loc_add_required_child(loc, INTERN("new_name"), module_name_range);
+    rbs_loc_add_required_child(loc, INTERN("eq"), eq_range);
+    rbs_loc_add_optional_child(loc, INTERN("old_name"), old_name_range);
 
     return rbs_ast_decl_module_alias(module_name, old_name, location, comment);
   } else {
@@ -2480,8 +2488,8 @@ static VALUE parse_class_decl_super(parserstate *state, range *lt_range) {
     VALUE location = rbs_new_location(state->buffer, super_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 2);
-    rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-    rbs_loc_add_optional_child(loc, rb_intern("args"), args_range);
+    rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+    rbs_loc_add_optional_child(loc, INTERN("args"), args_range);
 
     return rbs_ast_decl_class_super(name, args, location);
   } else {
@@ -2518,11 +2526,11 @@ static VALUE parse_class_decl0(parserstate *state, range keyword_range, VALUE na
   VALUE location = rbs_new_location(state->buffer, decl_range);
   rbs_loc *loc = rbs_check_location(location);
   rbs_loc_alloc_children(loc, 5);
-  rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-  rbs_loc_add_required_child(loc, rb_intern("name"), name_range);
-  rbs_loc_add_required_child(loc, rb_intern("end"), end_range);
-  rbs_loc_add_optional_child(loc, rb_intern("type_params"), type_params_range);
-  rbs_loc_add_optional_child(loc, rb_intern("lt"), lt_range);
+  rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+  rbs_loc_add_required_child(loc, INTERN("name"), name_range);
+  rbs_loc_add_required_child(loc, INTERN("end"), end_range);
+  rbs_loc_add_optional_child(loc, INTERN("type_params"), type_params_range);
+  rbs_loc_add_optional_child(loc, INTERN("lt"), lt_range);
 
   return rbs_ast_decl_class(
     name,
@@ -2565,10 +2573,10 @@ static VALUE parse_class_decl(parserstate *state, position comment_pos, VALUE an
     VALUE location = rbs_new_location(state->buffer, decl_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 4);
-    rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
-    rbs_loc_add_required_child(loc, rb_intern("new_name"), class_name_range);
-    rbs_loc_add_required_child(loc, rb_intern("eq"), eq_range);
-    rbs_loc_add_optional_child(loc, rb_intern("old_name"), old_name_range);
+    rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
+    rbs_loc_add_required_child(loc, INTERN("new_name"), class_name_range);
+    rbs_loc_add_required_child(loc, INTERN("eq"), eq_range);
+    rbs_loc_add_optional_child(loc, INTERN("old_name"), old_name_range);
 
     return rbs_ast_decl_class_alias(class_name, old_name, location, comment);
   } else {
@@ -2747,9 +2755,9 @@ static void parse_use_clauses(parserstate *state, VALUE clauses) {
         VALUE location = rbs_new_location(state->buffer, clause_range);
         rbs_loc *loc = rbs_check_location(location);
         rbs_loc_alloc_children(loc, 3);
-        rbs_loc_add_required_child(loc, rb_intern("type_name"), type_name_range);
-        rbs_loc_add_optional_child(loc, rb_intern("keyword"), keyword_range);
-        rbs_loc_add_optional_child(loc, rb_intern("new_name"), new_name_range);
+        rbs_loc_add_required_child(loc, INTERN("type_name"), type_name_range);
+        rbs_loc_add_optional_child(loc, INTERN("keyword"), keyword_range);
+        rbs_loc_add_optional_child(loc, INTERN("new_name"), new_name_range);
 
         rb_ary_push(clauses, rbs_ast_directives_use_single_clause(type_name, new_name, location));
 
@@ -2766,8 +2774,8 @@ static void parse_use_clauses(parserstate *state, VALUE clauses) {
         VALUE location = rbs_new_location(state->buffer, clause_range);
         rbs_loc *loc = rbs_check_location(location);
         rbs_loc_alloc_children(loc, 2);
-        rbs_loc_add_required_child(loc, rb_intern("namespace"), namespace_range);
-        rbs_loc_add_required_child(loc, rb_intern("star"), star_range);
+        rbs_loc_add_required_child(loc, INTERN("namespace"), namespace_range);
+        rbs_loc_add_required_child(loc, INTERN("star"), star_range);
 
         rb_ary_push(clauses, rbs_ast_directives_use_wildcard_clause(namespace, location));
 
@@ -2809,7 +2817,7 @@ static VALUE parse_use_directive(parserstate *state) {
     VALUE location = rbs_new_location(state->buffer, directive_range);
     rbs_loc *loc = rbs_check_location(location);
     rbs_loc_alloc_children(loc, 1);
-    rbs_loc_add_required_child(loc, rb_intern("keyword"), keyword_range);
+    rbs_loc_add_required_child(loc, INTERN("keyword"), keyword_range);
 
     return rbs_ast_directives_use(clauses, location);
   } else {

--- a/ext/rbs_extension/parserstate.c
+++ b/ext/rbs_extension/parserstate.c
@@ -353,8 +353,7 @@ parserstate *alloc_parser(VALUE buffer, lexstate *lexer, int start_pos, int end_
     parser_push_typevar_table(parser, true);
 
     for (long i = 0; i < rb_array_len(variables); i++) {
-      VALUE index = INT2FIX(i);
-      VALUE symbol = rb_ary_aref(1, &index, variables);
+      VALUE symbol = rb_ary_entry(variables, i);
       VALUE name = rb_sym2str(symbol);
 
       rbs_constant_id_t id = rbs_constant_pool_insert_shared(

--- a/ext/rbs_extension/parserstate.h
+++ b/ext/rbs_extension/parserstate.h
@@ -7,13 +7,13 @@
 #include "location.h"
 
 /**
- * id_table represents a set of IDs.
+ * id_table represents a set of RBS constant IDs.
  * This is used to manage the set of bound variables.
  * */
 typedef struct id_table {
   size_t size;
   size_t count;
-  ID *ids;
+  rbs_constant_id_t *ids;
   struct id_table *next;
 } id_table;
 
@@ -55,6 +55,8 @@ typedef struct {
 
   id_table *vars;         /* Known type variables */
   comment *last_comment;  /* Last read comment */
+
+  rbs_constant_pool_t constant_pool;
 } parserstate;
 
 comment *alloc_comment(token comment_token, comment *last_comment);
@@ -84,14 +86,14 @@ void parser_pop_typevar_table(parserstate *state);
 /**
  * Insert new type variable into the latest table.
  * */
-void parser_insert_typevar(parserstate *state, ID id);
+void parser_insert_typevar(parserstate *state, rbs_constant_id_t id);
 
 /**
  * Returns true if given type variable is recorded in the table.
  * If not found, it goes one table up, if it's not a reset table.
  * Or returns false, if it's a reset table.
  * */
-bool parser_typevar_member(parserstate *state, ID id);
+bool parser_typevar_member(parserstate *state, rbs_constant_id_t id);
 
 /**
  * Allocate new lexstate object.

--- a/include/rbs/util/rbs_constant_pool.h
+++ b/include/rbs/util/rbs_constant_pool.h
@@ -1,0 +1,101 @@
+/**
+ * @file rbs_constant_pool.h
+ *
+ * A data structure that stores a set of strings.
+ *
+ * Each string is assigned a unique id, which can be used to compare strings for
+ * equality. This comparison ends up being much faster than strcmp, since it
+ * only requires a single integer comparison.
+ */
+#ifndef RBS_CONSTANT_POOL_H
+#define RBS_CONSTANT_POOL_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * When we allocate constants into the pool, we reserve 0 to mean that the slot
+ * is not yet filled. This constant is reused in other places to indicate the
+ * lack of a constant id.
+ */
+#define RBS_CONSTANT_ID_UNSET 0
+
+/**
+ * A constant id is a unique identifier for a constant in the constant pool.
+ */
+typedef uintptr_t rbs_constant_id_t;
+
+/** A constant in the pool which effectively stores a string. */
+typedef uintptr_t rbs_constant_t;
+
+/** The overall constant pool, which stores constants found while parsing. */
+typedef struct {
+    void *dummy; // Workaround for structs not being allowed to be empty.
+} rbs_constant_pool_t;
+
+// A temporary stand-in for the constant pool until start using a real implementation.
+// For now, it just defers to Ruby's ID interning mechanism (`rb_intern3`).
+extern rbs_constant_pool_t *RBS_GLOBAL_CONSTANT_POOL;
+
+/**
+ * Initialize a new constant pool with a given capacity.
+ *
+ * @param pool The pool to initialize.
+ * @param capacity The initial capacity of the pool.
+ * @return Whether the initialization succeeded.
+ */
+bool rbs_constant_pool_init(rbs_constant_pool_t *pool, uint32_t capacity);
+
+/**
+ * Return a pointer to the constant indicated by the given constant id.
+ *
+ * @param pool The pool to get the constant from.
+ * @param constant_id The id of the constant to get.
+ * @return A pointer to the constant.
+ */
+rbs_constant_t * rbs_constant_pool_id_to_constant(const rbs_constant_pool_t *pool, rbs_constant_id_t constant_id);
+
+/**
+ * Find a constant in a constant pool. Returns the id of the constant, or 0 if
+ * the constant is not found.
+ *
+ * @param pool The pool to find the constant in.
+ * @param start A pointer to the start of the constant.
+ * @param length The length of the constant.
+ * @return The id of the constant.
+ */
+rbs_constant_id_t rbs_constant_pool_find(const rbs_constant_pool_t *pool, const uint8_t *start, size_t length);
+
+/**
+ * Insert a constant into a constant pool that is a slice of a source string.
+ * Returns the id of the constant, or 0 if any potential calls to resize fail.
+ *
+ * @param pool The pool to insert the constant into.
+ * @param start A pointer to the start of the constant.
+ * @param length The length of the constant.
+ * @return The id of the constant.
+ */
+rbs_constant_id_t rbs_constant_pool_insert_shared(rbs_constant_pool_t *pool, const uint8_t *start, size_t length);
+
+/**
+ * Insert a constant into a constant pool from memory that is constant. Returns
+ * the id of the constant, or 0 if any potential calls to resize fail.
+ *
+ * @param pool The pool to insert the constant into.
+ * @param start A pointer to the start of the constant.
+ * @param length The length of the constant.
+ * @return The id of the constant.
+ */
+rbs_constant_id_t rbs_constant_pool_insert_constant(rbs_constant_pool_t *pool, const uint8_t *start, size_t length);
+
+/**
+ * Free the memory associated with a constant pool.
+ *
+ * @param pool The pool to free.
+ */
+void rbs_constant_pool_free(rbs_constant_pool_t *pool);
+
+#endif

--- a/src/util/rbs_constant_pool.c
+++ b/src/util/rbs_constant_pool.c
@@ -1,0 +1,107 @@
+#include "rbs/util/rbs_constant_pool.h"
+#include "ruby.h" // Temporarily used for rb_intern2().
+#include "ruby/encoding.h" // Temporarily used for rb_usascii_encoding().
+
+
+#ifdef _MSC_VER
+    _STATIC_ASSERT(
+        sizeof(ID) == sizeof(rbs_constant_id_t)
+    );
+    _STATIC_ASSERT(
+        sizeof(VALUE) == sizeof(rbs_constant_t)
+    );
+#else
+    _Static_assert(
+        __builtin_types_compatible_p(ID, rbs_constant_id_t),
+        "rbs_constant_id_t must be the same as a Ruby ID for now."
+    );
+
+    _Static_assert(
+        __builtin_types_compatible_p(VALUE, rbs_constant_t),
+        "rbs_constant_t must be the same as a Ruby Symbol for now."
+    );
+#endif
+
+static rbs_constant_pool_t RBS_GLOBAL_CONSTANT_POOL_STORAGE = {};
+rbs_constant_pool_t *RBS_GLOBAL_CONSTANT_POOL = &RBS_GLOBAL_CONSTANT_POOL_STORAGE;
+
+// This mask is used to obfuscate the constant IDs returned by `rb_intern2()`,
+// so that we don't inadvertently mix usages of the RBS constant pool and the Ruby ID pool.
+static const rbs_constant_id_t XOR_MASK = 0b1111110000111010111111000011101011111100001110101111110000111010;
+
+/**
+ * Initialize a new constant pool with a given capacity.
+ */
+bool
+rbs_constant_pool_init(rbs_constant_pool_t *pool, uint32_t capacity) {
+    assert(capacity == 0); // The capacity parameter is not used yet.
+    return true;
+}
+
+/**
+ * Return a pointer to the constant indicated by the given constant id.
+ */
+rbs_constant_t *
+rbs_constant_pool_id_to_constant(const rbs_constant_pool_t *pool, rbs_constant_id_t constant_id) {
+    assert(pool == RBS_GLOBAL_CONSTANT_POOL);
+
+    if (constant_id == RBS_CONSTANT_ID_UNSET) return NULL;
+
+    ID ruby_id = constant_id ^ XOR_MASK;
+    VALUE symbol = ID2SYM(ruby_id);
+
+    return (rbs_constant_t *) symbol;
+}
+
+/**
+ * Find a constant in a constant pool. Returns the id of the constant, or 0 if
+ * the constant is not found.
+ */
+rbs_constant_id_t
+rbs_constant_pool_find(const rbs_constant_pool_t *pool, const uint8_t *start, size_t length) {
+    // Note: `rb_intern2(name, length)` just delegates to `rb_intern3(name, length, rb_usascii_encoding())`,
+    // so we're using `rb_usascii_encoding()` here to match that.
+    ID id = rb_check_id_cstr((const char *) start, length, rb_usascii_encoding());
+
+    if (id == 0) {
+        return RBS_CONSTANT_ID_UNSET;
+    }
+
+    return id ^ XOR_MASK;
+}
+
+/**
+ * Insert a constant into a constant pool. Returns the id of the constant, or
+ * RBS_CONSTANT_ID_UNSET if any potential calls to resize fail.
+ */
+rbs_constant_id_t
+rbs_constant_pool_insert_shared(rbs_constant_pool_t *pool, const uint8_t *start, size_t length) {
+    assert(pool != RBS_GLOBAL_CONSTANT_POOL);
+
+    ID id = rb_intern2((const char *) start, length);
+
+    if (id == 0) {
+        return RBS_CONSTANT_ID_UNSET;
+    }
+
+    return id ^ XOR_MASK;
+}
+
+/**
+ * Insert a constant into a constant pool from memory that is constant. Returns
+ * the id of the constant, or RBS_CONSTANT_ID_UNSET if any potential calls to
+ * resize fail.
+ */
+rbs_constant_id_t
+rbs_constant_pool_insert_constant(rbs_constant_pool_t *pool, const uint8_t *start, size_t length) {
+    assert(pool == RBS_GLOBAL_CONSTANT_POOL);
+    return rb_intern2((const char *) start, length) ^ XOR_MASK;
+}
+
+/**
+ * Free the memory associated with a constant pool.
+ */
+void
+rbs_constant_pool_free(rbs_constant_pool_t *pool) {
+    // no-op, for now.
+}


### PR DESCRIPTION
This PR extracts out an `rbs_constant_pool` interface, which mimics the [`pm_constant_pool`](https://github.com/ruby/prism/blob/88aae15b94b514e50d608e3ce26c0f08e0baceac/include/prism/util/pm_constant_pool.h) from Prism.

I use it to wrap all usages of `ID` as location child keys, instead of directly depending Ruby APIs like `rb_intern()`, `ID2SYM`, `SYM2ID`, etc. This includes the keys used to identify the children in a `rb_loc`, and the keys used in the parser's typevar tables.

For now, this is just a dummy implementation which delegates to those same Ruby APIs, but will eventually be replaced with Prism's real logic, which doesn't depend on `ruby.h` at all.

For easier reviewing, have a look at each commit separately.