### PR TITLE
Should validate self-type on Proc

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1427,6 +1427,7 @@ module RBS
       def each_type(&block)
         if block
           type.each_type(&block)
+          yield self_type if self_type
           self.block&.type&.each_type(&block)
           if self_type = self.block&.self_type
             yield self_type
@@ -1467,7 +1468,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        if type.with_nonreturn_void?
+        if type.with_nonreturn_void? || self_type&.with_nonreturn_void?
           true
         else
           if block = block()

--- a/test/rbs/types_test.rb
+++ b/test/rbs/types_test.rb
@@ -40,6 +40,7 @@ class RBS::TypesTest < Test::Unit::TestCase
       "[self]",
       "Array[self]",
       "^(self) -> void",
+      "^() [self: self] -> void",
       "^() { () [self: self] -> void } -> void"
     ].each do |str|
       type = parse_type(str)
@@ -61,6 +62,7 @@ class RBS::TypesTest < Test::Unit::TestCase
       "class",
       "class?",
       "^() -> instance",
+      "^() [self: class] -> void",
       "^() { () [self: class] -> void } -> void"
     ].each do |str|
       type = parse_type(str)
@@ -80,7 +82,8 @@ class RBS::TypesTest < Test::Unit::TestCase
     [
       "void",
       "[void]",
-      "void?"
+      "void?",
+      "^() [self: void] -> void"
     ].each do |str|
       type = parse_type(str)
       assert_predicate type, :with_nonreturn_void?


### PR DESCRIPTION
Proc's self_type is not a validate target.

```rbs
class Foo
  # validate pass
  def foo: () -> ^() [self: nothing] -> void
end
```

I fixed by including `self_type` in the checks for `Types::Proc#{each_type,with_nonreturn_void?}`.