### PR TITLE
`#gets`s, `#readline`s and `#readlines`s *also* accept `chomp: true`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -112,7 +112,7 @@ end
 
 task :stdlib_test => :compile do
   test_files = FileList["test/stdlib/**/*_test.rb"].reject do |path|
-    path =~ %r{Ractor} || path =~ %r{Encoding}
+    path =~ %r{Ractor} || path =~ %r{Encoding} || path =~ %r{CGI_test}
   end
 
   if ENV["RANDOMIZE_STDLIB_TEST_ORDER"] == "true"
@@ -121,6 +121,7 @@ task :stdlib_test => :compile do
 
   sh "#{ruby} -Ilib #{bin}/test_runner.rb #{test_files.join(' ')}"
   # TODO: Ractor tests need to be run in a separate process
+  sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/CGI_test.rb"
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/Ractor_test.rb"
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/Encoding_test.rb"
 end

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1486,7 +1486,7 @@ module Kernel : BasicObject
   # Optional keyword argument `chomp` specifies whether line separators are to be
   # omitted.
   #
-  def self?.readline: (?String arg0, ?Integer arg1) -> String
+  def self?.readline: (?String arg0, ?Integer arg1, ?chomp: boolish) -> String
 
   # <!--
   #   rdoc-file=io.c

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1163,7 +1163,7 @@ module Kernel : BasicObject
   # The style of programming using `$_` as an implicit parameter is gradually
   # losing favor in the Ruby community.
   #
-  def self?.gets: (?String arg0, ?Integer arg1) -> String?
+  def self?.gets: (?String sep, ?Integer limit, ?chomp: boolish) -> String?
 
   # <!--
   #   rdoc-file=eval.c

--- a/core/rbs/unnamed/argf.rbs
+++ b/core/rbs/unnamed/argf.rbs
@@ -639,7 +639,7 @@ module RBS
       # See IO.readlines for details about getline_args.
       #
       %a{annotate:rdoc:copy:ARGF#gets}
-      def gets: (?String sep, ?Integer limit) -> String?
+      def gets: (?String sep, ?Integer limit, ?chomp: boolish) -> String?
 
       # <!--
       #   rdoc-file=io.c

--- a/core/rbs/unnamed/argf.rbs
+++ b/core/rbs/unnamed/argf.rbs
@@ -1024,7 +1024,7 @@ module RBS
       # An EOFError is raised at the end of the file.
       #
       %a{annotate:rdoc:copy:ARGF#readline}
-      def readline: (?String sep, ?Integer limit) -> String
+      def readline: (?String sep, ?Integer limit, ?chomp: boolish) -> String
 
       # <!--
       #   rdoc-file=io.c
@@ -1044,7 +1044,7 @@ module RBS
       # See `IO.readlines` for a full description of all options.
       #
       %a{annotate:rdoc:copy:ARGF#readlines}
-      def readlines: (?String sep, ?Integer limit) -> ::Array[String]
+      def readlines: (?String sep, ?Integer limit, ?chomp: boolish) -> ::Array[String]
 
       # <!--
       #   rdoc-file=io.c

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -2025,7 +2025,7 @@ module OpenSSL
     #
     # Unlike IO#gets the separator must be provided if a limit is provided.
     #
-    def gets: (?String | Regexp eol, ?Integer limit) -> String?
+    def gets: (?String | Regexp eol, ?Integer limit, ?chomp: boolish) -> String?
 
     # <!--
     #   rdoc-file=ext/openssl/lib/openssl/buffering.rb

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -338,7 +338,7 @@ class StringIO
 
   def readchar: () -> String
 
-  def readline: (?String sep, ?Integer limit) -> String
+  def readline: (?String sep, ?Integer limit, ?chomp: boolish) -> String
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c

--- a/test/stdlib/ARGF_test.rb
+++ b/test/stdlib/ARGF_test.rb
@@ -27,6 +27,10 @@ class ARGFTest < Test::Unit::TestCase
                       ARGF.class.new(__FILE__), :gets, "\n"
     assert_send_type  "(::String sep, ::Integer limit) -> ::String",
                       ARGF.class.new(__FILE__), :gets, "\n", 1
+    assert_send_type  "(chomp: boolish) -> ::String",
+                      ARGF.class.new(__FILE__), :gets, chomp: true
+    assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::String",
+                      ARGF.class.new(__FILE__), :gets, "\n", 1, chomp: true
     assert_send_type  "() -> nil",
                       ARGF.class.new(Tempfile.new), :gets
   end

--- a/test/stdlib/ARGF_test.rb
+++ b/test/stdlib/ARGF_test.rb
@@ -64,6 +64,10 @@ class ARGFTest < Test::Unit::TestCase
                       ARGF.class.new(__FILE__), :readline, "\n"
     assert_send_type  "(::String sep, ::Integer limit) -> ::String",
                       ARGF.class.new(__FILE__), :readline, "\n", 1
+    assert_send_type  "(chomp: boolish) -> ::String",
+                      ARGF.class.new(__FILE__), :readline, chomp: true
+    assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::String",
+                      ARGF.class.new(__FILE__), :readline, "\n", 1, chomp: true
   end
 
   def test_readlines
@@ -73,6 +77,10 @@ class ARGFTest < Test::Unit::TestCase
                       ARGF.class.new(__FILE__), :readlines, "\n"
     assert_send_type  "(::String sep, ::Integer limit) -> ::Array[::String]",
                       ARGF.class.new(__FILE__), :readlines, "\n", 1
+    assert_send_type  "(chomp: boolish) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :readlines, chomp: true
+    assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::Array[::String]",
+                      ARGF.class.new(__FILE__), :readlines, "\n", 1, chomp: true
   end
 
   def test_inspect

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -561,4 +561,25 @@ class KernelInstanceTest < Test::Unit::TestCase
       end
     end
   end
+
+  def test_readlines
+    $stdin = File.open(__FILE__)
+
+    assert_send_type(
+      "() -> Array[String]",
+      JustKernel.new, :readlines
+    )
+
+    with_int(3) do |limit|
+      with_string(",") do |separator|
+        $stdin = File.open(__FILE__)
+        assert_send_type(
+          "(string, int, chomp: bool) -> Array[String]",
+          JustKernel.new, :readlines, ",", 3, chomp: true
+        )
+      end
+    end
+  ensure
+    $stdin = STDIN
+  end
 end

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -59,4 +59,30 @@ class StringIOTypeTest < Test::Unit::TestCase
       io, :truncate, 10
     )
   end
+
+  def test_readline
+    assert_send_type  "() -> ::String",
+                      StringIO.new("\n"), :readline
+    assert_send_type  "(::String sep) -> ::String",
+                      StringIO.new("\n"), :readline, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::String",
+                      StringIO.new("\n"), :readline, "\n", 1
+    assert_send_type  "(chomp: boolish) -> ::String",
+                      StringIO.new("\n"), :readline, chomp: true
+    assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::String",
+                      StringIO.new("\n"), :readline, "\n", 1, chomp: true
+  end
+
+  def test_readlines
+    assert_send_type  "() -> ::Array[::String]",
+                      StringIO.new("\n"), :readlines
+    assert_send_type  "(::String sep) -> ::Array[::String]",
+                      StringIO.new("\n"), :readlines, "\n"
+    assert_send_type  "(::String sep, ::Integer limit) -> ::Array[::String]",
+                      StringIO.new("\n"), :readlines, "\n", 1
+    assert_send_type  "(chomp: boolish) -> ::Array[::String]",
+                      StringIO.new("\n"), :readlines, chomp: true
+    assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::Array[::String]",
+                      StringIO.new("\n"), :readlines, "\n", 1, chomp: true
+  end
 end


### PR DESCRIPTION
* Sibing of #2151 😄

---

Test for `ARGF` and `StringIO` are included.
Testing `Kernel` currently unavailable [due to Broken Windows Theory](https://github.com/ruby/rbs/pull/2151#issuecomment-2558879163).
Testing `OpenSSL::Buffering` TBA… how do we use this thing?