### PR TITLE
Fix signature of IO.read and so on

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2278,7 +2278,7 @@ class IO < Object
   # potential security vulnerabilities if called with untrusted input; see
   # [Command Injection](rdoc-ref:command_injection.rdoc).
   #
-  def self.binread: (String name, ?Integer length, ?Integer offset) -> String
+  def self.binread: (String name, ?Integer? length, ?Integer offset) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2343,7 +2343,7 @@ class IO < Object
   #     IO.copy_stream('t.txt', 't.tmp', 11, 11) # => 11
   #     IO.read('t.tmp')                         # => "Second line"
   #
-  def self.copy_stream: (String | _Reader | _ReaderPartial src, String | _Writer dst, ?Integer copy_length, ?Integer src_offset) -> Integer
+  def self.copy_stream: (String | _Reader | _ReaderPartial src, String | _Writer dst, ?Integer? copy_length, ?Integer src_offset) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -2716,7 +2716,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.read: (String name, ?Integer length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
+  def self.read: (String name, ?Integer? length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
 
   # <!--
   #   rdoc-file=io.c

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -15,6 +15,8 @@ class IOSingletonTest < Test::Unit::TestCase
                      IO, :binread, File.expand_path(__FILE__), 3
     assert_send_type "(String, Integer, Integer) -> String",
                      IO, :binread, File.expand_path(__FILE__), 3, 0
+    assert_send_type "(String, Integer?, Integer) -> String",
+                     IO, :binread, File.expand_path(__FILE__), nil, 3
   end
 
   def test_binwrite
@@ -88,6 +90,8 @@ class IOSingletonTest < Test::Unit::TestCase
                        IO, :copy_stream, src_name, dst_name, 1
       assert_send_type "(String, String, Integer, Integer) -> Integer",
                        IO, :copy_stream, src_name, dst_name, 1, 0
+      assert_send_type "(String, String, Integer?, Integer) -> Integer",
+                       IO, :copy_stream, src_name, dst_name, nil, 1
 
       File.open(dst_name, "w") do |dst_io|
         assert_send_type "(String, IO) -> Integer",


### PR DESCRIPTION
Hi,

I fixed the signatures of `IO.binread`, `IO.copy_stream` and `IO.read` so that they can accept `nil` as a `length` argument. It is useful when we skip known length header and read data until EOF.

Thank you.