### PR TITLE
stdlib: Accept keyword arguments in `Net::HTTP.start`

### DIFF
--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -978,8 +978,8 @@ module Net
     # Note: If `port` is `nil` and `opts[:use_ssl]` is a truthy value, the value
     # passed to `new` is Net::HTTP.https_default_port, not `port`.
     #
-    def self.start: (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, **untyped opt) -> Net::HTTP
-                  | [T] (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, **untyped opt) { (Net::HTTP) -> T } -> T
+    def self.start: (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, ?Hash[Symbol, untyped]?, **untyped opt) -> Net::HTTP
+                  | [T] (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, ?Hash[Symbol, untyped]?, **untyped opt) { (Net::HTTP) -> T } -> T
 
     # <!--
     #   rdoc-file=lib/net/http.rb

--- a/stdlib/net-http/0/net-http.rbs
+++ b/stdlib/net-http/0/net-http.rbs
@@ -978,8 +978,8 @@ module Net
     # Note: If `port` is `nil` and `opts[:use_ssl]` is a truthy value, the value
     # passed to `new` is Net::HTTP.https_default_port, not `port`.
     #
-    def self.start: (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, ?Hash[Symbol, untyped]? opt) -> Net::HTTP
-                  | [T] (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, ?Hash[Symbol, untyped]? opt) { (Net::HTTP) -> T } -> T
+    def self.start: (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, **untyped opt) -> Net::HTTP
+                  | [T] (String address, ?Integer? port, ?String | :ENV | nil p_addr, ?Integer? p_port, ?String? p_user, ?String? p_pass, **untyped opt) { (Net::HTTP) -> T } -> T
 
     # <!--
     #   rdoc-file=lib/net/http.rb

--- a/test/stdlib/Net_HTTP_test.rb
+++ b/test/stdlib/Net_HTTP_test.rb
@@ -51,6 +51,17 @@ class NetSingletonTest < Test::Unit::TestCase
     assert_send_type "(String, Integer, nil, nil, nil, nil, nil) -> Net::HTTP",
                      Net::HTTP, :new, 'www.ruby-lang.org', 80, nil, nil, nil, nil, nil
   end
+
+  def test_start
+    assert_send_type "(String, Integer) -> Net::HTTP",
+                     Net::HTTP, :start, 'www.ruby-lang.org', 80
+    assert_send_type "(String, Integer, use_ssl: bool) -> Net::HTTP",
+                     Net::HTTP, :start, 'www.ruby-lang.org', 443, use_ssl: true
+    assert_send_type "(String, Integer) { (Net::HTTP) -> untyped } -> untyped",
+                     Net::HTTP, :start, 'www.ruby-lang.org', 80 do |net_http| net_http.class end
+    assert_send_type "(String, Integer, use_ssl: bool) { (Net::HTTP) -> untyped } -> untyped",
+                     Net::HTTP, :start, 'www.ruby-lang.org', 443, use_ssl: true do |net_http| net_http.class end
+  end
 end
 
 class NetInstanceTest < Test::Unit::TestCase

--- a/test/stdlib/Net_HTTP_test.rb
+++ b/test/stdlib/Net_HTTP_test.rb
@@ -61,7 +61,12 @@ class NetSingletonTest < Test::Unit::TestCase
                      Net::HTTP, :start, 'www.ruby-lang.org', 80 do |net_http| net_http.class end
     assert_send_type "(String, Integer, use_ssl: bool) { (Net::HTTP) -> untyped } -> untyped",
                      Net::HTTP, :start, 'www.ruby-lang.org', 443, use_ssl: true do |net_http| net_http.class end
-  end
+
+    assert_send_type(
+      "(String, Integer, nil, nil, nil, nil, Hash[Symbol, untyped]) { (Net::HTTP) -> Class } -> Class",
+      Net::HTTP, :start, 'www.ruby-lang.org', 443, nil, nil, nil, nil, { use_ssl: true }, &->(net_http) { net_http.class }
+    )
+   end
 end
 
 class NetInstanceTest < Test::Unit::TestCase

--- a/test/typecheck/net_http/Steepfile
+++ b/test/typecheck/net_http/Steepfile
@@ -1,0 +1,8 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  library "net-http"
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/net_http/start.rb
+++ b/test/typecheck/net_http/start.rb
@@ -1,0 +1,5 @@
+# Passing keyword args is allowed.
+Net::HTTP.start('example.com', open_timeout: 10)
+
+# Passing a hash object is also allowed, but it needs the predecessor arguments.
+Net::HTTP.start('example.com', 443, nil, nil, nil, nil, { open_timeout: 10, read_timeout: 10 })


### PR DESCRIPTION
In the original definition, keyword arguments could not be specified without specifying all positional arguments.

Specifically, the following call results in an error with `Ruby::ArgumentTypeMismatch`.

```rb
Net::HTTP.start('www.ruby-lang.org', 443, use_ssl: true)
```

This is because opt is treated as a hash positional argument. 
This problem is solved by treating opt as a variable-length keyword argument.

ref. https://docs.ruby-lang.org/ja/latest/method/Net=3a=3aHTTP/s/start.html