### PR TITLE
Union#to_s should follow RBS/Lint/AmbiguousOperatorPrecedence

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -751,10 +751,19 @@ module RBS
       end
 
       def to_s(level = 0)
+        strs = types.map do |ty|
+          case ty
+          when Intersection
+            ty.to_s([1, level].max)
+          else
+            ty.to_s
+          end
+        end
+
         if level > 0
-          "(#{types.join(" | ")})"
+          "(#{strs.join(" | ")})"
         else
-          types.join(" | ")
+          strs.join(" | ")
         end
       end
 

--- a/test/rbs/types_test.rb
+++ b/test/rbs/types_test.rb
@@ -23,9 +23,9 @@ class RBS::TypesTest < Test::Unit::TestCase
     assert_equal "(String | bool)?", parse_type("(String | bool)?").to_s
     assert_equal "String & bool?", parse_type("String & bool?").to_s
     assert_equal "(String & bool)?", parse_type("(String & bool)?").to_s
-    assert_equal "Integer | String & bool", parse_type("Integer | String & bool").to_s
+    assert_equal "Integer | (String & bool)", parse_type("Integer | String & bool").to_s
     assert_equal "(Integer | String) & bool", parse_type("(Integer | String) & bool").to_s
-    assert_equal "(Integer | String & bool)?", parse_type("(Integer | String & bool)?").to_s
+    assert_equal "(Integer | (String & bool))?", parse_type("(Integer | String & bool)?").to_s
     assert_equal "((Integer | String) & bool)?", parse_type("((Integer | String) & bool)?").to_s
     assert_equal "^() -> void", parse_type("^() -> void").to_s
     assert_equal "(^() -> void)?", parse_type("(^() -> void)?").to_s


### PR DESCRIPTION
At present, the result of `Union#to_s` does not respect `RBS/Lint/AmbiguousOperatorPrecedence` cop from rubocop-on-rbs.

It would be better to wrap intersections in unions by paranthesis.

* Before: `Integer | String & bool`
* After:  `Integer | (String & bool)`

ref: https://github.com/soutaro/rbs-inline/issues/174