### PR TITLE
deps: Add pstore, ostruct to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem "rbs-amber", path: "test/assets/test-gem"
 # Bundled gems
 gem "net-smtp"
 gem 'csv'
+gem 'ostruct'
+gem 'pstore'
 
 group :minitest do
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,11 +66,13 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nkf (0.2.0)
+    ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
     power_assert (2.0.5)
+    pstore (0.1.4)
     psych (4.0.6)
       stringio
     public_suffix (6.0.1)
@@ -174,6 +176,8 @@ DEPENDENCIES
   mutex_m
   net-smtp
   nkf
+  ostruct
+  pstore
   raap
   rake
   rake-compiler

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1174,7 +1174,7 @@ Processing `lib`...
           path: #{dir.join('gem_rbs_collection')}
         YAML
 
-        bundle_install('ast', 'abbrev', 'bigdecimal')
+        bundle_install('ast', 'abbrev', 'bigdecimal', 'logger')
         _stdout, _stderr = run_rbs_collection("install", bundler: true)
 
         rbs_collection_lock = dir.join('rbs_collection.lock.yaml')
@@ -1240,7 +1240,7 @@ Processing `lib`...
           path: #{dir.join('gem_rbs_collection')}
         YAML
 
-        bundle_install('ast', 'abbrev', 'bigdecimal')
+        bundle_install('ast', 'abbrev', 'bigdecimal', 'logger')
         run_rbs_collection("update", bundler: true)
 
         assert dir.join('rbs_collection.lock.yaml').exist?
@@ -1280,7 +1280,7 @@ Processing `lib`...
         RUBY
         (dir/"sig").mkdir
 
-        bundle_install(:gemspec, "abbrev", "bigdecimal")
+        bundle_install(:gemspec, "abbrev", "bigdecimal", "logger")
         stdout, _ = run_rbs_collection("install", bundler: true)
 
         assert_match(/Installing ast:(\d(\.\d)*)/, stdout)
@@ -1310,7 +1310,7 @@ Processing `lib`...
           - name: mutex_m
         YAML
 
-        bundle_install(["mutex_m", ">= 0.3.0"])
+        bundle_install("logger", ["mutex_m", ">= 0.3.0"])
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
         refute_match(/`mutex_m` as a stdlib in rbs-gem is deprecated./, stderr)
@@ -1343,7 +1343,7 @@ Processing `lib`...
           - name: mutex_m
         YAML
 
-        bundle_install(["mutex_m", "0.2.0"])
+        bundle_install("logger", ["mutex_m", "0.2.0"])
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
         assert_include stderr, '`mutex_m` as a stdlib in rbs-gem is deprecated.'
@@ -1379,7 +1379,7 @@ Processing `lib`...
               type: stdlib
         YAML
 
-        bundle_install
+        bundle_install("logger")
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
         assert_include stderr, '`mutex_m` as a stdlib in rbs-gem is deprecated.'
@@ -1410,7 +1410,7 @@ Processing `lib`...
           path: #{dir.join('gem_rbs_collection')}
         YAML
 
-        bundle_install(["mutex_m", ">= 0.3.0"])
+        bundle_install("logger", ["mutex_m", ">= 0.3.0"])
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
         refute_match(/`mutex_m` as a stdlib in rbs-gem is deprecated./, stderr)
@@ -1440,7 +1440,7 @@ Processing `lib`...
           path: #{dir.join('gem_rbs_collection')}
         YAML
 
-        bundle_install(["mutex_m", "0.2.0"])
+        bundle_install("logger", ["mutex_m", "0.2.0"])
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
         assert_include stderr, '`mutex_m` as a stdlib in rbs-gem is deprecated.'
@@ -1475,7 +1475,7 @@ Processing `lib`...
           - name: mutex_m
         YAML
 
-        bundle_install("true_string")  # true_string is a soutaro's gem that doesn't have sig directory
+        bundle_install("logger", "true_string")  # true_string is a soutaro's gem that doesn't have sig directory
 
         _stdout, stderr = run_rbs_collection("install", bundler: true)
 
@@ -1519,7 +1519,7 @@ Processing `lib`...
           - name: mutex_m
         YAML
 
-        bundle_install(["hola", { path: "gem" }])
+        bundle_install("logger", ["hola", { path: "gem" }])
 
         (dir + RBS::Collection::Config::PATH).write(<<~YAML)
           sources:


### PR DESCRIPTION
pstore became a bundled gem since Ruby-3.5.  Therefore it should be added to the dependency list to pass CI.

ref: https://bugs.ruby-lang.org/issues/20309