### PR TITLE
Add `resolve-type-names: false` magic comment

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -2935,12 +2935,12 @@ parse_signature_try(VALUE a) {
 }
 
 static VALUE
-rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE end_pos)
+rbsparser_parse_signature(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos)
 {
   VALUE string = rb_funcall(buffer, rb_intern("content"), 0);
   StringValue(string);
-  lexstate *lexer = alloc_lexer(string, 0, FIX2INT(end_pos));
-  parserstate *parser = alloc_parser(buffer, lexer, 0, FIX2INT(end_pos), Qnil);
+  lexstate *lexer = alloc_lexer(string, FIX2INT(start_pos), FIX2INT(end_pos));
+  parserstate *parser = alloc_parser(buffer, lexer, FIX2INT(start_pos), FIX2INT(end_pos), Qnil);
   return rb_ensure(parse_signature_try, (VALUE)parser, ensure_free_parser, (VALUE)parser);
 }
 
@@ -2974,6 +2974,6 @@ void rbs__init_parser(void) {
 
   rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 5);
   rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 5);
-  rb_define_singleton_method(RBS_Parser, "_parse_signature", rbsparser_parse_signature, 2);
+  rb_define_singleton_method(RBS_Parser, "_parse_signature", rbsparser_parse_signature, 3);
   rb_define_singleton_method(RBS_Parser, "_lex", rbsparser_lex, 2);
 }

--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -9,6 +9,7 @@ require "pp"
 require "ripper"
 require "logger"
 require "tsort"
+require "strscan"
 
 require "rbs/errors"
 require "rbs/buffer"

--- a/lib/rbs/ast/directives.rb
+++ b/lib/rbs/ast/directives.rb
@@ -34,6 +34,16 @@ module RBS
         end
       end
 
+      class ResolveTypeNames < Base
+        attr_reader :location
+
+        attr_reader :value
+
+        def initialize(value:, location:)
+          @value = value
+          @location = location
+        end
+      end
     end
   end
 end

--- a/lib/rbs/locator.rb
+++ b/lib/rbs/locator.rb
@@ -40,6 +40,8 @@ module RBS
     end
 
     def find_in_directive(pos, dir, array)
+      return false unless dir.is_a?(AST::Directives::Use)
+
       if test_loc(pos, location: dir.location)
         array.unshift(dir)
 

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -17,9 +17,46 @@ module RBS
 
     def self.parse_signature(source)
       buf = buffer(source)
-      dirs, decls = _parse_signature(buf, 0, buf.last_position)
+
+      resolved = magic_comment(buf)
+      start_pos =
+        if resolved
+          (resolved.location || raise).end_pos
+        else
+          0
+        end
+      dirs, decls = _parse_signature(buf, start_pos, buf.last_position)
+
+      if resolved
+        dirs = dirs.dup if dirs.frozen?
+        dirs.unshift(resolved)
+      end
 
       [buf, dirs, decls]
+    end
+
+    def self.magic_comment(buf)
+      start_pos = 0
+
+      while true
+        case
+        when match = /\A#\s*(?<keyword>resolve-type-names)\s*(?<colon>:)\s+(?<value>true|false)$/.match(buf.content, start_pos)
+          value = match[:value] or raise
+
+          kw_offset = match.offset(:keyword) #: [Integer, Integer]
+          colon_offset = match.offset(:colon) #: [Integer, Integer]
+          value_offset = match.offset(:value) #: [Integer, Integer]
+
+          location = Location.new(buf, kw_offset[0], value_offset[1])
+          location.add_required_child(:keyword, kw_offset[0]...kw_offset[1])
+          location.add_required_child(:colon, colon_offset[0]...colon_offset[1])
+          location.add_required_child(:value, value_offset[0]...value_offset[1])
+
+          return AST::Directives::ResolveTypeNames.new(value: value == "true", location: location)
+        else
+          return
+        end
+      end
     end
 
     def self.lex(source)

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -17,7 +17,7 @@ module RBS
 
     def self.parse_signature(source)
       buf = buffer(source)
-      dirs, decls = _parse_signature(buf, buf.last_position)
+      dirs, decls = _parse_signature(buf, 0, buf.last_position)
 
       [buf, dirs, decls]
     end

--- a/lib/rbs/writer.rb
+++ b/lib/rbs/writer.rb
@@ -77,14 +77,19 @@ module RBS
     end
 
     def write(contents)
-      dirs = contents.select {|c| c.is_a?(AST::Directives::Base) } #: Array[AST::Directives::t]
+      resolves = contents.select { _1.is_a?(AST::Directives::ResolveTypeNames) } #: Array[AST::Directives::ResolveTypeNames]
+      uses = contents.select {|c| c.is_a?(AST::Directives::Use) } #: Array[AST::Directives::Use]
       decls = contents.select {|c| c.is_a?(AST::Declarations::Base) } #: Array[AST::Declarations::t]
 
-      dirs.each do |dir|
-        write_directive(dir)
+      if first_resolves = resolves.first
+        puts "# resolve-type-names: #{first_resolves.value}"
+        puts
       end
 
-      puts unless dirs.empty?
+      uses.each do |dir|
+        write_use_directive(dir)
+      end
+      puts unless uses.empty?
 
       [nil, *decls].each_cons(2) do |prev, decl|
         raise unless decl
@@ -94,7 +99,7 @@ module RBS
       end
     end
 
-    def write_directive(dir)
+    def write_use_directive(dir)
       clauses = dir.clauses.map do |clause|
         case clause
         when AST::Directives::Use::SingleClause

--- a/sig/directives.rbs
+++ b/sig/directives.rbs
@@ -1,7 +1,7 @@
 module RBS
   module AST
     module Directives
-      type t = Use
+      type t = Use | ResolveTypeNames
 
       class Base
       end
@@ -55,6 +55,22 @@ module RBS
         attr_reader location: loc?
 
         def initialize: (clauses: Array[clause], location: loc?) -> void
+      end
+
+      class ResolveTypeNames < Base
+        # ```
+        # # resolve-type-names: false
+        #   ^^^^^^^^^^^^^^^^^^          keyword
+        #                     ^         colon
+        #                       ^^^^^   value
+        # ```
+        type loc = Location[:keyword | :colon | :value, bot]
+
+        attr_reader location: loc?
+
+        attr_reader value: bool
+
+        def initialize: (value: bool, location: loc?) -> void
       end
     end
   end

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -141,6 +141,8 @@ module RBS
     #
     def resolve_type_names: (?only: Set[AST::Declarations::t]?) -> Environment
 
+    def resolve_signature: (Resolver::TypeNameResolver, UseMap::Table, Array[AST::Directives::t], Array[AST::Declarations::t], ?only: Set[AST::Declarations::t]?) -> [Array[AST::Directives::t], Array[AST::Declarations::t]]
+
     def inspect: () -> String
 
     def buffers: () -> Array[Buffer]

--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -68,6 +68,10 @@ module RBS
     #
     def self.parse_signature: (Buffer | String) -> [Buffer, Array[AST::Directives::t], Array[AST::Declarations::t]]
 
+    # Returns the magic comment from the buffer
+    #
+    def self.magic_comment: (Buffer) -> AST::Directives::ResolveTypeNames?
+
     # Parse whole RBS file and return result.
     #
     # ```ruby
@@ -86,7 +90,7 @@ module RBS
 
     def self._parse_method_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables, bool require_eof) -> MethodType?
 
-    def self._parse_signature: (Buffer, Integer end_pos) -> [Array[AST::Directives::t], Array[AST::Declarations::t]]
+    def self._parse_signature: (Buffer, Integer start_pos, Integer end_pos) -> [Array[AST::Directives::t], Array[AST::Declarations::t]]
 
     def self._lex: (Buffer, Integer end_pos) -> Array[[Symbol, Location[untyped, untyped]]]
 

--- a/sig/writer.rbs
+++ b/sig/writer.rbs
@@ -96,7 +96,7 @@ module RBS
 
     def format_annotation: (AST::Annotation) -> String
 
-    def write_directive: (AST::Directives::t) -> void
+    def write_use_directive: (AST::Directives::Use) -> void
 
     def write_annotation: (Array[AST::Annotation]) -> void
 

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -549,4 +549,40 @@ end
       assert_operator env.class_decls, :key?, RBS::TypeName.parse("::OB")
     end
   end
+
+  def test_resolve_type_names_magic_comment
+    buf, dirs, decls = RBS::Parser.parse_signature(<<-RBS)
+# resolve-type-names: false
+
+type t = s
+
+type s = untyped
+    RBS
+
+    env = Environment.new
+    env.add_signature(buffer: buf, directives: dirs, decls: decls)
+
+    env.resolve_type_names.tap do |env|
+      alias_decl = env.type_alias_decls[RBS::TypeName.parse("::t")]
+      assert_equal "s", alias_decl.decl.type.to_s
+    end
+  end
+
+  def test_resolve_type_names_magic_comment__true
+    buf, dirs, decls = RBS::Parser.parse_signature(<<-RBS)
+# resolve-type-names: true
+
+type t = s
+
+type s = untyped
+    RBS
+
+    env = Environment.new
+    env.add_signature(buffer: buf, directives: dirs, decls: decls)
+
+    env.resolve_type_names.tap do |env|
+      alias_decl = env.type_alias_decls[RBS::TypeName.parse("::t")]
+      assert_equal "::s", alias_decl.decl.type.to_s
+    end
+  end
 end

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -2171,4 +2171,53 @@ end
       RBS
     end
   end
+
+  def test_resolved_directive
+    Parser.parse_signature(<<~RBS).tap do |_, dirs, _|
+        # resolve-type-names: false
+
+        module Baz
+        end
+      RBS
+
+      assert_equal 1, dirs.size
+      dirs[0].tap do
+        assert_instance_of RBS::AST::Directives::ResolveTypeNames, _1
+        assert_false _1.value
+        assert_equal "resolve-type-names: false", _1.location.source
+        assert_equal "resolve-type-names", _1.location[:keyword].source
+        assert_equal ":", _1.location[:colon].source
+        assert_equal "false", _1.location[:value].source
+      end
+    end
+
+    Parser.parse_signature(<<~RBS).tap do |_, dirs, _|
+        #resolve-type-names : true
+
+        module Baz
+        end
+      RBS
+
+      assert_equal 1, dirs.size
+      dirs[0].tap do
+        assert_instance_of RBS::AST::Directives::ResolveTypeNames, _1
+        assert_true _1.value
+        assert_equal "resolve-type-names : true", _1.location.source
+        assert_equal "resolve-type-names", _1.location[:keyword].source
+        assert_equal ":", _1.location[:colon].source
+        assert_equal "true", _1.location[:value].source
+      end
+    end
+
+    Parser.parse_signature(<<~RBS).tap do |_, dirs, _|
+        # This is a comment
+        # resolve-type-names: false
+
+        module Baz
+        end
+      RBS
+
+      assert_empty dirs
+    end
+  end
 end

--- a/test/rbs/writer_test.rb
+++ b/test/rbs/writer_test.rb
@@ -331,4 +331,53 @@ class Foo
 end
     SIG
   end
+
+  def test_magic_comment
+    assert_writer <<-SIG
+# resolve-type-names: false
+
+class Foo
+end
+    SIG
+
+    assert_writer <<-SIG
+# resolve-type-names: false
+
+use String as S
+
+type s = S
+    SIG
+  end
+
+  def test_magic_comment_with_additional_new_line
+    result = format(<<-SIG)
+# resolve-type-names: false
+# Class Foo is something...
+class Foo
+end
+    SIG
+
+    assert_equal <<-SIG, result
+# resolve-type-names: false
+
+# Class Foo is something...
+class Foo
+end
+    SIG
+  end
+
+  def test_magic_comment_with_additional_new_line2
+    result = format(<<-SIG)
+# resolve-type-names: false
+class Foo
+end
+    SIG
+
+    assert_equal <<-SIG, result
+# resolve-type-names: false
+
+class Foo
+end
+    SIG
+  end
 end


### PR DESCRIPTION
The `resolved: true` magic comment allows skipping type name resolution on a file-by-file basis.

* The magic comment can be placed on the first line of RBS files.
* Writer doesn't work if the magic comment is given, and the documentation is also given from the first line.

```rbs
# resolved: true
# The class is something to explain the writer bug.
class WriterHasABug
end
```

The output will have duplicated `resolved: true` lines.