### PR TITLE
Validate variable types

### DIFF
--- a/lib/rbs/cli/validate.rb
+++ b/lib/rbs/cli/validate.rb
@@ -196,6 +196,7 @@ EOU
                   end
                 InvalidTypeApplicationError.check!(type_name: member.name, params: params, args: member.args, location: member.location)
               when AST::Members::Var
+                @validator.validate_variable(member)
                 void_type_context_validator(member.type)
                 if member.is_a?(AST::Members::ClassVariable)
                   no_self_type_validator(member.type)

--- a/lib/rbs/validator.rb
+++ b/lib/rbs/validator.rb
@@ -151,6 +151,10 @@ module RBS
       end
     end
 
+    def validate_variable(var)
+      validate_type(var.type, context: nil)
+    end
+
     def validate_class_alias(entry:)
       case env.normalize_module_name?(entry.decl.new_name)
       when nil

--- a/sig/validator.rbs
+++ b/sig/validator.rbs
@@ -49,6 +49,10 @@ module RBS
     #
     def validate_class_alias: (entry: Environment::ClassAliasEntry | Environment::ModuleAliasEntry) -> void
 
+    # Validates instance/class-instance/class variables.
+    #
+    def validate_variable: (AST::Members::Var) -> void
+
     private
 
     # Resolves relative type names to absolute type names in given context.


### PR DESCRIPTION
The `rbs validate` command now checks the type of instance/class-instance/class variables.