### PR TITLE
Enable unchanged style in the current RBS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,8 @@ RBS/Style:
   Exclude:
     - 'sig/**/*'
     - 'test/**/*'
+RBS/Style/BlockReturnBoolish:
+  Enabled: true
 RBS/Style/EmptyArgument:
   Enabled: true
 RBS/Style/InitializeReturnType:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,8 @@ RBS/Style/InitializeReturnType:
   Enabled: true
 RBS/Style/OptionalNil:
   Enabled: true
+RBS/Style/RedundantParentheses:
+  Enabled: true
 
 Lint/DuplicateMethods:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,8 @@ RBS/Style:
     - 'test/**/*'
 RBS/Style/BlockReturnBoolish:
   Enabled: true
+RBS/Style/DuplicatedType:
+  Enabled: true
 RBS/Style/EmptyArgument:
   Enabled: true
 RBS/Style/InitializeReturnType:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,8 @@ RBS/Style/EmptyArgument:
   Enabled: true
 RBS/Style/InitializeReturnType:
   Enabled: true
+RBS/Style/OptionalNil:
+  Enabled: true
 
 Lint/DuplicateMethods:
   Enabled: true


### PR DESCRIPTION
By enabling this style, it will automatically be pointed out in future PR.

- [RBS/Style/BlockReturnBoolish](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_style.adoc#rbsstyleblockreturnboolish)
- [RBS/Style/DuplicatedType](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_style.adoc#rbsstyleduplicatedtype)
- [RBS/Style/OptionalNil](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_style.adoc#rbsstyleoptionalnil)
- [RBS/Style/RedundantParentheses](https://github.com/ksss/rubocop-on-rbs/blob/main/docs/modules/ROOT/pages/cops_rbs_style.adoc#rbsstyleredundantparentheses)