### PR TITLE
Remove call to `Any#todo!` from C parser

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -213,6 +213,7 @@ nodes:
       - name: location
   - name: RBS::Types::Bases::Any
     fields:
+      - name: todo
       - name: location
   - name: RBS::Types::Bases::Bool
     fields:

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -993,12 +993,10 @@ static VALUE parse_simple(parserstate *state) {
     return rbs_bases_void(rbs_location_current_token(state));
   }
   case kUNTYPED: {
-    return rbs_bases_any(rbs_location_current_token(state));
+    return rbs_bases_any(false, rbs_location_current_token(state));
   }
   case k__TODO__: {
-    VALUE type = rbs_bases_any(rbs_location_current_token(state));
-    rb_funcall(type, rb_intern("todo!"), 0);
-    return type;
+    return rbs_bases_any(true, rbs_location_current_token(state));
   }
   case tINTEGER: {
     VALUE literal = rb_funcall(

--- a/include/rbs/ruby_objs.h
+++ b/include/rbs/ruby_objs.h
@@ -44,7 +44,7 @@ VALUE rbs_method_type(VALUE type_params, VALUE type, VALUE block, VALUE location
 VALUE rbs_namespace(VALUE path, VALUE absolute);
 VALUE rbs_type_name(VALUE namespace, VALUE name);
 VALUE rbs_alias(VALUE name, VALUE args, VALUE location);
-VALUE rbs_bases_any(VALUE location);
+VALUE rbs_bases_any(VALUE todo, VALUE location);
 VALUE rbs_bases_bool(VALUE location);
 VALUE rbs_bases_bottom(VALUE location);
 VALUE rbs_bases_class(VALUE location);

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -107,9 +107,16 @@ module RBS
       class Bool < Base; end
       class Void < Base; end
       class Any < Base
+        def initialize(location:, todo: false)
+          super(location: location)
+          todo! if todo
+        end
+
         def to_s(level=0)
           @string || "untyped"
         end
+
+        private
 
         def todo!
           @string = '__todo__'

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -113,6 +113,10 @@ module RBS
       class Any < Base
         @string: String?
 
+        def initialize: (location: Location[bot, bot]?, ?todo: bool) -> void
+
+        private
+
         def todo!: () -> self
       end
 

--- a/src/ruby_objs.c
+++ b/src/ruby_objs.c
@@ -501,8 +501,9 @@ VALUE rbs_alias(VALUE name, VALUE args, VALUE location) {
   );
 }
 
-VALUE rbs_bases_any(VALUE location) {
+VALUE rbs_bases_any(VALUE todo, VALUE location) {
   VALUE _init_kwargs = rb_hash_new();
+  rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("todo")), todo);
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("location")), location);
 
   return CLASS_NEW_INSTANCE(


### PR DESCRIPTION
As we're trying to detangle the C parser implementation from Ruby, the call to `Any#todo!` is problematic.

Instead we can store a flag in the C structure and move this call to the Ruby implementation during the object initialization.