### PR TITLE
Fix OpenSSL::PKey::{RSA,DSA,DH}#params return type

### DIFF
--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -5648,7 +5648,7 @@ module OpenSSL
       # Stores all parameters of key to the hash INSECURE: PRIVATE INFORMATIONS CAN
       # LEAK OUT!!! Don't use :-)) (I's up to you)
       #
-      def params: () -> Hash[String, BN]
+      def params: () -> Hash[String, BN?]
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkey_dh.c
@@ -5942,7 +5942,7 @@ module OpenSSL
       # Stores all parameters of key to the hash INSECURE: PRIVATE INFORMATIONS CAN
       # LEAK OUT!!! Don't use :-)) (I's up to you)
       #
-      def params: () -> Hash[String, BN]
+      def params: () -> Hash[String, BN?]
 
       def priv_key: () -> BN
 
@@ -7220,7 +7220,7 @@ module OpenSSL
       #
       # Don't use :-)) (It's up to you)
       #
-      def params: () -> Hash[String, BN]
+      def params: () -> Hash[String, BN?]
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_pkey_rsa.c

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -1907,7 +1907,7 @@ module OpenSSL
     #         negative number.
     #
     def initialize: (instance) -> void
-                  | (int) -> void
+                  | (Integer) -> void
                   | (string) -> void
                   | (string, 0 | 2 | 10 | 16) -> void
 

--- a/test/stdlib/OpenSSL_test.rb
+++ b/test/stdlib/OpenSSL_test.rb
@@ -699,7 +699,7 @@ class OpenSSLDHTest < Test::Unit::TestCase
   end
 
   def test_params
-    assert_send_type "() -> Hash[String, OpenSSL::BN]",
+    assert_send_type "() -> Hash[String, OpenSSL::BN?]",
       pkey, :params
   end
 
@@ -914,6 +914,11 @@ class OpenSSLRSATest < Test::Unit::TestCase
 
     assert_send_type "(OpenSSL::Digest, String, String) -> bool",
       pkey, :verify, digest, sig, data
+  end
+
+  def test_params
+    assert_send_type "() -> Hash[String, OpenSSL::BN]",
+      pkey, :params
   end
 
   private


### PR DESCRIPTION
Follow up to https://github.com/ruby/openssl/pull/774