### PR TITLE
Remove call to `TypeParam#unchecked!` from C parser

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -191,6 +191,7 @@ nodes:
       - name: variance
       - name: upper_bound
       - name: default_type
+      - name: unchecked
       - name: location
   - name: RBS::MethodType
     fields:

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1158,7 +1158,7 @@ static VALUE parse_type_params(parserstate *state, range *rg, bool module_type_p
     rg->start = state->current_token.range.start;
 
     while (true) {
-      bool unchecked = false;
+      VALUE unchecked = Qfalse;
       VALUE variance = ID2SYM(rb_intern("invariant"));
       VALUE upper_bound = Qnil;
       VALUE default_type = Qnil;
@@ -1170,7 +1170,7 @@ static VALUE parse_type_params(parserstate *state, range *rg, bool module_type_p
       range unchecked_range = NULL_RANGE;
       if (module_type_params) {
         if (state->next_token.type == kUNCHECKED) {
-          unchecked = true;
+          unchecked = Qtrue;
           parser_advance(state);
           unchecked_range = state->current_token.range;
         }
@@ -1245,11 +1245,7 @@ static VALUE parse_type_params(parserstate *state, range *rg, bool module_type_p
       rbs_loc_add_optional_child(loc, INTERN("upper_bound"), upper_bound_range);
       rbs_loc_add_optional_child(loc, INTERN("default"), default_type_range);
 
-      VALUE param = rbs_ast_type_param(name, variance, upper_bound, default_type, location);
-
-      if (unchecked) {
-        rb_funcall(param, rb_intern("unchecked!"), 0);
-      }
+      VALUE param = rbs_ast_type_param(name, variance, upper_bound, default_type, unchecked, location);
 
       melt_array(&params);
       rb_ary_push(params, param);

--- a/include/rbs/ruby_objs.h
+++ b/include/rbs/ruby_objs.h
@@ -39,7 +39,7 @@ VALUE rbs_ast_members_method_definition_overload(VALUE annotations, VALUE method
 VALUE rbs_ast_members_prepend(VALUE name, VALUE args, VALUE annotations, VALUE location, VALUE comment);
 VALUE rbs_ast_members_private(VALUE location);
 VALUE rbs_ast_members_public(VALUE location);
-VALUE rbs_ast_type_param(VALUE name, VALUE variance, VALUE upper_bound, VALUE default_type, VALUE location);
+VALUE rbs_ast_type_param(VALUE name, VALUE variance, VALUE upper_bound, VALUE default_type, VALUE unchecked, VALUE location);
 VALUE rbs_method_type(VALUE type_params, VALUE type, VALUE block, VALUE location);
 VALUE rbs_namespace(VALUE path, VALUE absolute);
 VALUE rbs_type_name(VALUE namespace, VALUE name);

--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -5,13 +5,13 @@ module RBS
     class TypeParam
       attr_reader :name, :variance, :location, :upper_bound_type, :default_type
 
-      def initialize(name:, variance:, upper_bound:, location:, default_type: nil)
+      def initialize(name:, variance:, upper_bound:, location:, default_type: nil, unchecked: false)
         @name = name
         @variance = variance
         @upper_bound_type = upper_bound
         @location = location
-        @unchecked = false
         @default_type = default_type
+        @unchecked = unchecked
       end
 
       def upper_bound

--- a/sig/type_param.rbs
+++ b/sig/type_param.rbs
@@ -26,7 +26,7 @@ module RBS
 
       attr_reader default_type: Types::t?
 
-      def initialize: (name: Symbol, variance: variance, upper_bound: Types::t?, location: loc?, ?default_type: Types::t?) -> void
+      def initialize: (name: Symbol, variance: variance, upper_bound: Types::t?, location: loc?, ?default_type: Types::t?, ?unchecked: bool) -> void
 
       include _ToJson
 

--- a/src/ruby_objs.c
+++ b/src/ruby_objs.c
@@ -435,12 +435,13 @@ VALUE rbs_ast_members_public(VALUE location) {
   );
 }
 
-VALUE rbs_ast_type_param(VALUE name, VALUE variance, VALUE upper_bound, VALUE default_type, VALUE location) {
+VALUE rbs_ast_type_param(VALUE name, VALUE variance, VALUE upper_bound, VALUE default_type, VALUE unchecked, VALUE location) {
   VALUE _init_kwargs = rb_hash_new();
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("name")), name);
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("variance")), variance);
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("upper_bound")), upper_bound);
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("default_type")), default_type);
+  rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("unchecked")), unchecked);
   rb_hash_aset(_init_kwargs, ID2SYM(rb_intern("location")), location);
 
   return CLASS_NEW_INSTANCE(


### PR DESCRIPTION
Similar to #2249, as we're trying to detangle the C parser implementation from Ruby, the call to `TypeParam#unchecked!` is problematic.

Instead we can store a flag in the C structure and move this call to the Ruby implementation during the object initialization.