### PR TITLE
[rbs/unit_test] Treat nil as a return value

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :libs do
   gem "dbm"
   gem "mutex_m"
   gem "nkf"
+  gem "pathname"
 end
 
 group :profilers do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
+    pathname (0.4.0)
     power_assert (2.0.5)
     pstore (0.1.4)
     psych (4.0.6)
@@ -177,6 +178,7 @@ DEPENDENCIES
   net-smtp
   nkf
   ostruct
+  pathname
   pstore
   raap
   rake

--- a/core/gc.rbs
+++ b/core/gc.rbs
@@ -111,7 +111,7 @@ module GC
     # `:HAVE_FINALIZE`
     # :
     #
-    def self.raw_data: () -> Array[Hash[Symbol, untyped]]
+    def self.raw_data: () -> Array[Hash[Symbol, untyped]]?
 
     # <!--
     #   rdoc-file=gc.c

--- a/lib/rbs/unit_test/spy.rb
+++ b/lib/rbs/unit_test/spy.rb
@@ -20,6 +20,8 @@ module RBS
         attr_reader :object
         attr_reader :method_name
 
+        NO_RETURN = Object.new
+
         def initialize(object:, method_name:)
           @callback = -> (_) { }
           @object = object
@@ -39,7 +41,7 @@ module RBS
             define_method(
               spy.method_name,
               _ = -> (*args, &block) do
-                return_value = nil
+                return_value = NO_RETURN
                 exception = nil
                 block_calls = [] #: Array[Test::ArgumentsReturn]
 
@@ -105,7 +107,7 @@ module RBS
                       arguments: args,
                       exception: exception
                     )
-                  when return_value
+                  when ::RBS::UnitTest::Spy::WrapSpy::NO_RETURN != return_value
                     Test::ArgumentsReturn.return(
                       arguments: args,
                       value: return_value

--- a/sig/test/type_check.rbs
+++ b/sig/test/type_check.rbs
@@ -7,12 +7,12 @@ module RBS
       #
       # Returns an array with detected errors.
       #
-      def method_call: (Symbol, MethodType, CallTrace, errors: Array[Errors::t]) -> Array[Errors::t]
+      def method_call: (Symbol, MethodType, CallTrace, errors: Array[Errors::t], ?annotations: Array[AST::Annotation]) -> Array[Errors::t]
 
       # Test if given `value` is compatible to type
       #
       # Returns `true` if the value has the type.
-      # 
+      #
       def value: (untyped value, Types::t) -> bool
     end
   end

--- a/sig/unit_test/spy.rbs
+++ b/sig/unit_test/spy.rbs
@@ -5,6 +5,8 @@ module RBS
                    | [T, S] (untyped object, Symbol method_name) { (WrapSpy[T], T) -> S } -> S
 
       class WrapSpy[T]
+        NO_RETURN: Object
+
         attr_accessor callback: ^(Test::CallTrace) -> void
 
         attr_reader object: T

--- a/sig/unit_test/type_assertions.rbs
+++ b/sig/unit_test/type_assertions.rbs
@@ -104,6 +104,8 @@ module RBS
       #
       def class_class: () -> Class
 
+      def method_defs: (Symbol) -> Array[Definition::Method::TypeDef]
+
       def method_types: (Symbol) -> Array[MethodType]
 
       def allows_error: (*Exception) { () -> void } -> void

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -155,8 +155,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :at, 0
     assert_send_type "(ToInt) -> Integer",
                      [1,2,3], :at, ToInt.new(0)
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :at, ToInt.new(-5)
   end
 
   def test_bsearch
@@ -269,11 +267,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_delete_at
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :delete_at, 2
-    assert_send_type "(Integer) -> nil",
-                     [1,2,3], :delete_at, 100
-
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :delete_at, ToInt.new(300)
+    assert_send_type "(ToInt) -> Integer",
+                     [1,2,3], :delete_at, ToInt.new(2)
   end
 
   def test_delete_if
@@ -427,8 +422,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_first
     assert_send_type "() -> Integer",
                      [1,2,3], :first
-    assert_send_type "() -> nil",
-                     [], :first
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :first, 2
@@ -529,8 +522,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_last
     assert_send_type "() -> Integer",
                      [1,2,3], :last
-    assert_send_type "() -> nil",
-                     [], :last
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :last, 2
@@ -558,8 +549,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_max
     assert_send_type "() -> Integer",
                      [1,2,3], :max
-    assert_send_type "() -> nil",
-                     [], :max
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :max, 1
@@ -568,8 +557,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
 
     assert_send_type "() { (Integer, Integer) -> Integer } -> Integer",
                      [1,2,3], :max do |_, _| 1 end
-    assert_send_type "() { (Integer, Integer) -> Integer } -> nil",
-                     [], :max do |_, _| 0 end
 
     assert_send_type "(ToInt) { (Integer, Integer) -> Integer } -> Array[Integer]",
                      [1,2,3], :max, ToInt.new(2) do |_, _| 0 end
@@ -758,8 +745,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_sample
     assert_send_type "() -> Integer",
                      [1,2,3], :sample
-    assert_send_type "() -> nil",
-                     [], :sample
     assert_send_type "(random: Random) -> Integer",
                      [1,2,3], :sample, random: Random.new(1)
     assert_send_type "(random: Rand) -> Integer",
@@ -817,8 +802,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_slice
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :slice, 1
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :slice, ToInt.new(11)
 
     assert_send_type "(Integer, Integer) -> Array[Integer]",
                      [1,2,3], :slice, 1, 2
@@ -834,8 +817,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_slice!
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :slice!, 1
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :slice!, ToInt.new(11)
 
     assert_send_type "(Integer, Integer) -> Array[Integer]",
                      [1,2,3], :slice!, 1, 2

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -88,6 +88,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_aref
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :[], 0
+    assert_send_type "(Integer) -> nil",
+                     [1,2,3], :[], 1000
     assert_send_type "(Float) -> Integer",
                      [1,2,3], :[], 0.1
     assert_send_type "(ToInt) -> Integer",
@@ -155,6 +157,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :at, 0
     assert_send_type "(ToInt) -> Integer",
                      [1,2,3], :at, ToInt.new(0)
+    assert_send_type "(ToInt) -> nil",
+                     [1,2,3], :at, ToInt.new(-5)
   end
 
   def test_bsearch
@@ -267,8 +271,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_delete_at
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :delete_at, 2
-    assert_send_type "(ToInt) -> Integer",
-                     [1,2,3], :delete_at, ToInt.new(2)
+    assert_send_type "(Integer) -> nil",
+                     [1,2,3], :delete_at, 100
+
+    assert_send_type "(ToInt) -> nil",
+                     [1,2,3], :delete_at, ToInt.new(300)
   end
 
   def test_delete_if
@@ -422,6 +429,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_first
     assert_send_type "() -> Integer",
                      [1,2,3], :first
+    assert_send_type "() -> nil",
+                     [], :first
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :first, 2
@@ -522,6 +531,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_last
     assert_send_type "() -> Integer",
                      [1,2,3], :last
+    assert_send_type "() -> nil",
+                     [], :last
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :last, 2
@@ -549,6 +560,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_max
     assert_send_type "() -> Integer",
                      [1,2,3], :max
+    assert_send_type "() -> nil",
+                     [], :max
 
     assert_send_type "(Integer) -> Array[Integer]",
                      [1,2,3], :max, 1
@@ -557,6 +570,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
 
     assert_send_type "() { (Integer, Integer) -> Integer } -> Integer",
                      [1,2,3], :max do |_, _| 1 end
+    assert_send_type "() { (Integer, Integer) -> Integer } -> nil",
+                     [], :max do |_, _| 0 end
 
     assert_send_type "(ToInt) { (Integer, Integer) -> Integer } -> Array[Integer]",
                      [1,2,3], :max, ToInt.new(2) do |_, _| 0 end
@@ -745,6 +760,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_sample
     assert_send_type "() -> Integer",
                      [1,2,3], :sample
+    assert_send_type "() -> nil",
+                     [], :sample
     assert_send_type "(random: Random) -> Integer",
                      [1,2,3], :sample, random: Random.new(1)
     assert_send_type "(random: Rand) -> Integer",
@@ -779,6 +796,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1,2,3], :shift
     assert_send_type "(ToInt) -> Array[Integer]",
                      [1,2,3], :shift, ToInt.new(1)
+    assert_send_type "() -> nil",
+                     [], :shift
   end
 
   def test_shuffle
@@ -802,6 +821,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_slice
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :slice, 1
+    assert_send_type "(ToInt) -> nil",
+                     [1,2,3], :slice, ToInt.new(11)
 
     assert_send_type "(Integer, Integer) -> Array[Integer]",
                      [1,2,3], :slice, 1, 2
@@ -817,6 +838,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_slice!
     assert_send_type "(Integer) -> Integer",
                      [1,2,3], :slice!, 1
+    assert_send_type "(ToInt) -> nil",
+                     [1,2,3], :slice!, ToInt.new(11)
 
     assert_send_type "(Integer, Integer) -> Array[Integer]",
                      [1,2,3], :slice!, 1, 2

--- a/test/stdlib/MatchData_test.rb
+++ b/test/stdlib/MatchData_test.rb
@@ -23,23 +23,27 @@ class MatchDataInstanceTest < Test::Unit::TestCase
 
   def test_bytebegin
     if_ruby("3.4"...) do
-      with_backref do |backref|
-        assert_send_type  '(MatchData::capture) -> Integer',
-                          INSTANCE, :bytebegin, backref
-        assert_send_type  '(MatchData::capture) -> Integer',
-                          INSTANCE2, :bytebegin, backref
-      end
+      assert_send_type '(String) -> Integer',
+                       INSTANCE, :bytebegin, 'a'
+      assert_send_type '(Symbol) -> Integer',
+                       INSTANCE, :bytebegin, :a
+      assert_send_type '(Integer) -> Integer',
+                       INSTANCE2, :bytebegin, 0
+      assert_send_type '(Integer) -> nil',
+                       INSTANCE2, :bytebegin, 1
     end
   end
 
   def test_byteend
     if_ruby("3.4"...) do
-      with_backref do |backref|
-        assert_send_type  '(MatchData::capture) -> Integer',
-                          INSTANCE, :byteend, backref
-        assert_send_type  '(MatchData::capture) -> Integer',
-                          INSTANCE2, :byteend, backref
-      end
+      assert_send_type '(String) -> Integer',
+                       INSTANCE, :byteend, 'a'
+      assert_send_type '(Symbol) -> Integer',
+                       INSTANCE, :byteend, :a
+      assert_send_type '(Integer) -> Integer',
+                       INSTANCE2, :byteend, 0
+      assert_send_type '(Integer) -> nil',
+                       INSTANCE2, :byteend, 1
     end
   end
 

--- a/test/stdlib/ObjectSpace_WeakKeyMap_test.rb
+++ b/test/stdlib/ObjectSpace_WeakKeyMap_test.rb
@@ -76,8 +76,8 @@ class ObjectSpace_WeakKeyMapTest < Test::Unit::TestCase
     map["foo"] = 123
 
     assert_send_type(
-      "(::Integer) -> ::String",
-      map, :getkey, 123
+      "(::String) -> ::String",
+      map, :getkey, "foo"
     )
     assert_send_type(
       "(::String) -> nil",

--- a/test/stdlib/Symbol_test.rb
+++ b/test/stdlib/Symbol_test.rb
@@ -134,17 +134,12 @@ class SymbolInstanceTest < Test::Unit::TestCase
   def test_casecmp?
     %i[a A s S z Z].each do |other|
       assert_send_type '(Symbol) -> bool',
-                       :s, :casecmp?, other
+                        :s, :casecmp?, other
     end
-
-    # invalid encoding
-    assert_send_type '(Symbol) -> nil',
-                     '\u{e4 f6 fc}'.encode('ISO-8859-1').to_sym, :casecmp?, :'\u{c4 d6 dc}'
-
-    with_untyped.and :sym do |other|
-      assert_send_type '(untyped) -> bool?',
-                       :a, :casecmp?, other
-    end
+    assert_send_type '(String) -> nil',
+                     :abc, :casecmp?, "abc"
+    assert_send_type '(Integer) -> nil',
+                     :abc, :casecmp?, 1
   end
 
   def test_downcase
@@ -177,7 +172,7 @@ class SymbolInstanceTest < Test::Unit::TestCase
   def test_end_with?
     assert_send_type '() -> bool',
                      :a, :end_with?
-    
+
     with_string 'a' do |string_a|
       assert_send_type '(string) -> true',
                        :a, :end_with?, string_a


### PR DESCRIPTION
On the Ruby side, when `nil` is returned, `rbs/unit_test` interprets it as a break, which revealed that the return value was not being checked.
I have fixed this issue and also fixed the tests that depended on this issue.