### PR TITLE
Update Bundler to avoid permission error on GHA

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,6 +20,17 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+
+      # ucrt and mswin have the dev version Ruby.
+      # It introduce checksum mismatches for bundled gems. So remove them before `bundle install`
+      - name: Purge gem caches
+        run: |
+          ruby -e '
+            exit if "${{ matrix.ruby }}" != "ucrt" && "${{ matrix.ruby }}" != "mswin"
+            bundled_gems = Dir.glob("D:/ruby-${{ matrix.ruby }}/lib/ruby/gems/*/cache/*.gem")
+              .map { |path| File.basename(path, ".gem")[/^(.+)-[^-]+$/, 1] }
+            system "gem uninstall #{bundled_gems.join(" ")}", exception: true
+          '
       - name: bundle install
         run: |
           bundle config set without profilers libs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,4 +196,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.5.16
+   2.6.3

--- a/steep/Gemfile.lock
+++ b/steep/Gemfile.lock
@@ -76,4 +76,4 @@ DEPENDENCIES
   steep (~> 1.9.2)
 
 BUNDLED WITH
-   2.5.16
+   2.6.3


### PR DESCRIPTION
The following error happens in GHA and updating Bundler will solve it.

```
The installation path is insecure. Bundler cannot continue.
```

ref: https://github.com/rubygems/rubygems/issues/7983#issuecomment-2623808193



Also, this update causes the following error on Windows ucrt and mswin CI.


```
Bundler found mismatched checksums. This is a potential security risk.
net-smtp (0.5.0)
sha256=5fc0415e6ea1cc0b3dfea7270438ec22b278ca8d524986a3ae4e5ae8d087b42a
    from the API at https://rubygems.org/
net-smtp (0.5.0)
sha256=5040e34a1bbf11aa501e53d036d9c5e17a30004a08ed24304d7b1dc69c806c4d
    from the gem at D:/ruby-ucrt/lib/ruby/gems/3.5.0+0/cache/net-smtp-0.5.0.gem

If you trust the API at https://rubygems.org/, to resolve this issue you can:
1. remove the gem at
D:/ruby-ucrt/lib/ruby/gems/3.5.0+0/cache/net-smtp-0.5.0.gem
  2. run `bundle install`

To ignore checksum security warnings, disable checksum validation with
  `bundle config set --local disable_checksum_validation true`
```

Because their Rubies are the latest build. So, the bundled gems contain different content from the RubyGems' one.
To solve this problem, I updated the GHA to remove all bundled gems before `bundle install` on these CI.
