### PR TITLE
Fix type of `OpenSSL::BN` methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     psych (4.0.6)
       stringio
     public_suffix (6.0.1)
-    raap (1.1.0)
+    raap (1.2.0)
       rbs (~> 3.0)
       timeout (~> 0.4)
     racc (1.8.1)

--- a/Rakefile
+++ b/Rakefile
@@ -141,6 +141,7 @@ end
 task :raap => :compile do
   sh "ruby test/raap/core.rb"
   sh "ruby test/raap/digest.rb"
+  sh "ruby test/raap/openssl.rb"
 end
 
 task :rubocop do

--- a/Rakefile
+++ b/Rakefile
@@ -139,7 +139,8 @@ task :typecheck_test => :compile do
 end
 
 task :raap => :compile do
-  sh %q[ruby test/raap.rb | xargs bundle exec raap -r digest/bubblebabble --library digest --allow-private]
+  sh "ruby test/raap/core.rb"
+  sh "ruby test/raap/digest.rb"
 end
 
 task :rubocop do

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -1527,28 +1527,28 @@ module OpenSSL
     #   - bn % bn2 => aBN
     # -->
     #
-    def %: (int) -> instance
+    def %: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn * bn2 => aBN
     # -->
     #
-    def *: (int) -> instance
+    def *: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn ** bn2 => aBN
     # -->
     #
-    def **: (int) -> instance
+    def **: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn + bn2 => aBN
     # -->
     #
-    def +: (int) -> instance
+    def +: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1562,7 +1562,7 @@ module OpenSSL
     #   - bn - bn2 => aBN
     # -->
     #
-    def -: (int) -> instance
+    def -: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1577,7 +1577,7 @@ module OpenSSL
     # -->
     # Division of OpenSSL::BN instances
     #
-    def /: (int) -> [ instance, instance ]
+    def /: (bn) -> [ instance, instance ]
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1635,7 +1635,7 @@ module OpenSSL
     #   - bn.cmp(bn2) => integer
     # -->
     #
-    def cmp: (Integer) -> Integer
+    def cmp: (bn) -> Integer
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1650,7 +1650,7 @@ module OpenSSL
     #   - copy(p1)
     # -->
     #
-    def copy: (int) -> instance
+    def copy: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1666,7 +1666,7 @@ module OpenSSL
     #   - bn.gcd(bn2) => aBN
     # -->
     #
-    def gcd: (int) -> instance
+    def gcd: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1692,42 +1692,42 @@ module OpenSSL
     #   - bn.mod_add(bn1, bn2) -> aBN
     # -->
     #
-    def mod_add: (int, int) -> instance
+    def mod_add: (bn, bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn.mod_exp(bn1, bn2) -> aBN
     # -->
     #
-    def mod_exp: (int, int) -> instance
+    def mod_exp: (bn, bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn.mod_inverse(bn2) => aBN
     # -->
     #
-    def mod_inverse: (int) -> instance
+    def mod_inverse: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn.mod_mul(bn1, bn2) -> aBN
     # -->
     #
-    def mod_mul: (int, int) -> instance
+    def mod_mul: (bn, bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn.mod_sqr(bn2) => aBN
     # -->
     #
-    def mod_sqr: (int) -> instance
+    def mod_sqr: (bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
     #   - bn.mod_sub(bn1, bn2) -> aBN
     # -->
     #
-    def mod_sub: (int, int) -> instance
+    def mod_sub: (bn, bn) -> instance
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c
@@ -1868,7 +1868,7 @@ module OpenSSL
     #   - bn.ucmp(bn2) => integer
     # -->
     #
-    def ucmp: (int bn2) -> ::Integer
+    def ucmp: (bn bn2) -> ::Integer
 
     # <!--
     #   rdoc-file=ext/openssl/ossl_bn.c

--- a/test/raap/core.rb
+++ b/test/raap/core.rb
@@ -1,0 +1,11 @@
+require 'raap'
+
+argv = [
+  '--size-by', '2',
+  '--allow-private'
+]
+
+argv << 'Set[Integer]'
+argv << 'Enumerable[Integer]#to_set'
+
+RaaP::CLI.new(argv).load.run

--- a/test/raap/digest.rb
+++ b/test/raap/digest.rb
@@ -1,8 +1,11 @@
-# Specify the class/module and method names to be executed by RaaP.
-# By prefixing with `!`, you can skip testing a method.
+require 'raap'
 
-puts 'Set[Integer]'
-puts 'Enumerable[Integer]#to_set'
+argv = [
+  '-r', 'digest/bubblebabble',
+  '--library', 'digest',
+  '--size-by', '2',
+  '--allow-private'
+]
 
 %w[
   MD5
@@ -18,7 +21,7 @@ puts 'Enumerable[Integer]#to_set'
     digest
     hexdigest
   ].each do |singleton_method|
-    puts "Digest::#{klass}.#{singleton_method}"
+    argv << "Digest::#{klass}.#{singleton_method}"
   end
 
   %w[
@@ -47,6 +50,8 @@ puts 'Enumerable[Integer]#to_set'
     finish
     initialize_copy
   ].each do |instance_method|
-    puts "Digest::#{klass}##{instance_method}"
+    argv << "Digest::#{klass}##{instance_method}"
   end
 end
+
+RaaP::CLI.new(argv).load.run

--- a/test/raap/openssl.rb
+++ b/test/raap/openssl.rb
@@ -1,0 +1,36 @@
+require 'raap'
+
+RaaP::Type.register('OpenSSL::BN') do
+  sized do |size|
+    [:call, OpenSSL::BN, :new, [integer.pick(size: size)], {}, nil]
+  end
+end
+
+argv = [
+  '--require', 'openssl',
+  '--library', 'openssl',
+  '--size-by', '2',
+  '--log-level', 'info',
+]
+
+%w[
+  +
+  -
+  *
+  /
+  %
+  **
+  cmp
+  copy
+  gcd
+  mod_add
+  mod_exp
+  mod_mul
+  mod_sqr
+  mod_sub
+  ucmp
+].each do |instance_method|
+  argv << "OpenSSL::BN##{instance_method}"
+end
+
+RaaP::CLI.new(argv).load.run

--- a/test/stdlib/OpenSSL_test.rb
+++ b/test/stdlib/OpenSSL_test.rb
@@ -241,23 +241,25 @@ class OpenSSLBNTest < Test::Unit::TestCase
   library "openssl"
   testing "::OpenSSL::BN"
 
-  def test_operations
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :%, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :*, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :**, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :+, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :-, 2
-    assert_send_type "(::Integer) -> [OpenSSL::BN, OpenSSL::BN]",
-      OpenSSL::BN.new(2), :/, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :<<, 2
-    assert_send_type "(::Integer) -> OpenSSL::BN",
-      OpenSSL::BN.new(2), :>>, 2
+  def test_mod_inverse
+    assert_send_type "(OpenSSL::BN) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :mod_inverse, OpenSSL::BN.new(5)
+    assert_send_type "(Integer) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :mod_inverse, 5
+  end
+
+  def test_lshift
+    assert_send_type "(Integer) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :<<, 1
+    assert_send_type "(_ToInt) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :<<, ToInt.new(1)
+  end
+
+  def test_rshift
+    assert_send_type "(Integer) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :>>, 1
+    assert_send_type "(_ToInt) -> OpenSSL::BN",
+                     OpenSSL::BN.new(3), :>>, ToInt.new(1)
   end
 end
 


### PR DESCRIPTION
Several fixes to `OpenSSL::BN` method argument types.
All type errors were found by raap.
Therefore, the test should be run by raap.
For cases that are difficult to express with raap (e.g., numeric or string constraints), we will continue testing them with rbs/unit_test.

Additionally, I separated the executable files to allow running raap with different options.