### PR TITLE
core: Array#include? and Enumerable#include? should take non-Elem types

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2182,7 +2182,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def include?: (Elem object) -> bool
+  def include?: (untyped object) -> bool
 
   # <!-- rdoc-file=array.c -->
   # Returns the zero-based integer index of a specified element, or `nil`.

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -718,7 +718,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     {foo: 0, bar: 1, baz: 2}.include?('foo') # => false
   #     {foo: 0, bar: 1, baz: 2}.include?(0)     # => false
   #
-  def include?: (Elem arg0) -> bool
+  def include?: (untyped arg0) -> bool
 
   # <!--
   #   rdoc-file=enum.c

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -461,6 +461,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_include?
     assert_send_type "(Integer) -> bool",
                      [1,2,3], :include?, 1
+    assert_send_type "(Float) -> bool",
+                     [1,2,3], :include?, 1.0
   end
 
   def test_index

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -224,6 +224,13 @@ class EnumerableTest2 < Test::Unit::TestCase
                      TestEnumerable.new, :grep_v, '0' do 0 end
   end
 
+  def test_include?
+    assert_send_type "(String) -> bool",
+                     TestEnumerable.new, :include?, ''
+    assert_send_type "(Integer) -> bool",
+                     TestEnumerable.new, :include?, 1
+  end
+
   def test_inject
     assert_send_type "(String init, Symbol method) -> untyped", TestEnumerable.new, :inject, +'', :<<
     assert_send_type "(Symbol method) -> String", TestEnumerable.new, :inject, :+


### PR DESCRIPTION
For example, `Array[Integer]` can take other number types validly:

```
> [1, 2, 3].include? 2.0
=> true
> [1, 2, 3].include? Complex(2)
=> true
> [1, 2, 3].include? Rational(2)
=> true
```

refs: https://github.com/soutaro/steep/issues/1482