### PR TITLE
Reduce object creation during substitution

### DIFF
--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -30,6 +30,8 @@ module RBS
           end
 
           def sub(subst)
+            return self if subst.empty?
+
             update(method_type: self.method_type.sub(subst))
           end
 

--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -14,6 +14,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(
           parent_variable: parent_variable,
           type: type.sub(s),
@@ -142,6 +144,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(
           super_method: super_method&.sub(s),
           defs: defs.map {|defn| defn.update(type: defn.type.sub(s)) },
@@ -347,6 +351,8 @@ module RBS
     end
 
     def sub(s)
+      return self if s.empty?
+
       definition = self.class.new(type_name: type_name, self_type: _ = self_type.sub(s), ancestors: ancestors, entry: entry)
 
       definition.methods.merge!(methods.transform_values {|method| method.sub(s) })

--- a/lib/rbs/method_type.rb
+++ b/lib/rbs/method_type.rb
@@ -33,6 +33,8 @@ module RBS
     def sub(s)
       sub = s.without(*type_param_names)
 
+      return self if sub.empty?
+
       self.class.new(
         type_params: type_params.map do |param|
           param.map_type do |bound|

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -329,6 +329,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(name: name,
                        args: args.map {|ty| ty.sub(s) },
                        location: location)
@@ -371,6 +373,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(name: name,
                        args: args.map {|ty| ty.sub(s) },
                        location: location)
@@ -413,6 +417,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         Alias.new(name: name, args: args.map {|ty| ty.sub(s) }, location: location)
       end
 
@@ -469,6 +475,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(types: types.map {|ty| ty.sub(s) },
                        location: location)
       end
@@ -574,6 +582,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(
           all_fields: all_fields.transform_values {|ty, required| [ty.sub(s), required] },
           location: location
@@ -664,6 +674,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(type: type.sub(s), location: location)
       end
 
@@ -752,6 +764,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(types: types.map {|ty| ty.sub(s) },
                        location: location)
       end
@@ -841,6 +855,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(types: types.map {|ty| ty.sub(s) },
                        location: location)
       end
@@ -1093,6 +1109,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         map_type {|ty| ty.sub(s) }
       end
 
@@ -1272,6 +1290,8 @@ module RBS
       end
 
       def sub(subst)
+        return self if subst.empty?
+
         map_type { _1.sub(subst) }
       end
 
@@ -1346,6 +1366,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(
           type: type.sub(s),
           required: required,
@@ -1415,6 +1437,8 @@ module RBS
       end
 
       def sub(s)
+        return self if s.empty?
+
         self.class.new(
           type: type.sub(s),
           block: block&.sub(s),


### PR DESCRIPTION
The `#sub` method generates many objects, but in most classes, substitution does not occur at all. By modifying it so that no objects are created when there are no variables to substitute, we will optimize performance.

A side effect is that `#sub` no longer guarantees that a new object will be created.

## Benchmark

```rb
# validate.rb

require 'rbs'
require 'rbs/cli'
# require 'memory_profiler'

# MemoryProfiler.report do
  loader = RBS::EnvironmentLoader.new
  Dir["stdlib/*"].each do |path|
    lib = File.basename(path).to_s
    loader.add(library: lib, version: nil)
  end
  options = Data.define(:loader).new(loader:)
  RBS::CLI::Validate.new(args: [], options:).run
# end.pretty_print
```

```
$ time bundle exec ruby validate.rb
```

### Before

```
bundle exec ruby validate.rb  1.22s user 0.13s system 86% cpu 1.555 total
bundle exec ruby validate.rb  1.23s user 0.13s system 86% cpu 1.574 total
bundle exec ruby validate.rb  1.23s user 0.13s system 86% cpu 1.576 total
```

### After

```
bundle exec ruby validate.rb  1.00s user 0.13s system 82% cpu 1.374 total
bundle exec ruby validate.rb  1.00s user 0.13s system 84% cpu 1.334 total
bundle exec ruby validate.rb  1.00s user 0.13s system 84% cpu 1.335 total
```

## With memory_profiler

### Before

```
Total allocated: 309209155 bytes (3277248 objects)
Total retained:  191993 bytes (3441 objects)
```

### After

```
Total allocated: 190730219 bytes (1904943 objects)
Total retained:  191993 bytes (3441 objects)
```
