### PR TITLE
Remove case when `rubygems` and `set`

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -161,11 +161,6 @@ module RBS
           return if lockfile.gems.key?(name)
 
           case name
-          when 'rubygems', 'set'
-            msg = "`#{name}` has been moved to core library, so it is always loaded. Remove explicit loading `#{name}`"
-            msg << " from `#{from_gem}`" if from_gem
-            msg << "."
-            return
           when *ALUMNI_STDLIBS.keys
             version = ALUMNI_STDLIBS.fetch(name)
             if from_gem


### PR DESCRIPTION
This warnings have been removed from https://github.com/ruby/rbs/pull/2115 (v3.7.0).

This warning has been displayed since https://github.com/ruby/rbs/pull/1251 (v3.0.1) for about two years.  

Instead of restoring it, I propose removing it.