### PR TITLE
Fix CI failure on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,8 +27,12 @@ jobs:
         run: |
           ruby -e '
             exit if "${{ matrix.ruby }}" != "ucrt" && "${{ matrix.ruby }}" != "mswin"
-            bundled_gems = Dir.glob("D:/ruby-${{ matrix.ruby }}/lib/ruby/gems/*/cache/*.gem")
-              .map { |path| File.basename(path, ".gem")[/^(.+)-[^-]+$/, 1] }
+
+            require "open-uri"
+            require "json"
+
+            res = URI.parse("https://stdgems.org/bundled_gems.json").read
+            bundled_gems = JSON.parse(res)["gems"].map{_1["gem"]}
             system "gem uninstall #{bundled_gems.join(" ")}", exception: true
           '
       - name: bundle install


### PR DESCRIPTION
I worked on the Windows CI, but it was incomplete. https://github.com/ruby/rbs/pull/2265

So I tried fixing it again.


In the previous PR, it removes all bundled gems from Windows CI. But it finds gems from `lib/ruby/gems/*/cache/`. This directory includes non-bundled gems, like concurrent-ruby. These gems are added by [ruby-loco](https://github.com/MSP-Greg/ruby-loco) project perhaps. It introduced CI failure.


This PR fixes the problem by fetching the bundled gems list from stdgems.org. Then the CI process removes only bundled gems.
