### PR TITLE
Add bundled gems to alumnus 

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -4,7 +4,17 @@ module RBS
   module Collection
     class Config
       class LockfileGenerator
-        ALUMNI_STDLIBS = { "mutex_m" => ">= 0.3.0" }
+        ALUMNI_STDLIBS = {
+          "mutex_m" => ">= 0.3.0",
+          "abbrev" => nil,
+          "base64" => nil,
+          "bigdecimal" => nil,
+          "csv" => nil,
+          "minitest" => nil,
+          "net-smtp" => nil,
+          "nkf" => nil,
+          "observer" => nil,
+        }
 
         class GemfileLockMismatchError < StandardError
           def initialize(expected:, actual:)
@@ -165,15 +175,20 @@ module RBS
             # The `bigdecimal-math` is never released as a gem.
             # Therefore, `assign_gem` should not be called.
             RBS.logger.info {
-              "`#{name}` is included in the RBS dependencies of `#{from_gem}`, but the type definition as a stdlib in rbs-gem is deprecated. Delete `#{name}` from the RBS dependencies of `#{from_gem}`."
+              from = from_gem || "rbs_collection.yaml"
+              "`#{name}` is included in the RBS dependencies of `#{from}`, but the type definition as a stdlib in rbs-gem is deprecated. Delete `#{name}` from the RBS dependencies of `#{from}`."
             }
+            source = find_source(name: name)
+            if source&.is_a?(Sources::Stdlib)
+              lockfile.gems[name] = { name: name, version: "0", source: source }
+            end
             return
           when *ALUMNI_STDLIBS.keys
             version = ALUMNI_STDLIBS.fetch(name)
             if from_gem
               # From `dependencies:` of a `manifest.yaml` of a gem
               source = find_source(name: name) or raise
-              if source.is_a?(Sources::Stdlib)
+              if source.is_a?(Sources::Stdlib) && version
                 RBS.logger.warn {
                   "`#{name}` is included in the RBS dependencies of `#{from_gem}`, but the type definition as a stdlib in rbs-gem is deprecated. Add `#{name}` (#{version}) to the dependency of your Ruby program to use the gem-bundled type definition."
                 }
@@ -187,7 +202,11 @@ module RBS
             else
               # From `gems:` of a `rbs_collection.yaml`
               RBS.logger.warn {
-                "`#{name}` as a stdlib in rbs-gem is deprecated. Add `#{name}` (#{version}) to the dependency of your Ruby program to use the gem-bundled type definition."
+                if version
+                  "`#{name}` as a stdlib in rbs-gem is deprecated. Add `#{name}` (#{version}) to the dependency of your Ruby program to use the gem-bundled type definition."
+                else
+                  "`#{name}` as a stdlib in rbs-gem is deprecated. Delete `#{name}` from the RBS dependencies in your rbs_collection.yaml."
+                end
               }
             end
           end

--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -161,6 +161,13 @@ module RBS
           return if lockfile.gems.key?(name)
 
           case name
+          when 'bigdecimal-math'
+            # The `bigdecimal-math` is never released as a gem.
+            # Therefore, `assign_gem` should not be called.
+            RBS.logger.info {
+              "`#{name}` is included in the RBS dependencies of `#{from_gem}`, but the type definition as a stdlib in rbs-gem is deprecated. Delete `#{name}` from the RBS dependencies of `#{from_gem}`."
+            }
+            return
           when *ALUMNI_STDLIBS.keys
             version = ALUMNI_STDLIBS.fetch(name)
             if from_gem

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -4,7 +4,7 @@ module RBS
       class LockfileGenerator
         # Name of stdlibs that was rbs-bundled stdlib but is now a gem.
         #
-        ALUMNI_STDLIBS: Hash[String, String]
+        ALUMNI_STDLIBS: Hash[String, String?]
 
         class GemfileLockMismatchError < StandardError
           @expected: Pathname


### PR DESCRIPTION
Prepare to graduate bundled gems from the rbs repo.

The newly added gem has not been included in the gem repo itself, so its version cannot be specified.
Therefore, I set it to `nil`. Once it is added to the gem, I plan to specify the version accordingly.  

Since `bigdecimal-math` does not exist as a gem and is unlikely to exist in the future, adding it to `ALUMNI_STDLIBS` or not will lead to the same issue: when `bigdecimal-math` is removed from the RBS repository, it will fail midway because it cannot find a gem with the same name.  

To handle this, `bigdecimal-math` will receive special treatment—removing the specification will be encouraged, while still using it if it remains in the standard library.

## refs

* https://github.com/ruby/rbs/issues/2258
* https://github.com/ruby/gem_rbs_collection/pull/782