### PR TITLE
Validate superclass and module-self-type

### DIFF
--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -217,6 +217,7 @@ module RBS
             NoSuperclassFoundError.check!(super_name, env: env, location: primary.decl.location)
             if super_class
               InheritModuleError.check!(super_class, env: env)
+              InvalidTypeApplicationError.check2!(type_name: super_class.name, args: super_class.args, env: env, location: super_class.location)
             end
 
             super_entry = env.normalized_class_entry(super_name) or raise

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -244,6 +244,7 @@ module RBS
           else
             entry.self_types.each do |module_self|
               NoSelfTypeFoundError.check!(module_self, env: env)
+              InvalidTypeApplicationError.check2!(type_name: module_self.name, args: module_self.args, env: env, location: module_self.location)
 
               module_name = module_self.name
               if module_name.class?

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -671,7 +671,12 @@ end
 
 class E < D[Integer]
 end
+
+module F : D[Integer]
+end
 EOF
+
+
       manager.build do |env|
         builder = DefinitionBuilder::AncestorBuilder.new(env: env)
 
@@ -689,6 +694,10 @@ EOF
 
         assert_raises InvalidTypeApplicationError do
           builder.instance_ancestors(type_name("::E"))
+        end
+
+        assert_raises InvalidTypeApplicationError do
+          builder.instance_ancestors(type_name("::F"))
         end
       end
     end

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -665,6 +665,12 @@ end
 class C
   extend X
 end
+
+class D
+end
+
+class E < D[Integer]
+end
 EOF
       manager.build do |env|
         builder = DefinitionBuilder::AncestorBuilder.new(env: env)
@@ -679,6 +685,10 @@ EOF
 
         assert_raises InvalidTypeApplicationError do
           builder.singleton_ancestors(type_name("::C"))
+        end
+
+        assert_raises InvalidTypeApplicationError do
+          builder.instance_ancestors(type_name("::E"))
         end
       end
     end


### PR DESCRIPTION
I propose to validate for type application on the superclass and modules-self-type.
This change will allow users to quickly recognize this type specification error.

## Note

This change will cause Unexpected error in steep and needs to be corrected.
This is because `RBS::InvalidTypeApplicationError` is not expected to occur in certain cases.
https://github.com/soutaro/steep/blob/5705673a6ef631771cda36a77b4dc7c0294a3941/lib/steep/services/signature_service.rb#L297-L298