### PR TITLE
Exclude `attr_*` methods from duplicate checks.

### DIFF
--- a/lib/rbs/definition.rb
+++ b/lib/rbs/definition.rb
@@ -6,11 +6,13 @@ module RBS
       attr_reader :parent_variable
       attr_reader :type
       attr_reader :declared_in
+      attr_reader :source
 
-      def initialize(parent_variable:, type:, declared_in:)
+      def initialize(parent_variable:, type:, declared_in:, source:)
         @parent_variable = parent_variable
         @type = type
         @declared_in = declared_in
+        @source = source
       end
 
       def sub(s)
@@ -19,7 +21,8 @@ module RBS
         self.class.new(
           parent_variable: parent_variable,
           type: type.sub(s),
-          declared_in: declared_in
+          declared_in: declared_in,
+          source: source
         )
       end
     end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -340,31 +340,12 @@ module RBS
   end
 
   class InstanceVariableDuplicationError < VariableDuplicationError
-    def self.check!(variables:, member:, type_name:)
-      if old = variables[member.name]
-        if old.declared_in == type_name
-          raise new(member: member)
-        end
-      end
-    end
   end
 
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
-    def self.check!(variables:, member:, type_name:)
-      if old = variables[member.name]
-        if old.declared_in == type_name
-          raise new(member: member)
-        end
-      end
-    end
   end
 
   class ClassVariableDuplicationError < VariableDuplicationError
-    def self.check!(variables:, member:, type_name:)
-      if old = variables[member.name]
-        raise new(member: member)
-      end
-    end
   end
 
   class UnknownMethodAliasError < DefinitionError

--- a/sig/definition.rbs
+++ b/sig/definition.rbs
@@ -6,8 +6,15 @@ module RBS
       attr_reader parent_variable: Variable?
       attr_reader type: Types::t
       attr_reader declared_in: TypeName
+      type source = AST::Members::AttrAccessor
+                  | AST::Members::AttrReader
+                  | AST::Members::AttrWriter
+                  | AST::Members::InstanceVariable
+                  | AST::Members::ClassVariable
+                  | AST::Members::ClassInstanceVariable
+      attr_reader source: source
 
-      def initialize: (parent_variable: Variable?, type: Types::t, declared_in: TypeName) -> void
+      def initialize: (parent_variable: Variable?, type: Types::t, declared_in: TypeName, source: source) -> void
 
       def sub: (Substitution) -> Variable
     end

--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -105,7 +105,9 @@ module RBS
 
     def source_location: (Definition::Ancestor::Instance::source, AST::Declarations::t) -> Location[untyped, untyped]?
 
-    def insert_variable: (TypeName, Hash[Symbol, Definition::Variable], name: Symbol, type: Types::t) -> void
+    def validate_variable: (Definition::Variable) -> void
+
+    def insert_variable: (TypeName, Hash[Symbol, Definition::Variable], name: Symbol, type: Types::t, source: Definition::Variable::source) -> void
 
     # Add method definition to `methods`, which will be merged to `class_definition` after defining all methods at this *level* -- class, module, or interface
     #

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2730,6 +2730,12 @@ class InstanceVariableAttrInstanceVariable
   @instance: Integer
 end
 
+class ClassInstanceVariableSingletonAttrClassInstanceVariable
+  self.@class_instance: Integer
+  attr_accessor self.class_instance: Integer
+  self.@class_instance: Integer
+end
+
 class ClassInstanceVariable
   self.@class_instance: Integer
   self.@class_instance: Integer
@@ -2755,6 +2761,9 @@ end
         end
         assert_raises(RBS::InstanceVariableDuplicationError) do
           builder.build_instance(type_name("::InstanceVariableAttrInstanceVariable"))
+        end
+        assert_raises(RBS::ClassInstanceVariableDuplicationError) do
+          builder.build_singleton(type_name("::ClassInstanceVariableSingletonAttrClassInstanceVariable"))
         end
         assert_raises(RBS::ClassInstanceVariableDuplicationError) do
           builder.build_singleton(type_name("::ClassInstanceVariable"))

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2714,6 +2714,22 @@ class InstanceVariable
   @instance: Integer
 end
 
+class AttrInstanceVariable
+  attr_accessor instance: Integer
+  @instance: Integer
+end
+
+class InstanceVariableAttr
+  @instance: Integer
+  attr_accessor instance: Integer
+end
+
+class InstanceVariableAttrInstanceVariable
+  @instance: Integer
+  attr_accessor instance: Integer
+  @instance: Integer
+end
+
 class ClassInstanceVariable
   self.@class_instance: Integer
   self.@class_instance: Integer
@@ -2730,6 +2746,15 @@ end
 
         assert_raises(RBS::InstanceVariableDuplicationError) do
           builder.build_instance(type_name("::InstanceVariable"))
+        end
+        assert_nothing_raised do
+          builder.build_instance(type_name("::AttrInstanceVariable"))
+        end
+        assert_nothing_raised do
+          builder.build_instance(type_name("::InstanceVariableAttr"))
+        end
+        assert_raises(RBS::InstanceVariableDuplicationError) do
+          builder.build_instance(type_name("::InstanceVariableAttrInstanceVariable"))
         end
         assert_raises(RBS::ClassInstanceVariableDuplicationError) do
           builder.build_singleton(type_name("::ClassInstanceVariable"))


### PR DESCRIPTION
I will fix this since unintended duplicate checks were being performed.

## Before

```rb
# Error (not expected)
class Foo
  attr_accessor instance: Integer
  @instance: Integer
end

# No Error (expected)
class Foo
  @instance: Integer
  attr_accessor instance: Integer
end

# Error (expected)
class Foo
  @instance: Integer
  @instance: Integer
end
```

## After

```rb
# No Error (expected)
class Foo
  attr_accessor instance: Integer
  @instance: Integer
end

# No Error (expected)
class Foo
  @instance: Integer
  attr_accessor instance: Integer
end

# Error (expected)
class Foo
  @instance: Integer
  @instance: Integer
end
```
