### PR TITLE
Remove `nil` from the return type of `Module#name` and instead add the `%a{implicitly-returns-nil}` annotation

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -1164,7 +1164,7 @@ class Module < Object
   # -->
   # Returns the name of the module *mod*.  Returns `nil` for anonymous modules.
   #
-  def name: () -> String?
+  def name: %a{implicitly-returns-nil} () -> String
 
   # <!--
   #   rdoc-file=eval.c


### PR DESCRIPTION
Calling `Module#name` on an anonymous module or class is not a common use case, and I don’t see much benefit in always considering `nil`. Therefore, I believe using the `%a{implicitly-returns-nil}` annotation is appropriate.