### PR TITLE
Fix class variable

### DIFF
--- a/sig/definition_builder.rbs
+++ b/sig/definition_builder.rbs
@@ -107,7 +107,13 @@ module RBS
 
     def validate_variable: (Definition::Variable) -> void
 
-    def insert_variable: (TypeName, Hash[Symbol, Definition::Variable], name: Symbol, type: Types::t, source: Definition::Variable::source) -> void
+    def insert_variable: (
+      TypeName,
+      Hash[Symbol, Definition::Variable],
+      name: Symbol,
+      type: Types::t,
+      source: Definition::Variable::source
+    ) -> void
 
     # Add method definition to `methods`, which will be merged to `class_definition` after defining all methods at this *level* -- class, module, or interface
     #
@@ -144,11 +150,17 @@ module RBS
       Hash[Symbol, Definition::Method]? self_type_methods,
     ) -> void
 
-    # Updates `definition` with methods and variables of `type_name` that can be a module or a class
+    # Updates `definition` with methods and instance variables of `type_name` that can be a module or a class
     #
     # It processes includes and prepends recursively.
+    # If `define_class_vars:` is falsy, it skips inserting class variables.
     #
-    def define_instance: (Definition definition, TypeName type_name, Substitution subst) -> void
+    def define_instance: (
+      Definition definition,
+      TypeName type_name,
+      Substitution subst,
+      define_class_vars: bool
+    ) -> void
 
     # Updates `definition` with methods defined in an interface `type_name`
     #

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2706,6 +2706,104 @@ end
     end
   end
 
+  def test_class_var__mixin__include_defines_class_var
+    SignatureManager.new() do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+module M1
+  @@m1: Integer
+end
+
+class Foo
+  include M1
+end
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::Foo")).tap do |definition|
+          definition.class_variables[:@@m1].tap do |var|
+            assert_instance_of Definition::Variable, var
+            assert_equal type_name("::M1"), var.declared_in
+            assert_nil var.parent_variable
+            assert_equal "@@m1: Integer", var.source.location.source
+          end
+        end
+
+        builder.build_singleton(type_name("::Foo")).tap do |definition|
+          definition.class_variables[:@@m1].tap do |var|
+            assert_instance_of Definition::Variable, var
+            assert_equal type_name("::M1"), var.declared_in
+            assert_nil var.parent_variable
+            assert_equal "@@m1: Integer", var.source.location.source
+          end
+        end
+      end
+    end
+  end
+
+  def test_class_var__mixin__extend_no_class_var
+    SignatureManager.new() do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+module M1
+  @@m1: Integer
+end
+
+class Foo
+  extend M1
+end
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::Foo")).tap do |definition|
+          assert_nil definition.class_variables[:@@m1]
+        end
+
+        builder.build_singleton(type_name("::Foo")).tap do |definition|
+          assert_nil definition.class_variables[:@@m1]
+        end
+      end
+    end
+  end
+
+  def test_class_var__mixin__prepend_class_var
+    SignatureManager.new() do |manager|
+      manager.add_file("foo.rbs", <<-EOF)
+module M1
+  @@m1: Integer
+end
+
+class Foo
+  prepend M1
+end
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::Foo")).tap do |definition|
+          definition.class_variables[:@@m1].tap do |var|
+            assert_instance_of Definition::Variable, var
+            assert_equal type_name("::M1"), var.declared_in
+            assert_nil var.parent_variable
+            assert_equal "@@m1: Integer", var.source.location.source
+          end
+        end
+
+        builder.build_singleton(type_name("::Foo")).tap do |definition|
+          definition.class_variables[:@@m1].tap do |var|
+            assert_instance_of Definition::Variable, var
+            assert_equal type_name("::M1"), var.declared_in
+            assert_nil var.parent_variable
+            assert_equal "@@m1: Integer", var.source.location.source
+          end
+        end
+      end
+    end
+  end
+
   def test_duplicated_variable
     SignatureManager.new do |manager|
       manager.add_file("instance.rbs", <<-EOF)


### PR DESCRIPTION
This PR fixes class-variable accessibility, that is defined in modules and mixed-in to a class.

Class variables in modules are accessible to the class when the module is mixed-in by `include` or `prepend`, but not accessible when the module is `extend`-ed.