### PR TITLE
Reduce Array object allocation during parsing

### DIFF
--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1092,10 +1092,13 @@ static VALUE parse_intersection(parserstate *state) {
   rg.start = state->next_token.range.start;
 
   VALUE type = parse_optional(state);
-  VALUE intersection_types = rb_ary_new();
+  VALUE intersection_types = EMPTY_ARRAY;
 
-  rb_ary_push(intersection_types, type);
   while (state->next_token.type == pAMP) {
+    if (intersection_types == EMPTY_ARRAY) {
+      melt_array(&intersection_types);
+      rb_ary_push(intersection_types, type);
+    }
     parser_advance(state);
     rb_ary_push(intersection_types, parse_optional(state));
   }
@@ -1119,10 +1122,13 @@ VALUE parse_type(parserstate *state) {
   rg.start = state->next_token.range.start;
 
   VALUE type = parse_intersection(state);
-  VALUE union_types = rb_ary_new();
+  VALUE union_types = EMPTY_ARRAY;
 
-  rb_ary_push(union_types, type);
   while (state->next_token.type == pBAR) {
+    if (union_types == EMPTY_ARRAY) {
+      melt_array(&union_types);
+      rb_ary_push(union_types, type);
+    }
     parser_advance(state);
     rb_ary_push(union_types, parse_intersection(state));
   }

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -1088,29 +1088,24 @@ static VALUE parse_simple(parserstate *state) {
                  | {} <optional>
 */
 static VALUE parse_intersection(parserstate *state) {
-  range rg;
-  rg.start = state->next_token.range.start;
-
+  position start = state->next_token.range.start;
   VALUE type = parse_optional(state);
-  VALUE intersection_types = EMPTY_ARRAY;
+  if (state->next_token.type != pAMP) {
+    return type;
+  }
 
+  VALUE intersection_types = rb_ary_new();
+  rb_ary_push(intersection_types, type);
   while (state->next_token.type == pAMP) {
-    if (intersection_types == EMPTY_ARRAY) {
-      melt_array(&intersection_types);
-      rb_ary_push(intersection_types, type);
-    }
     parser_advance(state);
     rb_ary_push(intersection_types, parse_optional(state));
   }
-
-  rg.end = state->current_token.range.end;
-
-  if (rb_array_len(intersection_types) > 1) {
-    VALUE location = rbs_new_location(state->buffer, rg);
-    type = rbs_intersection(intersection_types, location);
-  }
-
-  return type;
+  range rg = (range) {
+    .start = start,
+    .end = state->current_token.range.end,
+  };
+  VALUE location = rbs_new_location(state->buffer, rg);
+  return rbs_intersection(intersection_types, location);
 }
 
 /*
@@ -1118,29 +1113,24 @@ static VALUE parse_intersection(parserstate *state) {
           | {} <intersection>
 */
 VALUE parse_type(parserstate *state) {
-  range rg;
-  rg.start = state->next_token.range.start;
-
+  position start = state->next_token.range.start;
   VALUE type = parse_intersection(state);
-  VALUE union_types = EMPTY_ARRAY;
+  if (state->next_token.type != pBAR) {
+    return type;
+  }
 
+  VALUE union_types = rb_ary_new();
+  rb_ary_push(union_types, type);
   while (state->next_token.type == pBAR) {
-    if (union_types == EMPTY_ARRAY) {
-      melt_array(&union_types);
-      rb_ary_push(union_types, type);
-    }
     parser_advance(state);
     rb_ary_push(union_types, parse_intersection(state));
   }
-
-  rg.end = state->current_token.range.end;
-
-  if (rb_array_len(union_types) > 1) {
-    VALUE location = rbs_new_location(state->buffer, rg);
-    type = rbs_union(union_types, location);
-  }
-
-  return type;
+  range rg = (range) {
+    .start = start,
+    .end = state->current_token.range.end,
+  };
+  VALUE location = rbs_new_location(state->buffer, rg);
+  return rbs_union(union_types, location);
 }
 
 /*


### PR DESCRIPTION
The most basic function for parsing a type, `parse_type`, always generates two Array objects each time it is executed.
However, for simple types, this Array object is not always needed, and the object allocation becomes unnecessary.

In this PR, I will make modifications to minimize unnecessary object allocations in `parse_type` as much as possible.

## Profile script

```rb
require 'rbs'
require 'rbs/cli'
require 'memory_profiler'

loader = RBS::EnvironmentLoader.new
Dir["stdlib/*"].each do |path|
  lib = File.basename(path).to_s
  loader.add(library: lib, version: nil)
end

MemoryProfiler.report do
  RBS::Environment.from_loader(loader)
end.pretty_print
```

Before

```
Total allocated: 49914684 bytes (453299 objects)
allocated memory by class: 3219256  Array
allocated objects by class: 70648  Array
```

After

```
Total allocated: 48873724 bytes (427275 objects)
allocated memory by class: 2178296  Array
allocated objects by class: 44624  Array
```
