### PR TITLE
No class variable duplication validation

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -575,10 +575,6 @@ module RBS
         if r.source.instance_of?(AST::Members::ClassInstanceVariable) && l.declared_in == r.declared_in
           raise ClassInstanceVariableDuplicationError.new(member: l.source)
         end
-      when AST::Members::ClassVariable
-        if r.source.instance_of?(AST::Members::ClassVariable)
-          raise ClassVariableDuplicationError.new(member: l.source)
-        end
       end
     end
 

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -345,9 +345,6 @@ module RBS
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
   end
 
-  class ClassVariableDuplicationError < VariableDuplicationError
-  end
-
   class UnknownMethodAliasError < DefinitionError
     include DetailedMessageable
 

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -193,11 +193,9 @@ module RBS
   end
 
   class InstanceVariableDuplicationError < VariableDuplicationError
-    def self.check!: (variables: Hash[Symbol, Definition::Variable], member: AST::Members::InstanceVariable, type_name: TypeName) -> void
   end
 
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
-    def self.check!: (variables: Hash[Symbol, Definition::Variable], member: AST::Members::ClassInstanceVariable, type_name: TypeName) -> void
   end
 
   class ClassVariableDuplicationError < VariableDuplicationError

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -198,10 +198,6 @@ module RBS
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
   end
 
-  class ClassVariableDuplicationError < VariableDuplicationError
-    def self.check!: (variables: Hash[Symbol, Definition::Variable], member: AST::Members::ClassVariable, type_name: TypeName) -> void
-  end
-
   # The `alias` member declares an alias from unknown method
   #
   class UnknownMethodAliasError < DefinitionError

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -2838,11 +2838,6 @@ class ClassInstanceVariable
   self.@class_instance: Integer
   self.@class_instance: Integer
 end
-
-class ClassVariable
-  @@class: Integer
-  @@class: Integer
-end
       EOF
 
       manager.build do |env|
@@ -2865,34 +2860,6 @@ end
         end
         assert_raises(RBS::ClassInstanceVariableDuplicationError) do
           builder.build_singleton(type_name("::ClassInstanceVariable"))
-        end
-        assert_raises(RBS::ClassVariableDuplicationError) do
-          builder.build_instance(type_name("::ClassVariable"))
-        end
-      end
-    end
-
-    SignatureManager.new do |manager|
-      manager.add_file("inherited.rbs", <<-EOF)
-class A
-  @instance: Integer
-  self.@class_instance: Integer
-  @@class: Integer
-end
-
-class B < A
-  @instance: Integer
-  self.@class_instance: Integer
-  @@class: Integer
-end
-      EOF
-
-      manager.build do |env|
-        builder = DefinitionBuilder.new(env: env)
-
-        builder.build_instance(type_name("::A"))
-        assert_raises(RBS::ClassVariableDuplicationError) do
-          builder.build_instance(type_name("::B"))
         end
       end
     end


### PR DESCRIPTION
This PR skips class variable duplication validation.

Class variable may be defined in `include`-ed modules, where the reference/assignment may cause a runtime error in Ruby. But, the implementation blocks `DefinitionBuilder#build_instance/singleton`. This is too early, while the error should be fixed before continuing type checks.

So, I think we need to overhaul class-variable implementation of RBS gem (maybe in 4.0?), and skips the validation for now. (Currently, class variables are managed in `Definition`, but in Ruby it's associated to *the inner-most class/module declaration*. This is a critical difference, and I don't want to work for class variable more before fixing it.)