### PR TITLE
Add information for VariableDuplicationError

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -569,11 +569,11 @@ module RBS
       case l.source
       when AST::Members::InstanceVariable
         if r.source.instance_of?(AST::Members::InstanceVariable) && l.declared_in == r.declared_in
-          raise InstanceVariableDuplicationError.new(member: l.source)
+          raise InstanceVariableDuplicationError.new(type_name: l.declared_in, variable_name: l.source.name, location: l.source.location)
         end
       when AST::Members::ClassInstanceVariable
         if r.source.instance_of?(AST::Members::ClassInstanceVariable) && l.declared_in == r.declared_in
-          raise ClassInstanceVariableDuplicationError.new(member: l.source)
+          raise ClassInstanceVariableDuplicationError.new(type_name: l.declared_in, variable_name: l.source.name, location: l.source.location)
         end
       end
     end

--- a/lib/rbs/errors.rb
+++ b/lib/rbs/errors.rb
@@ -325,24 +325,25 @@ module RBS
   class VariableDuplicationError < DefinitionError
     include DetailedMessageable
 
-    attr_reader :member
+    attr_reader :type_name
+    attr_reader :variable_name
+    attr_reader :location
 
-    def initialize(member:)
-      @member = member
+    def initialize(type_name:, variable_name:, location:)
+      @type_name = type_name
+      @variable_name = variable_name
+      @location = location
 
-      super "#{Location.to_string location}: Duplicated variable name #{member.name}"
-    end
-
-    def location
-      loc = @member.location or raise
-      loc[:name]
+      super "#{Location.to_string location}: Duplicated #{kind} variable name `#{variable_name}` in `#{type_name}`"
     end
   end
 
   class InstanceVariableDuplicationError < VariableDuplicationError
+    def kind = 'instance'
   end
 
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
+    def kind = 'class instance'
   end
 
   class UnknownMethodAliasError < DefinitionError

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -187,9 +187,9 @@ module RBS
 
     attr_reader type_name: TypeName
     attr_reader variable_name: Symbol
-    attr_reader location: Location[untyped, untyped]
+    attr_reader location: Location[untyped, untyped]?
 
-    def initialize: (type_name: TypeName, variable_name: Symbol, location: Location[untyped, untyped]) -> void
+    def initialize: (type_name: TypeName, variable_name: Symbol, location: Location[untyped, untyped]?) -> void
     def kind: () -> String
   end
 

--- a/sig/errors.rbs
+++ b/sig/errors.rbs
@@ -185,17 +185,20 @@ module RBS
   class VariableDuplicationError < DefinitionError
     include DetailedMessageable
 
-    attr_reader member: AST::Members::Var
+    attr_reader type_name: TypeName
+    attr_reader variable_name: Symbol
+    attr_reader location: Location[untyped, untyped]
 
-    def initialize: (member: AST::Members::Var) -> void
-
-    def location: () -> Location[bot, bot]
+    def initialize: (type_name: TypeName, variable_name: Symbol, location: Location[untyped, untyped]) -> void
+    def kind: () -> String
   end
 
   class InstanceVariableDuplicationError < VariableDuplicationError
+    def kind: () -> String
   end
 
   class ClassInstanceVariableDuplicationError < VariableDuplicationError
+    def kind: () -> String
   end
 
   # The `alias` member declares an alias from unknown method


### PR DESCRIPTION
To provide a more detailed message, I added information about which class/module the variable is defined in.
I would also like to offer a similar message at Steep.

```
$ bundle exec rbs -I sample.rbs validate
E, [2025-03-08T16:53:11.061295 #80748] ERROR -- rbs: sample.rbs:3:2...3:15: Duplicated instance variable name `@foo` in `::Foo` (RBS::InstanceVariableDuplicationError)

    @foo: Integer
    ^^^^^^^^^^^^^
```

```
$ bundle exec rbs -I sample.rbs validate
E, [2025-03-08T16:53:28.271229 #80802] ERROR -- rbs: sample.rbs:3:2...3:20: Duplicated class instance variable name `@foo` in `::Foo` (RBS::ClassInstanceVariableDuplicationError)

    self.@foo: Integer
    ^^^^^^^^^^^^^^^^^^
```