### PR TITLE
Add missing signature for IPAddr#netmask

### DIFF
--- a/stdlib/ipaddr/0/ipaddr.rbs
+++ b/stdlib/ipaddr/0/ipaddr.rbs
@@ -278,6 +278,14 @@ class IPAddr
 
   # <!--
   #   rdoc-file=lib/ipaddr.rb
+  #   - netmask()
+  # -->
+  # Returns the netmask in string format e.g. 255.255.0.0
+  #
+  def netmask: () -> String
+
+  # <!--
+  #   rdoc-file=lib/ipaddr.rb
   #   - prefix()
   # -->
   # Returns the prefix length in bits for the ipaddr.


### PR DESCRIPTION
## Problem

When I run Steep type checking on Ruby that includes calling `#netmask` on an instance of `IPAddr`, i.e., `IPAddr.new.netmask`, I see a no method error:

```sh
[error] Type `::IPAddr` does not have method `netmask`
│ Diagnostic ID: Ruby::NoMethod
```

## Fix

This pull request adds a type signature for `IPAddr#netmask` to return `String`.

~I’ve handwritten documentation for this change. Let me know if it should instead be generated by some task.~ I generated the doc with `rake annotate`—which created a large diff— but I only checked in the change for documenting `#netmask`.

* https://ruby-doc.org/3.4.1/stdlibs/ipaddr/IPAddr.html#method-i-netmask