### PR TITLE
Fix `define_method` method block self type

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -731,8 +731,8 @@ class Module < Object
   #     I'm Dino!
   #     #<B:0x401b39e8>
   #
-  def define_method: (interned symbol, ^() [self: self] -> untyped | Method | UnboundMethod method) -> Symbol
-                   | (interned symbol) { () [self: self] -> untyped } -> Symbol
+  def define_method: (interned symbol, ^(?) [self: top] -> untyped | Method | UnboundMethod method) -> Symbol
+                   | (interned symbol) { (?) [self: top] -> untyped } -> Symbol
 
   # <!--
   #   rdoc-file=object.c

--- a/ext/rbs_extension/parser.c
+++ b/ext/rbs_extension/parser.c
@@ -661,16 +661,16 @@ static void parse_function(parserstate *state, VALUE *function, VALUE *block, VA
     parser_advance_assert(state, pRPAREN);
   }
 
-  // Untyped method parameter means it cannot have block
-  if (rbs_is_untyped_params(&params)) {
-    if (state->next_token.type != pARROW) {
-      raise_syntax_error(state, state->next_token2, "A method type with untyped method parameter cannot have block");
-    }
-  }
-
   // Passing NULL to function_self_type means the function itself doesn't accept self type binding. (== method type)
   if (function_self_type) {
     *function_self_type = parse_self_type_binding(state);
+  } else {
+    // Parsing method type. untyped_params means it cannot have a block
+    if (rbs_is_untyped_params(&params)) {
+      if (state->next_token.type != pARROW) {
+        raise_syntax_error(state, state->next_token2, "A method type with untyped method parameter cannot have block");
+      }
+    }
   }
 
   VALUE required = Qtrue;

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -820,12 +820,6 @@ class RBS::ParserTest < Test::Unit::TestCase
     end
   end
 
-  def test_proc__untyped_function_parse_error
-    assert_raises(RBS::ParsingError) do
-      RBS::Parser.parse_type("^(?) { (?) -> void } -> Integer")
-    end
-  end
-
   def test__lex
     content = <<~RBS
       # LineComment

--- a/test/rbs/signature_parsing_test.rb
+++ b/test/rbs/signature_parsing_test.rb
@@ -2268,4 +2268,15 @@ end
       end
     end
   end
+
+  def test__method_type__untyped_function_and_block
+    assert_raises(RBS::ParsingError) do
+      Parser.parse_signature(<<~RBS).tap do |_, _, decls|
+          class Foo
+            def foo: (?) { () -> void } -> void
+          end
+        RBS
+      end
+    end
+  end
 end

--- a/test/rbs/type_parsing_test.rb
+++ b/test/rbs/type_parsing_test.rb
@@ -489,6 +489,23 @@ class RBS::TypeParsingTest < Test::Unit::TestCase
     end
   end
 
+  def test_untyped_proc_with_self
+    Parser.parse_type("^(?) -> void").yield_self do |type|
+      assert_instance_of Types::Proc, type
+      assert_instance_of Types::UntypedFunction, type.type
+      assert_equal "^(?) -> void", type.location.source
+      assert_nil type.self_type
+    end
+
+    Parser.parse_type("^(?) [self: String] -> void").yield_self do |type|
+      assert_instance_of Types::Proc, type
+      assert_instance_of Types::UntypedFunction, type.type
+
+      assert_equal "^(?) [self: String] -> void", type.location.source
+      assert_equal Parser.parse_type("String"), type.self_type
+    end
+  end
+
   def test_optional
     Parser.parse_type("untyped?").yield_self do |type|
       assert_instance_of Types::Optional, type


### PR DESCRIPTION
This PR also includes updating the parser to accept block-self-type hint after `(?)` parameter.