### PR TITLE
Forcibly uninstall gems even if there is a dependency problem.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,7 +33,7 @@ jobs:
 
             res = URI.parse("https://stdgems.org/bundled_gems.json").read
             bundled_gems = JSON.parse(res)["gems"].map{_1["gem"]}
-            system "gem uninstall #{bundled_gems.join(" ")}", exception: true
+            system "gem uninstall #{bundled_gems.join(" ")} --force", exception: true
           '
       - name: bundle install
         run: |


### PR DESCRIPTION
CI on Windows is down.

```
ERROR:  While executing gem ... (Gem::DependencyRemovalException)
    Uninstallation aborted due to dependent gem(s)
	D:/ruby-ucrt/lib/ruby/3.5.0+0/rubygems/uninstaller.rb:152:in 'Gem::Uninstaller#uninstall_gem'
	D:/ruby-ucrt/lib/ruby/3.5.0+0/rubygems/uninstaller.rb:138:in 'Gem::Uninstaller#uninstall'
	D:/ruby-ucrt/lib/ruby/3.5.0+0/rubygems/commands/uninstall_command.rb:202:in
```

It seems to be failing if the gem it is trying to remove has dependencies from other installed gems. (e.g. [timezone](https://github.com/panthomakos/timezone) dependent on base64)
Since these installed gems are unlikely to affect rbs's CI even if they don't work, I propose forcibly removing them.