### PR TITLE
Update rdoc to 6.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     rbs (4.0.0.dev)
       logger
+      rdoc (>= 6.13)
 
 PATH
   remote: test/assets/test-gem
@@ -93,7 +94,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.11.0)
+    rdoc (6.13.0)
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     rspec (3.13.0)

--- a/lib/rbs/annotate/formatter.rb
+++ b/lib/rbs/annotate/formatter.rb
@@ -81,10 +81,17 @@ module RBS
         end
       end
 
-      def self.translate(doc)
-        if doc.file
+      def self.translate(doc_or_comment)
+        if doc_or_comment.file
           formatter = RDoc::Markup::ToMarkdown.new
-          doc.accept(formatter).strip.lines.map(&:rstrip).join("\n")
+          case doc_or_comment
+          when RDoc::Markup::Document
+            doc_or_comment
+          when RDoc::Comment
+            doc_or_comment.parse
+          else
+            raise "Unexpected comment class: #{doc_or_comment.class}"
+          end.accept(formatter).strip.lines.map(&:rstrip).join("\n")
         end
       end
     end

--- a/lib/rbs/annotate/rdoc_source.rb
+++ b/lib/rbs/annotate/rdoc_source.rb
@@ -23,7 +23,7 @@ module RBS
         @stores.clear()
 
         RDoc::RI::Paths.each(with_system_dir, with_site_dir, with_home_dir, with_gems_dir ? :latest : false, *extra_dirs.map(&:to_s)) do |path, type|
-          store = RDoc::Store.new(path, type)
+          store = RDoc::Store.new(RDoc::Options.new, path:, type:)
           store.load_all
 
           @stores << store

--- a/lib/rdoc_plugin/parser.rb
+++ b/lib/rdoc_plugin/parser.rb
@@ -86,7 +86,7 @@ module RBS
       end
 
       def parse_method_alias_decl(decl:, context:, outer_name: nil)
-        alias_def = RDoc::Alias.new(nil, decl.old_name.to_s, decl.new_name.to_s, nil, decl.kind == :singleton)
+        alias_def = RDoc::Alias.new(nil, decl.old_name.to_s, decl.new_name.to_s, nil, singleton: decl.kind == :singleton)
         alias_def.comment = construct_comment(context: context, comment: comment_string(decl)) if decl.comment
         context.add_alias(alias_def)
       end
@@ -100,7 +100,7 @@ module RBS
              when ::RBS::AST::Members::AttrAccessor
                'RW'
              end
-        attribute = RDoc::Attr.new(nil, decl.name.to_s, rw, nil, decl.kind == :singleton)
+        attribute = RDoc::Attr.new(nil, decl.name.to_s, rw, nil, singleton: decl.kind == :singleton)
         attribute.visibility = decl.visibility
         attribute.comment = construct_comment(context: context, comment: comment_string(decl)) if decl.comment
         context.add_attribute(attribute)

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -46,4 +46,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 3.1"
   spec.add_dependency "logger"
+  spec.add_dependency "rdoc", '>= 6.13'
 end

--- a/sig/annotate/formatter.rbs
+++ b/sig/annotate/formatter.rbs
@@ -15,7 +15,7 @@ module RBS
 
       def format: (newline_at_end: bool) -> String
 
-      def self.translate: (RDoc::Markup::Document) -> String?
+      def self.translate: (RDoc::Markup::Document | RDoc::Comment) -> String?
 
       def self.each_part: (RDoc::Markup::Document | RDoc::Comment | String) { (RDoc::Markup::Document) -> void } -> void
                         | (RDoc::Markup::Document | RDoc::Comment | String) -> Enumerator[RDoc::Markup::Document, void]

--- a/stdlib/rdoc/0/comment.rbs
+++ b/stdlib/rdoc/0/comment.rbs
@@ -20,6 +20,8 @@ module RDoc
     #
     attr_accessor location: String
 
+    alias file location
+
     # <!--
     #   rdoc-file=lib/rdoc/comment.rb
     #   - new(text = nil, location = nil, language = nil)

--- a/stdlib/rdoc/0/options.rbs
+++ b/stdlib/rdoc/0/options.rbs
@@ -1,0 +1,6 @@
+%a{annotate:rdoc:skip}
+module RDoc
+  class Options
+    def initialize: (?untyped loaded_options) -> void
+  end
+end

--- a/stdlib/rdoc/0/rdoc.rbs
+++ b/stdlib/rdoc/0/rdoc.rbs
@@ -190,7 +190,7 @@ module RDoc
     #
     # Usually this is called by super from a subclass.
     #
-    def initialize: (String text, String name) -> void
+    def initialize: (String text, String name, ?singleton: bool) -> void
 
     # <!--
     #   rdoc-file=lib/rdoc/method_attr.rb
@@ -267,7 +267,7 @@ module RDoc
     # -->
     # Creates a new AnyMethod with a token stream `text` and `name`
     #
-    def initialize: (String? text, String name) -> void
+    def initialize: (String? text, String name, ?singleton: bool) -> void
   end
 
   # <!-- rdoc-file=lib/rdoc/attr.rb -->
@@ -286,7 +286,7 @@ module RDoc
     # Creates a new Attr with body `text`, `name`, read/write status `rw` and
     # `comment`.  `singleton` marks this as a class attribute.
     #
-    def initialize: (String? text, String name, String rw, RDoc::Comment? comment, ?bool `singleton`) -> void
+    def initialize: (String? text, String name, String rw, RDoc::Comment? comment, ?singleton: bool) -> void
   end
 
   # <!-- rdoc-file=lib/rdoc/constant.rb -->
@@ -372,6 +372,8 @@ module RDoc
     #
     attr_accessor old_name: String
 
+    attr_reader singleton: bool
+
     # <!--
     #   rdoc-file=lib/rdoc/alias.rb
     #   - new(text, old_name, new_name, comment, singleton = false)
@@ -379,7 +381,7 @@ module RDoc
     # Creates a new Alias with a token stream of `text` that aliases `old_name` to
     # `new_name`, has `comment` and is a `singleton` context.
     #
-    def initialize: (String? text, String name, String old_name, RDoc::Comment? comment, ?bool `singleton`) -> void
+    def initialize: (String? text, String name, String old_name, RDoc::Comment? comment, ?singleton: bool) -> void
   end
 
   # <!-- rdoc-file=lib/rdoc/stats.rb -->

--- a/stdlib/rdoc/0/store.rbs
+++ b/stdlib/rdoc/0/store.rbs
@@ -26,7 +26,7 @@ module RDoc
     # -->
     # Creates a new Store of `type` that will load or save to `path`
     #
-    def initialize: (?String? path, ?Symbol? type) -> void
+    def initialize: (Options, ?path: String? , ?type: Symbol?) -> void
 
     # <!--
     #   rdoc-file=lib/rdoc/store.rb

--- a/test/rbs/annotate/rdoc_source_test.rb
+++ b/test/rbs/annotate/rdoc_source_test.rb
@@ -57,10 +57,10 @@ end
       assert_equal 1, klss.size
       klss[0].tap do |klass|
         assert_predicate klass, :documented?
-        assert_equal 1, klass.comment.parts.size
+        assert_equal 1, klass.comment.parse.parts.size
 
         assert_nil RBS::Annotate::Formatter.translate(klass.comment)
-        assert_equal "Document for Hello1", RBS::Annotate::Formatter.translate(klass.comment.parts[0])
+        assert_equal "Document for Hello1", RBS::Annotate::Formatter.translate(klass.comment.parse.parts[0])
       end
     end
 
@@ -72,7 +72,7 @@ end
         refute_predicate klass, :documented?
 
         assert_nil RBS::Annotate::Formatter.translate(klass.comment)
-        assert_equal "", RBS::Annotate::Formatter.translate(klass.comment.parts[0])
+        assert_equal "", RBS::Annotate::Formatter.translate(klass.comment.parse.parts[0])
       end
     end
 
@@ -82,10 +82,10 @@ end
       assert_equal 1, klss.size
       klss[0].tap do |klass|
         assert_predicate klass, :documented?
-        assert_equal 2, klass.comment.parts.size
+        assert_equal 2, klass.comment.parse.parts.size
 
-        assert_equal "Document (1) for Hello3", RBS::Annotate::Formatter.translate(klass.comment.parts[0])
-        assert_equal "Document (2) for Hello3", RBS::Annotate::Formatter.translate(klass.comment.parts[1])
+        assert_equal "Document (1) for Hello3", RBS::Annotate::Formatter.translate(klass.comment.parse.parts[0])
+        assert_equal "Document (2) for Hello3", RBS::Annotate::Formatter.translate(klass.comment.parse.parts[1])
       end
     end
   end

--- a/test/rbs/rdoc/rbs_parser_test.rb
+++ b/test/rbs/rdoc/rbs_parser_test.rb
@@ -5,7 +5,7 @@ require "rdoc_plugin/parser"
 class RDocPluginParserTest < Test::Unit::TestCase
   def parser(content)
     top_level = RDoc::TopLevel.new("a.rbs")
-    top_level.store = RDoc::Store.new()
+    top_level.store = RDoc::Store.new(RDoc::Options.new)
 
     RBS::RDocPlugin::Parser.new(top_level, content)
   end


### PR DESCRIPTION
There are several breaking changes in RDoc.

* Interface of `RDoc::Store.new` has been changed.
    * https://github.com/ruby/rdoc/pull/1309
* Return value of `RDoc::Attr#comment` has been changed from `RDoc::Markup::Document` to `RDoc::Comment`.
    * https://github.com/ruby/rdoc/pull/1210
* Interface of `RDoc::Alias.new` has been changed
    * https://github.com/ruby/rdoc/pull/1312

This PR limits rdoc to **6.13** or higher to support these breaking changes.