### PR TITLE
Remove deprecated methods in `JSON`

### DIFF
--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1001,6 +1001,7 @@ module JSON
   #     opts = JSON.load_default_options
   #     opts # => {:max_nesting=>false, :allow_nan=>true, :allow_blank=>true, :create_additions=>true}
   #
+  %a{deprecated}
   def self.load_default_options: () -> options
 
   # <!-- rdoc-file=ext/json/lib/json/common.rb -->
@@ -1008,6 +1009,7 @@ module JSON
   #     opts = JSON.load_default_options
   #     opts # => {:max_nesting=>false, :allow_nan=>true, :allow_blank=>true, :create_additions=>true}
   #
+  %a{deprecated}
   def self.load_default_options=: (options) -> options
 
   # <!--

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -828,14 +828,6 @@ module JSON
 
   # <!--
   #   rdoc-file=ext/json/lib/json/common.rb
-  #   - iconv(to, from, string)
-  # -->
-  # Encodes string using String.encode.
-  #
-  def self.iconv: (encoding to, encoding from, String string) -> String
-
-  # <!--
-  #   rdoc-file=ext/json/lib/json/common.rb
   #   - JSON.load(source, proc = nil, options = {}) -> object
   # -->
   # Returns the Ruby objects created by parsing the given `source`.

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -780,6 +780,7 @@ module JSON
   #     # Raises SystemStackError (stack level too deep):
   #     JSON.fast_generate(a)
   #
+  %a{deprecated}
   def self?.fast_generate: (_ToJson obj, ?options opts) -> String
 
   # <!--

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -14,9 +14,6 @@ end
 class JSON::GeneratorError < JSON::JSONError
 end
 
-class JSON::UnparserError < JSON::GeneratorError
-end
-
 # <!-- rdoc-file=ext/json/lib/json/common.rb -->
 # This exception is raised if a parser error occurs.
 #

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1121,20 +1121,6 @@ module JSON
   #
   def self?.recurse_proc: (untyped result) { (*untyped) -> void } -> void
 
-  # <!--
-  #   rdoc-file=ext/json/lib/json/common.rb
-  #   - restore(source, proc = nil, options = nil)
-  # -->
-  #
-  alias self.restore self.load
-
-  # <!--
-  #   rdoc-file=ext/json/lib/json/common.rb
-  #   - restore(source, proc = nil, options = nil)
-  # -->
-  #
-  alias restore load
-
   # <!-- rdoc-file=ext/json/lib/json/common.rb -->
   # Sets or Returns the JSON generator state class that is used by JSON.
   #

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -962,7 +962,8 @@ module JSON
   #        #<Admin:0x00000000064c41f8
   #        @attributes={"type"=>"Admin", "password"=>"0wn3d"}>}
   #
-  def self?.load: (string | _ReadableIO | _Read source, ?Proc proc, ?options options) -> untyped
+  def self?.load: (string | _ReadableIO | _Read source, ?options options) -> untyped
+                | [T] (string | _ReadableIO | _Read source, ^(?) -> T, ?options options) -> T
 
   # <!--
   #   rdoc-file=ext/json/lib/json/common.rb
@@ -1109,11 +1110,6 @@ module JSON
   #     }
   #
   def self?.pretty_generate: (_ToJson obj, ?options opts) -> untyped
-
-  # Recursively calls passed *Proc* if the parsed data structure is an *Array* or
-  # *Hash*
-  #
-  def self?.recurse_proc: (untyped result) { (*untyped) -> void } -> void
 
   # <!-- rdoc-file=ext/json/lib/json/common.rb -->
   # Sets or Returns the JSON generator state class that is used by JSON.

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -780,10 +780,6 @@ module JSON
   #
   def self?.fast_generate: (_ToJson obj, ?options opts) -> String
 
-  alias self.fast_unparse self.fast_generate
-
-  alias fast_unparse fast_generate
-
   # <!--
   #   rdoc-file=ext/json/lib/json/common.rb
   #   - JSON.generate(obj, opts = nil) -> new_string

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -754,6 +754,7 @@ module JSON
   #     opts = JSON.dump_default_options
   #     opts # => {:max_nesting=>false, :allow_nan=>true}
   #
+  %a{deprecated}
   def self.dump_default_options: () -> options
 
   # <!-- rdoc-file=ext/json/lib/json/common.rb -->
@@ -761,6 +762,7 @@ module JSON
   #     opts = JSON.dump_default_options
   #     opts # => {:max_nesting=>false, :allow_nan=>true}
   #
+  %a{deprecated}
   def self.dump_default_options=: (options) -> options
 
   # <!--

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1157,6 +1157,7 @@ module Kernel
   # Outputs *objs* to STDOUT as JSON strings in the shortest form, that is in one
   # line.
   #
+  %a{deprecated}
   def j: (*_ToJson) -> nil
 
   # <!--
@@ -1166,6 +1167,7 @@ module Kernel
   # Outputs *objs* to STDOUT as JSON strings in a pretty format, with indentation
   # and over many lines.
   #
+  %a{deprecated}
   def jj: (*_ToJson) -> nil
 
   # <!--

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1116,10 +1116,6 @@ module JSON
   #
   def self?.pretty_generate: (_ToJson obj, ?options opts) -> untyped
 
-  alias self.pretty_unparse self.pretty_generate
-
-  alias pretty_unparse pretty_generate
-
   # Recursively calls passed *Proc* if the parsed data structure is an *Array* or
   # *Hash*
   #

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1130,10 +1130,6 @@ module JSON
   # Sets or Returns the JSON generator state class that is used by JSON.
   #
   def self.state=: (state) -> state
-
-  alias self.unparse self.generate
-
-  alias unparse generate
 end
 
 JSON::FAST_STATE_PROTOTYPE: JSON::state

--- a/test/stdlib/json/JSONKernel_test.rb
+++ b/test/stdlib/json/JSONKernel_test.rb
@@ -7,28 +7,6 @@ class JSONKernelInstanceTest < Test::Unit::TestCase
   library "json"
   testing "::Kernel"
 
-  def silent
-    orig_stdout = $stdout
-    $stdout = StringIO.new
-    yield
-  ensure
-    $stdout = orig_stdout
-  end
-
-  def test_j
-    silent do
-      assert_send_type("(Integer) -> nil", self, :j, 1)
-      assert_send_type("(Array[Integer]) -> nil", self, :j, [1, 2, 3])
-    end
-  end
-
-  def test_jj
-    silent do
-      assert_send_type("(Integer) -> nil", self, :jj, 1)
-      assert_send_type("(Array[Integer]) -> nil", self, :jj, [1, 2, 3])
-    end
-  end
-
   def test_JSON
     assert_send_type("(String) -> Hash[String, Integer]", self, :JSON, '{"a": 1}')
     assert_send_type("(Array[Integer]) -> String", self, :JSON, [1, 2, 3])

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -61,17 +61,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(ToJson, JsonWrite, Integer) -> JsonWrite", JSON, :dump, ToJson.new, JsonWrite.new, 100
   end
 
-  def test_dump_default_options
-    assert_send_type "() -> { max_nesting: false, allow_nan: true }", JSON, :dump_default_options
-  end
-
-  def test_dump_default_options_eq
-    assert_send_type "(max_nesting: false, allow_nan: true, allow_blank: true) -> { max_nesting: false, allow_nan: true, allow_blank: true }",
-                     JSON,
-                     :dump_default_options=,
-                     { max_nesting: false, allow_nan: true, allow_blank: true }
-  end
-
   def test_fast_generate
     assert_send_type "(ToJson) -> String", JSON, :fast_generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", JSON, :fast_generate, ToJson.new, { indent: "\t" }

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -114,14 +114,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     end
   end
 
-  def test_load_default_options
-    assert_send_type "() -> Hash[untyped, untyped]", JSON, :load_default_options
-  end
-
-  def test_load_default_options_eq
-    assert_send_type "(allow_nan: true) -> Hash[untyped, untyped]", JSON, :load_default_options=, { allow_nan: true }
-  end
-
   def test_parse
     assert_send_type "(String) -> 42", JSON, :parse, "42"
     assert_send_type "(_ToStr) -> 42", JSON, :parse, JsonToStr.new("42")

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -158,11 +158,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(ToJson, indent: String) -> String", JSON, :pretty_generate, ToJson.new, { indent: "\t" }
   end
 
-  def test_pretty_unparse
-    assert_send_type "(ToJson) -> String", JSON, :pretty_unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", JSON, :pretty_unparse, ToJson.new, { indent: "\t" }
-  end
-
   def test_recurse_proc
     assert_send_type "(Integer) { (Integer) -> void } -> void", JSON, :recurse_proc, 42 do |_i| end
   end
@@ -246,11 +241,6 @@ class JSONInstanceTest < Test::Unit::TestCase
   def test_pretty_generate
     assert_send_type "(ToJson) -> String", MyJSON.new, :pretty_generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :pretty_generate, ToJson.new, { indent: "\t" }
-  end
-
-  def test_pretty_unparse
-    assert_send_type "(ToJson) -> String", MyJSON.new, :pretty_unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :pretty_unparse, ToJson.new, { indent: "\t" }
   end
 
   def test_recurse_proc

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -77,11 +77,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(ToJson, indent: String) -> String", JSON, :fast_generate, ToJson.new, { indent: "\t" }
   end
 
-  def test_fast_unparse
-    assert_send_type "(ToJson) -> String", JSON, :fast_unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", JSON, :fast_unparse, ToJson.new, { indent: "\t" }
-  end
-
   def test_generate
     assert_send_type "(ToJson) -> String", JSON, :generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", JSON, :generate, ToJson.new, { indent: "\t" }
@@ -220,11 +215,6 @@ class JSONInstanceTest < Test::Unit::TestCase
   def test_fast_generate
     assert_send_type "(ToJson) -> String", MyJSON.new, :fast_generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :fast_generate, ToJson.new, { indent: "\t" }
-  end
-
-  def test_fast_unparse
-    assert_send_type "(ToJson) -> String", MyJSON.new, :fast_unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :fast_unparse, ToJson.new, { indent: "\t" }
   end
 
   def test_generate

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -61,11 +61,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(ToJson, JsonWrite, Integer) -> JsonWrite", JSON, :dump, ToJson.new, JsonWrite.new, 100
   end
 
-  def test_fast_generate
-    assert_send_type "(ToJson) -> String", JSON, :fast_generate, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", JSON, :fast_generate, ToJson.new, { indent: "\t" }
-  end
-
   def test_generate
     assert_send_type "(ToJson) -> String", JSON, :generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", JSON, :generate, ToJson.new, { indent: "\t" }
@@ -172,11 +167,6 @@ class JSONInstanceTest < Test::Unit::TestCase
     assert_send_type "(ToJson, JsonToWritableIO) -> JsonWrite", MyJSON.new, :dump, ToJson.new, JsonToWritableIO.new
     assert_send_type "(ToJson, JsonWrite) -> JsonWrite", MyJSON.new, :dump, ToJson.new, JsonWrite.new
     assert_send_type "(ToJson, JsonWrite, Integer) -> JsonWrite", MyJSON.new, :dump, ToJson.new, JsonWrite.new, 100
-  end
-
-  def test_fast_generate
-    assert_send_type "(ToJson) -> String", MyJSON.new, :fast_generate, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :fast_generate, ToJson.new, { indent: "\t" }
   end
 
   def test_generate

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -74,12 +74,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(singleton(JSON::Ext::Generator)) -> void", JSON, :generator=, JSON::Ext::Generator
   end
 
-  def test_iconv
-    assert_send_type "(Encoding, Encoding, String) -> String", JSON, :iconv, Encoding::UTF_8, Encoding::UTF_16, "".encode(Encoding::UTF_16)
-    assert_send_type "(String, String, String) -> String", JSON, :iconv, 'UTF-8', 'UTF-16', "".encode(Encoding::UTF_16)
-    assert_send_type "(_ToStr, _ToStr, String) -> String", JSON, :iconv, JsonToStr.new('UTF-8'), JsonToStr.new('UTF-16'), "".encode(Encoding::UTF_16)
-  end
-
   def test_load
     assert_send_type "(String) -> 42", JSON, :load, "42"
     assert_send_type "(_ToStr) -> 42", JSON, :load, JsonToStr.new("42")

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -169,11 +169,6 @@ class JSONSingletonTest < Test::Unit::TestCase
   def test_state_eq
     assert_send_type "(singleton(JSON::Ext::Generator::State)) -> singleton(JSON::Ext::Generator::State)", JSON, :state=, JSON::Ext::Generator::State
   end
-
-  def test_unparse
-    assert_send_type "(ToJson) -> String", JSON, :unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", JSON, :unparse, ToJson.new, { indent: "\t" }
-  end
 end
 
 class JSONInstanceTest < Test::Unit::TestCase
@@ -236,11 +231,6 @@ class JSONInstanceTest < Test::Unit::TestCase
 
   def test_recurse_proc
     assert_send_type "(Integer) { (Integer) -> void } -> void", MyJSON.new, :recurse_proc, 42 do |_i| end
-  end
-
-  def test_unparse
-    assert_send_type "(ToJson) -> String", MyJSON.new, :unparse, ToJson.new
-    assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :unparse, ToJson.new, { indent: "\t" }
   end
 
   def test_to_json_with_object

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -162,15 +162,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(Integer) { (Integer) -> void } -> void", JSON, :recurse_proc, 42 do |_i| end
   end
 
-  def test_restore
-    assert_send_type "(String) -> 42", JSON, :restore, "42"
-    assert_send_type "(_ToStr) -> 42", JSON, :restore, JsonToStr.new("42")
-    assert_send_type "(JsonToReadableIO) -> 42", JSON, :restore, JsonToReadableIO.new
-    assert_send_type "(JsonRead) -> 42", JSON, :restore, JsonRead.new
-    assert_send_type "(String, Proc) -> 42", JSON, :restore, "42", proc { }
-    assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", JSON, :restore, "42", proc { }, { alllow_nan: true }
-  end
-
   def test_state
     assert_send_type "() -> singleton(JSON::Ext::Generator::State)", JSON, :state
   end
@@ -245,15 +236,6 @@ class JSONInstanceTest < Test::Unit::TestCase
 
   def test_recurse_proc
     assert_send_type "(Integer) { (Integer) -> void } -> void", MyJSON.new, :recurse_proc, 42 do |_i| end
-  end
-
-  def test_restore
-    assert_send_type "(String) -> 42", MyJSON.new, :restore, "42"
-    assert_send_type "(_ToStr) -> 42", MyJSON.new, :restore, JsonToStr.new("42")
-    assert_send_type "(JsonToReadableIO) -> 42", MyJSON.new, :restore, JsonToReadableIO.new
-    assert_send_type "(JsonRead) -> 42", MyJSON.new, :restore, JsonRead.new
-    assert_send_type "(String, Proc) -> 42", MyJSON.new, :restore, "42", proc { }
-    assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", MyJSON.new, :restore, "42", proc { }, { alllow_nan: true }
   end
 
   def test_unparse

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -79,8 +79,8 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(_ToStr) -> 42", JSON, :load, JsonToStr.new("42")
     assert_send_type "(JsonToReadableIO) -> 42", JSON, :load, JsonToReadableIO.new
     assert_send_type "(JsonRead) -> 42", JSON, :load, JsonRead.new
-    assert_send_type "(String, Proc) -> 42", JSON, :load, "42", proc { }
-    assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", JSON, :load, "42", proc { }, { alllow_nan: true }
+    assert_send_type "(String, Proc) -> 42", JSON, :load, "42", proc { |a| a }
+    assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", JSON, :load, "42", proc { |a| a }, { alllow_nan: true }
   end
 
   def test_load_file
@@ -128,10 +128,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(ToJson, indent: String) -> String", JSON, :pretty_generate, ToJson.new, { indent: "\t" }
   end
 
-  def test_recurse_proc
-    assert_send_type "(Integer) { (Integer) -> void } -> void", JSON, :recurse_proc, 42 do |_i| end
-  end
-
   def test_state
     assert_send_type "() -> singleton(JSON::Ext::Generator::State)", JSON, :state
   end
@@ -168,15 +164,6 @@ class JSONInstanceTest < Test::Unit::TestCase
     assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :generate, ToJson.new, { indent: "\t" }
   end
 
-  def test_load
-    assert_send_type "(String) -> 42", MyJSON.new, :load, "42"
-    assert_send_type "(_ToStr) -> 42", MyJSON.new, :load, JsonToStr.new("42")
-    assert_send_type "(JsonToReadableIO) -> 42", MyJSON.new, :load, JsonToReadableIO.new
-    assert_send_type "(JsonRead) -> 42", MyJSON.new, :load, JsonRead.new
-    assert_send_type "(String, Proc) -> 42", MyJSON.new, :load, "42", proc { }
-    assert_send_type "(String, Proc, Hash[untyped, untyped]) -> 42", MyJSON.new, :load, "42", proc { }, { alllow_nan: true }
-  end
-
   def test_parse
     assert_send_type "(String) -> 42", MyJSON.new, :parse, "42"
     assert_send_type "(_ToStr) -> 42", MyJSON.new, :parse, JsonToStr.new("42")
@@ -192,10 +179,6 @@ class JSONInstanceTest < Test::Unit::TestCase
   def test_pretty_generate
     assert_send_type "(ToJson) -> String", MyJSON.new, :pretty_generate, ToJson.new
     assert_send_type "(ToJson, indent: String) -> String", MyJSON.new, :pretty_generate, ToJson.new, { indent: "\t" }
-  end
-
-  def test_recurse_proc
-    assert_send_type "(Integer) { (Integer) -> void } -> void", MyJSON.new, :recurse_proc, 42 do |_i| end
   end
 
   def test_to_json_with_object


### PR DESCRIPTION
Some methods have been removed in the JSON head.

- https://github.com/ruby/json/pull/773
- https://github.com/ruby/json/pull/774
- https://github.com/ruby/json/pull/775
- https://github.com/ruby/json/pull/778
- https://github.com/ruby/json/pull/779
- https://github.com/ruby/json/commit/27155b650066f941fe886419f63c43826188aa86

I have removed the deleted method signatures and tests.
In addition, methods that can be confirmed to be currently deprecated are annotated and tests are removed.