### PR TITLE
Support pattern argument for Enumerable#{all,any,none,one}?

### DIFF
--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -192,6 +192,11 @@
 #     find exactly one of each Hash entry.
 #
 module Enumerable[unchecked out Elem] : _Each[Elem]
+  %a{private}
+  interface _Pattern
+    def ===: (untyped) -> bool
+  end
+
   # <!--
   #   rdoc-file=enum.c
   #   - all?                  -> true or false
@@ -234,6 +239,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Related: #any?, #none? #one?.
   #
   def all?: () -> bool
+          | (_Pattern) -> bool
           | () { (Elem) -> boolish } -> bool
 
   # <!--
@@ -277,6 +283,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Related: #all?, #none?, #one?.
   #
   def any?: () -> bool
+          | (_Pattern) -> bool
           | () { (Elem) -> boolish } -> bool
 
   # <!--
@@ -1167,6 +1174,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Related: #one?, #all?, #any?.
   #
   def none?: () -> bool
+           | (_Pattern) -> bool
            | () { (Elem) -> boolish } -> bool
 
   # <!--
@@ -1210,6 +1218,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Related: #none?, #all?, #any?.
   #
   def one?: () -> bool
+          | (_Pattern) -> bool
           | () { (Elem) -> boolish } -> bool
 
   # <!--

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -241,4 +241,28 @@ class EnumerableTest2 < Test::Unit::TestCase
     assert_send_type '(ToInt n) -> ::Array[::String]' , TestEnumerable.new, :first, ToInt.new(42)
     assert_send_type '(ToInt n) -> ::Array[::String]' , TestEmptyEnumerable.new, :first, ToInt.new(42)
   end
+
+  def test_all_p
+    assert_send_type '() -> bool', TestEnumerable.new, :all?
+    assert_send_type '(Class) -> bool', TestEnumerable.new, :all?, String
+    assert_send_type '() { (String) -> bool } -> bool', TestEnumerable.new, :all? do |x| x == '0' end
+  end
+
+  def test_any_p
+    assert_send_type '() -> bool', TestEnumerable.new, :any?
+    assert_send_type '(Class) -> bool', TestEnumerable.new, :any?, String
+    assert_send_type '() { (String) -> bool } -> bool', TestEnumerable.new, :any? do |x| x == '0' end
+  end
+
+  def test_none_p
+    assert_send_type '() -> bool', TestEnumerable.new, :none?
+    assert_send_type '(Class) -> bool', TestEnumerable.new, :none?, String
+    assert_send_type '() { (String) -> bool } -> bool', TestEnumerable.new, :none? do |x| x == '0' end
+  end
+
+  def test_one_p
+    assert_send_type '() -> bool', TestEnumerable.new, :one?
+    assert_send_type '(Class) -> bool', TestEnumerable.new, :one?, String
+    assert_send_type '() { (String) -> bool } -> bool', TestEnumerable.new, :one? do |x| x == '0' end
+  end
 end


### PR DESCRIPTION
I have corrected the pattern that has been missed.

- https://rubyapi.org/3.4/o/enumerable#method-i-all-3F
- https://rubyapi.org/3.4/o/enumerable#method-i-any-3F
- https://rubyapi.org/3.4/o/enumerable#method-i-none-3F
- https://rubyapi.org/3.4/o/enumerable#method-i-one-3F