### PR TITLE
Fix subtraction of civar

### DIFF
--- a/lib/rbs/subtractor.rb
+++ b/lib/rbs/subtractor.rb
@@ -107,7 +107,9 @@ module RBS
       each_member(owner).any? do |m|
         case m
         when AST::Members::InstanceVariable
-          m.name == name
+          m.name == name && kind == :instance
+        when AST::Members::ClassInstanceVariable
+          m.name == name && kind == :singleton
         when AST::Members::Attribute
           ivar_name = m.ivar_name == false ? nil : m.ivar_name || :"@#{m.name}"
           ivar_name == name && m.kind == kind

--- a/test/rbs/subtractor_test.rb
+++ b/test/rbs/subtractor_test.rb
@@ -472,6 +472,34 @@ class RBS::SubtractorTest < Test::Unit::TestCase
     RBS
   end
 
+  def test_civar
+    decls = to_decls(<<~RBS)
+      class C
+        @v1: untyped
+        self.@v1: untyped
+        @v2: untyped
+        self.@v2: untyped
+      end
+    RBS
+
+    env = to_env(<<~RBS)
+      class C
+        self.@v1: untyped
+      end
+    RBS
+
+    subtracted = RBS::Subtractor.new(decls, env).call
+
+    assert_subtracted <<~RBS, subtracted
+      class C
+        @v1: untyped
+
+        @v2: untyped
+        self.@v2: untyped
+      end
+    RBS
+  end
+
   def test_cvar
     decls = to_decls(<<~RBS)
       class C


### PR DESCRIPTION
Fix https://github.com/ruby/rbs/issues/2277

I’ve fixed it to check the `kind`.