### PR TITLE
Suppress warnings during testing

### DIFF
--- a/lib/rbs/unit_test/convertibles.rb
+++ b/lib/rbs/unit_test/convertibles.rb
@@ -5,6 +5,7 @@ module RBS
     module Convertibles
       class BlankSlate < BasicObject
         instance_methods.each do |im|
+          next if im == :__id__
           next if im == :__send__
           undef_method im
         end

--- a/test/stdlib/BasicObject_test.rb
+++ b/test/stdlib/BasicObject_test.rb
@@ -29,16 +29,20 @@ class BasicObjectSingletonTest < Test::Unit::TestCase
   end
 
   def test___id__
-    assert_send_type  '() -> Integer',
-                      BOBJ, :__id__
+    suppress_warning do
+      assert_send_type  '() -> Integer',
+                        BOBJ, :__id__
+    end
   end
 
   def test___send__
-    with_interned :__send__ do |name|
-      assert_send_type  '(interned, *untyped, **untyped) -> untyped',
-                        BOBJ, :__send__, name, :__id__
-      assert_send_type  '(interned, *untyped, **untyped) { (*untyped, **untyped) -> untyped} -> untyped',
-                        BOBJ, :__send__, name, :instance_exec do _1 end
+    suppress_warning do
+      with_interned :__send__ do |name|
+        assert_send_type  '(interned, *untyped, **untyped) -> untyped',
+                          BOBJ, :__send__, name, :__id__
+        assert_send_type  '(interned, *untyped, **untyped) { (*untyped, **untyped) -> untyped} -> untyped',
+                          BOBJ, :__send__, name, :instance_exec do _1 end
+      end
     end
   end
 
@@ -69,5 +73,15 @@ class BasicObjectSingletonTest < Test::Unit::TestCase
   def test_instance_exec
     assert_send_type  '(*String) { (*String) [self: BasicObject] -> Integer } -> Integer',
                       BOBJ, :instance_exec, '1', '2' do |*x| x.join.to_i end
+  end
+
+  def suppress_warning
+    origstderr = $stderr
+    begin
+      $stderr = StringIO.new
+      yield
+    ensure
+      $stderr = origstderr
+    end
   end
 end

--- a/test/stdlib/Ripper_test.rb
+++ b/test/stdlib/Ripper_test.rb
@@ -13,7 +13,7 @@ class RipperSingletonTest < Test::Unit::TestCase
 
   def test_dedent_string
     assert_send_type "(::String input, ::int width) -> ::Integer",
-                     Ripper, :dedent_string, "", 0
+                     Ripper, :dedent_string, +"", 0
   end
 
   def test_lex
@@ -180,7 +180,7 @@ class RipperTest < Test::Unit::TestCase
 
   def test_dedent_string
     assert_send_type "(String input, Integer width) -> Integer",
-                     Ripper.new("def a; end"), :dedent_string, "", 0
+                     Ripper.new("def a; end"), :dedent_string, +"", 0
   end
 
   def test_warning


### PR DESCRIPTION
Suppress the following warnings during running `rake stdlib_test`.

```
rbs/lib/rbs/unit_test/convertibles.rb:9: warning: undefining '__id__' may cause serious problems
rbs/lib/rbs/unit_test/convertibles.rb:9: warning: redefining '__id__' may cause serious problems
rbs/lib/rbs/unit_test/spy.rb:41: warning: redefining '__send__' may cause serious problems
rbs/lib/rbs/unit_test/spy.rb:94: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```