### PR TITLE
Make IO.binread, IO.binwrite, IO.read and IO.write accept _ToPath

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2278,7 +2278,7 @@ class IO < Object
   # potential security vulnerabilities if called with untrusted input; see
   # [Command Injection](rdoc-ref:command_injection.rdoc).
   #
-  def self.binread: (_ToPath | string name, ?Integer? length, ?Integer offset) -> String
+  def self.binread: (path name, ?Integer? length, ?Integer offset) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2291,7 +2291,7 @@ class IO < Object
   # potential security vulnerabilities if called with untrusted input; see
   # [Command Injection](rdoc-ref:command_injection.rdoc).
   #
-  def self.binwrite: (_ToPath | string name, _ToS string, ?Integer offset, ?mode: String mode) -> Integer
+  def self.binwrite: (path name, _ToS string, ?Integer offset, ?mode: String mode) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -2716,7 +2716,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.read: (_ToPath | string name, ?Integer? length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
+  def self.read: (path name, ?Integer? length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2986,7 +2986,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.write: (_ToPath | string path, _ToS data, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> Integer
+  def self.write: (path path, _ToS data, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> Integer
 
   # <!--
   #   rdoc-file=io.c

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -2278,7 +2278,7 @@ class IO < Object
   # potential security vulnerabilities if called with untrusted input; see
   # [Command Injection](rdoc-ref:command_injection.rdoc).
   #
-  def self.binread: (String name, ?Integer? length, ?Integer offset) -> String
+  def self.binread: (_ToPath | string name, ?Integer? length, ?Integer offset) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2291,7 +2291,7 @@ class IO < Object
   # potential security vulnerabilities if called with untrusted input; see
   # [Command Injection](rdoc-ref:command_injection.rdoc).
   #
-  def self.binwrite: (String name, _ToS string, ?Integer offset, ?mode: String mode) -> Integer
+  def self.binwrite: (_ToPath | string name, _ToS string, ?Integer offset, ?mode: String mode) -> Integer
 
   # <!--
   #   rdoc-file=io.c
@@ -2716,7 +2716,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.read: (String name, ?Integer? length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
+  def self.read: (_ToPath | string name, ?Integer? length, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> String
 
   # <!--
   #   rdoc-file=io.c
@@ -2986,7 +2986,7 @@ class IO < Object
   # *   [Open Options](rdoc-ref:IO@Open+Options).
   # *   [Encoding options](rdoc-ref:encodings.rdoc@Encoding+Options).
   #
-  def self.write: (String path, _ToS data, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> Integer
+  def self.write: (_ToPath | string path, _ToS data, ?Integer offset, ?external_encoding: String | Encoding | nil, ?internal_encoding: String | Encoding | nil, ?encoding: String | Encoding | nil, ?textmode: boolish, ?binmode: boolish, ?autoclose: boolish, ?mode: String) -> Integer
 
   # <!--
   #   rdoc-file=io.c

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -11,6 +11,8 @@ class IOSingletonTest < Test::Unit::TestCase
   def test_binread
     assert_send_type "(String) -> String",
                      IO, :binread, File.expand_path(__FILE__)
+    assert_send_type "(Pathname) -> String",
+                     IO, :binread, Pathname(File.expand_path(__FILE__))
     assert_send_type "(String, Integer) -> String",
                      IO, :binread, File.expand_path(__FILE__), 3
     assert_send_type "(String, Integer, Integer) -> String",
@@ -26,6 +28,8 @@ class IOSingletonTest < Test::Unit::TestCase
 
       assert_send_type "(String, String) -> Integer",
                        IO, :binwrite, filename, content
+      assert_send_type "(Pathname, String) -> Integer",
+                       IO, :binwrite, Pathname(filename), content
       assert_send_type "(String, String, Integer) -> Integer",
                        IO, :binwrite, filename, content, 0
       assert_send_type "(String, String, mode: String) -> Integer",
@@ -38,6 +42,8 @@ class IOSingletonTest < Test::Unit::TestCase
   def test_read
     assert_send_type "(String) -> String",
                      IO, :read, File.expand_path(__FILE__)
+    assert_send_type "(Pathname) -> String",
+                     IO, :read, Pathname(File.expand_path(__FILE__))
     assert_send_type "(String, Integer) -> String",
                      IO, :read, File.expand_path(__FILE__), 3
     assert_send_type "(String, Integer, Integer) -> String",
@@ -51,6 +57,8 @@ class IOSingletonTest < Test::Unit::TestCase
 
       assert_send_type "(String, String) -> Integer",
                        IO, :write, filename, content
+      assert_send_type "(Pathname, String) -> Integer",
+                       IO, :write, Pathname(filename), content
       assert_send_type "(String, String, Integer) -> Integer",
                        IO, :write, filename, content, 0
       assert_send_type "(String, String, mode: String) -> Integer",

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -35,6 +35,31 @@ class IOSingletonTest < Test::Unit::TestCase
     end
   end
 
+  def test_read
+    assert_send_type "(String) -> String",
+                     IO, :read, File.expand_path(__FILE__)
+    assert_send_type "(String, Integer) -> String",
+                     IO, :read, File.expand_path(__FILE__), 3
+    assert_send_type "(String, Integer, Integer) -> String",
+                     IO, :read, File.expand_path(__FILE__), 3, 0
+  end
+
+  def test_write
+    Dir.mktmpdir do |dir|
+      filename = File.join(dir, "some_file")
+      content = "foo"
+
+      assert_send_type "(String, String) -> Integer",
+                       IO, :write, filename, content
+      assert_send_type "(String, String, Integer) -> Integer",
+                       IO, :write, filename, content, 0
+      assert_send_type "(String, String, mode: String) -> Integer",
+                       IO, :write, filename, content, mode: "a"
+      assert_send_type "(String, String, Integer, mode: String) -> Integer",
+                       IO, :write, filename, content, 0, mode: "a"
+    end
+  end
+
   def test_open
     Dir.mktmpdir do |dir|
       assert_send_type "(Integer) -> IO",


### PR DESCRIPTION
Hi,

I found `IO.binread`, `IO.binwrite`, `IO.read` and `IO.write`'s signatures don't allow `Pathname` for the first argument and fixed it.

Thanks.