### PR TITLE
Suppress to GCC warning with multi-line comment

### DIFF
--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -18,14 +18,15 @@ Init_rbs_extension(void)
   rbs__init_location();
   rbs__init_parser();
 
-  // Calculated based on the number of unique strings used with the `INTERN` macro in `parser.c`.
-  //
-  // ```bash
-  // grep -o 'INTERN("\([^"]*\)")' ext/rbs_extension/parser.c \
-  //     | sed 's/INTERN("\(.*\)")/\1/' \
-  //     | sort -u \
-  //     | wc -l
-  // ```
+  /* Calculated based on the number of unique strings used with the `INTERN` macro in `parser.c`.
+   *
+   * ```bash
+   * grep -o 'INTERN("\([^"]*\)")' ext/rbs_extension/parser.c \
+   *     | sed 's/INTERN("\(.*\)")/\1/' \
+   *     | sort -u \
+   *     | wc -l
+   * ```
+   */
   const size_t num_uniquely_interned_strings = 26;
   rbs_constant_pool_init(RBS_GLOBAL_CONSTANT_POOL, num_uniquely_interned_strings);
 


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/debian11/ruby-master/log/20250404T003003Z.log.html.gz shows compilation warning with `main.c`.

```
main.c: In function ‘Init_rbs_extension’:
main.c:24:3: warning: multi-line comment [-Wcomment]
   24 |   // grep -o 'INTERN("\([^"]*\)")' ext/rbs_extension/parser.c \
      |   ^
```

I replaced that comment with `/* */` style. I'm not sure this is good for that.