### PR TITLE
Restore RBS::Environment#declarations for backwards-compatibility

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -11,6 +11,10 @@ module RBS
 
     attr_reader :sources
 
+    def declarations
+      sources.flat_map(&:declarations)
+    end
+
     class SingleEntry
       attr_reader :name
       attr_reader :context

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -31,7 +31,7 @@ module RBS
     end
 
     # Top level declarations
-    attr_reader declarations: Array[AST::Declarations::t]
+    def declarations: () -> Array[AST::Ruby::Declarations::t | AST::Declarations::t]
 
     # Array of source objects loaded in the environment
     #

--- a/sig/environment.rbs
+++ b/sig/environment.rbs
@@ -30,6 +30,9 @@ module RBS
     class GlobalEntry < SingleEntry[Symbol, AST::Declarations::Global]
     end
 
+    # Top level declarations
+    attr_reader declarations: Array[AST::Declarations::t]
+
     # Array of source objects loaded in the environment
     #
     attr_reader sources: Array[Source::t]


### PR DESCRIPTION
RBS::Environment#declarations was removed recently in favor of a more flexible interface in RBS::Environment#declarations

I'd like to restore RBS::Environment#declarations as a simplified consumer of RBS::Environment#declarations so that current users of the rbs gem are not broken by this change.

In particular, the situation I am facing:

1. [Solargraph](https://github.com/castwide/solargraph) is a user of the rbs gem to pull in RBS types to work alongside YARD-style types.

2. Solargraph is striving to maintain compatibility with Ruby 3.0, and thus we'd like to support older versions of the rbs gem, given the requirement of Ruby 3.1 for the current rbs gem.

3. Solargraph uses RBS::Environment#declarations - the code which uses RBS::Environment#declarations is here: https://github.com/castwide/solargraph/blob/master/lib/solargraph/rbs_map/conversions.rb

Would you accept this small shim to maintain compatibility, or perhaps advise on how we can prepare for the new version by switching to a more stable API?  I'm not sure if you intended this function to be used from the outside world.

BTW, very excited to see the current work landing--looks very interesting for everyone  🎉 