### PR TITLE
Remove unused code path from trailing_block methods

### DIFF
--- a/lib/rbs/inline_parser/comment_association.rb
+++ b/lib/rbs/inline_parser/comment_association.rb
@@ -60,21 +60,15 @@ module RBS
         end
       end
 
-      def trailing_block(node)
-        location =
-          if node.is_a?(Prism::Node)
-            node.location
-          else
-            node
-          end #: Prism::Location
+      def trailing_block(location)
         end_line = location.end_line
         if block = start_line_map.fetch(end_line, nil)
           Reference.new(block, associated_blocks)
         end
       end
 
-      def trailing_block!(node)
-        if ref = trailing_block(node)
+      def trailing_block!(location)
+        if ref = trailing_block(location)
           unless ref.associated?
             ref.associate!.block
           end

--- a/sig/inline_parser/comment_association.rbs
+++ b/sig/inline_parser/comment_association.rbs
@@ -47,13 +47,13 @@ module RBS
       #
       # Update association status.
       #
-      def trailing_block!: (Prism::Node | Prism::Location) -> CommentBlock?
+      def trailing_block!: (Prism::Location) -> CommentBlock?
 
       # Returns a Reference that is associated to given node, or by its location
       #
       # Updates association explicitly through the reference.
       #
-      def trailing_block: (Prism::Node | Prism::Location) -> Reference?
+      def trailing_block: (Prism::Location) -> Reference?
 
       # Yields leading CommentBlocks that is enclosed in the given node
       #


### PR DESCRIPTION
The `trailing_block!` method is only called in one place:

```
end_loc = node.rparen_loc || node.parameters&.location || node.name_loc
```

And all three possible values for `end_loc` are of type `Prism::Location`, so the `trailing_block!` method's implementation and signature can be simplified to only handle `Prism::Location`.