### PR TITLE
Use `erb` instead of `set` for load path testing

### DIFF
--- a/test/stdlib/global_variables_test.rb
+++ b/test/stdlib/global_variables_test.rb
@@ -262,7 +262,7 @@ class GlobalVariablesTest < Test::Unit::TestCase
     # is a singleton method), we can't use `assert_send_type` and must use `assert_type`.
     loadpath = eval(gvar.to_s)
 
-    with_path 'set' do |path|
+    with_path 'erb' do |path|
       assert_type '[:rb | :so, String]', loadpath.resolve_feature_path(path)
     end
 


### PR DESCRIPTION
The recent CI failure seems to be related to https://github.com/ruby/ruby/pull/13074. So changing the testing target to `erb` should resolve it.