### PR TITLE
Fix error at Ruby CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -106,3 +106,31 @@ jobs:
       - run: bundle exec rake test:valgrind
         env:
           RUBY_FREE_AT_EXIT: 1
+  C99_compile:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.4', head]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          brew install ruby-build
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: none
+      - name: Set working directory as safe
+        run: git config --global --add safe.directory $(pwd)
+      - name: Update rubygems & bundler
+        run: |
+          ruby -v
+          gem update --system
+      - name: clang version
+        run: clang --version
+      - name: bin/setup
+        run: |
+          bin/setup
+      - run: bundle exec rake clean compile_c99
+

--- a/Rakefile
+++ b/Rakefile
@@ -437,3 +437,11 @@ task :changelog do
     puts "  (🤑 There is no *unreleased* pull request associated to the milestone.)"
   end
 end
+
+desc "Compile extension without C23 extensions"
+task :compile_c99 do
+  ENV["TEST_NO_C23"] = "true"
+  Rake::Task[:"compile"].invoke
+ensure
+  ENV.delete("TEST_NO_C23")
+end

--- a/ext/rbs_extension/ast_translation.c
+++ b/ext/rbs_extension/ast_translation.c
@@ -1146,4 +1146,6 @@ VALUE rbs_struct_to_ruby_value(rbs_translation_context_t ctx, rbs_node_t *instan
             return ID2SYM(rb_intern3((const char *) constant->start, constant->length, ctx.encoding));
         }
     }
+
+    rb_raise(rb_eRuntimeError, "Unknown node type: %d", instance->type);
 }

--- a/ext/rbs_extension/ast_translation.h
+++ b/ext/rbs_extension/ast_translation.h
@@ -8,8 +8,12 @@
 #ifndef RBS_EXTENSION_AST_TRANSLATION_H
 #define RBS_EXTENSION_AST_TRANSLATION_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
 #include "ruby/encoding.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 #include "rbs/ast.h"
 #include "rbs/location.h"

--- a/ext/rbs_extension/class_constants.h
+++ b/ext/rbs_extension/class_constants.h
@@ -8,7 +8,11 @@
 #ifndef RBS__CONSTANTS_H
 #define RBS__CONSTANTS_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 extern VALUE RBS;
 

--- a/ext/rbs_extension/compat.h
+++ b/ext/rbs_extension/compat.h
@@ -1,0 +1,10 @@
+#ifdef __clang__
+#define SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN \
+  _Pragma("clang diagnostic push")        \
+  _Pragma("clang diagnostic ignored \"-Wc2x-extensions\"")
+#define SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END \
+  _Pragma("clang diagnostic pop")
+#else
+#define SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
+#define SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
+#endif

--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -13,5 +13,9 @@ $srcs = Dir.glob("#{root_dir}/src/**/*.c") +
 
 append_cflags ['-std=gnu99', '-Wimplicit-fallthrough', '-Wunused-result']
 append_cflags ['-O0', '-g'] if ENV['DEBUG']
+if ENV["TEST_NO_C23"]
+  puts "Adding -Wc2x-extensions to CFLAGS"
+  $CFLAGS << " -Werror -Wc2x-extensions"
+end
 
 create_makefile 'rbs_extension'

--- a/ext/rbs_extension/legacy_location.h
+++ b/ext/rbs_extension/legacy_location.h
@@ -1,7 +1,12 @@
 #ifndef RBS_LOCATION_H
 #define RBS_LOCATION_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
+
 #include "rbs.h"
 
 /**

--- a/ext/rbs_extension/rbs_extension.h
+++ b/ext/rbs_extension/rbs_extension.h
@@ -1,8 +1,11 @@
 #include <stdbool.h>
+#include "compat.h"
 
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
 #include "ruby/re.h"
 #include "ruby/encoding.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 #include "class_constants.h"
 #include "rbs.h"

--- a/ext/rbs_extension/rbs_string_bridging.h
+++ b/ext/rbs_extension/rbs_string_bridging.h
@@ -1,8 +1,12 @@
 #ifndef RBS__RBS_STRING_BRIDGING_H
 #define RBS__RBS_STRING_BRIDGING_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
 #include "ruby/encoding.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 #include "rbs/string.h"
 

--- a/include/rbs/lexer.h
+++ b/include/rbs/lexer.h
@@ -140,9 +140,9 @@ typedef struct {
   const rbs_encoding_t *encoding;
 } rbs_lexer_t;
 
-extern rbs_token_t NullToken;
-extern rbs_position_t NullPosition;
-extern rbs_range_t NULL_RANGE;
+extern const rbs_token_t NullToken;
+extern const rbs_position_t NullPosition;
+extern const rbs_range_t NULL_RANGE;
 
 char *rbs_peek_token(rbs_lexer_t *lexer, rbs_token_t tok);
 int rbs_token_chars(rbs_token_t tok);

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -92,9 +92,9 @@ static const char *RBS_TOKENTYPE_NAMES[] = {
   "tANNOTATION",      /* Annotation */
 };
 
-rbs_token_t NullToken = { .type = NullType, .range = {0} };
-rbs_position_t NullPosition = { -1, -1, -1, -1 };
-rbs_range_t NULL_RANGE = { { -1, -1, -1, -1 }, { -1, -1, -1, -1 } };
+const rbs_position_t NullPosition = { -1, -1, -1, -1 };
+const rbs_range_t NULL_RANGE = { { -1, -1, -1, -1 }, { -1, -1, -1, -1 } };
+const rbs_token_t NullToken = { .type = NullType, .range = { {0}, {0} } };
 
 const char *rbs_token_type_str(enum RBSTokenType type) {
   return RBS_TOKENTYPE_NAMES[type];

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -92,7 +92,7 @@ static const char *RBS_TOKENTYPE_NAMES[] = {
   "tANNOTATION",      /* Annotation */
 };
 
-rbs_token_t NullToken = { .type = NullType, .range = {} };
+rbs_token_t NullToken = { .type = NullType, .range = {0} };
 rbs_position_t NullPosition = { -1, -1, -1, -1 };
 rbs_range_t NULL_RANGE = { { -1, -1, -1, -1 }, { -1, -1, -1, -1 } };
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -3415,7 +3415,7 @@ rbs_parser_t *rbs_parser_new(rbs_string_t string, const rbs_encoding_t *encoding
     .vars = NULL,
     .last_comment = NULL,
 
-    .constant_pool = {},
+    .constant_pool = {0},
     .allocator = allocator,
     .error = NULL,
   };

--- a/src/util/rbs_constant_pool.c
+++ b/src/util/rbs_constant_pool.c
@@ -96,7 +96,7 @@ rbs_constant_pool_resize(rbs_constant_pool_t *pool) {
 }
 
 // This storage is initialized by `Init_rbs_extension()` in `main.c`.
-static rbs_constant_pool_t RBS_GLOBAL_CONSTANT_POOL_STORAGE = {};
+static rbs_constant_pool_t RBS_GLOBAL_CONSTANT_POOL_STORAGE = {0};
 rbs_constant_pool_t *RBS_GLOBAL_CONSTANT_POOL = &RBS_GLOBAL_CONSTANT_POOL_STORAGE;
 
 /**

--- a/templates/ext/rbs_extension/ast_translation.c.erb
+++ b/templates/ext/rbs_extension/ast_translation.c.erb
@@ -183,4 +183,6 @@ VALUE rbs_struct_to_ruby_value(rbs_translation_context_t ctx, rbs_node_t *instan
             return ID2SYM(rb_intern3((const char *) constant->start, constant->length, ctx.encoding));
         }
     }
+
+    rb_raise(rb_eRuntimeError, "Unknown node type: %d", instance->type);
 }

--- a/templates/ext/rbs_extension/ast_translation.h.erb
+++ b/templates/ext/rbs_extension/ast_translation.h.erb
@@ -1,8 +1,12 @@
 #ifndef RBS_EXTENSION_AST_TRANSLATION_H
 #define RBS_EXTENSION_AST_TRANSLATION_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
 #include "ruby/encoding.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 #include "rbs/ast.h"
 #include "rbs/location.h"

--- a/templates/ext/rbs_extension/class_constants.h.erb
+++ b/templates/ext/rbs_extension/class_constants.h.erb
@@ -1,7 +1,11 @@
 #ifndef RBS__CONSTANTS_H
 #define RBS__CONSTANTS_H
 
+#include "compat.h"
+
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_BEGIN
 #include "ruby.h"
+SUPPRESS_RUBY_HEADER_DIAGNOSTICS_END
 
 extern VALUE RBS;
 


### PR DESCRIPTION
This PR is to fix build errors which is reported in https://github.com/ruby/ruby/pull/13237.

* This PR adds CI job to compile without C23 extensions.
* You can compile in C99 mode in your local environment with `compile_c99` Rake task