### PR TITLE
Expose a method to parse type parameters

### DIFF
--- a/include/rbs/parser.h
+++ b/include/rbs/parser.h
@@ -130,6 +130,8 @@ bool rbs_parse_type(rbs_parser_t *parser, rbs_node_t **type);
 bool rbs_parse_method_type(rbs_parser_t *parser, rbs_method_type_t **method_type);
 bool rbs_parse_signature(rbs_parser_t *parser, rbs_signature_t **signature);
 
+bool rbs_parse_type_params(rbs_parser_t *parser, bool module_type_params, rbs_node_list_t **params);
+
 /**
  * Parse an inline leading annotation from a string.
  *

--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -35,6 +35,11 @@ module RBS
       [buf, dirs, decls]
     end
 
+    def self.parse_type_params(source, module_type_params: true)
+      buf = buffer(source)
+      _parse_type_params(buf, 0, buf.last_position, module_type_params)
+    end
+
     def self.magic_comment(buf)
       start_pos = 0
 

--- a/sig/parser.rbs
+++ b/sig/parser.rbs
@@ -68,6 +68,24 @@ module RBS
     #
     def self.parse_signature: (Buffer | String) -> [Buffer, Array[AST::Directives::t], Array[AST::Declarations::t]]
 
+    # Parse a list of type parameters and return it
+    #
+    # ```ruby
+    # RBS::Parser.parse_type_params("")                          # => nil
+    # RBS::Parser.parse_type_params("[U, V]")                    # => `[:U, :V]`
+    # RBS::Parser.parse_type_params("[in U, V < Integer]")       # => `[:U, :V]`
+    # ```
+    #
+    # When `module_type_params` is `false`, an error is raised if `unchecked`, `in` or `out` are used.
+    #
+    # ```ruby
+    # RBS::Parser.parse_type_params("[unchecked U]", module_type_params: false)   # => Raises an error
+    # RBS::Parser.parse_type_params("[out U]", module_type_params: false)         # => Raises an error
+    # RBS::Parser.parse_type_params("[in U]", module_type_params: false)          # => Raises an error
+    # ```
+    #
+    def self.parse_type_params: (Buffer | String, ?module_type_params: bool) -> Array[AST::TypeParam]
+
     # Returns the magic comment from the buffer
     #
     def self.magic_comment: (Buffer) -> AST::Directives::ResolveTypeNames?
@@ -103,6 +121,8 @@ module RBS
     def self._parse_method_type: (Buffer, Integer start_pos, Integer end_pos, Array[Symbol] variables, bool require_eof) -> MethodType?
 
     def self._parse_signature: (Buffer, Integer start_pos, Integer end_pos) -> [Array[AST::Directives::t], Array[AST::Declarations::t]]
+
+    def self._parse_type_params: (Buffer, Integer start_pos, Integer end_pos, bool module_type_params) -> Array[AST::TypeParam]
 
     def self._lex: (Buffer, Integer end_pos) -> Array[[Symbol, Location[untyped, untyped]]]
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -3258,6 +3258,26 @@ bool rbs_parse_signature(rbs_parser_t *parser, rbs_signature_t **signature) {
   return true;
 }
 
+bool rbs_parse_type_params(rbs_parser_t *parser, bool module_type_params, rbs_node_list_t **params) {
+  if (parser->next_token.type != pLBRACKET) {
+    rbs_parser_set_error(parser, parser->next_token, true, "expected a token `pLBRACKET`");
+    return false;
+  }
+
+  rbs_range_t rg = NULL_RANGE;
+  rbs_parser_push_typevar_table(parser, true);
+  bool res = parse_type_params(parser, &rg, module_type_params, params);
+  rbs_parser_push_typevar_table(parser, false);
+
+  rbs_parser_advance(parser);
+  if (parser->current_token.type != pEOF) {
+    rbs_parser_set_error(parser, parser->current_token, true, "expected a token `%s`", rbs_token_type_str(pEOF));
+    return false;
+  }
+
+  return res;
+}
+
 id_table *alloc_empty_table(rbs_allocator_t *allocator) {
   id_table *table = rbs_allocator_alloc(allocator, id_table);
 


### PR DESCRIPTION
With Sorbet we use RBS signatures directly as comments:

```rb
#: (Integer, Integer) -> Integer
def add(a, b)
  a + b
end
```

We parse these comments using `rbs_parse_method_type`.

When it comes to generic class we want to offer the same syntax so the user can simply specify the type parameters:

```rb
#: [in A, B < Object]
class Foo
end
```

We need to expose a parsing method for those.

Note that the Ruby method is not required per se, it just makes it easier to test.