### PR TITLE
Enable `-Wc++-compat`

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -11,7 +11,13 @@ root_dir = File.expand_path('../../../', __FILE__)
 $srcs = Dir.glob("#{root_dir}/src/**/*.c") +
         Dir.glob("#{root_dir}/ext/rbs_extension/*.c")
 
-append_cflags ['-std=gnu99', '-Wimplicit-fallthrough', '-Wunused-result']
+append_cflags [
+  '-std=gnu99',
+  '-Wimplicit-fallthrough',
+  '-Wunused-result',
+  '-Wc++-compat',
+]
+
 append_cflags ['-O0', '-g'] if ENV['DEBUG']
 
 create_makefile 'rbs_extension'


### PR DESCRIPTION
Adds a flag which makes the compiler warn if we use anything that's invalid C++. This is handy because we compile RBS as part of Sorbet. There's no warnings today, but it'll catch them going forward.

Docs: [Clang](https://clang.llvm.org/docs/DiagnosticsReference.html#wc-compat), [GCC](https://gcc.gnu.org/onlinedocs/gcc-4.4.0/gcc/Warning-Options.html#:~:text=%2DWc%2B%2B%2Dcompat%20(C%20and%20Objective%2DC%20only))
