### PR TITLE
Add clangd integration for improved C extension development

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+    CompilationDatabase: ext/rbs_extension

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ lib/**/*.dll
 doc/
 
 **/*.gem
+
+# For clangd's editor integration
+ext/rbs_extension/compile_commands.json
+ext/rbs_extension/.cache

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "rdoc"
 gem "fileutils"
 gem "raap"
 gem "activesupport", "~> 7.0"
+gem "extconf_compile_commands_json"
 
 group :libs do
   # Libraries required for stdlib test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
     diff-lcs (1.6.2)
     digest (3.2.0)
     drb (2.2.1)
+    extconf_compile_commands_json (0.0.7)
     ffi (1.17.2)
     fileutils (1.7.3)
     goodcheck (3.1.0)
@@ -184,6 +185,7 @@ DEPENDENCIES
   csv
   dbm
   digest
+  extconf_compile_commands_json
   fileutils
   goodcheck
   json

--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -25,3 +25,7 @@ if ENV["TEST_NO_C23"]
 end
 
 create_makefile 'rbs_extension'
+
+require 'extconf_compile_commands_json'
+ExtconfCompileCommandsJson.generate!
+ExtconfCompileCommandsJson.symlink!


### PR DESCRIPTION
(This is @amomchilov's idea and I just implemented it in a pairing 😛)

- Added extconf_compile_commands_json for generating and symlinking compile_commands.json
- Added .clangd config to point to compilation database

This will enable LSP features like go-to-definition and hover...etc.

https://github.com/user-attachments/assets/e806396c-244d-49d5-af81-5a7240740cdc

### Usage

1. Run `bundle exec rake compile`
2. Restart the `clangd` language server