### PR TITLE
Add `super` calls in `setup`

### DIFF
--- a/test/stdlib/CGI_test.rb
+++ b/test/stdlib/CGI_test.rb
@@ -72,6 +72,7 @@ class CGITest < Test::Unit::TestCase
   testing "::CGI"
 
   def setup
+    super
     ARGV.replace(%w(abc=001 def=002))
   end
 

--- a/test/stdlib/Forwardable_test.rb
+++ b/test/stdlib/Forwardable_test.rb
@@ -71,6 +71,7 @@ class SingleForwardableTest < Test::Unit::TestCase
   testing "::SingleForwardable"
 
   def setup
+    super
     @tested = Object.new
     @tested.extend SingleForwardable
   end

--- a/test/stdlib/Minitest_test.rb
+++ b/test/stdlib/Minitest_test.rb
@@ -51,9 +51,10 @@ class MinitestTestLifecycleHooksTest < Test::Unit::TestCase
 
   class LifecycleSetup < Minitest::Test
     def setup
+      super
       @foo = 123
     end
-  end  
+  end
 
   def test_setup_return_type_void
     test = LifecycleSetup.new("setup")

--- a/test/stdlib/uri/rfc2396_parser_test.rb
+++ b/test/stdlib/uri/rfc2396_parser_test.rb
@@ -20,6 +20,7 @@ class URIRFC2396_ParserInstanceTest < Test::Unit::TestCase
   testing "::URI::RFC2396_Parser"
 
   def setup
+    super
     @instance = URI::RFC2396_Parser.new
   end
 


### PR DESCRIPTION
Missing `super` calls in `#setup` breaks `RBS_SKIP_TESTS` feature in some tests.