### PR TITLE
Only load extconf_compile_commands_json when compiling through Rake 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,14 @@ bin = File.join(__dir__, "bin")
 
 Rake::ExtensionTask.new("rbs_extension")
 
+compile_task = Rake::Task[:compile]
+
+task :setup_extconf_compile_commands_json do
+  ENV["COMPILE_COMMANDS_JSON"] = "1"
+end
+
+compile_task.prerequisites.unshift(:setup_extconf_compile_commands_json)
+
 test_config = lambda do |t|
   t.libs << "test"
   t.libs << "lib"

--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -26,6 +26,10 @@ end
 
 create_makefile 'rbs_extension'
 
-require 'extconf_compile_commands_json'
-ExtconfCompileCommandsJson.generate!
-ExtconfCompileCommandsJson.symlink!
+# Only generate compile_commands.json when compiling through Rake tasks
+# This is to avoid adding extconf_compile_commands_json as a runtime dependency
+if ENV["COMPILE_COMMANDS_JSON"]
+  require 'extconf_compile_commands_json'
+  ExtconfCompileCommandsJson.generate!
+  ExtconfCompileCommandsJson.symlink!
+end


### PR DESCRIPTION
Otherwise, it'd cause LoadError in official release because `extconf_compile_commands_json` is not a runtime dependency.