### PR TITLE
Add URI::Generic#+

### DIFF
--- a/stdlib/uri/0/generic.rbs
+++ b/stdlib/uri/0/generic.rbs
@@ -910,6 +910,13 @@ module URI
     #
     def merge: (URI::Generic | string oth) -> URI::Generic
 
+    # <!--
+    #   rdoc-file=lib/uri/generic.rb
+    #   - uri + "/main.rbx?page=1"
+    # -->
+    #
+    alias + merge
+
     # :stopdoc:
     def route_from_path: (String src, String dst) -> String
 

--- a/stdlib/uri/0/generic.rbs
+++ b/stdlib/uri/0/generic.rbs
@@ -912,7 +912,7 @@ module URI
 
     # <!--
     #   rdoc-file=lib/uri/generic.rb
-    #   - uri + "/main.rbx?page=1"
+    #   - +(oth)
     # -->
     #
     alias + merge


### PR DESCRIPTION
Hello,

I found a signature of `URI::Generic#+` is missing and completed it.

Tell me if there's a problem. Especially, I'm not sure how to write document comment for aliases.
Update: CI taught me how to write comment and I fixed it.

Thank you.