### PR TITLE
Delegate to `Enumerable` from `Range#{min,max}`

### DIFF
--- a/core/range.rbs
+++ b/core/range.rbs
@@ -741,10 +741,7 @@ class Range[out Elem] < Object
   #
   # Related: Range#min, Range#minmax.
   #
-  def max: () -> Elem
-         | () { (Elem a, Elem b) -> Integer } -> Elem
-         | (Integer n) -> ::Array[Elem]
-         | (Integer n) { (Elem a, Elem b) -> Integer } -> ::Array[Elem]
+  def max: ...
 
   # <!--
   #   rdoc-file=range.c
@@ -826,10 +823,7 @@ class Range[out Elem] < Object
   #
   # Related: Range#max, Range#minmax.
   #
-  def min: () -> Elem
-         | () { (Elem a, Elem b) -> Integer } -> Elem
-         | (Integer n) -> ::Array[Elem]
-         | (Integer n) { (Elem a, Elem b) -> Integer } -> ::Array[Elem]
+  def min: ...
 
   # <!--
   #   rdoc-file=range.c

--- a/test/stdlib/Range_test.rb
+++ b/test/stdlib/Range_test.rb
@@ -80,20 +80,6 @@ class RangeTest < StdlibTest
     ('A'...'Z').last
   end
 
-  def test_max
-    (1..10).max
-    (1..10).max(3)
-    (1..10).max { |i, j| i <=> j }
-    (1..10).max(3) { |i, j| i <=> j }
-  end
-
-  def test_min
-    (1..10).min
-    (1..10).min(3)
-    (1..10).min { |i, j| i <=> j }
-    (1..10).min(3) { |i, j| i <=> j }
-  end
-
   def test_percent
     (1..10).%(2)
     if_ruby(..."3.4.0", skip: false) do
@@ -151,5 +137,23 @@ class RangeInstanceTest < Test::Unit::TestCase
       "(::Range[::Integer]) -> bool",
       (2..5), :overlap?, (3..4)
     )
+  end
+
+  def test_min
+    assert_send_type "() -> ::Integer", (1..4), :min
+    assert_send_type "() -> nil", (4..1), :min
+    assert_send_type "() { (::Integer, ::Integer) -> ::Integer } -> ::Integer", (1..4), :min do |a, b| a <=> b end
+    assert_send_type "() { (::Integer, ::Integer) -> ::Integer } -> nil", (4..1), :min do |a, b| a <=> b end
+    assert_send_type "(::Integer) -> ::Array[::Integer]", (1..4), :min, 2
+    assert_send_type "(::Integer) { (::Integer, ::Integer) -> ::Integer } -> ::Array[::Integer]", (1..4), :min, 0 do |a, b| a <=> b end
+  end
+
+  def test_max
+    assert_send_type "() -> ::Integer", (1..4), :max
+    assert_send_type "() -> nil", (4..1), :max
+    assert_send_type "() { (::Integer, ::Integer) -> ::Integer } -> ::Integer", (1..4), :max do |a, b| a <=> b end
+    assert_send_type "() { (::Integer, ::Integer) -> ::Integer } -> nil", (4..1), :max do |a, b| a <=> b end
+    assert_send_type "(::Integer) -> ::Array[::Integer]", (1..4), :max, 2
+    assert_send_type "(::Integer) { (::Integer, ::Integer) -> ::Integer } -> ::Array[::Integer]", (4..1), :max, 0 do |a, b| a <=> b end
   end
 end


### PR DESCRIPTION
`Range#{min,max}` may return `nil`.
I also realized that their signatures are exactly the same as those of `Enumerable#{min,max}`.
I propose reusing the existing signature as-is while keeping the current documentation unchanged.
Since the specification might change in the future, I’ve written detailed tests just in case.
