### PR TITLE
[prototype runtime] Find redefined methods

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -27,6 +27,10 @@ module RBS
           method_definition = @builder.build_singleton(module_name.absolute!).methods[method.name]
           return false unless method_definition
 
+          return false unless method_definition.defs.any? do |type_def|
+            type_def.implemented_in&.relative!.to_s == method.owner.to_s.delete_prefix("#<Class:").delete_suffix(">")
+          end
+
           method_definition.accessibility == accessibility
         end
 
@@ -35,6 +39,10 @@ module RBS
 
           method_definition = @builder.build_instance(module_name.absolute!).methods[method.name]
           return false unless method_definition
+
+          return false unless method_definition.defs.any? do |type_def|
+            type_def.implemented_in&.relative!.to_s == method.owner.to_s
+          end
 
           method_definition.accessibility == accessibility
         end

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -584,11 +584,19 @@ end
 
     CONST_DEFINED = 1
     CONST_TODO = 1
+
+    def self.singleton_inherited; end
+    def public_inherited; end
   end
 
   module TodoModule
     def public_defined; end
     def public_todo; end
+  end
+
+  class InheritedTodoClass < TodoClass
+    def self.singleton_inherited; end
+    def public_inherited; end
   end
 
   def test_todo
@@ -605,9 +613,13 @@ end
               def self.singleton_defined: () -> void
               def accessibility_mismatch: () -> void
               CONST_DEFINED: Integer
+              def self.singleton_inherited: () -> void
+              def public_inherited: () -> void
             end
             module TodoModule
               def public_defined: () -> void
+            end
+            class InheritedTodoClass < TodoClass
             end
           end
         end
@@ -643,6 +655,19 @@ end
             class RuntimePrototypeTest < ::Test::Unit::TestCase
               module TodoModule
                 def public_todo: () -> untyped
+              end
+            end
+          end
+        RBS
+
+        p = Runtime.new(patterns: ["RBS::RuntimePrototypeTest::InheritedTodoClass"], env: env, merge: false, todo: true)
+        assert_write p.decls, <<~RBS
+          module RBS
+            class RuntimePrototypeTest < ::Test::Unit::TestCase
+              class InheritedTodoClass < ::RBS::RuntimePrototypeTest::TodoClass
+                def self.singleton_inherited: () -> untyped
+
+                def public_inherited: () -> untyped
               end
             end
           end


### PR DESCRIPTION
Since methods redefined in subclasses may have different types, I believe we should display the prototypes of such redefined methods when using `--todo`.

# Repro

```rb
# sample.rb
class A
  def foo; 1; end
end
class B < A
  def foo; 'a'; end
end
```

```rbs
# sample.rbs
class A
  def foo: () -> Integer
end
class B < A
end
```

```
$ bundle exec rbs -I sample.rbs prototype runtime --require-relative sample.rb --todo B
```

### Actual

```rbs
class B < ::A
end
```

### Expect

```rbs
class B < ::A
  def foo: () -> untyped
end
```