### PR TITLE
Remove undocumented `#nonzero?`

### DIFF
--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -535,8 +535,6 @@ class Complex < Numeric
 
   def negative?: () -> bot
 
-  def nonzero?: () -> self?
-
   # <!--
   #   rdoc-file=complex.c
   #   - numerator -> new_complex

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -737,8 +737,6 @@ class Float < Numeric
   #
   def next_float: () -> Float
 
-  def nonzero?: () -> self?
-
   # <!--
   #   rdoc-file=rational.c
   #   - flo.numerator  ->  integer

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -1015,8 +1015,6 @@ class Integer < Numeric
   #
   def nobits?: (int mask) -> bool
 
-  def nonzero?: () -> self?
-
   # <!--
   #   rdoc-file=numeric.rb
   #   - numerator -> self

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -336,8 +336,6 @@ class Rational < Numeric
   #
   def negative?: () -> bool
 
-  def nonzero?: () -> self?
-
   # <!--
   #   rdoc-file=rational.c
   #   - rat.numerator  ->  integer


### PR DESCRIPTION
`{Integer,Float,Complex,Rational}#nonzero?` methods are not defined as a method in ruby and is not useful at all because it also inhibits the display of documents in steep.
It should be removed.