### PR TITLE
Restrict the execution of the valgrind task to when the C code has been modified.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -65,30 +65,6 @@ jobs:
       - name: Run test
         run: |
           bundle exec rake ${{ matrix.job }}
-  valgrind:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.4"
-          bundler-cache: none
-      - name: Set working directory as safe
-        run: git config --global --add safe.directory $(pwd)
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libdb-dev curl autoconf automake m4 libtool python3 valgrind
-      - name: Update rubygems & bundler
-        run: |
-          ruby -v
-          gem update --system
-      - name: bin/setup
-        run: |
-          bin/setup
-      - run: bundle exec rake test:valgrind
-        env:
-          RUBY_FREE_AT_EXIT: 1
   C99_compile:
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,38 @@
+name: Valgrind
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "ext/**"
+      - "include/**"
+      - "src/**"
+  pull_request: {}
+  merge_group: {}
+
+jobs:
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: none
+      - name: Set working directory as safe
+        run: git config --global --add safe.directory $(pwd)
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdb-dev curl autoconf automake m4 libtool python3 valgrind
+      - name: Update rubygems & bundler
+        run: |
+          ruby -v
+          gem update --system
+      - name: bin/setup
+        run: |
+          bin/setup
+      - run: bundle exec rake test:valgrind
+        env:
+          RUBY_FREE_AT_EXIT: 1

--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,8 @@ test_config = lambda do |t|
   t.test_files = FileList["test/**/*_test.rb"].reject do |path|
     path =~ %r{test/stdlib/}
   end
+  t.verbose = true
+  t.options = '-v'
 end
 
 Rake::TestTask.new(test: :compile, &test_config)


### PR DESCRIPTION
Valgrind is a powerful tool, but it seems costly as it takes 50 minutes to run in CI tasks.
Since it is a tool for C language, I configured it to run only when the C code has been modified.