### PR TITLE
Set force_ruby_platform for bundler when head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -112,6 +112,10 @@ jobs:
           gem update --system
       - name: clang version
         run: clang --version
+      - name: bundle config set force_ruby_platform true if head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: |
+          bundle config set force_ruby_platform true
       - name: bin/setup
         run: |
           bin/setup


### PR DESCRIPTION
Solves the problem that CI currently fails on macOS and ruby head version.
Since it seems that CI can't find an installable pre-built binary of nokogiri perhaps, we will force the use of the ruby platform for the head version only.

If we add the ruby platform to the Gemfile.lock, it seems to be removed by dependabot.
https://github.com/ruby/rbs/pull/2522/files