### PR TITLE
Avoid overloading where arguments are identical

### DIFF
--- a/core/encoding.rbs
+++ b/core/encoding.rbs
@@ -923,8 +923,7 @@ class Encoding::Converter < Object
   #     p ec.primitive_convert(src, dst, nil, 1)             #=> :destination_buffer_full
   #     p ec.last_error      #=> nil
   #
-  def last_error: () -> Encoding::InvalidByteSequenceError?
-                | () -> Encoding::UndefinedConversionError?
+  def last_error: () -> (InvalidByteSequenceError | UndefinedConversionError | nil)
 
   # <!--
   #   rdoc-file=transcode.c

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -930,8 +930,7 @@ class Range[out Elem] < Object
   #
   # Related: Range#count.
   #
-  def size: () -> Integer?
-          | () -> Float?
+  def size: () -> (Integer | Float | nil)
 
   # <!--
   #   rdoc-file=range.c

--- a/stdlib/ripper/0/ripper.rbs
+++ b/stdlib/ripper/0/ripper.rbs
@@ -247,8 +247,8 @@ class Ripper
       #   - to_a()
       # -->
       #
-      def to_a: () -> [ [ Integer, Integer ], Symbol, String, Ripper::Lexer::State, String ]
-              | () -> [ [ Integer, Integer ], Symbol, String, Ripper::Lexer::State ]
+      def to_a: () -> ( [ [ Integer, Integer ], Symbol, String, Ripper::Lexer::State, String ]
+                      | [ [ Integer, Integer ], Symbol, String, Ripper::Lexer::State ] )
     end
 
     class State


### PR DESCRIPTION
It is meaningless to overload functions with exactly the same arguments, so it should be avoided.
I found overloads with identical arguments through static syntax analysis.
Different return types were consolidated into a union type.