### PR TITLE
Support BasicObject to avoid NoMethodError for `RBS::Test::TypeCheck`

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -245,7 +245,7 @@ module RBS
         when Types::Bases::Any
           true
         when Types::Bases::Bool
-          val.is_a?(TrueClass) || val.is_a?(FalseClass)
+          Test.call(val, IS_AP, TrueClass) || Test.call(val, IS_AP, FalseClass)
         when Types::Bases::Top
           true
         when Types::Bases::Bottom
@@ -323,7 +323,7 @@ module RBS
                             rescue TypeError
                               return false
                             end
-          val.is_a?(singleton_class)
+          Test.call(val, IS_AP, singleton_class)
         when Types::Interface
           if (definition = builder.build_interface(type.name.absolute!))
             definition.methods.each.all? do |method_name, method|

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -49,6 +49,7 @@ EOF
         assert typecheck.value(String, parse_type("singleton(::String)"))
         assert typecheck.value(String, parse_type("singleton(::Object)"))
         refute typecheck.value(String, parse_type("singleton(::Integer)"))
+        refute typecheck.value(BasicObject.new, parse_type("singleton(::BasicObject)"))
 
         assert typecheck.value(3, parse_type("::M::t"))
         assert typecheck.value(3, parse_type("::M::s"))
@@ -65,6 +66,7 @@ EOF
         assert typecheck.value(false, parse_type("bool"))
         refute typecheck.value(nil, parse_type("bool"))
         refute typecheck.value("", parse_type("bool"))
+        refute typecheck.value(BasicObject.new, parse_type("bool"))
       end
     end
   end


### PR DESCRIPTION
Fixes a type-checking problem for `bool` and `singleton()` types of objects that do not have an `is_a?` method, such as `BasicObject` instance.