### PR TITLE
Add signature for `Fiber#blocking`

### DIFF
--- a/core/fiber.rbs
+++ b/core/fiber.rbs
@@ -103,6 +103,17 @@ class Fiber < Object
 
   # <!--
   #   rdoc-file=cont.c
+  #   - Fiber.blocking{|fiber| ...} -> result
+  # -->
+  # Forces the fiber to be blocking for the duration of the block. Returns the
+  # result of the block.
+  #
+  # See the "Non-blocking fibers" section in class docs for details.
+  #
+  def self.blocking: [T] () { (Fiber) -> T } -> T
+
+  # <!--
+  #   rdoc-file=cont.c
   #   - Fiber.blocking? -> false or 1
   # -->
   # Returns `false` if the current fiber is non-blocking. Fiber is non-blocking if

--- a/test/stdlib/Fiber_test.rb
+++ b/test/stdlib/Fiber_test.rb
@@ -17,6 +17,13 @@ class FiberSingletonTest < Test::Unit::TestCase
     )
   end
 
+  def test_blocking
+    if_ruby("3.2"...) do
+      assert_send_type "() { (Fiber) -> 42 } -> 42",
+                        Fiber, :blocking do 42 end
+    end
+  end
+
   def test_blocking?
     assert_send_type "() -> 1",
                      Fiber, :blocking?


### PR DESCRIPTION
`Fiber.blocking` introduced from ruby v3.2.
https://bugs.ruby-lang.org/issues/18411