### PR TITLE
Add signature for `Enumerator#+`

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -450,6 +450,18 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
 
   # <!--
   #   rdoc-file=enumerator.c
+  #   - e + enum -> enumerator
+  # -->
+  # Returns an enumerator object generated from this enumerator and a given
+  # enumerable.
+  #
+  #     e = (1..3).each + [4, 5]
+  #     e.to_a #=> [1, 2, 3, 4, 5]
+  #
+  def +: [Elem2] (::_Each[Elem2]) -> ::Enumerator::Chain[Elem | Elem2]
+
+  # <!--
+  #   rdoc-file=enumerator.c
   #   - e.with_index(offset = 0) {|(*args), idx| ... }
   #   - e.with_index(offset = 0)
   # -->

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -24,6 +24,10 @@ class EnumeratorTest < Test::Unit::TestCase
     assert_send_type "() { (Integer) -> nil } -> [1,2,3]",
                      enum, :each do end
   end
+
+  def test_plus
+    assert_send_type "(Array[Integer]) -> Enumerator::Chain[Integer]", (1..3).each, :+, [4, 5]
+  end
 end
 
 class EnumeratorSingletonTest < Test::Unit::TestCase


### PR DESCRIPTION
`Enumerator#+` was added in ruby v2.6.
https://bugs.ruby-lang.org/issues/15144