### PR TITLE
Add signature for `Enumerator::Lazy#eager`

### DIFF
--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -578,6 +578,14 @@ class Enumerator::Lazy[out Elem, out Return = void] < Enumerator[Elem, Return]
   # Like Enumerable#compact, but chains operation to be lazy-evaluated.
   #
   def compact: () -> Enumerator::Lazy[Elem, Return]
+
+  # <!--
+  #   rdoc-file=enumerator.c
+  #   - lzy.eager -> enum
+  # -->
+  # Returns a non-lazy Enumerator converted from the lazy enumerator.
+  #
+  def eager: () -> ::Enumerator[Elem, Return]
 end
 
 # <!-- rdoc-file=enumerator.c -->

--- a/test/stdlib/Enumerator_test.rb
+++ b/test/stdlib/Enumerator_test.rb
@@ -89,6 +89,16 @@ class EnumeratorYielderTest < Test::Unit::TestCase
   end
 end
 
+class EnumeratorLazyInstanceTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing "::Enumerator::Lazy[::Integer, ::Range[Integer]]"
+
+  def test_eager
+    assert_send_type "() -> Enumerator[Integer, Range[Integer]]", (1..3).lazy, :eager
+  end
+end
+
 class EnumeratorChainInstanceTest < Test::Unit::TestCase
   include TestHelper
 


### PR DESCRIPTION
`Enumerator::Lazy#eager` was added in ruby v2.7.
https://bugs.ruby-lang.org/issues/15901