### PR TITLE
Add signatures for `Set`

### DIFF
--- a/core/set.rbs
+++ b/core/set.rbs
@@ -488,6 +488,15 @@ class Set[unchecked out A]
 
   # <!--
   #   rdoc-file=lib/set.rb
+  #   - flatten!()
+  # -->
+  # Equivalent to Set#flatten, but replaces the receiver with the
+  # result in place. Returns nil if no modifications were made.
+  #
+  def flatten!: () -> self?
+
+  # <!--
+  #   rdoc-file=lib/set.rb
   #   - intersect?(set)
   # -->
   # Returns true if the set and the given enumerable have at least one


### PR DESCRIPTION
I added several signatures for methods in `Set`.
All method tests are testing by raap.

* Aliases
    * `#<=`
    * `#<`
    * `#>`
    * `#>=`
        * ruby 2.0
        * https://github.com/ruby/ruby/commit/aa7dc0f305c11c2ef9e67f6d48acbd1264022024
    * `#filter!`
        * ruby 2.6
        * https://bugs.ruby-lang.org/issues/13784
* Methods
    * `#compare_by_identity?`
        * ruby 2.4
        * https://bugs.ruby-lang.org/issues/12210
    * `#join`
        * ruby 3.0
        * https://bugs.ruby-lang.org/issues/16991
    * `#flatten!`
        * From the beginning of `Set`
