### PR TITLE
Add signature for `IO::TimeoutError`

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -3404,3 +3404,9 @@ end
 #
 module IO::WaitWritable
 end
+
+# <!-- rdoc-file=io.c -->
+# Can be raised by IO operations when IO#timeout= is set.
+#
+class IO::TimeoutError < IOError
+end


### PR DESCRIPTION
`IO::TimeoutError` was added in ruby 3.2.
https://bugs.ruby-lang.org/issues/18630