### PR TITLE
Add signature for `Digest::SHA2`

### DIFF
--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -471,6 +471,116 @@ end
 class Digest::SHA1 < Digest::Base
 end
 
+# <!-- rdoc-file=ext/digest/sha2/lib/sha2.rb -->
+# A meta digest provider class for SHA256, SHA384 and SHA512.
+#
+# FIPS 180-2 describes SHA2 family of digest algorithms. It defines three
+# algorithms:
+# *   one which works on chunks of 512 bits and returns a 256-bit digest
+#     (SHA256),
+# *   one which works on chunks of 1024 bits and returns a 384-bit digest
+#     (SHA384),
+# *   and one which works on chunks of 1024 bits and returns a 512-bit digest
+#     (SHA512).
+#
+# ## Examples
+#     require 'digest'
+#
+#     # Compute a complete digest
+#     Digest::SHA2.hexdigest 'abc'          # => "ba7816bf8..."
+#     Digest::SHA2.new(256).hexdigest 'abc' # => "ba7816bf8..."
+#     Digest::SHA256.hexdigest 'abc'        # => "ba7816bf8..."
+#
+#     Digest::SHA2.new(384).hexdigest 'abc' # => "cb00753f4..."
+#     Digest::SHA384.hexdigest 'abc'        # => "cb00753f4..."
+#
+#     Digest::SHA2.new(512).hexdigest 'abc' # => "ddaf35a19..."
+#     Digest::SHA512.hexdigest 'abc'        # => "ddaf35a19..."
+#
+#     # Compute digest by chunks
+#     sha2 = Digest::SHA2.new               # =>#<Digest::SHA2:256>
+#     sha2.update "ab"
+#     sha2 << "c"                           # alias for #update
+#     sha2.hexdigest                        # => "ba7816bf8..."
+#
+#     # Use the same object to compute another digest
+#     sha2.reset
+#     sha2 << "message"
+#     sha2.hexdigest                        # => "ab530a13e..."
+#
+class Digest::SHA2 < Digest::Class
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - Digest::SHA2.new(bitlen = 256) -> digest_obj
+  # -->
+  # Create a new SHA2 hash object with a given bit length.
+  #
+  # Valid bit lengths are 256, 384 and 512.
+  #
+  def initialize: (?(256 | 384 | 512) bitlen) -> void
+
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - digest_obj.reset -> digest_obj
+  # -->
+  # Reset the digest to the initial state and return self.
+  #
+  def reset: () -> self
+
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - digest_obj.update(string) -> digest_obj
+  #   - digest_obj << string -> digest_obj
+  # -->
+  # Update the digest using a given *string* and return self.
+  #
+  def update: (String) -> self
+
+  private def finish: () -> String
+
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - <<(str)
+  # -->
+  #
+  alias << update
+
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - digest_obj.block_length -> Integer
+  # -->
+  # Return the block length of the digest in bytes.
+  #
+  #     Digest::SHA256.new.block_length * 8
+  #     # => 512
+  #     Digest::SHA384.new.block_length * 8
+  #     # => 1024
+  #     Digest::SHA512.new.block_length * 8
+  #     # => 1024
+  #
+  def block_length: () -> Integer
+
+  # <!--
+  #   rdoc-file=ext/digest/sha2/lib/sha2.rb
+  #   - digest_obj.digest_length -> Integer
+  # -->
+  # Return the length of the hash value (the digest) in bytes.
+  #
+  #     Digest::SHA256.new.digest_length * 8
+  #     # => 256
+  #     Digest::SHA384.new.digest_length * 8
+  #     # => 384
+  #     Digest::SHA512.new.digest_length * 8
+  #     # => 512
+  #
+  # For example, digests produced by Digest::SHA256 will always be 32 bytes (256
+  # bits) in size.
+  #
+  def digest_length: () -> Integer
+
+  def initialize_copy: (untyped) -> untyped
+end
+
 # <!-- rdoc-file=ext/digest/md5/md5init.c -->
 # A class for calculating message digests using the MD5 Message-Digest Algorithm
 # by RSA Data Security, Inc., described in RFC1321.

--- a/test/raap/digest.rb
+++ b/test/raap/digest.rb
@@ -54,4 +54,6 @@ argv = [
   end
 end
 
+argv << 'Digest::SHA2'
+
 RaaP::CLI.new(argv).load.run


### PR DESCRIPTION
I have added signatures that are likely to be used somewhat frequently and for which no type exists.
See also https://github.com/ruby/ruby/blob/5e9be99ef5a640b59b52ff83d29070672ed0758c/ext/digest/sha2/lib/sha2.rb