### PR TITLE
Fix clang-format

### DIFF
--- a/.github/workflows/c-check.yml
+++ b/.github/workflows/c-check.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Install clang-format from LLVM
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main"
+          sudo apt-add-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main"
           sudo apt-get update
-          sudo apt-get install -y clang-format
+          sudo apt-get install -y clang-format-20
+          sudo ln -sf /usr/bin/clang-format-20 /usr/local/bin/clang-format
           clang-format --version
       - name: Install Re2c
         run: |


### PR DESCRIPTION
Using released version of clang-format (20) makes the format result more stable.