### PR TITLE
Move `exit` calls to `exe/rbs`

### DIFF
--- a/exe/rbs
+++ b/exe/rbs
@@ -4,4 +4,4 @@ $LOAD_PATH << File.join(__dir__, "../lib")
 require "rbs"
 require "rbs/cli"
 
-RBS::CLI.new(stdout: STDOUT, stderr: STDERR).run(ARGV.dup)
+exit RBS::CLI.new(stdout: STDOUT, stderr: STDERR).run(ARGV.dup)

--- a/sig/cli.rbs
+++ b/sig/cli.rbs
@@ -46,41 +46,41 @@ module RBS
 
     def has_parser?: () -> bool
 
-    def run: (Array[String] args) -> void
+    def run: (Array[String] args) -> Integer
 
-    def run_ast: (Array[String], LibraryOptions) -> void
+    def run_ast: (Array[String], LibraryOptions) -> Integer
 
-    def run_list: (Array[String], LibraryOptions) -> void
+    def run_list: (Array[String], LibraryOptions) -> Integer
 
-    def run_ancestors: (Array[String], LibraryOptions) -> void
+    def run_ancestors: (Array[String], LibraryOptions) -> Integer
 
-    def run_methods: (Array[String], LibraryOptions) -> void
+    def run_methods: (Array[String], LibraryOptions) -> Integer
 
-    def run_method: (Array[String], LibraryOptions) -> void
+    def run_method: (Array[String], LibraryOptions) -> Integer
 
-    def run_validate: (Array[String], LibraryOptions) -> void
+    def run_validate: (Array[String], LibraryOptions) -> Integer
 
-    def run_constant: (Array[String], LibraryOptions) -> void
+    def run_constant: (Array[String], LibraryOptions) -> Integer
 
-    def run_paths: (Array[String], LibraryOptions) -> void
+    def run_paths: (Array[String], LibraryOptions) -> Integer
 
-    def run_prototype: (Array[String], LibraryOptions) -> void
+    def run_prototype: (Array[String], LibraryOptions) -> Integer
 
-    def run_prototype_file: (String format, Array[String]) -> void
+    def run_prototype_file: (String format, Array[String]) -> Integer
 
-    def run_vendor: (Array[String], LibraryOptions) -> void
+    def run_vendor: (Array[String], LibraryOptions) -> Integer
 
-    def run_parse: (Array[String], LibraryOptions) -> void
+    def run_parse: (Array[String], LibraryOptions) -> Integer
 
-    def run_test: (Array[String], LibraryOptions) -> void
+    def run_test: (Array[String], LibraryOptions) -> Integer
 
-    def run_collection: (Array[String], LibraryOptions) -> void
+    def run_collection: (Array[String], LibraryOptions) -> Integer
 
-    def run_annotate: (Array[String], top) -> void
+    def run_annotate: (Array[String], top) -> Integer
 
-    def run_subtract: (Array[String], top) -> void
+    def run_subtract: (Array[String], top) -> Integer
 
-    def run_diff: (Array[String], LibraryOptions) -> void
+    def run_diff: (Array[String], LibraryOptions) -> Integer
 
     def test_opt: (LibraryOptions) -> String?
 

--- a/sig/cli/diff.rbs
+++ b/sig/cli/diff.rbs
@@ -1,21 +1,15 @@
 module RBS
   class CLI
     class Diff
-      @format: String
       @stdout: _IO
       @stderr: _IO
-      @diff: RBS::Diff
 
-      def initialize: (
-        argv: Array[String],
-        library_options: RBS::CLI::LibraryOptions,
-        ?stdout: _IO,
-        ?stderr: _IO,
-      ) -> void
+      def initialize: (?stdout: _IO, ?stderr: _IO) -> void
 
-      def run: () -> void
-      def run_diff: () -> void
-      def run_markdown: () -> void
+      def run: (library_options: RBS::CLI::LibraryOptions, argv: Array[String]) -> Integer
+
+      def run_diff: (RBS::Diff) -> void
+      def run_markdown: (RBS::Diff) -> void
     end
   end
 end

--- a/sig/cli/validate.rbs
+++ b/sig/cli/validate.rbs
@@ -7,11 +7,20 @@ module RBS
         @has_syntax_error: bool
         @errors: Array[BaseError]
 
+        # The tag that will be thrown in #finish method
+        @tag: top
+
         def initialize: (limit: Integer?, exit_error: boolish) -> void
 
         def add: (BaseError) -> void
 
-        def finish: () -> void
+        # Throws the `@tag` with 0 or 1
+        #
+        # Must be called from the block passed to `#try` method.
+        #
+        def finish: () -> Integer
+
+        def try: () { () -> void } -> Integer
 
         private
 
@@ -25,7 +34,7 @@ module RBS
 
       def initialize: (args: Array[String], options: LibraryOptions) -> void
 
-      def run: () -> void
+      def run: () -> Integer
 
       private
 


### PR DESCRIPTION
Some code in RBS library calls `exit` to set the exit status of the command. This makes testing really difficult. This PR replaces the `exit` calls with one `exit` call in `exe/rbs`.