### PR TITLE
Just use `Numeric#+@` and return self

### DIFF
--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -221,8 +221,6 @@ class Complex < Numeric
   #
   def +: (Numeric) -> Complex
 
-  def +@: () -> Complex
-
   # <!--
   #   rdoc-file=complex.c
   #   - complex - numeric -> new_complex

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -153,8 +153,6 @@ class Float < Numeric
   def +: (Complex) -> Complex
        | (Numeric) -> Float
 
-  def +@: () -> Float
-
   # <!--
   #   rdoc-file=numeric.c
   #   - self - other -> numeric

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -246,8 +246,6 @@ class Integer < Numeric
        | (Rational) -> Rational
        | (Complex) -> Complex
 
-  def +@: () -> Integer
-
   # <!--
   #   rdoc-file=numeric.c
   #   - self - numeric -> numeric_result

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -201,7 +201,7 @@ class Numeric
   # -->
   # Returns `self`.
   #
-  def +@: () -> Numeric
+  def +@: () -> self
 
   # Performs subtraction: the class of the resulting object depends on the class
   # of `numeric`.
@@ -214,7 +214,7 @@ class Numeric
   # -->
   # Unary Minus---Returns the receiver, negated.
   #
-  def -@: () -> Numeric
+  def -@: () -> self
 
   # <!--
   #   rdoc-file=numeric.c

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -99,8 +99,6 @@ class Rational < Numeric
        | (Complex) -> Complex
        | (Numeric) -> Rational
 
-  def +@: () -> Rational
-
   # <!--
   #   rdoc-file=rational.c
   #   - rat - numeric  ->  numeric


### PR DESCRIPTION
`Numeric#+@` is now just this.

```rb
class Numeric
  def +@
    self
  end
end
```

Unnecessary definitions should be removed for the sake of document display.