### PR TITLE
Drop undocumented `#dup`

### DIFF
--- a/core/binding.rbs
+++ b/core/binding.rbs
@@ -32,8 +32,6 @@
 class Binding
   def clone: () -> self
 
-  def dup: () -> self
-
   # <!--
   #   rdoc-file=proc.c
   #   - binding.eval(string [, filename [,lineno]])  -> obj

--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -411,8 +411,6 @@ class Complex < Numeric
 
   def divmod: (Numeric) -> bot
 
-  def dup: () -> self
-
   def eql?: (untyped) -> bool
 
   # <!--

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -462,8 +462,6 @@ class Float < Numeric
   def divmod: (Integer | Float | Rational) -> [ Integer, Float ]
             | (Numeric) -> [ Numeric, Numeric ]
 
-  def dup: () -> self
-
   # <!--
   #   rdoc-file=numeric.c
   #   - eql?(other) -> true or false

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -801,8 +801,6 @@ class Integer < Numeric
   def downto: (Numeric limit) { (Integer) -> void } -> Integer
             | (Numeric limit) -> ::Enumerator[Integer, self]
 
-  def dup: () -> self
-
   def eql?: (untyped) -> bool
 
   # <!--

--- a/core/method.rbs
+++ b/core/method.rbs
@@ -54,8 +54,6 @@ class Method
   #
   def hash: () -> Integer
 
-  def dup: () -> self
-
   # <!--
   #   rdoc-file=proc.c
   #   - meth.to_s      ->  string

--- a/core/proc.rbs
+++ b/core/proc.rbs
@@ -377,7 +377,6 @@ class Proc
   def self.new: () { (?) -> untyped } -> instance
 
   def clone: () -> self
-  def dup: () -> self
 
   # <!-- rdoc-file=proc.c -->
   # Invokes the block, setting the block's parameters to the values in *params*

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -244,8 +244,6 @@ class Rational < Numeric
   def divmod: (Integer | Float | Rational) -> [ Integer, Rational ]
             | (Numeric) -> [ Numeric, Numeric ]
 
-  def dup: () -> self
-
   def eql?: (untyped) -> bool
 
   # <!--

--- a/test/stdlib/Binding_test.rb
+++ b/test/stdlib/Binding_test.rb
@@ -10,11 +10,6 @@ class BindingInstanceTest < Test::Unit::TestCase
                       binding, :clone
   end
 
-  def test_dup
-    assert_send_type  '() -> Binding',
-                      binding, :dup
-  end
-
   def test_eval
     with_string '123' do |src|
       assert_send_type  '(string) -> untyped',


### PR DESCRIPTION
Unnecessary definitions should be removed for the sake of document display.