### PR TITLE
Add explicit dependency on the tsort gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     rbs (4.0.0.dev.4)
       logger
       prism (>= 1.3.0)
+      tsort
 
 PATH
   remote: test/assets/test-gem
@@ -166,6 +167,7 @@ GEM
     test-unit (3.6.8)
       power_assert
     timeout (0.4.3)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.2"
   spec.add_dependency "logger"
   spec.add_dependency "prism", ">= 1.3.0"
+  spec.add_dependency "tsort"
 end


### PR DESCRIPTION
This is being bundled, starting in the next Ruby it will warn: https://github.com/ruby/ruby/commit/65a0f46880ecb13994d3011b7a95ecbc5c61c5a0