### PR TITLE
Remove undocumented methods for `imaginary`

### DIFF
--- a/core/complex.rbs
+++ b/core/complex.rbs
@@ -450,6 +450,19 @@ class Complex < Numeric
   #
   def hash: () -> Integer
 
+  # <!--
+  #   rdoc-file=numeric.c
+  #   - i -> complex
+  # -->
+  # Returns `Complex(0, self)`:
+  #
+  #     2.i              # => (0+2i)
+  #     -2.i             # => (0-2i)
+  #     2.0.i            # => (0+2.0i)
+  #     Rational(1, 2).i # => (0+(1/2)*i)
+  #     Complex(3, 4).i  # Raises NoMethodError.
+  #
+  %a{annotate:rdoc:copy:Numeric#i}
   def i: () -> bot
 
   # <!-- rdoc-file=complex.c -->

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -584,10 +584,6 @@ class Float < Numeric
 
   def i: () -> Complex
 
-  def imag: () -> Integer
-
-  def imaginary: () -> Integer
-
   # <!--
   #   rdoc-file=numeric.c
   #   - infinite? -> -1, 1, or nil

--- a/core/float.rbs
+++ b/core/float.rbs
@@ -582,8 +582,6 @@ class Float < Numeric
   #
   def hash: () -> Integer
 
-  def i: () -> Complex
-
   # <!--
   #   rdoc-file=numeric.c
   #   - infinite? -> -1, 1, or nil

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -897,8 +897,6 @@ class Integer < Numeric
   #
   def gcdlcm: (Integer) -> [ Integer, Integer ]
 
-  def i: () -> Complex
-
   def infinite?: () -> Integer?
 
   # <!-- rdoc-file=numeric.c -->

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -899,10 +899,6 @@ class Integer < Numeric
 
   def i: () -> Complex
 
-  def imag: () -> Integer
-
-  def imaginary: () -> Integer
-
   def infinite?: () -> Integer?
 
   # <!-- rdoc-file=numeric.c -->

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -445,18 +445,18 @@ class Numeric
 
   # <!--
   #   rdoc-file=numeric.rb
-  #   - imag()
-  # -->
-  #
-  def imag: () -> Numeric
-
-  # <!--
-  #   rdoc-file=numeric.rb
   #   - imag -> 0
   # -->
   # Returns zero.
   #
-  def imaginary: () -> Numeric
+  def imaginary: () -> 0
+
+  # <!--
+  #   rdoc-file=numeric.rb
+  #   - imag()
+  # -->
+  #
+  alias imag imaginary
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -291,8 +291,6 @@ class Rational < Numeric
   #
   def hash: () -> Integer
 
-  def i: () -> Complex
-
   def infinite?: () -> Integer?
 
   # <!--

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -293,10 +293,6 @@ class Rational < Numeric
 
   def i: () -> Complex
 
-  def imag: () -> Integer
-
-  def imaginary: () -> Integer
-
   def infinite?: () -> Integer?
 
   # <!--


### PR DESCRIPTION
It has no documentation and no merit as a type.
`Complex#i` makes sense, so I copied the documentation.