### PR TITLE
Allow `self` for inline `@rbs @ivar: self`

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3789,7 +3789,7 @@ static bool parse_inline_leading_annotation(rbs_parser_t *parser, rbs_ast_ruby_a
             rbs_location_t *colon_loc = rbs_location_new(ALLOCATOR(), colon_range);
 
             rbs_node_t *type = NULL;
-            if (!rbs_parse_type(parser, &type, false, false)) {
+            if (!rbs_parse_type(parser, &type, false, true)) {
                 return false;
             }
 

--- a/test/rbs/inline_annotation_parsing_test.rb
+++ b/test/rbs/inline_annotation_parsing_test.rb
@@ -190,6 +190,17 @@ class RBS::InlineAnnotationParsingTest < Test::Unit::TestCase
       assert_equal "Array[String]", annot.type.location.source
       assert_nil annot.comment_location
     end
+
+    Parser.parse_inline_leading_annotation("@rbs @self: self", 0...).tap do |annot|
+      assert_instance_of AST::Ruby::Annotations::InstanceVariableAnnotation, annot
+      assert_equal "@rbs @self: self", annot.location.source
+      assert_equal "@rbs", annot.prefix_location.source
+      assert_equal "@self", annot.ivar_name_location.source
+      assert_equal :@self, annot.ivar_name
+      assert_equal ":", annot.colon_location.source
+      assert_equal "self", annot.type.location.source
+      assert_nil annot.comment_location
+    end
   end
 
   def test_error__instance_variable
@@ -207,10 +218,6 @@ class RBS::InlineAnnotationParsingTest < Test::Unit::TestCase
 
     assert_raises RBS::ParsingError do
       Parser.parse_inline_leading_annotation("@rbs @name: void", 0...)
-    end
-
-    assert_raises RBS::ParsingError do
-      Parser.parse_inline_leading_annotation("@rbs @name: self", 0...)
     end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ruby/rbs/pull/2627

I had set it to prohibit `self` in instance variables, but this was a mistake.
`self` should be allowed in instance variables.