### PR TITLE
Introduce `type_fingerprint`

### DIFF
--- a/docs/type_fingerprint.md
+++ b/docs/type_fingerprint.md
@@ -1,0 +1,21 @@
+# Type Fingerprint of RBS Inline AST
+
+Type fingerprint of RBS Inline AST is an object that can be used to detect if the RBS Inline AST is updated and the type checker should type check the whole codebase again.
+
+1. If the AST update is related to the type information, the fingerprint is changed -- adding new type, including new module, changing method type, etc. The type checker should type check the codebase with updated type information.
+2. If the AST updated is not related to the type information, the fingerprint keeps the last value -- changing the method implementation, adding a method call in the top level, adding white spaces and new lines, etc. The type checker can skip updating the type information, and type checking only the implementation of the file is sufficient.
+3. Documentation comments are considered type related information for now.
+
+## Type Fingerprint Calculation
+
+The type fingerprint is calculated by converting AST nodes to standardized data structures that represent only the type-relevant information. Each AST class implements a `type_fingerprint` method that returns mainly arrays and strings.
+
+We expect not using the values for something other than change detection. Compare old and new fingerprints, and we can detect the change between the RBS inline AST if the fingerprints are different.
+
+The fingerprint methods are implemented across:
+
+- `AST::Ruby::Annotations::*#type_fingerprint` - Returns `untyped` (arrays, strings, or nil)
+- `AST::Ruby::Members::*#type_fingerprint` - Returns `untyped` (typically arrays)
+- `AST::Ruby::Declarations::*#type_fingerprint` - Returns `untyped` (typically arrays)
+- `InlineParser::Result#type_fingerprint` - Returns `untyped` (array of declaration fingerprints)
+

--- a/lib/rbs/ast/ruby/annotations.rb
+++ b/lib/rbs/ast/ruby/annotations.rb
@@ -31,6 +31,13 @@ module RBS
               type: type.map_type_name { yield _1 }
             ) #: self
           end
+
+          def type_fingerprint
+            [
+              "annots/node_type_assertion",
+              type.to_s
+            ]
+          end
         end
 
         class AliasAnnotation < Base
@@ -55,9 +62,21 @@ module RBS
         end
 
         class ClassAliasAnnotation < AliasAnnotation
+          def type_fingerprint
+            [
+              "annots/class-alias",
+              type_name&.to_s
+            ]
+          end
         end
 
         class ModuleAliasAnnotation < AliasAnnotation
+          def type_fingerprint
+            [
+              "annots/module-alias",
+              type_name&.to_s
+            ]
+          end
         end
 
         class ColonMethodTypeAnnotation < Base
@@ -76,6 +95,14 @@ module RBS
               annotations: annotations,
               method_type: method_type.map_type {|type| type.map_type_name { yield _1 }}
             ) #: self
+          end
+
+          def type_fingerprint
+            [
+              "annots/colon_method_type",
+              annotations.map(&:to_s),
+              method_type.to_s
+            ]
           end
         end
 
@@ -100,6 +127,13 @@ module RBS
 
             self.class.new(location:, prefix_location:, overloads: ovs, vertical_bar_locations:) #: self
           end
+
+          def type_fingerprint
+            [
+              "annots/method_types",
+              overloads.map { |o| [o.annotations.map(&:to_s), o.method_type.to_s] }
+            ]
+          end
         end
 
         class SkipAnnotation < Base
@@ -109,6 +143,10 @@ module RBS
             super(location, prefix_location)
             @skip_location = skip_location
             @comment_location = comment_location
+          end
+
+          def type_fingerprint
+            "annots/skip"
           end
         end
 
@@ -139,6 +177,14 @@ module RBS
               comment_location: comment_location
             ) #: self
           end
+
+          def type_fingerprint
+            [
+              "annots/return_type",
+              return_type.to_s,
+              comment_location&.source
+            ]
+          end
         end
 
         class TypeApplicationAnnotation < Base
@@ -161,6 +207,13 @@ module RBS
               close_bracket_location:,
               comma_locations:
             ) #: self
+          end
+
+          def type_fingerprint
+            [
+              "annots/type_application",
+              type_args.map(&:to_s)
+            ]
           end
         end
 
@@ -186,6 +239,15 @@ module RBS
               type: type.map_type_name { yield _1 },
               comment_location:
             ) #: self
+          end
+
+          def type_fingerprint
+            [
+              "annots/instance_variable",
+              ivar_name.to_s,
+              type.to_s,
+              comment_location&.source
+            ]
           end
         end
       end

--- a/lib/rbs/inline_parser.rb
+++ b/lib/rbs/inline_parser.rb
@@ -11,6 +11,10 @@ module RBS
         @declarations = []
         @diagnostics = []
       end
+
+      def type_fingerprint
+        declarations.map(&:type_fingerprint)
+      end
     end
 
     module Diagnostic

--- a/sig/ast/ruby/annotations.rbs
+++ b/sig/ast/ruby/annotations.rbs
@@ -27,6 +27,9 @@ module RBS
           def initialize: (Location location, Location prefix_location) -> void
 
           def buffer: () -> Buffer
+
+          # Returns the type fingerprint for this annotation
+          def type_fingerprint: () -> untyped
         end
 
         # `: TYPE` annotation attached to nodes
@@ -37,6 +40,8 @@ module RBS
           def initialize: (location: Location, prefix_location: Location, type: Types::t) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
 
         class AliasAnnotation < Base
@@ -66,6 +71,7 @@ module RBS
         # ```
         #
         class ClassAliasAnnotation < AliasAnnotation
+          def type_fingerprint: () -> untyped
         end
 
         # `: module-alias` annotation
@@ -78,6 +84,7 @@ module RBS
         # ```
         #
         class ModuleAliasAnnotation < AliasAnnotation
+          def type_fingerprint: () -> untyped
         end
 
         # `: METHOD-TYPE` annotation in leading comments
@@ -90,6 +97,8 @@ module RBS
           def initialize: (location: Location, prefix_location: Location, annotations: Array[AST::Annotation], method_type: MethodType) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
 
         # `@rbs METHOD-TYPEs` annotation in leading comments
@@ -109,6 +118,8 @@ module RBS
           def initialize: (location: Location, prefix_location: Location, overloads: Array[Overload], vertical_bar_locations: Array[Location]) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
 
         # `@rbs skip -- comment` annotation in leading comments
@@ -118,6 +129,8 @@ module RBS
           attr_reader comment_location: Location?
 
           def initialize: (location: Location, prefix_location: Location, skip_location: Location, comment_location: Location?) -> void
+
+          def type_fingerprint: () -> untyped
         end
 
         # `@rbs return: T -- comment` annotation in leading comments
@@ -148,6 +161,8 @@ module RBS
           ) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
 
         # `[T1, T2, ...]` annotation in trailing comments
@@ -175,6 +190,8 @@ module RBS
           ) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
 
         # `@rbs IVAR-NAME : TYPE` annotation in leading comments
@@ -208,6 +225,8 @@ module RBS
           ) -> void
 
           def map_type_name: () { (TypeName) -> TypeName } -> self
+
+          def type_fingerprint: () -> untyped
         end
       end
     end

--- a/sig/ast/ruby/declarations.rbs
+++ b/sig/ast/ruby/declarations.rbs
@@ -11,6 +11,8 @@ module RBS
           include Helpers::LocationHelper
 
           def initialize: (Buffer) -> void
+
+          def type_fingerprint: () -> untyped
         end
 
         class ClassDecl < Base
@@ -32,6 +34,8 @@ module RBS
             def initialize: (Location type_name_location, Location operator_location, TypeName, RBS::AST::Ruby::Annotations::TypeApplicationAnnotation?) -> void
 
             def location: () -> Location
+
+            def type_fingerprint: () -> untyped
           end
 
           type member = t | Members::t
@@ -54,6 +58,8 @@ module RBS
           def location: () -> Location
 
           def name_location: () -> Location
+
+          def type_fingerprint: () -> untyped
         end
 
         class ModuleDecl < Base
@@ -77,6 +83,8 @@ module RBS
           def self_types: () -> Array[AST::Declarations::Module::Self]
 
           def name_location: () -> Location
+
+          def type_fingerprint: () -> untyped
         end
 
         class ConstantDecl < Base
@@ -107,6 +115,8 @@ module RBS
           # Returns the comment content extracted from the leading comment block
           #
           def comment: () -> AST::Comment?
+
+          def type_fingerprint: () -> untyped
         end
 
         class ClassModuleAliasDecl < Base
@@ -139,6 +149,8 @@ module RBS
           def old_name: () -> TypeName
 
           def comment: () -> Comment?
+
+          def type_fingerprint: () -> untyped
         end
       end
     end

--- a/sig/ast/ruby/members.rbs
+++ b/sig/ast/ruby/members.rbs
@@ -8,6 +8,8 @@ module RBS
           def initialize: (Buffer) -> void
 
           include Helpers::LocationHelper
+
+          def type_fingerprint: () -> untyped
         end
 
         type t = DefMember
@@ -24,6 +26,8 @@ module RBS
             def map_type_name: () { (TypeName) -> TypeName } -> self
 
             def method_type: () -> MethodType
+
+            def type_fingerprint: () -> untyped
           end
 
           type type_annotations = DocStyle | Array[Annotations::ColonMethodTypeAnnotation | Annotations::MethodTypesAnnotation] | nil
@@ -50,6 +54,8 @@ module RBS
           # Returns the method type overloads
           #
           def overloads: () -> Array[AST::Members::MethodDefinition::Overload]
+
+          def type_fingerprint: () -> untyped
         end
 
         class DefMember < Base
@@ -71,6 +77,8 @@ module RBS
           def annotations: () -> Array[AST::Annotation]
 
           def name_location: () -> Location
+
+          def type_fingerprint: () -> untyped
         end
 
         class MixinMember < Base
@@ -87,6 +95,8 @@ module RBS
           def name_location: () -> Location
 
           def type_args: () -> Array[Types::t]
+
+          def type_fingerprint: () -> untyped
         end
 
         class IncludeMember < MixinMember
@@ -116,6 +126,8 @@ module RBS
           def name_locations: () -> Array[Location]
 
           def type: () -> Types::t?
+
+          def type_fingerprint: () -> untyped
         end
 
         class AttrReaderMember < AttributeMember
@@ -137,6 +149,8 @@ module RBS
           def type: () -> Types::t
 
           def location: () -> Location
+
+          def type_fingerprint: () -> untyped
         end
       end
     end

--- a/sig/inline_parser.rbs
+++ b/sig/inline_parser.rbs
@@ -9,6 +9,8 @@ module RBS
       attr_reader diagnostics: Array[Diagnostic::t]
 
       def initialize: (Buffer, Prism::ParseResult) -> void
+
+      def type_fingerprint: () -> untyped
     end
 
     module Diagnostic

--- a/test/rbs/inline_type_fingerprint_test.rb
+++ b/test/rbs/inline_type_fingerprint_test.rb
@@ -1,0 +1,302 @@
+require "test_helper"
+
+class RBS::InlineTypeFingerprintTest < Test::Unit::TestCase
+  include TestHelper
+
+  def fingerprint(src)
+    buffer = RBS::Buffer.new(name: Pathname("test.rb"), content: src)
+
+    prism = Prism.parse(src)
+    RBS::InlineParser.parse(buffer, prism).type_fingerprint
+  end
+
+  def test_class_decl_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo
+end
+
+module Bar
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo; end
+module Bar; end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+module Foo; end
+class Bar; end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_class_with_superclass_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo < Bar
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo < Bar; end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo < Bar1
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_class_with_type_args_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo < Bar #[String]
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo < Bar    #[ String ]
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo < Bar    #[ str ]
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_method_fingerprint_changes_with_type
+    result = fingerprint(<<-RUBY)
+class Foo
+  # @rbs return:    String
+  def bar
+  end
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  # @rbs return: String
+  def bar
+  end
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo
+  def bar
+  end
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_method_fingerprint_same_with_impl_change
+    result = fingerprint(<<-RUBY)
+class Foo
+  # @rbs return: String
+  def bar
+    "hello"
+  end
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  # @rbs return: String
+  def bar
+    "world"
+  end
+end
+    RUBY
+
+    assert_equal result, result2
+  end
+
+  def test_method_with_overloads_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo
+  # : () -> String
+  # : (Integer) -> Integer
+  def bar(x = nil)
+  end
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  # : () -> String
+  # : (Integer) -> Integer
+  def bar(x = nil); end
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo
+  # : (Integer) -> Integer
+  # : () -> String
+  def bar(x = nil); end
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_mixin_fingerprint
+    result = fingerprint(<<-RUBY)
+module Foo
+  include Bar
+  extend Baz
+  prepend Qux
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+module Foo
+  include Bar; extend Baz; prepend Qux
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+module Foo
+  prepend Qux
+  extend Baz
+  include Bar
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_mixin_with_type_args_fingerprint
+    result = fingerprint(<<-RUBY)
+module Foo
+  include Bar #[String, Integer]
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+module Foo
+  include Bar #[  String,   Integer  ]
+end
+    RUBY
+
+    assert_equal result, result2
+  end
+
+  def test_attribute_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo
+  attr_reader :name #: String
+
+  attr_writer :age
+
+  attr_accessor :active #: bool
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  attr_reader :name #: String
+  attr_writer :age
+  attr_accessor :active  #: bool
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo
+  attr_reader :name1 #: String
+  attr_writer :age
+  attr_accessor :active  #: bool
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_instance_variable_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo
+  # @rbs @name: String
+  # @rbs @age: Integer
+
+  def initialize
+    @name = ""
+    @age = 0
+  end
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  # @rbs @name: String
+
+  # @rbs @age: Integer
+
+  def initialize
+    @name = ""; @age = 0
+  end
+end
+    RUBY
+
+    assert_equal result, result2
+  end
+
+  def test_constant_fingerprint
+    result = fingerprint(<<-RUBY)
+class Foo
+  VERSION = "1.0.0"
+  MAX_SIZE = 100
+end
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+class Foo
+  VERSION = "1.0.1"
+
+  MAX_SIZE = 100
+end
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+class Foo
+  VERSION = "1.0.1" #: String
+
+  MAX_SIZE = 100 #: untyped
+end
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+
+  def test_class_alias_fingerprint
+    result = fingerprint(<<-RUBY)
+NewName = OldName #: class-alias
+    RUBY
+
+    result2 = fingerprint(<<-RUBY)
+NewName =
+  OldName #: class-alias
+    RUBY
+
+    result3 = fingerprint(<<-RUBY)
+NewName = ::OldName #: class-alias
+    RUBY
+
+    assert_equal result, result2
+    refute_equal result, result3
+  end
+end


### PR DESCRIPTION
This PR introduces `#type_fingerprint` method that compute a *fingerprint* of inline RBS type declarations.

* The *fingerprint* is changed if the inline Ruby code changes it's RBS type declarations -- adding classes, renaming methods, changing method types
* The *fingerprint* stays same if the inline Ruby code is updated only for it's implementations -- changing the implementation of `def` node or adding new lines/white spaces to the source code

Using the method, type checkers can detect if the codebase needs re-type-checking after inline Ruby code edits.