### PR TITLE
Add sig `IO#pread` and `IO#pwrite`

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1445,6 +1445,61 @@ class IO < Object
 
   # <!--
   #   rdoc-file=io.c
+  #   - pread(maxlen, offset)             -> string
+  #   - pread(maxlen, offset, out_string) -> string
+  # -->
+  # Behaves like IO#readpartial, except that it:
+  #
+  # *   Reads at the given `offset` (in bytes).
+  # *   Disregards, and does not modify, the stream's position (see
+  #     [Position](rdoc-ref:IO@Position)).
+  # *   Bypasses any user space buffering in the stream.
+  #
+  # Because this method does not disturb the stream's state (its position, in
+  # particular), `pread` allows multiple threads and processes to use the same IO
+  # object for reading at various offsets.
+  #
+  #     f = File.open('t.txt')
+  #     f.read # => "First line\nSecond line\n\nFourth line\nFifth line\n"
+  #     f.pos  # => 52
+  #     # Read 12 bytes at offset 0.
+  #     f.pread(12, 0) # => "First line\n"
+  #     # Read 9 bytes at offset 8.
+  #     f.pread(9, 8)  # => "ne\nSecon"
+  #     f.close
+  #
+  # Not available on some platforms.
+  #
+  def pread: (Integer maxlen, Integer offset, ?String out_string) -> String
+
+  # <!--
+  #   rdoc-file=io.c
+  #   - pwrite(object, offset) -> integer
+  # -->
+  # Behaves like IO#write, except that it:
+  #
+  # *   Writes at the given `offset` (in bytes).
+  # *   Disregards, and does not modify, the stream's position (see
+  #     [Position](rdoc-ref:IO@Position)).
+  # *   Bypasses any user space buffering in the stream.
+  #
+  # Because this method does not disturb the stream's state (its position, in
+  # particular), `pwrite` allows multiple threads and processes to use the same IO
+  # object for writing at various offsets.
+  #
+  #     f = File.open('t.tmp', 'w+')
+  #     # Write 6 bytes at offset 3.
+  #     f.pwrite('ABCDEF', 3) # => 6
+  #     f.rewind
+  #     f.read # => "\u0000\u0000\u0000ABCDEF"
+  #     f.close
+  #
+  # Not available on some platforms.
+  #
+  def pwrite: (_ToS object, Integer offset) -> Integer
+
+  # <!--
+  #   rdoc-file=io.c
   #   - read(maxlen = nil, out_string = nil) -> new_string, out_string, or nil
   # -->
   # Reads bytes from the stream; the stream must be opened for reading (see

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -484,6 +484,28 @@ class IOInstanceTest < Test::Unit::TestCase
                        io, :readline, "\n", 100, chomp: true
     end
   end
+
+  def test_pwrite
+    Dir.mktmpdir do |dir|
+      File.open(File.join(dir, "io-pwrite"), "w") do |io|
+        assert_send_type "(String, Integer) -> Integer",
+                         io, :pwrite, "hello", 0
+      end
+    end
+  end
+
+  def test_pread
+    IO.open(IO.sysopen(File.expand_path(__FILE__))) do |io|
+      assert_send_type(
+        "(Integer, Integer) -> String",
+        io, :pread, 10, 0
+      )
+      assert_send_type(
+        "(Integer, Integer, String) -> String",
+        io, :pread, 10, 0, +"buffer"
+      )
+    end
+  end
 end
 
 class IOWaitTest < Test::Unit::TestCase


### PR DESCRIPTION
I will add the type signature for `IO#pread` and `IO#pwrite`.

* https://docs.ruby-lang.org/en/3.4/IO.html#method-i-pread
* https://docs.ruby-lang.org/en/3.4/IO.html#method-i-pwrite