### PR TITLE
Update `string.rbs` to avoid deprecation warning in Steep

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -3580,4 +3580,15 @@ interface _ArefFromStringToString
 end
 
 %a{deprecated}
-type String::encode_fallback = Hash[String, String] | Proc | Method | _ArefFromStringToString
+type String::encode_fallback = Hash[String, String] | Proc | Method | String::_ArefFromStringToString
+
+# Don't use this interface directly
+#
+# This is a copy of `::_ArefFromStringToString` but without deprecated attribute.
+# This is a workaround to avoid deprecation warnings in `String::encode_fallback` type.
+#
+# This type will be deprecated soon once `::_ArefFromStringToString` and `String::encode_fallback` are removed.
+#
+interface String::_ArefFromStringToString
+  def []: (String) -> String
+end


### PR DESCRIPTION
Both `::_ArefFromStringToString` and `String::encode_fallback` are marked as *deprecated*, and referencing the interface from `encode_fallback` results in `RBS::DeprecatedTypeName` error in RBS file reported by Steep.

```
$ bundle exec steep check --no-type-check --validate=library
# Type checking files:

....................................................................................................................................................................................................F..............

core/string.rbs:3583:70: [warning] Type `::String::_ArefFromStringToString` is deprecated
│ Diagnostic ID: RBS::DeprecatedTypeName
│
└ type String::encode_fallback = Hash[String, String] | Proc | Method | String::_ArefFromStringToString
                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Detected 1 problem from 1 file
```

This warning doesn't make sense:

1. `String::encode_fallback` itself is a deprecated, so using the type in user's code are already reported as a type error
2. Users cannot silence the warning by changing Steep configuration

This PR changes the type definition to remove the warning.