### PR TITLE
Add -j option to make

### DIFF
--- a/.github/workflows/c-check.yml
+++ b/.github/workflows/c-check.yml
@@ -28,6 +28,8 @@ jobs:
           sudo apt-get install -y clang-format-20
           sudo ln -sf /usr/bin/clang-format-20 /usr/local/bin/clang-format
           clang-format --version
+      - name: Count processors
+        run: nproc
       - name: Install Re2c
         run: |
           cd /tmp
@@ -36,7 +38,7 @@ jobs:
           cd re2c-4.3
           autoreconf -i -W all
           ./configure
-          make
+          make -j"$(nproc)" -l"$(nproc)"
           sudo make install
       - name: Update rubygems & bundler
         run: |


### PR DESCRIPTION
This PR adds `-j` option to make the re2c compilation faster. The result is about 2x faster! 🚀 (~10mins -> ~4mins)