### PR TITLE
Set %a{deprecated} to deprecated core methods

### DIFF
--- a/core/process.rbs
+++ b/core/process.rbs
@@ -1861,6 +1861,7 @@ class Process::Status < Object
   #
   # ArgumentError is raised if `mask` is negative.
   #
+  %a{deprecated}
   def &: (Integer num) -> Integer
 
   # <!--
@@ -1893,6 +1894,7 @@ class Process::Status < Object
   #
   # ArgumentError is raised if `places` is negative.
   #
+  %a{deprecated}
   def >>: (Integer num) -> Integer
 
   # <!--

--- a/core/string.rbs
+++ b/core/string.rbs
@@ -1547,6 +1547,7 @@ class String
   # hashing algorithms, install the string-crypt gem and `require 'string/crypt'`
   # to continue using it.
   #
+  %a{deprecated}
   def crypt: (string salt_str) -> String
 
   # <!-- rdoc-file=string.c -->


### PR DESCRIPTION
* `Process::Status#&` and `Process::Status#>>` [[Bug #19868]](https://bugs.ruby-lang.org/issues/19868)
* `String#crypt` [[Feature #14915]](https://bugs.ruby-lang.org/issues/14915)