### PR TITLE
Reuse empty array and hash

### DIFF
--- a/ext/rbs_extension/ast_translation.c
+++ b/ext/rbs_extension/ast_translation.c
@@ -11,6 +11,9 @@
 #include "rbs_string_bridging.h"
 #include "legacy_location.h"
 
+VALUE EMPTY_ARRAY;
+VALUE EMPTY_HASH;
+
 #define RBS_LOC_CHILDREN_SIZE(cap) (sizeof(rbs_loc_children) + sizeof(rbs_loc_entry) * ((cap) - 1))
 
 rbs_translation_context_t rbs_translation_context_create(rbs_constant_pool_t *constant_pool, VALUE buffer, rb_encoding *ruby_encoding) {
@@ -32,6 +35,10 @@ VALUE rbs_node_list_to_ruby_array(rbs_translation_context_t ctx, rbs_node_list_t
 }
 
 VALUE rbs_hash_to_ruby_hash(rbs_translation_context_t ctx, rbs_hash_t *rbs_hash) {
+    if (!rbs_hash->head) {
+        return EMPTY_HASH;
+    }
+
     VALUE ruby_hash = rb_hash_new();
 
     for (rbs_hash_node_t *n = rbs_hash->head; n != NULL; n = n->next) {
@@ -60,11 +67,11 @@ VALUE rbs_loc_to_ruby_location(rbs_translation_context_t ctx, rbs_location_t *so
 }
 
 VALUE rbs_location_list_to_ruby_array(rbs_translation_context_t ctx, rbs_location_list_t *list) {
-    VALUE ruby_array = rb_ary_new();
-
     if (list == NULL) {
-        return ruby_array;
+        return EMPTY_ARRAY;
     }
+
+    VALUE ruby_array = rb_ary_new();
 
     for (rbs_location_list_node_t *n = list->head; n != NULL; n = n->next) {
         rb_ary_push(ruby_array, rbs_loc_to_ruby_location(ctx, n->loc));

--- a/ext/rbs_extension/ast_translation.h
+++ b/ext/rbs_extension/ast_translation.h
@@ -31,4 +31,7 @@ VALUE rbs_node_list_to_ruby_array(rbs_translation_context_t, rbs_node_list_t *li
 VALUE rbs_hash_to_ruby_hash(rbs_translation_context_t, rbs_hash_t *hash);
 VALUE rbs_struct_to_ruby_value(rbs_translation_context_t, rbs_node_t *instance);
 
+extern VALUE EMPTY_ARRAY;
+extern VALUE EMPTY_HASH;
+
 #endif

--- a/ext/rbs_extension/main.c
+++ b/ext/rbs_extension/main.c
@@ -450,8 +450,12 @@ static VALUE rbsparser_lex(VALUE self, VALUE buffer, VALUE end_pos) {
 void rbs__init_parser(void) {
     RBS_Parser = rb_define_class_under(RBS, "Parser", rb_cObject);
     rb_gc_register_mark_object(RBS_Parser);
-    VALUE empty_array = rb_obj_freeze(rb_ary_new());
-    rb_gc_register_mark_object(empty_array);
+
+    EMPTY_ARRAY = rb_obj_freeze(rb_ary_new());
+    rb_gc_register_mark_object(EMPTY_ARRAY);
+
+    EMPTY_HASH = rb_obj_freeze(rb_hash_new());
+    rb_gc_register_mark_object(EMPTY_HASH);
 
     rb_define_singleton_method(RBS_Parser, "_parse_type", rbsparser_parse_type, 7);
     rb_define_singleton_method(RBS_Parser, "_parse_method_type", rbsparser_parse_method_type, 5);

--- a/templates/ext/rbs_extension/ast_translation.c.erb
+++ b/templates/ext/rbs_extension/ast_translation.c.erb
@@ -4,6 +4,9 @@
 #include "rbs_string_bridging.h"
 #include "legacy_location.h"
 
+VALUE EMPTY_ARRAY;
+VALUE EMPTY_HASH;
+
 #define RBS_LOC_CHILDREN_SIZE(cap) (sizeof(rbs_loc_children) + sizeof(rbs_loc_entry) * ((cap) - 1))
 
 rbs_translation_context_t rbs_translation_context_create(rbs_constant_pool_t *constant_pool, VALUE buffer, rb_encoding *ruby_encoding) {
@@ -25,6 +28,10 @@ VALUE rbs_node_list_to_ruby_array(rbs_translation_context_t ctx, rbs_node_list_t
 }
 
 VALUE rbs_hash_to_ruby_hash(rbs_translation_context_t ctx, rbs_hash_t *rbs_hash) {
+    if (!rbs_hash->head) {
+        return EMPTY_HASH;
+    }
+
     VALUE ruby_hash = rb_hash_new();
 
     for (rbs_hash_node_t *n = rbs_hash->head; n != NULL; n = n->next) {
@@ -53,11 +60,11 @@ VALUE rbs_loc_to_ruby_location(rbs_translation_context_t ctx, rbs_location_t *so
 }
 
 VALUE rbs_location_list_to_ruby_array(rbs_translation_context_t ctx, rbs_location_list_t *list) {
-    VALUE ruby_array = rb_ary_new();
-
     if (list == NULL) {
-        return ruby_array;
+        return EMPTY_ARRAY;
     }
+
+    VALUE ruby_array = rb_ary_new();
 
     for (rbs_location_list_node_t *n = list->head; n != NULL; n = n->next) {
         rb_ary_push(ruby_array, rbs_loc_to_ruby_location(ctx, n->loc));

--- a/templates/ext/rbs_extension/ast_translation.h.erb
+++ b/templates/ext/rbs_extension/ast_translation.h.erb
@@ -24,4 +24,7 @@ VALUE rbs_node_list_to_ruby_array(rbs_translation_context_t, rbs_node_list_t *li
 VALUE rbs_hash_to_ruby_hash(rbs_translation_context_t, rbs_hash_t *hash);
 VALUE rbs_struct_to_ruby_value(rbs_translation_context_t, rbs_node_t *instance);
 
+extern VALUE EMPTY_ARRAY;
+extern VALUE EMPTY_HASH;
+
 #endif


### PR DESCRIPTION
Reuse empty array and hash objects as in #1950.

Evaluation with `bin/benchmark-parse.rb` did not show any improvement in either performance or memory usage. I believe memory usage can be improved with this when we keep the AST in memory after parsing -- the actual usecase, unlike the benchmark.