### PR TITLE
[Kernel] Tweak signatures for conversion methods, and add unit tests in

### DIFF
--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -501,7 +501,7 @@ module Kernel : BasicObject
                    | (String real_or_both, ?exception: true) -> Complex
                    | (untyped real_or_both, exception: bool) -> Complex?
                    | (Numeric | String real, Numeric | String imag, ?exception: true) -> Complex
-                   | (Numeric | String real, Integer | Float | Rational | Complex imag, exception: bool) -> Complex
+                   | (Numeric | String real, Integer | Float | Rational | Complex imag, exception: bool) -> Complex?
                    | (Numeric | String real, untyped imag, exception: bool) -> Complex?
 
   # <!--

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -497,9 +497,12 @@ module Kernel : BasicObject
   #
   def self?.Complex: (_ToC complex_like, ?exception: true) -> Complex
                    | (_ToC complex_like, exception: bool) -> Complex?
-                   | (Numeric | String real, ?Numeric | String imag, ?exception: true) -> Complex
-                   | (Numeric | String real, ?Numeric | String imag, exception: bool) -> Complex?
-                   | (untyped, ?untyped, ?exception: bool) -> Complex?
+                   | (Numeric numeric, ?exception: bool) -> Complex
+                   | (String real_or_both, ?exception: true) -> Complex
+                   | (untyped real_or_both, exception: bool) -> Complex?
+                   | (Numeric | String real, Numeric | String imag, ?exception: true) -> Complex
+                   | (Numeric | String real, Integer | Float | Rational | Complex imag, exception: bool) -> Complex
+                   | (Numeric | String real, untyped imag, exception: bool) -> Complex?
 
   # <!--
   #   rdoc-file=kernel.rb
@@ -519,7 +522,7 @@ module Kernel : BasicObject
   #
   def self?.Float: (_ToF float_like, ?exception: true) -> Float
                  | (_ToF float_like, exception: bool) -> Float?
-                 | (untyped, ?exception: bool) -> Float?
+                 | (untyped, exception: bool) -> Float?
 
   # <!--
   #   rdoc-file=object.c
@@ -542,7 +545,7 @@ module Kernel : BasicObject
   #     Hash(nil)              # => {}
   #     Hash([])               # => {}
   #
-  def self?.Hash: [K, V] (nil | [] _empty) -> Hash[K, V]
+  def self?.Hash: [K, V] (nil | []) -> Hash[K, V]
                 | [K, V] (hash[K, V] hash_like) -> Hash[K, V]
 
   # <!--
@@ -632,7 +635,7 @@ module Kernel : BasicObject
                    | (int | _ToI int_like, exception: bool) -> Integer?
                    | (string str, int base, ?exception: true) -> Integer
                    | (string str, int base, exception: bool) -> Integer?
-                   | (untyped, ?untyped, ?exception: bool) -> Integer?
+                   | (untyped, ?int base, exception: bool) -> Integer?
 
   # <!--
   #   rdoc-file=rational.c
@@ -673,14 +676,19 @@ module Kernel : BasicObject
   #
   def self?.Rational: (int | _ToR rational_like, ?exception: true) -> Rational
                     | (int | _ToR rational_like, exception: bool) -> Rational?
-                    | (int | _ToR numer, ?int | _ToR denom, ?exception: true) -> Rational
-                    | (int | _ToR numer, ?int | _ToR denom, exception: bool) -> Rational?
-                    | [T] (Numeric & _RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
+                    | (int | _ToR numer, int | _ToR denom, ?exception: true) -> Rational
+                    | (int | _ToR numer, int | _ToR denom, exception: bool) -> Rational?
                     | [T < Numeric] (T value, 1, ?exception: bool) -> T
-                    | (untyped, ?untyped, ?exception: bool) -> Rational?
+                    | [T] (Numeric & _RationalDiv[T] numer, Numeric denom, ?exception: bool) -> T
+                    | (untyped, ?untyped, exception: bool) -> Rational?
 
+  # An interface used in `Kernel.Rational` when both arguments are `Numeric`s,
+  # but don't define `to_r` or `to_int`.
+  #
+  # The return type of the division is the return type of `Rational(numer, denom)`.
   interface _RationalDiv[T]
-    def /: (Numeric) -> T
+    # Divide the numerator by `denom`
+    def /: (Numeric denom) -> T
   end
 
   # <!--

--- a/lib/rbs/unit_test/type_assertions.rb
+++ b/lib/rbs/unit_test/type_assertions.rb
@@ -180,11 +180,11 @@ module RBS
           )
           errors = typecheck.method_call(method, method_type, trace, errors: [])
 
-          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.inspect}"
+          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, proc { "Call trace does not match with given method type: #{trace.inspect}" }
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.any? {|es| es.empty? }, "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.any? {|es| es.empty? }, proc { "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           raise exception if exception
 

--- a/sig/unit_test/type_assertions.rbs
+++ b/sig/unit_test/type_assertions.rbs
@@ -30,19 +30,19 @@ module RBS
       type target_type = Types::ClassInstance | Types::ClassSingleton
 
       interface _BaseAssertions
-        def assert: (untyped, ?String?) -> void
+        def assert: (untyped, ?String? | Proc) -> void
 
-        def refute: (untyped, ?String?) -> void
+        def refute: (untyped, ?String? | Proc) -> void
 
-        def assert_empty: (untyped, ?String?) -> void
+        def assert_empty: (untyped, ?String | nil | Proc) -> void
 
         def assert_operator: (untyped, Symbol, *untyped) -> void
 
         def notify: (untyped) -> void
 
-        def assert_predicate: (untyped, Symbol, ?String?) -> void
+        def assert_predicate: (untyped, Symbol, ?String? | Proc) -> void
 
-        def refute_predicate: (untyped, Symbol, ?String?) -> void
+        def refute_predicate: (untyped, Symbol, ?String? | Proc) -> void
       end
 
       module ClassMethods

--- a/test/stdlib/Kernel_test.rb
+++ b/test/stdlib/Kernel_test.rb
@@ -62,13 +62,17 @@ class KernelSingletonTest < Test::Unit::TestCase
                        Kernel, :Complex, real_untype, exception: false
     end
 
-    with '1', 1, 1r, 1.0, (1+0i), numeric do |real|
-      with '2', 2, 2r, 2.0, (2+0i), numeric do |imag|
+    numeric_fail = Class.new(Numeric) { def to_c = fail }.new
+
+    with '1', 1, 1r, 1.0, (1+0i), numeric, numeric_fail do |real|
+      with '2', 2, 2r, 2.0, (2+0i), numeric, numeric_fail do |imag|
         # (Numeric | String real, Numeric | String imag, ?exception: true) -> Complex
-        assert_send_type "(Numeric | String, Numeric | String) -> Complex",
-                         Kernel, :Complex, real, imag
-        assert_send_type "(Numeric | String, Numeric | String, exception: true) -> Complex",
-                         Kernel, :Complex, real, imag, exception: true
+        if real != numeric_fail && imag != numeric_fail
+          assert_send_type "(Numeric | String, Numeric | String) -> Complex",
+                           Kernel, :Complex, real, imag
+          assert_send_type "(Numeric | String, Numeric | String, exception: true) -> Complex",
+                           Kernel, :Complex, real, imag, exception: true
+        end
 
         # Complex has an awkward edgecase where `exception: false` will unconditionally return `nil`
         # if the imaginary argument is not one of the builtin `Numeric`s. Oddly enough, it's not for
@@ -76,7 +80,7 @@ class KernelSingletonTest < Test::Unit::TestCase
         case imag
         when Integer, Float, Rational, Complex
           # (Numeric | String real, Integer | Float | Rational | Complex imag, exception: bool) -> Complex
-          assert_send_type "(Numeric | String, Integer | Float | Rational | Complex, exception: bool) -> Complex",
+          assert_send_type "(Numeric | String, Integer | Float | Rational | Complex, exception: bool) -> Complex?",
                            Kernel, :Complex, real, imag, exception: false
         end
       end

--- a/test/typecheck/complex/Steepfile
+++ b/test/typecheck/complex/Steepfile
@@ -1,0 +1,7 @@
+D = Steep::Diagnostic
+
+target :test do
+  signature "."
+  check "."
+  configure_code_diagnostics(D::Ruby.all_error)
+end

--- a/test/typecheck/complex/test.rb
+++ b/test/typecheck/complex/test.rb
@@ -1,0 +1,41 @@
+class Raises
+  def to_c = fail
+end
+
+class RaisesNumeric < Numeric
+  def to_c = fail
+end
+
+Complex(1) #: Complex
+Complex(1.23) #: Complex
+Complex(1r) #: Complex
+Complex(1i) #: Complex
+Complex(1ri) #: Complex
+Complex(Numeric.new) #: Complex
+Complex('1+2i') #: Complex
+
+Complex(1, exception: true) #: Complex
+Complex(1.23, exception: true) #: Complex
+Complex(1r, exception: true) #: Complex
+Complex(1i, exception: true) #: Complex
+Complex(1ri, exception: true) #: Complex
+Complex(Numeric.new, exception: true) #: Complex
+Complex("1+2i", exception: true) #: Complex
+
+Complex(Raises.new, exception: false) #: nil
+Complex(RaisesNumeric.new, exception: false) #: nil
+Complex('a', exception: false) #: nil
+
+Complex(1, 1) #: Complex
+Complex(1.23, 1.23) #: Complex
+Complex(1r, 1r) #: Complex
+Complex(1i, 1i) #: Complex
+Complex(1ri, 1ri) #: Complex
+Complex(Numeric.new, Numeric.new) #: Complex
+Complex('1+2i', '1+2i') #: Complex
+Complex(2, '1+2i') #: Complex
+
+Complex(1, Raises.new, exception: false) #: nil
+Complex(RaisesNumeric.new, 2, exception: false) #: nil
+Complex('a', 3, exception: false) #: nil
+Complex(2, :untyped, exception: false) #: nil

--- a/test/typecheck/complex/test.rbs
+++ b/test/typecheck/complex/test.rbs
@@ -1,0 +1,7 @@
+class Raises
+  def to_c: () -> bot
+end
+
+class RaisesNumeric < Numeric
+  def to_c: () -> bot
+end


### PR DESCRIPTION
This PR tweaks some of the `Kernel` conversion methods' signatures, as well as cleaning up/adding relevant tests.

Of particular note is that the numeric conversions (`Integer`/`Float`/`Complex`/`Rational`)'s final signature (the `(untyped, ?exception: bool) -> type?` one) now marks the `exception: bool` as required.