### PR TITLE
Add signature for `SecureRandom.bytes`

### DIFF
--- a/stdlib/securerandom/0/securerandom.rbs
+++ b/stdlib/securerandom/0/securerandom.rbs
@@ -35,5 +35,15 @@
 # raised.
 #
 module SecureRandom
+  # <!--
+  #   rdoc-file=lib/securerandom.rb
+  #   - bytes(n)
+  # -->
+  # Returns a random binary string containing `size` bytes.
+  #
+  # See Random.bytes
+  #
+  def self.bytes: (Integer) -> String
+
   extend Random::Formatter
 end

--- a/test/stdlib/SecureRandom_test.rb
+++ b/test/stdlib/SecureRandom_test.rb
@@ -7,6 +7,11 @@ class SecureRandomSingletonTest < Test::Unit::TestCase
   library "securerandom"
   testing "singleton(::SecureRandom)"
 
+  def test_bytes
+    assert_send_type "(::Integer) -> ::String",
+                     SecureRandom, :bytes, 10
+  end
+
   def test_uuid
     assert_send_type "() -> ::String",
                      SecureRandom, :uuid


### PR DESCRIPTION
since: ruby v2.4
rdoc: https://docs.ruby-lang.org/en/3.4/SecureRandom.html#method-c-bytes
impl: https://github.com/ruby/securerandom/blob/ce183eedf609a9cdfaccfb1bcf725528924b83e9/lib/securerandom.rb#L50-L52