### PR TITLE
Accept `nil` state parameter in `to_json` type signatures

### DIFF
--- a/lib/rbs/ast/annotation.rb
+++ b/lib/rbs/ast/annotation.rb
@@ -21,7 +21,7 @@ module RBS
         self.class.hash ^ string.hash
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { string: string, location: location }.to_json(state)
       end
     end

--- a/lib/rbs/ast/comment.rb
+++ b/lib/rbs/ast/comment.rb
@@ -21,7 +21,7 @@ module RBS
         self.class.hash ^ string.hash
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { string: string, location: location }.to_json(state)
       end
     end

--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -74,7 +74,7 @@ module RBS
             self.class.hash ^ name.hash ^ args.hash
           end
 
-          def to_json(state = _ = nil)
+          def to_json(state = nil)
             {
               name: name,
               args: args,
@@ -130,7 +130,7 @@ module RBS
           self.class.hash ^ name.hash ^ type_params.hash ^ super_class.hash ^ members.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :class,
             name: name,
@@ -166,7 +166,7 @@ module RBS
             self.class.hash ^ name.hash ^ args.hash ^ location.hash
           end
 
-          def to_json(state = _ = nil)
+          def to_json(state = nil)
             {
               name: name,
               args: args,
@@ -231,7 +231,7 @@ module RBS
           self.class.hash ^ name.hash ^ type_params.hash ^ self_types.hash ^ members.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :module,
             name: name,
@@ -288,7 +288,7 @@ module RBS
           self.class.hash ^ type_params.hash ^ members.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :interface,
             name: name,
@@ -331,7 +331,7 @@ module RBS
           self.class.hash ^ name.hash ^ type_params.hash ^ type.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :alias,
             name: name,
@@ -371,7 +371,7 @@ module RBS
           self.class.hash ^ name.hash ^ type.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :constant,
             name: name,
@@ -409,7 +409,7 @@ module RBS
           self.class.hash ^ name.hash ^ type.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :global,
             name: name,
@@ -445,7 +445,7 @@ module RBS
       end
 
       class ClassAlias < AliasDecl
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :class_alias,
             new_name: new_name,
@@ -457,7 +457,7 @@ module RBS
       end
 
       class ModuleAlias < AliasDecl
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             declaration: :module_alias,
             new_name: new_name,

--- a/lib/rbs/ast/members.rb
+++ b/lib/rbs/ast/members.rb
@@ -35,7 +35,7 @@ module RBS
             update(method_type: self.method_type.sub(subst))
           end
 
-          def to_json(state = _ = nil)
+          def to_json(state = nil)
             {
               annotations: annotations,
               method_type: method_type
@@ -103,7 +103,7 @@ module RBS
           )
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :method_definition,
             name: name,
@@ -145,7 +145,7 @@ module RBS
       class InstanceVariable < Base
         include Var
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :instance_variable,
             name: name,
@@ -159,7 +159,7 @@ module RBS
       class ClassInstanceVariable < Base
         include Var
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :class_instance_variable,
             name: name,
@@ -173,7 +173,7 @@ module RBS
       class ClassVariable < Base
         include Var
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :class_variable,
             name: name,
@@ -215,7 +215,7 @@ module RBS
       class Include < Base
         include Mixin
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :include,
             name: name,
@@ -230,7 +230,7 @@ module RBS
       class Extend < Base
         include Mixin
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :extend,
             name: name,
@@ -245,7 +245,7 @@ module RBS
       class Prepend < Base
         include Mixin
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :prepend,
             name: name,
@@ -311,7 +311,7 @@ module RBS
       class AttrReader < Base
         include Attribute
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :attr_reader,
             name: name,
@@ -329,7 +329,7 @@ module RBS
       class AttrAccessor < Base
         include Attribute
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :attr_accessor,
             name: name,
@@ -347,7 +347,7 @@ module RBS
       class AttrWriter < Base
         include Attribute
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :attr_writer,
             name: name,
@@ -383,7 +383,7 @@ module RBS
       class Public < Base
         include LocationOnly
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           { member: :public, location: location }.to_json(state)
         end
       end
@@ -391,7 +391,7 @@ module RBS
       class Private < Base
         include LocationOnly
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           { member: :private, location: location }.to_json(state)
         end
       end
@@ -426,7 +426,7 @@ module RBS
           new_name.hash ^ old_name.hash ^ kind.hash
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           {
             member: :alias,
             new_name: new_name,

--- a/lib/rbs/location_aux.rb
+++ b/lib/rbs/location_aux.rb
@@ -83,7 +83,7 @@ module RBS
         other.end_pos == end_pos
     end
 
-    def to_json(state = _ = nil)
+    def to_json(state = nil)
       {
         start: {
           line: start_line,

--- a/lib/rbs/method_type.rb
+++ b/lib/rbs/method_type.rb
@@ -21,7 +21,7 @@ module RBS
         other.block == block
     end
 
-    def to_json(state = _ = nil)
+    def to_json(state = nil)
       {
         type_params: type_params,
         type: type,

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -36,7 +36,7 @@ module RBS
       "#{namespace.to_s}#{name}"
     end
 
-    def to_json(state = _ = nil)
+    def to_json(state = nil)
       to_s.to_json(state)
     end
 

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -61,7 +61,7 @@ module RBS
         include EmptyEachType
         include NoTypeName
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           klass = to_s.to_sym
           { class: klass, location: location }.to_json(state)
         end
@@ -157,7 +157,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :variable, name: name, location: location }.to_json(state)
       end
 
@@ -221,7 +221,7 @@ module RBS
       include NoFreeVariables
       include NoSubst
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :class_singleton, name: name, location: location }.to_json(state)
       end
 
@@ -320,7 +320,7 @@ module RBS
         @location = location
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :interface, name: name, args: args, location: location }.to_json(state)
       end
 
@@ -364,7 +364,7 @@ module RBS
         @location = location
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :class_instance, name: name, args: args, location: location }.to_json(state)
       end
 
@@ -408,7 +408,7 @@ module RBS
         @location = location
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :alias, name: name, args: args, location: location }.to_json(state)
       end
 
@@ -466,7 +466,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :tuple, types: types, location: location }.to_json(state)
       end
 
@@ -573,7 +573,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :record, fields: fields, optional_fields: optional_fields, location: location }.to_json(state)
       end
 
@@ -665,7 +665,7 @@ module RBS
         type.free_variables(set)
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :optional, type: type, location: location }.to_json(state)
       end
 
@@ -755,7 +755,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :union, types: types, location: location }.to_json(state)
       end
 
@@ -846,7 +846,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :intersection, types: types, location: location }.to_json(state)
       end
 
@@ -932,7 +932,7 @@ module RBS
           end
         end
 
-        def to_json(state = _ = nil)
+        def to_json(state = nil)
           { type: type, name: name }.to_json(state)
         end
 
@@ -1091,7 +1091,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         {
           required_positionals: required_positionals,
           optional_positionals: optional_positionals,
@@ -1279,7 +1279,7 @@ module RBS
         end
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         {
           return_type: return_type
         }.to_json(state)
@@ -1355,7 +1355,7 @@ module RBS
           other.self_type == self_type
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         {
           type: type,
           required: required,
@@ -1424,7 +1424,7 @@ module RBS
         set
       end
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         {
           class: :proc,
           type: type,
@@ -1541,7 +1541,7 @@ module RBS
       include EmptyEachType
       include NoTypeName
 
-      def to_json(state = _ = nil)
+      def to_json(state = nil)
         { class: :literal, literal: literal.inspect, location: location }.to_json(state)
       end
 

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1,5 +1,5 @@
 interface _ToJson
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 # <!-- rdoc-file=ext/json/lib/json/common.rb -->
@@ -1191,28 +1191,28 @@ class Object
   # it to a JSON string, and returns the result. This is a fallback, if no
   # special method #to_json was defined for some object.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
 class NilClass
   # Returns a JSON string for nil: 'null'.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
 class TrueClass
   # Returns a JSON string for true: 'true'.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
 class FalseClass
   # Returns a JSON string for false: 'false'.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1221,21 +1221,21 @@ class String
   # returns a JSON string encoded with UTF16 big endian characters as
   # \u????.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
 class Integer
   # Returns a JSON string representation for this Integer number.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
 class Float
   # Returns a JSON string representation for this Float number.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1245,7 +1245,7 @@ class Hash[unchecked out K, unchecked out V]
   # _state_ is a JSON::State object, that can also be used to configure the
   # produced JSON string output further.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1255,7 +1255,7 @@ class Array[unchecked out Elem]
   # _state_ is a JSON::State object, that can also be used to configure the
   # produced JSON string output further.
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1309,7 +1309,7 @@ class BigDecimal
   #     {"json_class":"BigDecimal","b":"36:0.2e1"}
   #     {"json_class":"BigDecimal","b":"27:0.2e1"}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1358,7 +1358,7 @@ class Complex
   #     {"json_class":"Complex","r":2,"i":0}
   #     {"json_class":"Complex","r":2.0,"i":4}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1405,7 +1405,7 @@ class Date
   #
   #     {"json_class":"Date","y":2023,"m":11,"d":21,"sg":2299161.0}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1451,7 +1451,7 @@ class DateTime
   #
   #     {"json_class":"DateTime","y":2023,"m":11,"d":21,"sg":2299161.0}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1496,7 +1496,7 @@ class Exception
   #
   #     {"json_class":"Exception","m":"Foo","b":null}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1544,7 +1544,7 @@ class OpenStruct
   #
   #     {"json_class":"OpenStruct","t":{'name':'Rowdy',"age":null}}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1597,7 +1597,7 @@ class Range[out Elem]
   #     {"json_class":"Range","a":[1,4,true]}
   #     {"json_class":"Range","a":["a","d",false]}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1644,7 +1644,7 @@ class Rational
   #
   #     {"json_class":"Rational","n":2,"d":3}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1690,7 +1690,7 @@ class Regexp
   #
   #     {"json_class":"Regexp","o":0,"s":"foo"}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1736,7 +1736,7 @@ class Set[unchecked out A]
   #
   #     {"json_class":"Set","a":["foo","bar","baz"]}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1785,7 +1785,7 @@ class Struct[Elem]
   #
   #     {"json_class":"Struct","t":{'name':'Rowdy',"age":null}}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1831,7 +1831,7 @@ class Symbol
   #
   #     # {"json_class":"Symbol","s":"foo"}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end
 
 %a{annotate:rdoc:skip}
@@ -1878,5 +1878,5 @@ class Time
   #
   #     {"json_class":"Time","s":1700931678,"n":980650786}
   #
-  def to_json: (?JSON::State state) -> String
+  def to_json: (?JSON::State? state) -> String
 end

--- a/test/stdlib/json/JSONBigDecimal_test.rb
+++ b/test/stdlib/json/JSONBigDecimal_test.rb
@@ -28,6 +28,8 @@ class JSONBigDecimalInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      BigDecimal("0"), :to_json
+    assert_send_type "(nil) -> String",
+                     BigDecimal("0"), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      BigDecimal("0"), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONComplex_test.rb
+++ b/test/stdlib/json/JSONComplex_test.rb
@@ -28,6 +28,8 @@ class JSONComplexInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Complex(0), :to_json
+    assert_send_type "(nil) -> String",
+                     Complex(0), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Complex(0), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONDateTime_test.rb
+++ b/test/stdlib/json/JSONDateTime_test.rb
@@ -28,6 +28,8 @@ class JSONDateTimeInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      DateTime.now, :to_json
+    assert_send_type "(nil) -> String",
+                     DateTime.now, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      DateTime.now, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONDate_test.rb
+++ b/test/stdlib/json/JSONDate_test.rb
@@ -28,6 +28,8 @@ class JSONDateInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Date.today, :to_json
+    assert_send_type "(nil) -> String",
+                     Date.today, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Date.today, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONException_test.rb
+++ b/test/stdlib/json/JSONException_test.rb
@@ -42,6 +42,8 @@ class JSONExceptionInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Exception.new("foo"), :to_json
+    assert_send_type "(nil) -> String",
+                     Exception.new("foo"), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Exception.new("foo"), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONOpenStruct_test.rb
+++ b/test/stdlib/json/JSONOpenStruct_test.rb
@@ -28,6 +28,8 @@ class JSONOpenStructInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      OpenStruct.new, :to_json
+    assert_send_type "(nil) -> String",
+                     OpenStruct.new, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      OpenStruct.new, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONRange_test.rb
+++ b/test/stdlib/json/JSONRange_test.rb
@@ -28,6 +28,8 @@ class JSONRangeInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      (0..9), :to_json
+    assert_send_type "(nil) -> String",
+                     (0..9), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      (0..9), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONRational_test.rb
+++ b/test/stdlib/json/JSONRational_test.rb
@@ -28,6 +28,8 @@ class JSONRationalInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Rational(1, 3), :to_json
+    assert_send_type "(nil) -> String",
+                     Rational(1, 3), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Rational(1, 3), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONRegexp_test.rb
+++ b/test/stdlib/json/JSONRegexp_test.rb
@@ -28,6 +28,8 @@ class JSONRegexpInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      /foo/, :to_json
+    assert_send_type "(nil) -> String",
+                     /foo/, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      /foo/, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONSet_test.rb
+++ b/test/stdlib/json/JSONSet_test.rb
@@ -28,6 +28,8 @@ class JSONSetInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Set[1, 2], :to_json
+    assert_send_type "(nil) -> String",
+                     Set[1, 2], :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Set[1, 2], :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONStruct_test.rb
+++ b/test/stdlib/json/JSONStruct_test.rb
@@ -32,6 +32,8 @@ class JSONStructInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Foo.new(1), :to_json
+    assert_send_type "(nil) -> String",
+                     Foo.new(1), :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Foo.new(1), :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONSymbol_test.rb
+++ b/test/stdlib/json/JSONSymbol_test.rb
@@ -28,6 +28,8 @@ class JSONSymbolInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      :foo, :to_json
+    assert_send_type "(nil) -> String",
+                     :foo, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      :foo, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSONTime_test.rb
+++ b/test/stdlib/json/JSONTime_test.rb
@@ -28,6 +28,8 @@ class JSONTimeInstanceTest < Test::Unit::TestCase
   def test_to_json
     assert_send_type "() -> String",
                      Time.now, :to_json
+    assert_send_type "(nil) -> String",
+                     Time.now, :to_json, nil
     assert_send_type "(JSON::State) -> String",
                      Time.now, :to_json, JSON::State.new
   end

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -183,46 +183,55 @@ class JSONInstanceTest < Test::Unit::TestCase
 
   def test_to_json_with_object
     assert_send_type "() -> String", Object.new, :to_json
+    assert_send_type "(nil) -> String", Object.new, :to_json, nil
     assert_send_type "(JSON::State) -> String",  Object.new, :to_json, JSON::State.new
   end
 
   def test_to_json_with_nil
     assert_send_type "() -> String", nil, :to_json
+    assert_send_type "(nil) -> String", nil, :to_json, nil
     assert_send_type "(JSON::State) -> String", nil, :to_json, JSON::State.new
   end
 
   def test_to_json_with_true
     assert_send_type "() -> String", true, :to_json
+    assert_send_type "(nil) -> String", true, :to_json, nil
     assert_send_type "(JSON::State) -> String", true, :to_json, JSON::State.new
   end
 
   def test_to_json_with_false
     assert_send_type "() -> String", false, :to_json
+    assert_send_type "(nil) -> String", false, :to_json, nil
     assert_send_type "(JSON::State) -> String", false, :to_json, JSON::State.new
   end
 
   def test_to_json_with_string
     assert_send_type "() -> String", "foo", :to_json
+    assert_send_type "(nil) -> String", "foo", :to_json, nil
     assert_send_type "(JSON::State) -> String", "foo", :to_json, JSON::State.new
   end
 
   def test_to_json_with_integer
     assert_send_type "() -> String", 123, :to_json
+    assert_send_type "(nil) -> String", 123, :to_json, nil
     assert_send_type "(JSON::State) -> String", 123, :to_json, JSON::State.new
   end
 
   def test_to_json_with_float
     assert_send_type "() -> String", 0.123, :to_json
+    assert_send_type "(nil) -> String", 0.123, :to_json, nil
     assert_send_type "(JSON::State) -> String", 0.123, :to_json, JSON::State.new
   end
 
   def test_to_json_with_hash
     assert_send_type "() -> String", { a: 1 }, :to_json
+    assert_send_type "(nil) -> String", { a: 1 }, :to_json, nil
     assert_send_type "(JSON::State) -> String", { a: 1 }, :to_json, JSON::State.new
   end
 
   def test_to_json_with_array
     assert_send_type "() -> String", [], :to_json
+    assert_send_type "(nil) -> String", [], :to_json, nil
     assert_send_type "(JSON::State) -> String", [], :to_json, JSON::State.new
   end
 end


### PR DESCRIPTION
This PR adds `nil` state parameter to the type signature for all `to_json` methods. [`cState_from_state_s`](https://github.com/ruby/json/blob/a630388d4dc6f5ddf5d965e4b3844d627f47ceb1/ext/json/ext/generator/generator.c#L1567) will return an unconfigured instance if `nil` is passed. A lot of implementations of `to_json` have `nil` as the default value.