### PR TITLE
Add deprecated annotation to `attr` with bool args

### DIFF
--- a/core/module.rbs
+++ b/core/module.rbs
@@ -1694,7 +1694,8 @@ class Module < Object
   # `attr_reader(name)` but deprecated. Returns an array of defined method names
   # as symbols.
   #
-  def attr: (*interned arg0) -> Array[Symbol]
+  def attr: %a{deprecated} (interned, bool) -> Array[Symbol]
+          | (*interned arg0) -> Array[Symbol]
 
   # A previous incarnation of `interned` for backward-compatibility (see #1499)
   %a{deprecated: Use `interned`}


### PR DESCRIPTION
It is stated in the documentation that it is deprecated, and a warning actually appears.

```
$ ruby -we 'class Foo; attr :foo, true; end'
-e:1: warning: optional boolean argument is obsoleted
```

The `deprecated` annotation should be added.