### PR TITLE
Update FileUtils to v1.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
-    fileutils (1.7.3)
+    fileutils (1.8.0)
     goodcheck (3.1.0)
       marcel (>= 1.0, < 2.0)
       psych (>= 3.1, < 5.0)

--- a/test/stdlib/FileUtils_test.rb
+++ b/test/stdlib/FileUtils_test.rb
@@ -360,8 +360,8 @@ class FileUtilsSingletonTest < Test::Unit::TestCase
                         FileUtils, :ln_sr, ToStr.new("src"), ToStr.new("dest"), noop: true
       assert_send_type  "(ToPath, ToPath, noop: bool) -> void",
                         FileUtils, :ln_sr, ToPath.new("src"), ToPath.new("dest"), noop: true
-      assert_send_type  "(Array[String | ToStr | ToPath], String, noop: bool, verbose: bool, target_directory: false) -> void",
-                        FileUtils, :ln_sr, ["src", ToStr.new("src"), ToStr.new("src")], "dest_dir", noop: true, verbose: false, target_directory: false
+      assert_send_type  "(Array[String | ToStr | ToPath], String, noop: bool, verbose: bool, target_directory: true) -> void",
+                        FileUtils, :ln_sr, ["src", ToStr.new("src"), ToStr.new("src")], "dest_dir", noop: true, verbose: false, target_directory: true
     end
   end
 


### PR DESCRIPTION
Updating fileutils to v1.8.0 causes tests to fail.
I fix this by correcting the test code and updating fileutils to v1.8.0.

Refs:
* https://github.com/ruby/rbs/actions/runs/19053637232
* https://github.com/ruby/fileutils/pull/134