### PR TITLE
Remove reference to `JSON.deep_const_get`

### DIFF
--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -708,8 +708,6 @@ module JSON
   #
   def self.create_id=: (_ToS create_id) -> _ToS
 
-  def self.deep_const_get: (interned path) -> untyped
-
   # <!--
   #   rdoc-file=ext/json/lib/json/common.rb
   #   - JSON.dump(obj, io = nil, limit = nil)

--- a/test/stdlib/json/JSON_test.rb
+++ b/test/stdlib/json/JSON_test.rb
@@ -47,12 +47,6 @@ class JSONSingletonTest < Test::Unit::TestCase
     assert_send_type "(String) -> String", JSON, :create_id=, "json_class"
   end
 
-  def test_deep_const_get
-    with_interned("File") do |val|
-      assert_send_type "(interned) -> singleton(File)", JSON, :deep_const_get, val
-    end
-  end
-
   def test_dump
     assert_send_type "(ToJson) -> String", JSON, :dump, ToJson.new
     assert_send_type "(ToJson, Integer) -> String", JSON, :dump, ToJson.new, 100


### PR DESCRIPTION
This was always meant as internal API and was removed in `json 2.16.0`.