### PR TITLE
Skip io/wait tests for methods deleted in Ruby 4

### DIFF
--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -528,20 +528,22 @@ class IOWaitTest < Test::Unit::TestCase
   def test_readyp
     # This method returns true|false in Ruby 2.7, nil|IO in 3.0, and true|false in 3.1.
 
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "() -> untyped",
-        r, :ready?
-      )
-    end
+    if_ruby(..."4.0.0", skip: false) do
+      IO.pipe.tap do |r, w|
+        assert_send_type(
+          "() -> untyped",
+          r, :ready?
+        )
+      end
 
-    IO.pipe.tap do |r, w|
-      w.write("hello")
+      IO.pipe.tap do |r, w|
+        w.write("hello")
 
-      assert_send_type(
-        "() -> untyped",
-        r, :ready?
-      )
+        assert_send_type(
+          "() -> untyped",
+          r, :ready?
+        )
+      end
     end
   end
 
@@ -584,11 +586,13 @@ class IOWaitTest < Test::Unit::TestCase
   end
 
   def test_nread
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "() -> Integer",
-        r, :nread
-      )
+    if_ruby(..."4.0.0", skip: false) do
+      IO.pipe.tap do |r, w|
+        assert_send_type(
+          "() -> Integer",
+          r, :nread
+        )
+      end
     end
   end
 


### PR DESCRIPTION
See: https://github.com/ruby/io-wait/pull/49


---

Note that you probably want to also make changes to https://github.com/ruby/rbs/blob/master/core/io/wait.rbs to remove `ready?` and `nread`. I'm not sure the best way to go about it would be, though.