### PR TITLE
[Enumerable] Update include? to accept untyped

### DIFF
--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -725,7 +725,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     {foo: 0, bar: 1, baz: 2}.include?('foo') # => false
   #     {foo: 0, bar: 1, baz: 2}.include?(0)     # => false
   #
-  def include?: (Elem arg0) -> bool
+  def include?: (untyped object) -> bool
 
   # <!--
   #   rdoc-file=enum.c
@@ -1571,7 +1571,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     {foo: 0, bar: 1, baz: 2}.include?('foo') # => false
   #     {foo: 0, bar: 1, baz: 2}.include?(0)     # => false
   #
-  def member?: (Elem arg0) -> bool
+  alias member? include?
 
   # <!-- rdoc-file=enum.c -->
   # Returns the result of applying a reducer to an initial value and the first

--- a/test/stdlib/Enumerable_test.rb
+++ b/test/stdlib/Enumerable_test.rb
@@ -265,4 +265,15 @@ class EnumerableTest2 < Test::Unit::TestCase
     assert_send_type '(Class) -> bool', TestEnumerable.new, :one?, String
     assert_send_type '() { (String) -> bool } -> bool', TestEnumerable.new, :one? do |x| x == '0' end
   end
+
+  def test_include?(method: :include?)
+    with_untyped.and '1' do |element|
+      assert_send_type '(untyped) -> bool',
+                       TestEnumerable.new, method, element
+    end
+  end
+
+  def test_member?
+    test_include?(method: :member?)
+  end
 end


### PR DESCRIPTION
This PR updates `Enumerable#include?` (and `member?`) to accept `untyped` instead of `Elem`