### PR TITLE
Backport "Remove sig for IO#{ready?,nread}"

### DIFF
--- a/core/io/wait.rbs
+++ b/core/io/wait.rbs
@@ -2,27 +2,6 @@
 class IO
   # <!--
   #   rdoc-file=ext/io/wait/wait.c
-  #   - io.nread -> int
-  # -->
-  # Returns number of bytes that can be read without blocking. Returns zero if no
-  # information available.
-  #
-  # You must require 'io/wait' to use this method.
-  #
-  def nread: () -> Integer
-
-  # <!--
-  #   rdoc-file=ext/io/wait/wait.c
-  #   - io.ready? -> truthy or falsy
-  # -->
-  # Returns a truthy value if input available without blocking, or a falsy value.
-  #
-  # You must require 'io/wait' to use this method.
-  #
-  def ready?: () -> boolish
-
-  # <!--
-  #   rdoc-file=ext/io/wait/wait.c
   #   - io.wait(events, timeout) -> event mask, false or nil
   #   - io.wait(timeout = nil, mode = :read) -> self, true, or false
   # -->

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -458,26 +458,6 @@ class IOWaitTest < Test::Unit::TestCase
 
   testing "::IO"
 
-  def test_readyp
-    # This method returns true|false in Ruby 2.7, nil|IO in 3.0, and true|false in 3.1.
-
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "() -> untyped",
-        r, :ready?
-      )
-    end
-
-    IO.pipe.tap do |r, w|
-      w.write("hello")
-
-      assert_send_type(
-        "() -> untyped",
-        r, :ready?
-      )
-    end
-  end
-
   def test_wait_readable
     if_ruby "3.0.0"..."3.2.0" do
       IO.pipe.tap do |r, w|
@@ -513,15 +493,6 @@ class IOWaitTest < Test::Unit::TestCase
           w, :wait_writable, 1
         )
       end
-    end
-  end
-
-  def test_nread
-    IO.pipe.tap do |r, w|
-      assert_send_type(
-        "() -> Integer",
-        r, :nread
-      )
     end
   end
 


### PR DESCRIPTION
* https://github.com/ruby/rbs/pull/2710