### PR TITLE
Add RFC2396_PARSER to URI module

### DIFF
--- a/stdlib/uri/0/common.rbs
+++ b/stdlib/uri/0/common.rbs
@@ -561,6 +561,11 @@ URI::REL_URI: Regexp
 URI::REL_URI_REF: Regexp
 
 # <!-- rdoc-file=lib/uri/common.rb -->
+# The default parser instance for RFC 2396.
+#
+URI::RFC2396_PARSER: URI::RFC2396_Parser
+
+# <!-- rdoc-file=lib/uri/common.rb -->
 # The default parser instance for RFC 3986.
 #
 URI::RFC3986_PARSER: URI::RFC3986_Parser


### PR DESCRIPTION
The URI module defines the constant `URI::RFC2396_PARSER` [here](https://github.com/ruby/uri/blob/master/lib/uri/common.rb#L17C3-L17C17) but it was missing in the RBS declaration, so I got the following warning:

```rb
URI::RFC2396_PARSER.escape("https://example.org")
```

```sh
something.rb:32:29: [warning] Cannot find the declaration of constant: `RFC2396_PARSER`
│ Diagnostic ID: Ruby::UnknownConstant
│
└         URI::RFC2396_PARSER.escape("https://example.org")
```
 