### PR TITLE
Update rdoc and comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.16.0)
+    rdoc (6.17.0)
       erb
       psych (>= 4.0.0)
       tsort

--- a/core/file.rbs
+++ b/core/file.rbs
@@ -1839,12 +1839,12 @@ class File < IO
   # Returns `false` if `File::LOCK_NB` is specified and the operation would have
   # blocked;
   # otherwise returns `0`.
-  #    Constant    |    Lock    |                                                    Effect
-  # ---------------|------------|--------------------------------------------------------------------------------------------------------------
-  # +File::LOCK_EX+| Exclusive  |                      Only one process may hold an exclusive lock for +self+ at a time.
-  # +File::LOCK_NB+|Non-blocking|No blocking; may be combined with +File::LOCK_SH+ or +File::LOCK_EX+ using the bitwise OR operator <tt>|</tt>.
-  # +File::LOCK_SH+|   Shared   |                 Multiple processes may each hold a shared lock for +self+ at the same time.
-  # +File::LOCK_UN+|   Unlock   |                                Remove an existing lock held by this process.
+  #    Constant    |    Lock    |                                                Effect
+  # ---------------|------------|-------------------------------------------------------------------------------------------------------
+  # `File::LOCK_EX`| Exclusive  |                   Only one process may hold an exclusive lock for `self` at a time.
+  # `File::LOCK_NB`|Non-blocking|No blocking; may be combined with `File::LOCK_SH` or `File::LOCK_EX` using the bitwise OR operator `|`.
+  # `File::LOCK_SH`|   Shared   |              Multiple processes may each hold a shared lock for `self` at the same time.
+  # `File::LOCK_UN`|   Unlock   |                             Remove an existing lock held by this process.
   # Example:
   #     # Update a counter using an exclusive lock.
   # # Don't use File::WRONLY because it truncates the file.

--- a/core/kernel.rbs
+++ b/core/kernel.rbs
@@ -1779,58 +1779,58 @@ module Kernel : BasicObject
   # *   Each of these tests operates only on the entity at `path0`,
   #      and returns `true` or `false`;
   #      for a non-existent entity, returns `false` (does not raise exception):
-  #  Character  |Test
-  # ------------|-------------------------------------------------------------------------
-  # <tt>'b'</tt>|Whether the entity is a block device.
-  # <tt>'c'</tt>|Whether the entity is a character device.
-  # <tt>'d'</tt>|Whether the entity is a directory.
-  # <tt>'e'</tt>|Whether the entity is an existing entity.
-  # <tt>'f'</tt>|Whether the entity is an existing regular file.
-  # <tt>'g'</tt>|Whether the entity's setgid bit is set.
-  # <tt>'G'</tt>|Whether the entity's group ownership is equal to the caller's.
-  # <tt>'k'</tt>|Whether the entity's sticky bit is set.
-  # <tt>'l'</tt>|Whether the entity is a symbolic link.
-  # <tt>'o'</tt>|Whether the entity is owned by the caller's effective uid.
-  # <tt>'O'</tt>|Like <tt>'o'</tt>, but uses the real uid (not the effective uid).
-  # <tt>'p'</tt>|Whether the entity is a FIFO device (named pipe).
-  # <tt>'r'</tt>|Whether the entity is readable by the caller's effective uid/gid.
-  # <tt>'R'</tt>|Like <tt>'r'</tt>, but uses the real uid/gid (not the effective uid/gid).
-  # <tt>'S'</tt>|Whether the entity is a socket.
-  # <tt>'u'</tt>|Whether the entity's setuid bit is set.
-  # <tt>'w'</tt>|Whether the entity is writable by the caller's effective uid/gid.
-  # <tt>'W'</tt>|Like <tt>'w'</tt>, but uses the real uid/gid (not the effective uid/gid).
-  # <tt>'x'</tt>|Whether the entity is executable by the caller's effective uid/gid.
-  # <tt>'X'</tt>|Like <tt>'x'</tt>, but uses the real uid/gid (not the effective uid/git).
-  # <tt>'z'</tt>|Whether the entity exists and is of length zero.
+  # Character|Test
+  # ---------|-------------------------------------------------------------------
+  #   `'b'`  |Whether the entity is a block device.
+  #   `'c'`  |Whether the entity is a character device.
+  #   `'d'`  |Whether the entity is a directory.
+  #   `'e'`  |Whether the entity is an existing entity.
+  #   `'f'`  |Whether the entity is an existing regular file.
+  #   `'g'`  |Whether the entity's setgid bit is set.
+  #   `'G'`  |Whether the entity's group ownership is equal to the caller's.
+  #   `'k'`  |Whether the entity's sticky bit is set.
+  #   `'l'`  |Whether the entity is a symbolic link.
+  #   `'o'`  |Whether the entity is owned by the caller's effective uid.
+  #   `'O'`  |Like `'o'`, but uses the real uid (not the effective uid).
+  #   `'p'`  |Whether the entity is a FIFO device (named pipe).
+  #   `'r'`  |Whether the entity is readable by the caller's effective uid/gid.
+  #   `'R'`  |Like `'r'`, but uses the real uid/gid (not the effective uid/gid).
+  #   `'S'`  |Whether the entity is a socket.
+  #   `'u'`  |Whether the entity's setuid bit is set.
+  #   `'w'`  |Whether the entity is writable by the caller's effective uid/gid.
+  #   `'W'`  |Like `'w'`, but uses the real uid/gid (not the effective uid/gid).
+  #   `'x'`  |Whether the entity is executable by the caller's effective uid/gid.
+  #   `'X'`  |Like `'x'`, but uses the real uid/gid (not the effective uid/git).
+  #   `'z'`  |Whether the entity exists and is of length zero.
   # *   This test operates only on the entity at `path0`,
   #      and returns an integer size or `nil`:
-  #  Character  |Test
-  # ------------|--------------------------------------------------------------------------------------------
-  # <tt>'s'</tt>|Returns positive integer size if the entity exists and has non-zero length, +nil+ otherwise.
+  # Character|Test
+  # ---------|--------------------------------------------------------------------------------------------
+  #   `'s'`  |Returns positive integer size if the entity exists and has non-zero length, `nil` otherwise.
   # *   Each of these tests operates only on the entity at `path0`,
   #      and returns a Time object;
   #      raises an exception if the entity does not exist:
-  #  Character  |Test
-  # ------------|--------------------------------------
-  # <tt>'A'</tt>|Last access time for the entity.
-  # <tt>'C'</tt>|Last change time for the entity.
-  # <tt>'M'</tt>|Last modification time for the entity.
+  # Character|Test
+  # ---------|--------------------------------------
+  #   `'A'`  |Last access time for the entity.
+  #   `'C'`  |Last change time for the entity.
+  #   `'M'`  |Last modification time for the entity.
   # *   Each of these tests operates on the modification time (`mtime`)
   #      of each of the entities at `path0` and `path1`,
   #      and returns a `true` or `false`;
   #      returns `false` if either entity does not exist:
-  #  Character  |Test
-  # ------------|------------------------------------------------------------------------------------------------
-  # <tt>'<'</tt>|Whether the <code>mtime</code> at <code>path0</code> is less than that at <code>path1</code>.
-  # <tt>'='</tt>|Whether the <code>mtime</code> at <code>path0</code> is equal to that at <code>path1</code>.
-  # <tt>'>'</tt>|Whether the <code>mtime</code> at <code>path0</code> is greater than that at <code>path1</code>.
+  # Character|Test
+  # ---------|---------------------------------------------------------------
+  #   `'<'`  |Whether the `mtime` at `path0` is less than that at `path1`.
+  #   `'='`  |Whether the `mtime` at `path0` is equal to that at `path1`.
+  #   `'>'`  |Whether the `mtime` at `path0` is greater than that at `path1`.
   # *   This test operates on the content of each of the entities at `path0` and
   #     `path1`,
   #      and returns a `true` or `false`;
   #      returns `false` if either entity does not exist:
-  #  Character  |Test
-  # ------------|---------------------------------------------
-  # <tt>'-'</tt>|Whether the entities exist and are identical.
+  # Character|Test
+  # ---------|---------------------------------------------
+  #   `'-'`  |Whether the entities exist and are identical.
   #
   def self?.test: (String | Integer cmd, String | IO file1, ?String | IO file2) -> (TrueClass | FalseClass | Time | nil | Integer)
 

--- a/stdlib/strscan/0/string_scanner.rbs
+++ b/stdlib/strscan/0/string_scanner.rbs
@@ -211,12 +211,12 @@
 # This table summarizes (details and examples at the links):
 #        Method        |                   Returns                   |Sets Match Values?
 # ---------------------|---------------------------------------------|------------------
-#    #check(pattern)   |     Matched leading substring or +nil+.     |       Yes.
-# #check_until(pattern)|   Matched substring (anywhere) or +nil+.    |       Yes.
+#    #check(pattern)   |     Matched leading substring or `nil`.     |       Yes.
+# #check_until(pattern)|   Matched substring (anywhere) or `nil`.    |       Yes.
 #   #exist?(pattern)   |   Matched substring (anywhere) end index.   |       Yes.
-#   #match?(pattern)   | Size of matched leading substring or +nil+. |       Yes.
+#   #match?(pattern)   | Size of matched leading substring or `nil`. |       Yes.
 #      #peek(size)     | Leading substring of given length (bytes).  |       No.
-#      #peek_byte      |       Integer leading byte or +nil+.        |       No.
+#      #peek_byte      |       Integer leading byte or `nil`.        |       No.
 #         #rest        |Target substring (from byte position to end).|       No.
 # ### Traversing the Target Substring
 # A *traversal* method examines the target substring,
@@ -226,24 +226,24 @@
 # This table summarizes (details and examples at links):
 #        Method       |                      Returns                       |Sets Match Values?
 # --------------------|----------------------------------------------------|------------------
-#      #get_byte      |               Leading byte or +nil+.               |       No.
-#        #getch       |            Leading character or +nil+.             |       No.
-#    #scan(pattern)   |        Matched leading substring or +nil+.         |       Yes.
-#      #scan_byte     |           Integer leading byte or +nil+.           |       No.
-# #scan_until(pattern)|       Matched substring (anywhere) or +nil+.       |       Yes.
-#    #skip(pattern)   |      Matched leading substring size or +nil+.      |       Yes.
-# #skip_until(pattern)|Position delta to end-of-matched-substring or +nil+.|       Yes.
-#       #unscan       |                      +self+.                       |       No.
+#      #get_byte      |               Leading byte or `nil`.               |       No.
+#        #getch       |            Leading character or `nil`.             |       No.
+#    #scan(pattern)   |        Matched leading substring or `nil`.         |       Yes.
+#      #scan_byte     |           Integer leading byte or `nil`.           |       No.
+# #scan_until(pattern)|       Matched substring (anywhere) or `nil`.       |       Yes.
+#    #skip(pattern)   |      Matched leading substring size or `nil`.      |       Yes.
+# #skip_until(pattern)|Position delta to end-of-matched-substring or `nil`.|       Yes.
+#       #unscan       |                      `self`.                       |       No.
 # ## Querying the Scanner
 # Each of these methods queries the scanner object
 # without modifying it (details and examples at links)
 #       Method       |            Returns
 # -------------------|--------------------------------
-# #beginning_of_line?|       +true+ or +false+.
+# #beginning_of_line?|       `true` or `false`.
 #      #charpos      |      Character position.
-#        #eos?       |       +true+ or +false+.
-#   #fixed_anchor?   |       +true+ or +false+.
-#      #inspect      |String representation of +self+.
+#        #eos?       |       `true` or `false`.
+#   #fixed_anchor?   |       `true` or `false`.
+#      #inspect      |String representation of `self`.
 #        #pos        |         Byte position.
 #        #rest       |       Target substring.
 #     #rest_size     |   Size of target substring.
@@ -312,11 +312,11 @@
 # Each of these methods returns a basic match value:
 #    Method    |          Return After Match          |Return After No Match
 # -------------|--------------------------------------|---------------------
-#   #matched?  |               +true+.                |      +false+.
-# #matched_size|      Size of matched substring.      |       +nil+.
-#   #matched   |          Matched substring.          |       +nil+.
-#  #pre_match  |Substring preceding matched substring.|       +nil+.
-#  #post_match |Substring following matched substring.|       +nil+.
+#   #matched?  |               `true`.                |      `false`.
+# #matched_size|      Size of matched substring.      |       `nil`.
+#   #matched   |          Matched substring.          |       `nil`.
+#  #pre_match  |Substring preceding matched substring.|       `nil`.
+#  #post_match |Substring following matched substring.|       `nil`.
 #
 # See examples below.
 # #### Captured Match Values
@@ -326,11 +326,11 @@
 # Each of these methods returns a captured match value:
 #     Method     |          Return After Match           |Return After No Match
 # ---------------|---------------------------------------|---------------------
-#      #size     |     Count of captured substrings.     |       +nil+.
-#     #{}[n]     |   <tt>n</tt>th captured substring.    |       +nil+.
-#    #captures   |   Array of all captured substrings.   |       +nil+.
-# #values_at(*n) |Array of specified captured substrings.|       +nil+.
-# #named_captures|        Hash of named captures.        |    <tt>{}</tt>.
+#      #size     |     Count of captured substrings.     |       `nil`.
+#     #[](n)     |       `n`th captured substring.       |       `nil`.
+#    #captures   |   Array of all captured substrings.   |       `nil`.
+# #values_at(*n) |Array of specified captured substrings.|       `nil`.
+# #named_captures|        Hash of named captures.        |        `{}`.
 #
 # See examples below.
 # #### Match Values Examples


### PR DESCRIPTION
The table notation in rdoc v6.17.0 has been corrected, resulting in a more Markdown-like representation.

ref: https://github.com/ruby/rdoc/pull/1483