### PR TITLE
Add signature for `OptionParser#raise_unknown`

### DIFF
--- a/stdlib/optparse/0/optparse.rbs
+++ b/stdlib/optparse/0/optparse.rbs
@@ -825,6 +825,11 @@ class OptionParser
   #
   attr_accessor program_name: String
 
+  # <!-- rdoc-file=lib/optparse.rb -->
+  # Whether to raise at unknown option.
+  #
+  attr_accessor raise_unknown: boolish
+
   # <!--
   #   rdoc-file=lib/optparse.rb
   #   - reject(*args, &blk)

--- a/test/stdlib/OptionParser_test.rb
+++ b/test/stdlib/OptionParser_test.rb
@@ -201,6 +201,14 @@ class OptionParserTest < Test::Unit::TestCase
     assert_send_type "(String) -> String", opt, :program_name=, 'foo'
   end
 
+  def test_raise_unknown
+    assert_send_type "() -> boolish", opt, :raise_unknown
+  end
+
+  def test_raise_unknown=
+    assert_send_type "(boolish) -> boolish", opt, :raise_unknown=, true
+  end
+
   def test_reject
     assert_send_type '(Class) -> void', opt, :reject, Class.new
   end


### PR DESCRIPTION
Fix https://github.com/ruby/rbs/issues/2640
docs: https://docs.ruby-lang.org/en/3.4/OptionParser.html#attribute-i-raise_unknown