### PR TITLE
[Backport] Remove deprecated method Kernel#Namespace. Also remove Kernel#TypeName.

### DIFF
--- a/lib/rbs/namespace.rb
+++ b/lib/rbs/namespace.rb
@@ -116,10 +116,3 @@ module RBS
     end
   end
 end
-
-module Kernel
-  def Namespace(name)
-    warn "Kernel#Namespace() is deprecated. Use RBS::Namespace.parse instead.", category: :deprecated
-    RBS::Namespace.parse(name)
-  end
-end

--- a/lib/rbs/type_name.rb
+++ b/lib/rbs/type_name.rb
@@ -100,10 +100,3 @@ module RBS
     end
   end
 end
-
-module Kernel
-  def TypeName(string)
-    warn "Kernel#TypeName() is deprecated. Use RBS::TypeName.parse instead.", category: :deprecated
-    RBS::TypeName.parse(string)
-  end
-end

--- a/sig/namespace.rbs
+++ b/sig/namespace.rbs
@@ -139,8 +139,3 @@ module RBS
               | () -> Enumerator[Namespace, void]
   end
 end
-
-module Kernel
-  # Deprecated: Use `RBS::Namespace.parse` instead
-  %a{deprecated} def Namespace: (String) -> RBS::Namespace
-end

--- a/sig/typename.rbs
+++ b/sig/typename.rbs
@@ -72,8 +72,3 @@ module RBS
     def self.parse: (String name) -> RBS::TypeName
   end
 end
-
-module Kernel
-  # Deprecated: Use `RBS::TypeName.parse` instead
-  %a{deprecated: Use `RBS::TypeName.parse` instead} def TypeName: (String name) -> RBS::TypeName
-end


### PR DESCRIPTION
* https://github.com/ruby/rbs/pull/2480