### PR TITLE
Update v4_0_0_preview2 to v4.0.0-preview2

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -11,7 +11,7 @@ jobs:
   comments:
     runs-on: "ubuntu-latest"
     env:
-      RUBY_COMMIT: v4_0_0_preview2
+      RUBY_COMMIT: v4.0.0-preview2
     steps:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The `v4_0_0_preview2` git tag has been renamed to `v4.0.0-preview2`.

https://bugs.ruby-lang.org/issues/21774