### PR TITLE
Fix C++ compiler warnings

### DIFF
--- a/ext/rbs_extension/class_constants.c
+++ b/ext/rbs_extension/class_constants.c
@@ -7,8 +7,6 @@
 
 #include "rbs_extension.h"
 
-VALUE RBS_Parser;
-
 VALUE RBS;
 VALUE RBS_AST;
 VALUE RBS_AST_Declarations;

--- a/ext/rbs_extension/legacy_location.c
+++ b/ext/rbs_extension/legacy_location.c
@@ -33,7 +33,7 @@ void rbs_loc_legacy_alloc_children(rbs_loc *loc, unsigned short cap) {
     check_children_max(cap);
 
     size_t s = RBS_LOC_CHILDREN_SIZE(cap);
-    loc->children = malloc(s);
+    loc->children = (rbs_loc_children *) malloc(s);
 
     *loc->children = (rbs_loc_children) {
         .len = 0,
@@ -50,7 +50,7 @@ static void check_children_cap(rbs_loc *loc) {
         if (loc->children->len == loc->children->cap) {
             check_children_max(loc->children->cap + 1);
             size_t s = RBS_LOC_CHILDREN_SIZE(++loc->children->cap);
-            loc->children = realloc(loc->children, s);
+            loc->children = (rbs_loc_children *) realloc(loc->children, s);
         }
     }
 }
@@ -86,12 +86,12 @@ void rbs_loc_free(rbs_loc *loc) {
 }
 
 static void rbs_loc_mark(void *ptr) {
-    rbs_loc *loc = ptr;
+    rbs_loc *loc = (rbs_loc *) ptr;
     rb_gc_mark(loc->buffer);
 }
 
 static size_t rbs_loc_memsize(const void *ptr) {
-    const rbs_loc *loc = ptr;
+    const rbs_loc *loc = (const rbs_loc *) ptr;
     if (loc->children == NULL) {
         return sizeof(rbs_loc);
     } else {
@@ -117,7 +117,7 @@ static VALUE location_s_allocate(VALUE klass) {
 }
 
 rbs_loc *rbs_check_location(VALUE obj) {
-    return rb_check_typeddata(obj, &location_type);
+    return (rbs_loc *) rb_check_typeddata(obj, &location_type);
 }
 
 static VALUE location_initialize(VALUE self, VALUE buffer, VALUE start_pos, VALUE end_pos) {

--- a/include/rbs/parser.h
+++ b/include/rbs/parser.h
@@ -44,7 +44,7 @@ typedef struct rbs_error_t {
  * An RBS parser is a LL(3) parser.
  * */
 typedef struct {
-    rbs_lexer_t *rbs_lexer_t;
+    rbs_lexer_t *lexer;
 
     rbs_token_t current_token;
     rbs_token_t next_token;  /* The first lookahead token */

--- a/src/location.c
+++ b/src/location.c
@@ -8,7 +8,7 @@
 void rbs_loc_alloc_children(rbs_allocator_t *allocator, rbs_location_t *loc, size_t capacity) {
     RBS_ASSERT(capacity <= sizeof(rbs_loc_entry_bitmap) * 8, "Capacity %zu is too large. Max is %zu", capacity, sizeof(rbs_loc_entry_bitmap) * 8);
 
-    loc->children = rbs_allocator_malloc_impl(allocator, RBS_LOC_CHILDREN_SIZE(capacity), rbs_alignof(rbs_loc_children));
+    loc->children = (rbs_loc_children *) rbs_allocator_malloc_impl(allocator, RBS_LOC_CHILDREN_SIZE(capacity), rbs_alignof(rbs_loc_children));
 
     loc->children->len = 0;
     loc->children->required_p = 0;

--- a/src/parser.c
+++ b/src/parser.c
@@ -20,12 +20,12 @@
         strlen(str)                    \
     )
 
-#define INTERN_TOKEN(parser, tok)                                   \
-    rbs_constant_pool_insert_shared_with_encoding(                  \
-        &parser->constant_pool,                                     \
-        (const uint8_t *) rbs_peek_token(parser->rbs_lexer_t, tok), \
-        rbs_token_bytes(tok),                                       \
-        (void *) parser->rbs_lexer_t->encoding                      \
+#define INTERN_TOKEN(parser, tok)                             \
+    rbs_constant_pool_insert_shared_with_encoding(            \
+        &parser->constant_pool,                               \
+        (const uint8_t *) rbs_peek_token(parser->lexer, tok), \
+        rbs_token_bytes(tok),                                 \
+        parser->lexer->encoding                               \
     )
 
 #define KEYWORD_CASES   \
@@ -130,7 +130,7 @@ static bool parse_simple(rbs_parser_t *parser, rbs_node_t **type, bool void_allo
 static rbs_string_t rbs_parser_peek_current_token(rbs_parser_t *parser) {
     rbs_range_t rg = parser->current_token.range;
 
-    const char *start = parser->rbs_lexer_t->string.start + rg.start.byte_pos;
+    const char *start = parser->lexer->string.start + rg.start.byte_pos;
     size_t length = rg.end.byte_pos - rg.start.byte_pos;
 
     return rbs_string_new(start, start + length);
@@ -191,7 +191,7 @@ static bool parse_type_name(rbs_parser_t *parser, TypeNameKind kind, rbs_range_t
         .end = parser->current_token.range.end
     };
     rbs_location_t *loc = rbs_location_new(ALLOCATOR(), namespace_range);
-    rbs_namespace_t *namespace = rbs_namespace_new(ALLOCATOR(), loc, path, absolute);
+    rbs_namespace_t *ns = rbs_namespace_new(ALLOCATOR(), loc, path, absolute);
 
     switch (parser->current_token.type) {
     case tLIDENT:
@@ -217,7 +217,7 @@ success: {
     rbs_location_t *symbolLoc = rbs_location_current_token(parser);
     rbs_constant_id_t name = INTERN_TOKEN(parser, parser->current_token);
     rbs_ast_symbol_t *symbol = rbs_ast_symbol_new(ALLOCATOR(), symbolLoc, &parser->constant_pool, name);
-    *type_name = rbs_type_name_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), *rg), namespace, symbol);
+    *type_name = rbs_type_name_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), *rg), ns, symbol);
     return true;
 }
 
@@ -358,7 +358,7 @@ static bool parse_function_param(rbs_parser_t *parser, rbs_types_function_param_
             return false;
         }
 
-        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), rbs_parser_peek_current_token(parser), parser->rbs_lexer_t->encoding);
+        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), rbs_parser_peek_current_token(parser), parser->lexer->encoding);
         rbs_location_t *symbolLoc = rbs_location_current_token(parser);
         rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&parser->constant_pool, unquoted_str);
         rbs_ast_symbol_t *name = rbs_ast_symbol_new(ALLOCATOR(), symbolLoc, &parser->constant_pool, constant_id);
@@ -375,9 +375,9 @@ static bool parse_function_param(rbs_parser_t *parser, rbs_types_function_param_
 static rbs_constant_id_t intern_token_start_end(rbs_parser_t *parser, rbs_token_t start_token, rbs_token_t end_token) {
     return rbs_constant_pool_insert_shared_with_encoding(
         &parser->constant_pool,
-        (const uint8_t *) rbs_peek_token(parser->rbs_lexer_t, start_token),
+        (const uint8_t *) rbs_peek_token(parser->lexer, start_token),
         end_token.range.end.byte_pos - start_token.range.start.byte_pos,
-        parser->rbs_lexer_t->encoding
+        parser->lexer->encoding
     );
 }
 
@@ -948,7 +948,7 @@ static bool parse_record_attributes(rbs_parser_t *parser, rbs_hash_t **fields, b
 */
 NODISCARD
 static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_types_literal_t **symbol) {
-    size_t offset_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) ":", (size_t) 1);
+    size_t offset_bytes = parser->lexer->encoding->char_width((const uint8_t *) ":", (size_t) 1);
     size_t bytes = rbs_token_bytes(parser->current_token) - offset_bytes;
 
     rbs_ast_symbol_t *literal;
@@ -957,7 +957,7 @@ static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_typ
     case tSYMBOL: {
         rbs_location_t *symbolLoc = rbs_location_current_token(parser);
 
-        char *buffer = rbs_peek_token(parser->rbs_lexer_t, parser->current_token);
+        char *buffer = rbs_peek_token(parser->lexer, parser->current_token);
         rbs_constant_id_t constant_id = rbs_constant_pool_insert_shared(
             &parser->constant_pool,
             (const uint8_t *) buffer + offset_bytes,
@@ -973,7 +973,7 @@ static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_typ
 
         rbs_string_t symbol = rbs_string_new(current_token.start + offset_bytes, current_token.end);
 
-        rbs_string_t unquoted_symbol = rbs_unquote_string(ALLOCATOR(), symbol, parser->rbs_lexer_t->encoding);
+        rbs_string_t unquoted_symbol = rbs_unquote_string(ALLOCATOR(), symbol, parser->lexer->encoding);
 
         rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&parser->constant_pool, unquoted_symbol);
 
@@ -997,9 +997,9 @@ static bool parse_symbol(rbs_parser_t *parser, rbs_location_t *location, rbs_typ
  */
 NODISCARD
 static bool parse_instance_type(rbs_parser_t *parser, bool parse_alias, rbs_node_t **type) {
-    TypeNameKind expected_kind = INTERFACE_NAME | CLASS_NAME;
+    TypeNameKind expected_kind = (TypeNameKind) (INTERFACE_NAME | CLASS_NAME);
     if (parse_alias) {
-        expected_kind |= ALIAS_NAME;
+        expected_kind = (TypeNameKind) (expected_kind | ALIAS_NAME);
     }
 
     rbs_range_t name_range;
@@ -1215,7 +1215,7 @@ static bool parse_simple(rbs_parser_t *parser, rbs_node_t **type, bool void_allo
     case tDQSTRING: {
         rbs_location_t *loc = rbs_location_current_token(parser);
 
-        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), rbs_parser_peek_current_token(parser), parser->rbs_lexer_t->encoding);
+        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), rbs_parser_peek_current_token(parser), parser->lexer->encoding);
         rbs_node_t *literal = (rbs_node_t *) rbs_ast_string_new(ALLOCATOR(), loc, unquoted_str);
         *type = (rbs_node_t *) rbs_types_literal_new(ALLOCATOR(), loc, literal);
         return true;
@@ -1230,7 +1230,7 @@ static bool parse_simple(rbs_parser_t *parser, rbs_node_t **type, bool void_allo
         return true;
     }
     case tUIDENT: {
-        const char *name_str = rbs_peek_token(parser->rbs_lexer_t, parser->current_token);
+        const char *name_str = rbs_peek_token(parser->lexer, parser->current_token);
         size_t name_len = rbs_token_bytes(parser->current_token);
 
         rbs_constant_id_t name = rbs_constant_pool_find(&parser->constant_pool, (const uint8_t *) name_str, name_len);
@@ -1705,12 +1705,12 @@ static bool parse_annotation(rbs_parser_t *parser, rbs_ast_annotation_t **annota
     rbs_range_t rg = parser->current_token.range;
 
     size_t offset_bytes =
-        parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "%", (size_t) 1) +
-        parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "a", (size_t) 1);
+        parser->lexer->encoding->char_width((const uint8_t *) "%", (size_t) 1) +
+        parser->lexer->encoding->char_width((const uint8_t *) "a", (size_t) 1);
 
     rbs_string_t str = rbs_string_new(
-        parser->rbs_lexer_t->string.start + rg.start.byte_pos + offset_bytes,
-        parser->rbs_lexer_t->string.end
+        parser->lexer->string.start + rg.start.byte_pos + offset_bytes,
+        parser->lexer->string.end
     );
 
     // Assumes the input is ASCII compatible
@@ -1739,8 +1739,8 @@ static bool parse_annotation(rbs_parser_t *parser, rbs_ast_annotation_t **annota
         return false;
     }
 
-    size_t open_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) &open_char, (size_t) 1);
-    size_t close_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) &close_char, (size_t) 1);
+    size_t open_bytes = parser->lexer->encoding->char_width((const uint8_t *) &open_char, (size_t) 1);
+    size_t close_bytes = parser->lexer->encoding->char_width((const uint8_t *) &close_char, (size_t) 1);
 
     rbs_string_t current_token = rbs_parser_peek_current_token(parser);
     size_t total_offset = offset_bytes + open_bytes;
@@ -1804,9 +1804,9 @@ static bool parse_method_name(rbs_parser_t *parser, rbs_range_t *range, rbs_ast_
 
             rbs_constant_id_t constant_id = rbs_constant_pool_insert_shared_with_encoding(
                 &parser->constant_pool,
-                (const uint8_t *) parser->rbs_lexer_t->string.start + range->start.byte_pos,
+                (const uint8_t *) parser->lexer->string.start + range->start.byte_pos,
                 range->end.byte_pos - range->start.byte_pos,
-                parser->rbs_lexer_t->encoding
+                parser->lexer->encoding
             );
 
             rbs_location_t *symbolLoc = rbs_location_new(ALLOCATOR(), *range);
@@ -1827,7 +1827,7 @@ static bool parse_method_name(rbs_parser_t *parser, rbs_range_t *range, rbs_ast_
     }
     case tQIDENT: {
         rbs_string_t string = rbs_parser_peek_current_token(parser);
-        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), string, parser->rbs_lexer_t->encoding);
+        rbs_string_t unquoted_str = rbs_unquote_string(ALLOCATOR(), string, parser->lexer->encoding);
         rbs_constant_id_t constant_id = rbs_constant_pool_insert_string(&parser->constant_pool, unquoted_str);
         rbs_location_t *symbolLoc = rbs_location_current_token(parser);
         *symbol = rbs_ast_symbol_new(ALLOCATOR(), symbolLoc, &parser->constant_pool, constant_id);
@@ -2131,7 +2131,7 @@ static bool parse_mixin_member(rbs_parser_t *parser, bool from_interface, rbs_po
     rbs_type_name_t *name = NULL;
     CHECK_PARSE(class_instance_name(
         parser,
-        from_interface ? INTERFACE_NAME : (INTERFACE_NAME | CLASS_NAME),
+        from_interface ? INTERFACE_NAME : (TypeNameKind) (INTERFACE_NAME | CLASS_NAME),
         args,
         &name_range,
         &args_range,
@@ -2597,7 +2597,7 @@ static bool parse_module_self_types(rbs_parser_t *parser, rbs_node_list_t *array
 
         rbs_range_t name_range;
         rbs_type_name_t *module_name = NULL;
-        CHECK_PARSE(parse_type_name(parser, CLASS_NAME | INTERFACE_NAME, &name_range, &module_name));
+        CHECK_PARSE(parse_type_name(parser, (TypeNameKind) (CLASS_NAME | INTERFACE_NAME), &name_range, &module_name));
         self_range.end = name_range.end;
 
         rbs_node_list_t *args = rbs_node_list_new(ALLOCATOR());
@@ -3061,7 +3061,7 @@ static bool parse_decl(rbs_parser_t *parser, rbs_node_t **decl) {
               | {} <>                                            (empty -- returns empty namespace)
 */
 NODISCARD
-static bool parse_namespace(rbs_parser_t *parser, rbs_range_t *rg, rbs_namespace_t **namespace) {
+static bool parse_namespace(rbs_parser_t *parser, rbs_range_t *rg, rbs_namespace_t **out_ns) {
     bool is_absolute = false;
 
     if (parser->next_token.type == pCOLON2) {
@@ -3092,7 +3092,7 @@ static bool parse_namespace(rbs_parser_t *parser, rbs_range_t *rg, rbs_namespace
         }
     }
 
-    *namespace = rbs_namespace_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), *rg), path, is_absolute);
+    *out_ns = rbs_namespace_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), *rg), path, is_absolute);
     return true;
 }
 
@@ -3107,8 +3107,8 @@ NODISCARD
 static bool parse_use_clauses(rbs_parser_t *parser, rbs_node_list_t *clauses) {
     while (true) {
         rbs_range_t namespace_range = NULL_RANGE;
-        rbs_namespace_t *namespace = NULL;
-        CHECK_PARSE(parse_namespace(parser, &namespace_range, &namespace));
+        rbs_namespace_t *ns = NULL;
+        CHECK_PARSE(parse_namespace(parser, &namespace_range, &ns));
 
         switch (parser->next_token.type) {
         case tLIDENT:
@@ -3122,7 +3122,7 @@ static bool parse_use_clauses(rbs_parser_t *parser, rbs_node_list_t *clauses) {
 
             rbs_location_t *symbolLoc = rbs_location_current_token(parser);
             rbs_ast_symbol_t *symbol = rbs_ast_symbol_new(ALLOCATOR(), symbolLoc, &parser->constant_pool, INTERN_TOKEN(parser, parser->current_token));
-            rbs_type_name_t *type_name = rbs_type_name_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), type_name_range), namespace, symbol);
+            rbs_type_name_t *type_name = rbs_type_name_new(ALLOCATOR(), rbs_location_new(ALLOCATOR(), type_name_range), ns, symbol);
 
             rbs_range_t keyword_range = NULL_RANGE;
             rbs_range_t new_name_range = NULL_RANGE;
@@ -3165,7 +3165,7 @@ static bool parse_use_clauses(rbs_parser_t *parser, rbs_node_list_t *clauses) {
             rbs_loc_add_required_child(loc, INTERN("namespace"), namespace_range);
             rbs_loc_add_required_child(loc, INTERN("star"), star_range);
 
-            rbs_ast_directives_use_wildcard_clause_t *clause = rbs_ast_directives_use_wildcard_clause_new(ALLOCATOR(), loc, namespace);
+            rbs_ast_directives_use_wildcard_clause_t *clause = rbs_ast_directives_use_wildcard_clause_new(ALLOCATOR(), loc, ns);
             rbs_node_list_append(clauses, (rbs_node_t *) clause);
 
             break;
@@ -3212,8 +3212,8 @@ static bool parse_use_directive(rbs_parser_t *parser, rbs_ast_directives_use_t *
 }
 
 static rbs_ast_comment_t *parse_comment_lines(rbs_parser_t *parser, rbs_comment_t *com) {
-    size_t hash_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) "#", (size_t) 1);
-    size_t space_bytes = parser->rbs_lexer_t->encoding->char_width((const uint8_t *) " ", (size_t) 1);
+    size_t hash_bytes = parser->lexer->encoding->char_width((const uint8_t *) "#", (size_t) 1);
+    size_t space_bytes = parser->lexer->encoding->char_width((const uint8_t *) " ", (size_t) 1);
 
     rbs_buffer_t rbs_buffer;
     rbs_buffer_init(ALLOCATOR(), &rbs_buffer);
@@ -3221,12 +3221,12 @@ static rbs_ast_comment_t *parse_comment_lines(rbs_parser_t *parser, rbs_comment_
     for (size_t i = 0; i < com->line_tokens_count; i++) {
         rbs_token_t tok = com->line_tokens[i];
 
-        const char *comment_start = parser->rbs_lexer_t->string.start + tok.range.start.byte_pos + hash_bytes;
+        const char *comment_start = parser->lexer->string.start + tok.range.start.byte_pos + hash_bytes;
         size_t comment_bytes = RBS_RANGE_BYTES(tok.range) - hash_bytes;
 
         rbs_string_t str = rbs_string_new(
             comment_start,
-            parser->rbs_lexer_t->string.end
+            parser->lexer->string.end
         );
 
         // Assumes the input is ASCII compatible
@@ -3446,7 +3446,7 @@ void rbs_parser_advance(rbs_parser_t *parser) {
             break;
         }
 
-        parser->next_token3 = rbs_lexer_next_token(parser->rbs_lexer_t);
+        parser->next_token3 = rbs_lexer_next_token(parser->lexer);
 
         if (parser->next_token3.type == tCOMMENT) {
             // skip
@@ -3538,7 +3538,7 @@ rbs_parser_t *rbs_parser_new(rbs_string_t string, const rbs_encoding_t *encoding
     rbs_parser_t *parser = rbs_allocator_alloc(allocator, rbs_parser_t);
 
     *parser = (rbs_parser_t) {
-        .rbs_lexer_t = lexer,
+        .lexer = lexer,
 
         .current_token = NullToken,
         .next_token = NullToken,

--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -57,7 +57,7 @@ static size_t get_system_page_size(void) {
 static rbs_allocator_page_t *rbs_allocator_page_new(size_t payload_size) {
     const size_t page_header_size = sizeof(rbs_allocator_page_t);
 
-    rbs_allocator_page_t *page = malloc(page_header_size + payload_size);
+    rbs_allocator_page_t *page = (rbs_allocator_page_t *) malloc(page_header_size + payload_size);
     page->size = payload_size;
     page->used = 0;
 
@@ -65,7 +65,7 @@ static rbs_allocator_page_t *rbs_allocator_page_new(size_t payload_size) {
 }
 
 rbs_allocator_t *rbs_allocator_init(void) {
-    rbs_allocator_t *allocator = malloc(sizeof(rbs_allocator_t));
+    rbs_allocator_t *allocator = (rbs_allocator_t *) malloc(sizeof(rbs_allocator_t));
 
     const size_t system_page_size = get_system_page_size();
 

--- a/src/util/rbs_constant_pool.c
+++ b/src/util/rbs_constant_pool.c
@@ -57,8 +57,8 @@ rbs_constant_pool_resize(rbs_constant_pool_t *pool) {
     void *next = calloc(next_capacity, element_size);
     if (next == NULL) return false;
 
-    rbs_constant_pool_bucket_t *next_buckets = next;
-    rbs_constant_t *next_constants = (void *) (((char *) next) + next_capacity * sizeof(rbs_constant_pool_bucket_t));
+    rbs_constant_pool_bucket_t *next_buckets = (rbs_constant_pool_bucket_t *) next;
+    rbs_constant_t *next_constants = (rbs_constant_t *) (((char *) next) + next_capacity * sizeof(rbs_constant_pool_bucket_t));
 
     // For each bucket in the current constant pool, find the index in the
     // next constant pool, and insert it.
@@ -111,8 +111,8 @@ bool rbs_constant_pool_init(rbs_constant_pool_t *pool, uint32_t capacity) {
     void *memory = calloc(capacity, element_size);
     if (memory == NULL) return false;
 
-    pool->buckets = memory;
-    pool->constants = (void *) (((char *) memory) + capacity * sizeof(rbs_constant_pool_bucket_t));
+    pool->buckets = (rbs_constant_pool_bucket_t *) memory;
+    pool->constants = (rbs_constant_t *) (((char *) memory) + capacity * sizeof(rbs_constant_pool_bucket_t));
     pool->size = 0;
     pool->capacity = capacity;
     return true;

--- a/templates/ext/rbs_extension/class_constants.c.erb
+++ b/templates/ext/rbs_extension/class_constants.c.erb
@@ -1,7 +1,5 @@
 #include "rbs_extension.h"
 
-VALUE RBS_Parser;
-
 VALUE RBS;
 VALUE RBS_AST;
 VALUE RBS_AST_Declarations;


### PR DESCRIPTION
claude-code fixed the problems:

  1. include/rbs/parser.h: Renamed field rbs_lexer_t *rbs_lexer_t to rbs_lexer_t *lexer to avoid using the type name as a field name (invalid in C++).
  2. src/parser.c:
    - Updated all references from ->rbs_lexer_t to ->lexer
    - Updated struct initializer from .rbs_lexer_t to .lexer
    - Renamed local variables named namespace to ns or out_ns (since namespace is a C++ keyword)
    - Fixed the INTERN_TOKEN macro by removing the unnecessary (void *) cast
    - Added explicit (TypeNameKind) casts for bitwise OR operations on enum values
  3. src/location.c: Added explicit cast for rbs_allocator_malloc_impl return value
  4. src/util/rbs_allocator.c: Added explicit casts for malloc return values to rbs_allocator_page_t * and rbs_allocator_t *
  5. src/util/rbs_constant_pool.c: Added explicit casts for void pointer assignments to rbs_constant_pool_bucket_t * and rbs_constant_t *
  6. ext/rbs_extension/legacy_location.c: Added explicit casts for malloc, realloc, and rb_check_typeddata return values
  7. ext/rbs_extension/class_constants.c: Removed duplicate declaration of RBS_Parser