### PR TITLE
Support rdoc v7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "json-schema"
 gem "goodcheck"
 gem 'digest'
 gem 'tempfile'
-gem "rdoc", "~> 6.16"
+gem "rdoc"
 gem "fileutils"
 gem "raap"
 gem "activesupport", "~> 7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.17.0)
+    rdoc (7.0.1)
       erb
       psych (>= 4.0.0)
       tsort
@@ -219,7 +219,7 @@ DEPENDENCIES
   rake-compiler
   rbs!
   rbs-amber!
-  rdoc (~> 6.16)
+  rdoc
   rspec
   rubocop
   rubocop-on-rbs

--- a/lib/rdoc/discover.rb
+++ b/lib/rdoc/discover.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 begin
-  gem 'rdoc', '~> 6.16'
+  gem 'rdoc', '>= 6.16'
   require 'rdoc_plugin/parser'
   module RDoc
     class Parser


### PR DESCRIPTION
[rdoc v7.0.0](https://github.com/ruby/rdoc/releases/tag/v7.0.0) has been released.
We should support it.