### PR TITLE
Debug no memory

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -238,6 +238,8 @@ task :stdlib_test => :compile do
     test_files.shuffle!
   end
 
+  ENV["TESTOPTS"] ||= "--verbose"
+
   sh "#{ruby} -Ilib #{bin}/test_runner.rb #{test_files.join(' ')}"
   # TODO: Ractor tests need to be run in a separate process
   sh "#{ruby} -Ilib #{bin}/test_runner.rb test/stdlib/CGI-escape_test.rb"

--- a/Rakefile
+++ b/Rakefile
@@ -25,12 +25,12 @@ test_config = lambda do |t|
   t.test_files = FileList["test/**/*_test.rb"].reject do |path|
     path =~ %r{test/stdlib/}
   end
-  if defined?(RubyMemcheck)
-    if t.is_a?(RubyMemcheck::TestTask)
+  # if defined?(RubyMemcheck)
+  #   if t.is_a?(RubyMemcheck::TestTask)
       t.verbose = true
       t.options = '-v'
-    end
-  end
+  #   end
+  # end
 end
 
 Rake::TestTask.new(test: :compile, &test_config)

--- a/bin/test_runner.rb
+++ b/bin/test_runner.rb
@@ -18,6 +18,8 @@ KNOWN_FAILS = %w(dbm mutex_m).map do |lib|
   /cannot load such file -- #{lib}/
 end
 
+require 'test/unit'
+
 ARGV.each do |arg|
   begin
     load arg
@@ -29,3 +31,14 @@ ARGV.each do |arg|
     end
   end
 end
+
+args = []
+
+unless ENV["TESTOPTS"].nil?
+  require "shellwords"
+  args.concat Shellwords.shellsplit(ENV["TESTOPTS"])
+end
+
+exit Test::Unit::AutoRunner.run(false, nil, args)
+
+

--- a/test/stdlib/ObjectSpace_test.rb
+++ b/test/stdlib/ObjectSpace_test.rb
@@ -189,6 +189,10 @@ class ObjectSpaceTest < Test::Unit::TestCase
       ObjectSpace, :reachable_objects_from, nil
   end
 
+  def test_reachable_objects_from_root_no_assertion
+    ObjectSpace.reachable_objects_from_root
+  end
+
   def test_reachable_objects_from_root
     assert_send_type "() -> Hash[String, untyped]",
       ObjectSpace, :reachable_objects_from_root


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/20480628393/job/58853288287#step:22:353

```
  D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testcase.rb:641:in 'block (2 levels) in Test::Unit::TestCase#run': failed to allocate memory (NoMemoryError)
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/fixture.rb:276:in 'block in Test::Unit::Fixture#create_fixtures_runner'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/fixture.rb:276:in 'block in Test::Unit::Fixture#create_fixtures_runner'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/fixture.rb:257:in 'Test::Unit::Fixture#run_fixture'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/fixture.rb:292:in 'Test::Unit::Fixture#run_setup'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testcase.rb:632:in 'block in Test::Unit::TestCase#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testcase.rb:631:in 'Kernel#catch'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testcase.rb:631:in 'Test::Unit::TestCase#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:97:in 'Test::Unit::TestSuiteRunner#run_test'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:63:in 'block in Test::Unit::TestSuiteRunner#run_tests'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:62:in 'Array#each'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:62:in 'Test::Unit::TestSuiteRunner#run_tests'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:39:in 'Test::Unit::TestSuiteRunner#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testsuite.rb:77:in 'Test::Unit::TestSuite#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:97:in 'Test::Unit::TestSuiteRunner#run_test'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:63:in 'block in Test::Unit::TestSuiteRunner#run_tests'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:62:in 'Array#each'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:62:in 'Test::Unit::TestSuiteRunner#run_tests'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:39:in 'Test::Unit::TestSuiteRunner#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testsuite.rb:77:in 'Test::Unit::TestSuite#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/ui/testrunnermediator.rb:79:in 'Test::Unit::UI::TestRunnerMediator#run_suite'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/ui/testrunnermediator.rb:55:in 'block (3 levels) in Test::Unit::UI::TestRunnerMediator#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/ui/testrunnermediator.rb:50:in 'Kernel#catch'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/ui/testrunnermediator.rb:50:in 'block (2 levels) in Test::Unit::UI::TestRunnerMediator#run'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/test-suite-runner.rb:19:in 'Test::Unit::TestSuiteRunner.run_all_tests'
  	from D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/ui/testrunnermediator.rb:49:in 'block in Test::Unit::UI::TestRunnerMediator#run'
```