### PR TITLE
Support selector for `String#strip` family.

### DIFF
--- a/core/string.rbs
+++ b/core/string.rbs
@@ -3670,7 +3670,7 @@ class String
   # Related: see [Converting to New
   # String](rdoc-ref:String@Converting+to+New+String).
   #
-  def lstrip: () -> String
+  def lstrip: (*selector) -> String
 
   # <!--
   #   rdoc-file=string.c
@@ -3683,7 +3683,7 @@ class String
   #
   # Related: see [Modifying](rdoc-ref:String@Modifying).
   #
-  def lstrip!: () -> self?
+  def lstrip!: (*selector) -> self?
 
   # <!--
   #   rdoc-file=string.c
@@ -4195,7 +4195,7 @@ class String
   # Related: see [Converting to New
   # String](rdoc-ref:String@Converting+to+New+String).
   #
-  def rstrip: () -> String
+  def rstrip: (*selector) -> String
 
   # <!--
   #   rdoc-file=string.c
@@ -4208,7 +4208,7 @@ class String
   #
   # Related: see [Modifying](rdoc-ref:String@Modifying).
   #
-  def rstrip!: () -> self?
+  def rstrip!: (*selector) -> self?
 
   # <!--
   #   rdoc-file=string.c
@@ -4681,7 +4681,7 @@ class String
   # Related: see [Converting to New
   # String](rdoc-ref:String@Converting+to+New+String).
   #
-  def strip: () -> String
+  def strip: (*selector) -> String
 
   # <!--
   #   rdoc-file=string.c
@@ -4694,7 +4694,7 @@ class String
   #
   # Related: see [Modifying](rdoc-ref:String@Modifying).
   #
-  def strip!: () -> self?
+  def strip!: (*selector) -> self?
 
   # <!--
   #   rdoc-file=string.c

--- a/test/stdlib/String_test.rb
+++ b/test/stdlib/String_test.rb
@@ -1099,6 +1099,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       ' hello', :lstrip
     assert_send_type  '() -> String',
                       'hello', :lstrip
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type  '(String::selector) -> String',
+                          "01234abc56789", :lstrip, selector
+      end
+    end
   end
 
   def test_lstrip!
@@ -1106,6 +1113,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       +' hello', :lstrip!
     assert_send_type  '() -> nil',
                       +'hello', :lstrip!
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type  '(String::selector) -> String',
+                          "01234abc56789", :lstrip!, selector
+      end
+    end
   end
 
   def test_match
@@ -1252,6 +1266,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       'hello ', :rstrip
     assert_send_type  '() -> String',
                       'hello', :rstrip
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type '(String::selector) -> String',
+                         "01234abc56789", :rstrip, selector
+      end
+    end
   end
 
   def test_rstrip!
@@ -1259,6 +1280,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       +'hello ', :rstrip!
     assert_send_type  '() -> nil',
                       +'hello', :rstrip!
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type '(String::selector) -> String',
+                         "01234abc56789", :rstrip!, selector
+      end
+    end
   end
 
   def test_scan
@@ -1491,6 +1519,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       ' hello ', :strip
     assert_send_type  '() -> String',
                       'hello', :strip
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type '(String::selector) -> String',
+                         "01234abc56789", :strip, selector
+      end
+    end
   end
 
   def test_strip!
@@ -1498,6 +1533,13 @@ class StringInstanceTest < Test::Unit::TestCase
                       ' hello ', :strip!
     assert_send_type  '() -> nil',
                       'hello', :strip!
+
+    if_ruby("4.0"...) do
+      with_string "0-9" do |selector|
+        assert_send_type '(String::selector) -> String',
+                         "01234abc56789", :strip!, selector
+      end
+    end
   end
 
   def test_sub


### PR DESCRIPTION
I found the following description as a new feature in Ruby v4.

> String#strip, strip!, lstrip, lstrip!, rstrip, and rstrip! are extended to accept *selectors arguments. [[Feature #21552](https://bugs.ruby-lang.org/issues/21552)]

https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
