### PR TITLE
Split pathname to core and stdlib

### DIFF
--- a/core/pathname.rbs
+++ b/core/pathname.rbs
@@ -671,28 +671,6 @@ class Pathname
   def file?: () -> bool
 
   # <!--
-  #   rdoc-file=lib/pathname.rb
-  #   - find(ignore_error: true) { |pathname| ... }
-  # -->
-  # Iterates over the directory tree in a depth first manner, yielding a Pathname
-  # for each file under "this" directory.
-  #
-  # Note that you need to require 'pathname' to use this method.
-  #
-  # Returns an Enumerator if no block is given.
-  #
-  # Since it is implemented by the standard library module Find, Find.prune can be
-  # used to control the traversal.
-  #
-  # If `self` is `.`, yielded pathnames begin with a filename in the current
-  # directory, not `./`.
-  #
-  # See Find.find
-  #
-  def find: (?ignore_error: boolish) { (Pathname) -> untyped } -> nil
-          | (?ignore_error: boolish) -> Enumerator[Pathname, nil]
-
-  # <!--
   #   rdoc-file=pathname_builtin.rb
   #   - fnmatch(pattern, ...)
   # -->
@@ -1016,18 +994,6 @@ class Pathname
   # See `Dir.rmdir`.  Remove the referenced directory.
   #
   def rmdir: () -> 0
-
-  # <!--
-  #   rdoc-file=lib/pathname.rb
-  #   - rmtree(noop: nil, verbose: nil, secure: nil)
-  # -->
-  # Recursively deletes a directory, including all directories beneath it.
-  #
-  # Note that you need to require 'pathname' to use this method.
-  #
-  # See FileUtils.rm_rf
-  #
-  def rmtree: () -> self
 
   # <!--
   #   rdoc-file=pathname_builtin.rb

--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -50,12 +50,6 @@ module RBS
       when path
         dirs << path
       when library
-        case library
-        when 'pathname'
-          RBS.logger.warn "`#{library}` has been moved to core library, so it is always loaded. Remove explicit loading `#{library}`"
-          return
-        end
-
         if libs.add?(Library.new(name: library, version: version)) && resolve_dependencies
           resolve_dependencies(library: library, version: version)
         end

--- a/stdlib/pathname/0/pathname.rbs
+++ b/stdlib/pathname/0/pathname.rbs
@@ -1,0 +1,36 @@
+%a{annotate:rdoc:skip}
+class Pathname
+  # <!--
+  #   rdoc-file=lib/pathname.rb
+  #   - find(ignore_error: true) { |pathname| ... }
+  # -->
+  # Iterates over the directory tree in a depth first manner, yielding a Pathname
+  # for each file under "this" directory.
+  #
+  # Note that you need to require 'pathname' to use this method.
+  #
+  # Returns an Enumerator if no block is given.
+  #
+  # Since it is implemented by the standard library module Find, Find.prune can be
+  # used to control the traversal.
+  #
+  # If `self` is `.`, yielded pathnames begin with a filename in the current
+  # directory, not `./`.
+  #
+  # See Find.find
+  #
+  def find: (?ignore_error: boolish) { (Pathname) -> untyped } -> nil
+          | (?ignore_error: boolish) -> Enumerator[Pathname, nil]
+
+  # <!--
+  #   rdoc-file=lib/pathname.rb
+  #   - rmtree(noop: nil, verbose: nil, secure: nil)
+  # -->
+  # Recursively deletes a directory, including all directories beneath it.
+  #
+  # Note that you need to require 'pathname' to use this method.
+  #
+  # See FileUtils.rm_rf
+  #
+  def rmtree: () -> self
+end

--- a/test/stdlib/Pathname_ext_test.rb
+++ b/test/stdlib/Pathname_ext_test.rb
@@ -1,0 +1,29 @@
+require_relative "test_helper"
+require 'pathname'
+
+class PathnameExtInstanceTest < Test::Unit::TestCase
+  include TestHelper
+
+  library 'pathname'
+  testing '::Pathname'
+
+  def test_find
+    assert_send_type '() { (Pathname) -> untyped } -> nil',
+                     Pathname(__dir__), :find do end
+    assert_send_type '(ignore_error: bool) -> Enumerator[Pathname, nil]',
+                     Pathname(__dir__), :find, ignore_error: true
+    assert_send_type '(ignore_error: Symbol) -> Enumerator[Pathname, nil]',
+                     Pathname(__dir__), :find, ignore_error: :true
+    assert_send_type '() -> Enumerator[Pathname, nil]',
+                     Pathname(__dir__), :find
+  end
+
+  def test_rmtree
+    Dir.mktmpdir do |dir|
+      target = Pathname(dir).join('target')
+      target.mkdir
+      assert_send_type '() -> Pathname',
+                       target, :rmtree
+    end
+  end
+end

--- a/test/stdlib/Pathname_test.rb
+++ b/test/stdlib/Pathname_test.rb
@@ -1,5 +1,5 @@
 require_relative "test_helper"
-require 'pathname'
+require "pathname" unless defined?(Pathname)
 
 class PathnameSingletonTest < Test::Unit::TestCase
   include TestHelper
@@ -314,17 +314,6 @@ class PathnameInstanceTest < Test::Unit::TestCase
                      Pathname('/unknown'), :file?
   end
 
-  def test_find
-    assert_send_type '() { (Pathname) -> untyped } -> nil',
-                     Pathname(__dir__), :find do end
-    assert_send_type '(ignore_error: bool) -> Enumerator[Pathname, nil]',
-                     Pathname(__dir__), :find, ignore_error: true
-    assert_send_type '(ignore_error: Symbol) -> Enumerator[Pathname, nil]',
-                     Pathname(__dir__), :find, ignore_error: :true
-    assert_send_type '() -> Enumerator[Pathname, nil]',
-                     Pathname(__dir__), :find
-  end
-
   def test_fnmatch
     assert_send_type '(String) -> bool',
                      Pathname('foo'), :fnmatch, 'fo*'
@@ -635,15 +624,6 @@ class PathnameInstanceTest < Test::Unit::TestCase
       target.mkdir
       assert_send_type '() -> 0',
                        target, :rmdir
-    end
-  end
-
-  def test_rmtree
-    Dir.mktmpdir do |dir|
-      target = Pathname(dir).join('target')
-      target.mkdir
-      assert_send_type '() -> Pathname',
-                       target, :rmtree
     end
   end
 


### PR DESCRIPTION
The pathname class has been available without requiring it since Ruby v4.
However, some methods still require `require 'pathname'` and should not be available by default.
Therefore, I propose reintroducing the pathname stdlib and defining the methods that require `require 'pathname'`.