### PR TITLE
Remove ObjectSpace.count_nodes

### DIFF
--- a/stdlib/objspace/0/objspace.rbs
+++ b/stdlib/objspace/0/objspace.rbs
@@ -128,29 +128,6 @@ module ObjectSpace
 
   # <!--
   #   rdoc-file=ext/objspace/objspace.c
-  #   - ObjectSpace.count_nodes([result_hash]) -> hash
-  # -->
-  # Counts nodes for each node type.
-  #
-  # This method is only for MRI developers interested in performance and memory
-  # usage of Ruby programs.
-  #
-  # It returns a hash as:
-  #
-  #     {:NODE_METHOD=>2027, :NODE_FBODY=>1927, :NODE_CFUNC=>1798, ...}
-  #
-  # If the optional argument, result_hash, is given, it is overwritten and
-  # returned. This is intended to avoid probe effect.
-  #
-  # Note: The contents of the returned hash is implementation defined. It may be
-  # changed in future.
-  #
-  # This method is only expected to work with C Ruby.
-  #
-  def self?.count_nodes: (?Hash[Symbol, Integer] result_hash) -> Hash[Symbol, Integer]
-
-  # <!--
-  #   rdoc-file=ext/objspace/objspace.c
   #   - ObjectSpace.count_objects_size([result_hash]) -> hash
   # -->
   # Counts objects size (in bytes) for each type.

--- a/test/stdlib/ObjectSpace_test.rb
+++ b/test/stdlib/ObjectSpace_test.rb
@@ -99,17 +99,6 @@ class ObjectSpaceTest < Test::Unit::TestCase
       ObjectSpace, :count_imemo_objects, { TOTAL: 0 }
   end
 
-  def test_count_nodes
-    ObjectSpace::trace_object_allocations do
-      assert_send_type "() -> Hash[Symbol, Integer]",
-        ObjectSpace, :count_nodes
-      assert_send_type "(Hash[Symbol, Integer]) -> Hash[Symbol, Integer]",
-        ObjectSpace, :count_nodes, {}
-      assert_send_type "(Hash[Symbol, Integer]) -> Hash[Symbol, Integer]",
-        ObjectSpace, :count_nodes, { TOTAL: 0 }
-    end
-  end
-
   def test_count_objects_size
     assert_send_type "() -> Hash[Symbol, Integer]",
       ObjectSpace, :count_objects_size


### PR DESCRIPTION
I want to remove ObjectSpace.count_nodes in https://github.com/ruby/ruby/pull/15766. ObjectSpace.count_nodes been a no-op and returning an empty hash since Ruby 2.5 because parser nodes are not GC managed.