### PR TITLE
update rbs signatures to be more consistent with generics

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -546,8 +546,8 @@
 #     given block.
 #
 %a{annotate:rdoc:source:from=array.c}
-class Array[unchecked out Elem] < Object
-  include Enumerable[Elem]
+class Array[unchecked out E] < Object
+  include Enumerable[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -604,9 +604,9 @@ class Array[unchecked out Elem] < Object
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
   def initialize: () -> void
-                | (::Array[Elem] ary) -> void
-                | (int size, ?Elem val) -> void
-                | (int size) { (::Integer index) -> Elem } -> void
+                | (::Array[E] ary) -> void
+                | (int size, ?E val) -> void
+                | (int size) { (::Integer index) -> E } -> void
 
   # <!--
   #   rdoc-file=array.c
@@ -664,7 +664,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def &: (::Array[untyped] | _ToAry[untyped]) -> ::Array[Elem]
+  def &: (::Array[untyped] | _ToAry[untyped]) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -683,7 +683,7 @@ class Array[unchecked out Elem] < Object
   #     [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {foo: 0}"
   #
   def *: (string str) -> ::String
-       | (int int) -> ::Array[Elem]
+       | (int int) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -697,7 +697,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def +: [U] (_ToAry[U]) -> ::Array[Elem | U]
+  def +: [U] (_ToAry[U]) -> ::Array[E | U]
 
   # <!--
   #   rdoc-file=array.c
@@ -715,7 +715,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def -: (_ToAry[untyped]) -> ::Array[Elem]
+  def -: (_ToAry[untyped]) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -731,7 +731,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def <<: (Elem) -> self
+  def <<: (E) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -918,9 +918,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def []: %a{implicitly-returns-nil} (int index) -> Elem
-        | (int start, int length) -> ::Array[Elem]?
-        | (::Range[::Integer?] range) -> ::Array[Elem]?
+  def []: %a{implicitly-returns-nil} (int index) -> E
+        | (int start, int length) -> ::Array[E]?
+        | (::Range[::Integer?] range) -> ::Array[E]?
 
   # <!--
   #   rdoc-file=array.c
@@ -1068,12 +1068,12 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def []=: (int index, Elem obj) -> Elem
-         | (int start, int length, Elem obj) -> Elem
-         | (int start, int length, ::Array[Elem]) -> ::Array[Elem]
+  def []=: (int index, E obj) -> E
+         | (int start, int length, E obj) -> E
+         | (int start, int length, ::Array[E]) -> ::Array[E]
          | (int start, int length, nil) -> nil
-         | (::Range[::Integer?], Elem obj) -> Elem
-         | (::Range[::Integer?], ::Array[Elem]) -> ::Array[Elem]
+         | (::Range[::Integer?], E obj) -> E
+         | (::Range[::Integer?], ::Array[E]) -> ::Array[E]
          | (::Range[::Integer?], nil) -> nil
 
   # <!--
@@ -1114,8 +1114,8 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def all?: () -> bool
-          | (_Pattern[Elem] pattern) -> bool
-          | () { (Elem obj) -> boolish } -> bool
+          | (_Pattern[E] pattern) -> bool
+          | () { (E obj) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=array.c
@@ -1211,7 +1211,7 @@ class Array[unchecked out Elem] < Object
   # Related: Array#[]; see also [Methods for
   # Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def at: %a{implicitly-returns-nil} (int index) -> Elem
+  def at: %a{implicitly-returns-nil} (int index) -> E
 
   # <!--
   #   rdoc-file=array.c
@@ -1225,9 +1225,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch: () -> ::Enumerator[Elem, Elem?]
-             | () { (Elem) -> (true | false) } -> Elem?
-             | () { (Elem) -> ::Integer } -> Elem?
+  def bsearch: () -> ::Enumerator[E, E?]
+             | () { (E) -> (true | false) } -> E?
+             | () { (E) -> ::Integer } -> E?
 
   # <!--
   #   rdoc-file=array.c
@@ -1241,8 +1241,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch_index: () { (Elem) -> (true | false) } -> ::Integer?
-                   | () { (Elem) -> ::Integer } -> ::Integer?
+  def bsearch_index: () { (E) -> (true | false) } -> ::Integer?
+                   | () { (E) -> ::Integer } -> ::Integer?
 
   # <!--
   #   rdoc-file=array.c
@@ -1276,8 +1276,8 @@ class Array[unchecked out Elem] < Object
   # Related: #collect!; see also [Methods for
   # Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def collect: [U] () { (Elem item) -> U } -> ::Array[U]
-             | () -> ::Enumerator[Elem, ::Array[untyped]]
+  def collect: [U] () { (E item) -> U } -> ::Array[U]
+             | () -> ::Enumerator[E, ::Array[untyped]]
 
   # <!--
   #   rdoc-file=array.c
@@ -1297,8 +1297,8 @@ class Array[unchecked out Elem] < Object
   # Related: #collect; see also [Methods for
   # Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def collect!: () { (Elem item) -> Elem } -> self
-              | () -> ::Enumerator[Elem, self]
+  def collect!: () { (E item) -> E } -> self
+              | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1342,8 +1342,8 @@ class Array[unchecked out Elem] < Object
   # Related: Array#permutation; see also [Methods for
   # Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def combination: (int n) { (::Array[Elem]) -> void } -> self
-                 | (int n) -> ::Enumerator[::Array[Elem], self]
+  def combination: (int n) { (::Array[E]) -> void } -> self
+                 | (int n) -> ::Enumerator[::Array[E], self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1358,7 +1358,7 @@ class Array[unchecked out Elem] < Object
   # Related: Array#compact!; see also [Methods for
   # Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def compact: () -> ::Array[Elem]
+  def compact: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -1389,7 +1389,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def concat: (*::Array[Elem] arrays) -> self
+  def concat: (*::Array[E] arrays) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -1419,8 +1419,8 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def count: () -> ::Integer
-           | (Elem obj) -> ::Integer
-           | () { (Elem) -> boolish } -> ::Integer
+           | (E obj) -> ::Integer
+           | () { (E) -> boolish } -> ::Integer
 
   # <!--
   #   rdoc-file=array.c
@@ -1454,8 +1454,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def cycle: (?int? n) { (Elem) -> void } -> nil
-           | (?int? n) -> ::Enumerator[Elem, nil]
+  def cycle: (?int? n) { (E) -> void } -> nil
+           | (?int? n) -> ::Enumerator[E, nil]
 
   # <!--
   #   rdoc-file=array.c
@@ -1499,8 +1499,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def delete: (Elem obj) -> Elem?
-            | [S, T] (S obj) { (S) -> T } -> (Elem | T)
+  def delete: (E obj) -> E?
+            | [S, T] (S obj) { (S) -> T } -> (E | T)
 
   # <!--
   #   rdoc-file=array.c
@@ -1530,7 +1530,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def delete_at: %a{implicitly-returns-nil} (int index) -> Elem
+  def delete_at: %a{implicitly-returns-nil} (int index) -> E
 
   # <!--
   #   rdoc-file=array.c
@@ -1547,8 +1547,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def delete_if: () { (Elem item) -> boolish } -> self
-               | () -> ::Enumerator[Elem, self]
+  def delete_if: () { (E item) -> boolish } -> self
+               | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1568,7 +1568,7 @@ class Array[unchecked out Elem] < Object
   # Related: Array#-; see also [Methods for
   # Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def difference: (*::Array[untyped] arrays) -> ::Array[Elem]
+  def difference: (*::Array[untyped] arrays) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -1588,7 +1588,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def dig: (int idx) -> Elem?
+  def dig: (int idx) -> E?
          | (int idx, untyped, *untyped) -> untyped
 
   # <!--
@@ -1608,7 +1608,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def drop: (int n) -> ::Array[Elem]
+  def drop: (int n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -1627,8 +1627,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def drop_while: () { (Elem obj) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def drop_while: () { (E obj) -> boolish } -> ::Array[E]
+                | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -1661,8 +1661,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def each: () -> ::Enumerator[Elem, self]
-          | () { (Elem item) -> void } -> self
+  def each: () -> ::Enumerator[E, self]
+          | () { (E item) -> void } -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -1769,9 +1769,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def fetch: (int index) -> Elem
-           | [T] (int index, T default) -> (Elem | T)
-           | [T] (int index) { (int index) -> T } -> (Elem | T)
+  def fetch: (int index) -> E
+           | [T] (int index, T default) -> (E | T)
+           | [T] (int index) { (int index) -> T } -> (E | T)
 
   # <!--
   #   rdoc-file=array.rb
@@ -1988,11 +1988,11 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def fill: (Elem obj) -> self
-          | (Elem obj, int? start, ?int? length) -> self
-          | (Elem obj, ::Range[::Integer] range) -> self
-          | (?int? start, ?int? length) { (::Integer index) -> Elem } -> self
-          | (::Range[::Integer] range) { (::Integer index) -> Elem } -> self
+  def fill: (E obj) -> self
+          | (E obj, int? start, ?int? length) -> self
+          | (E obj, ::Range[::Integer] range) -> self
+          | (?int? start, ?int? length) { (::Integer index) -> E } -> self
+          | (::Range[::Integer] range) { (::Integer index) -> E } -> self
 
   # <!-- rdoc-file=array.c -->
   # With a block given, calls the block with each element of `self`; returns a new
@@ -2007,8 +2007,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def filter: () { (Elem item) -> boolish } -> ::Array[Elem]
-            | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def filter: () { (E item) -> boolish } -> ::Array[E]
+            | () -> ::Enumerator[E, ::Array[E]]
 
   # <!-- rdoc-file=array.c -->
   # With a block given, calls the block with each element of `self`; removes from
@@ -2025,8 +2025,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def filter!: () { (Elem item) -> boolish } -> self?
-             | () -> ::Enumerator[Elem, self?]
+  def filter!: () { (E item) -> boolish } -> self?
+             | () -> ::Enumerator[E, self?]
 
   # <!--
   #   rdoc-file=array.c
@@ -2047,10 +2047,10 @@ class Array[unchecked out Elem] < Object
   #
   # With no block given, returns an Enumerator.
   #
-  def find: () { (Elem) -> boolish } -> Elem?
-          | () -> ::Enumerator[Elem, Elem?]
-          | [T] (Enumerable::_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
-          | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
+  def find: () { (E) -> boolish } -> E?
+          | () -> ::Enumerator[E, E?]
+          | [T] (Enumerable::_NotFound[T] ifnone) { (E) -> boolish } -> (E | T)
+          | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[E, E | T]
 
   # <!--
   #   rdoc-file=array.c
@@ -2084,8 +2084,8 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def find_index: (untyped obj) -> ::Integer?
-                | () { (Elem item) -> boolish } -> ::Integer?
-                | () -> ::Enumerator[Elem, ::Integer?]
+                | () { (E item) -> boolish } -> ::Integer?
+                | () -> ::Enumerator[E, ::Integer?]
 
   # <!--
   #   rdoc-file=array.rb
@@ -2113,8 +2113,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def first: %a{implicitly-returns-nil} () -> Elem
-           | (int n) -> ::Array[Elem]
+  def first: %a{implicitly-returns-nil} () -> E
+           | (int n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2278,7 +2278,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def insert: (int index, *Elem obj) -> self
+  def insert: (int index, *E obj) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2331,7 +2331,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def intersection: (*::Array[untyped] | _ToAry[untyped] other_ary) -> ::Array[Elem]
+  def intersection: (*::Array[untyped] | _ToAry[untyped] other_ary) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2380,8 +2380,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def keep_if: () { (Elem item) -> boolish } -> self
-             | () -> ::Enumerator[Elem, self]
+  def keep_if: () { (E item) -> boolish } -> self
+             | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.rb
@@ -2408,8 +2408,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def last: %a{implicitly-returns-nil} () -> Elem
-          | (int n) -> ::Array[Elem]
+  def last: %a{implicitly-returns-nil} () -> E
+          | (int n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2502,10 +2502,10 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def max: %a{implicitly-returns-nil} () -> Elem
-         | %a{implicitly-returns-nil} () { (Elem a, Elem b) -> ::Integer? } -> Elem
-         | (int n) -> ::Array[Elem]
-         | (int n) { (Elem a, Elem b) -> ::Integer? } -> ::Array[Elem]
+  def max: %a{implicitly-returns-nil} () -> E
+         | %a{implicitly-returns-nil} () { (E a, E b) -> ::Integer? } -> E
+         | (int n) -> ::Array[E]
+         | (int n) { (E a, E b) -> ::Integer? } -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2579,8 +2579,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def minmax: () -> [ Elem?, Elem? ]
-            | () { (Elem a, Elem b) -> ::Integer? } -> [ Elem?, Elem? ]
+  def minmax: () -> [ E?, E? ]
+            | () { (E a, E b) -> ::Integer? } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=array.c
@@ -2704,8 +2704,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def permutation: (?int n) -> ::Enumerator[::Array[Elem], ::Array[Elem]]
-                 | (?int n) { (::Array[Elem] p) -> void } -> ::Array[Elem]
+  def permutation: (?int n) -> ::Enumerator[::Array[E], ::Array[E]]
+                 | (?int n) { (::Array[E] p) -> void } -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2736,8 +2736,8 @@ class Array[unchecked out Elem] < Object
   # Related: Array#push; see also [Methods for
   # Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def pop: () -> Elem?
-         | (int n) -> ::Array[Elem]
+  def pop: () -> E?
+         | (int n) -> ::Array[E]
 
   # <!-- rdoc-file=array.c -->
   # Prepends the given `objects` to `self`:
@@ -2803,10 +2803,10 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def product: () -> ::Array[[ Elem ]]
-             | [X] (::Array[X] other_ary) -> ::Array[[ Elem, X ]]
-             | [X, Y] (::Array[X] other_ary1, ::Array[Y] other_ary2) -> ::Array[[ Elem, X, Y ]]
-             | [U] (*::Array[U] other_arys) -> ::Array[::Array[Elem | U]]
+  def product: () -> ::Array[[ E ]]
+             | [X] (::Array[X] other_ary) -> ::Array[[ E, X ]]
+             | [X, Y] (::Array[X] other_ary1, ::Array[Y] other_ary2) -> ::Array[[ E, X, Y ]]
+             | [U] (*::Array[U] other_arys) -> ::Array[::Array[E | U]]
 
   # <!--
   #   rdoc-file=array.c
@@ -2825,7 +2825,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def push: (*Elem obj) -> self
+  def push: (*E obj) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2882,8 +2882,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def reject!: () { (Elem item) -> boolish } -> self?
-             | () -> ::Enumerator[Elem, self?]
+  def reject!: () { (E item) -> boolish } -> self?
+             | () -> ::Enumerator[E, self?]
 
   # <!--
   #   rdoc-file=array.c
@@ -2922,8 +2922,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def repeated_combination: (int n) { (::Array[Elem] c) -> void } -> self
-                          | (int n) -> ::Enumerator[::Array[Elem], self]
+  def repeated_combination: (int n) { (::Array[E] c) -> void } -> self
+                          | (int n) -> ::Enumerator[::Array[E], self]
 
   # <!--
   #   rdoc-file=array.c
@@ -2962,8 +2962,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def repeated_permutation: (int n) { (::Array[Elem] p) -> void } -> self
-                          | (int n) -> ::Enumerator[::Array[Elem], self]
+  def repeated_permutation: (int n) { (::Array[E] p) -> void } -> self
+                          | (int n) -> ::Enumerator[::Array[E], self]
 
   # <!-- rdoc-file=array.c -->
   # Replaces the elements of `self` with the elements of `other_array`, which must
@@ -2976,7 +2976,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def replace: (::Array[Elem]) -> self
+  def replace: (::Array[E]) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2988,7 +2988,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def reverse: () -> ::Array[Elem]
+  def reverse: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3002,7 +3002,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def reverse!: () -> ::Array[Elem]
+  def reverse!: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3026,8 +3026,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def reverse_each: () { (Elem item) -> void } -> self
-                  | () -> ::Enumerator[Elem, self]
+  def reverse_each: () { (E item) -> void } -> self
+                  | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -3049,10 +3049,10 @@ class Array[unchecked out Elem] < Object
   #
   # With no block given, returns an Enumerator.
   #
-  def rfind: () { (Elem) -> boolish } -> Elem?
-           | () -> ::Enumerator[Elem, Elem?]
-           | [T] (Enumerable::_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
-           | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
+  def rfind: () { (E) -> boolish } -> E?
+           | () -> ::Enumerator[E, E?]
+           | [T] (Enumerable::_NotFound[T] ifnone) { (E) -> boolish } -> (E | T)
+           | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[E, E | T]
 
   # <!--
   #   rdoc-file=array.c
@@ -3084,8 +3084,8 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def rindex: (untyped obj) -> ::Integer?
-            | () { (Elem item) -> boolish } -> ::Integer?
-            | () -> ::Enumerator[Elem, ::Integer?]
+            | () { (E item) -> boolish } -> ::Integer?
+            | () -> ::Enumerator[E, ::Integer?]
 
   # <!--
   #   rdoc-file=array.c
@@ -3120,7 +3120,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def rotate: (?int count) -> ::Array[Elem]
+  def rotate: (?int count) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3206,8 +3206,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def sample: %a{implicitly-returns-nil} (?random: _Rand rng) -> Elem
-            | (int n, ?random: _Rand rng) -> ::Array[Elem]
+  def sample: %a{implicitly-returns-nil} (?random: _Rand rng) -> E
+            | (int n, ?random: _Rand rng) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3228,8 +3228,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def select: () { (Elem item) -> boolish } -> ::Array[Elem]
-            | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def select: () { (E item) -> boolish } -> ::Array[E]
+            | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -3252,8 +3252,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def select!: () { (Elem item) -> boolish } -> self?
-             | () -> ::Enumerator[Elem, self?]
+  def select!: () { (E item) -> boolish } -> self?
+             | () -> ::Enumerator[E, self?]
 
   # <!--
   #   rdoc-file=array.c
@@ -3291,8 +3291,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def shift: %a{implicitly-returns-nil} () -> Elem
-           | (int n) -> ::Array[Elem]
+  def shift: %a{implicitly-returns-nil} () -> E
+           | (int n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.rb
@@ -3316,7 +3316,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def shuffle: (?random: _Rand rng) -> ::Array[Elem]
+  def shuffle: (?random: _Rand rng) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.rb
@@ -3464,9 +3464,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def slice: %a{implicitly-returns-nil} (int index) -> Elem
-           | (int start, int length) -> ::Array[Elem]?
-           | (::Range[::Integer] range) -> ::Array[Elem]?
+  def slice: %a{implicitly-returns-nil} (int index) -> E
+           | (int start, int length) -> ::Array[E]?
+           | (::Range[::Integer] range) -> ::Array[E]?
 
   # <!--
   #   rdoc-file=array.c
@@ -3558,9 +3558,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def slice!: %a{implicitly-returns-nil} (int index) -> Elem
-            | (int start, int length) -> ::Array[Elem]?
-            | (::Range[::Integer] range) -> ::Array[Elem]?
+  def slice!: %a{implicitly-returns-nil} (int index) -> E
+            | (int start, int length) -> ::Array[E]?
+            | (::Range[::Integer] range) -> ::Array[E]?
 
   # <!--
   #   rdoc-file=array.c
@@ -3595,8 +3595,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def sort: () -> ::Array[Elem]
-          | () { (Elem a, Elem b) -> ::Integer } -> ::Array[Elem]
+  def sort: () -> ::Array[E]
+          | () { (E a, E b) -> ::Integer } -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3608,7 +3608,7 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
   def sort!: () -> self
-           | () { (Elem a, Elem b) -> ::Integer } -> self
+           | () { (E a, E b) -> ::Integer } -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3631,8 +3631,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def sort_by!: [U] () { (Elem obj) -> U } -> ::Array[Elem]
-              | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def sort_by!: [U] () { (E obj) -> U } -> ::Array[E]
+              | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -3677,7 +3677,7 @@ class Array[unchecked out Elem] < Object
   #     as Integer#+.
   #
   def sum: (?untyped init) -> untyped
-         | (?untyped init) { (Elem e) -> untyped } -> untyped
+         | (?untyped init) { (E e) -> untyped } -> untyped
 
   # <!--
   #   rdoc-file=array.c
@@ -3694,7 +3694,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def take: (int n) -> ::Array[Elem]
+  def take: (int n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3716,8 +3716,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def take_while: () { (Elem obj) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def take_while: () { (E obj) -> boolish } -> ::Array[E]
+                | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -3735,7 +3735,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def to_a: () -> ::Array[Elem]
+  def to_a: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3770,7 +3770,7 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
   def to_h: () -> Hash[untyped, untyped]
-          | [T, S] () { (Elem) -> [ T, S ] } -> Hash[T, S]
+          | [T, S] () { (E) -> [ T, S ] } -> Hash[T, S]
 
   # <!-- rdoc-file=array.c -->
   # Returns the new string formed by calling method <code>#inspect</code> on each
@@ -3820,7 +3820,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def union: [T] (*::Array[T] other_arys) -> ::Array[T | Elem]
+  def union: [T] (*::Array[T] other_arys) -> ::Array[T | E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3846,8 +3846,8 @@ class Array[unchecked out Elem] < Object
   #
   # Related: [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def uniq: () -> ::Array[Elem]
-          | () { (Elem item) -> untyped } -> ::Array[Elem]
+  def uniq: () -> ::Array[E]
+          | () { (E item) -> untyped } -> ::Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3876,7 +3876,7 @@ class Array[unchecked out Elem] < Object
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def uniq!: () -> self?
-           | () { (Elem) -> untyped } -> self?
+           | () { (E) -> untyped } -> self?
 
   # <!--
   #   rdoc-file=array.c
@@ -3891,7 +3891,7 @@ class Array[unchecked out Elem] < Object
   # Related: Array#shift; see also [Methods for
   # Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def unshift: (*Elem obj) -> self
+  def unshift: (*E obj) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3999,7 +3999,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def values_at: (*int | ::Range[::Integer] selector) -> ::Array[Elem?]
+  def values_at: (*int | ::Range[::Integer] selector) -> ::Array[E?]
 
   # <!--
   #   rdoc-file=array.c
@@ -4093,9 +4093,9 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def zip: [U] (_Each[U] arg) -> Array[[ Elem, U? ]]
+  def zip: [U] (_Each[U] arg) -> Array[[ E, U? ]]
          | (_Each[untyped] arg, *_Each[untyped] args) -> Array[Array[untyped]]
-         | [U] (_Each[U] arg) { ([ Elem, U? ]) -> void } -> nil
+         | [U] (_Each[U] arg) { ([ E, U? ]) -> void } -> nil
          | (_Each[untyped] arg, *_Each[untyped] args) { (Array[untyped]) -> void } -> nil
 
   # <!--
@@ -4111,7 +4111,7 @@ class Array[unchecked out Elem] < Object
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def |: [T] (::Array[T] other_ary) -> ::Array[Elem | T]
+  def |: [T] (::Array[T] other_ary) -> ::Array[E | T]
 
   private
 

--- a/core/builtin.rbs
+++ b/core/builtin.rbs
@@ -170,12 +170,12 @@ interface _Inspect
   def inspect: () -> String
 end
 
-interface _Each[out E, out R = void]
-  def each: () { (E) -> void } -> R
+interface _Each[out T, out R = void]
+  def each: () { (T) -> void } -> R
 end
 
-interface _EachEntry[out E]
-  def each_entry: () { (E) -> void } -> self
+interface _EachEntry[out T]
+  def each_entry: () { (T) -> void } -> self
 end
 
 interface _Reader

--- a/core/enumerable.rbs
+++ b/core/enumerable.rbs
@@ -271,7 +271,7 @@
 # Enumerator#size. For example, File#size returns the number of bytes in the
 # file, not the number of lines.
 #
-module Enumerable[unchecked out Elem] : _Each[Elem]
+module Enumerable[unchecked out E] : _Each[E]
   %a{private}
   interface _Pattern
     def ===: (untyped) -> bool
@@ -320,7 +320,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def all?: () -> bool
           | (_Pattern) -> bool
-          | () { (Elem) -> boolish } -> bool
+          | () { (E) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=enum.c
@@ -364,7 +364,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def any?: () -> bool
           | (_Pattern) -> bool
-          | () { (Elem) -> boolish } -> bool
+          | () { (E) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=enum.c
@@ -381,8 +381,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def collect: [U] () { (Elem arg0) -> U } -> ::Array[U]
-             | () -> ::Enumerator[Elem, ::Array[untyped]]
+  def collect: [U] () { (E arg0) -> U } -> ::Array[U]
+             | () -> ::Enumerator[E, ::Array[untyped]]
 
   # <!-- rdoc-file=enum.c -->
   # Returns an array of flattened objects returned by the block.
@@ -399,8 +399,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Alias: #collect_concat.
   #
-  def collect_concat: [U] () { (Elem) -> (::Array[U] | U) } -> ::Array[U]
-                    | () -> ::Enumerator[Elem, ::Array[untyped]]
+  def collect_concat: [U] () { (E) -> (::Array[U] | U) } -> ::Array[U]
+                    | () -> ::Enumerator[E, ::Array[untyped]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -411,7 +411,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     a = [nil, 0, nil, 'a', false, nil, false, nil, 'a', nil, 0, nil]
   #     a.compact # => [0, "a", false, false, "a", 0]
   #
-  def compact: () -> Array[Elem]
+  def compact: () -> Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -439,8 +439,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     {foo: 0, bar: 1, baz: 2}.count {|key, value| value < 2} # => 2
   #
   def count: () -> Integer
-           | (Elem) -> Integer
-           | () { (Elem) -> boolish } -> Integer
+           | (E) -> Integer
+           | () { (E) -> boolish } -> Integer
 
   # <!--
   #   rdoc-file=enum.c
@@ -467,8 +467,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # When no block is given, returns an Enumerator.
   #
-  def cycle: (?Integer n) { (Elem arg0) -> untyped } -> NilClass
-           | (?Integer n) -> ::Enumerator[Elem, NilClass]
+  def cycle: (?Integer n) { (E arg0) -> untyped } -> NilClass
+           | (?Integer n) -> ::Enumerator[E, NilClass]
 
   # <!-- rdoc-file=enum.c -->
   # Returns the first element for which the block returns a truthy value.
@@ -488,8 +488,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def detect: (?Proc ifnone) { (Elem) -> boolish } -> Elem?
-            | (?Proc ifnone) -> ::Enumerator[Elem, Elem?]
+  def detect: (?Proc ifnone) { (E) -> boolish } -> E?
+            | (?Proc ifnone) -> ::Enumerator[E, E?]
 
   # <!--
   #   rdoc-file=enum.c
@@ -508,7 +508,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     h = {foo: 0, bar: 1, baz: 2, bat: 3}
   #     h.drop(2) # => [[:baz, 2], [:bat, 3]]
   #
-  def drop: (Integer n) -> ::Array[Elem]
+  def drop: (Integer n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -536,8 +536,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #       p $!.result #=> [3, 4]
   #     end
   #
-  def drop_while: () { (Elem) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def drop_while: () { (E) -> boolish } -> ::Array[E]
+                | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -558,8 +558,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def each_cons: (Integer n) { (::Array[Elem]) -> void } -> self
-               | (Integer n) -> ::Enumerator[::Array[Elem], self]
+  def each_cons: (Integer n) { (::Array[E]) -> void } -> self
+               | (Integer n) -> ::Enumerator[::Array[E], self]
 
   # <!--
   #   rdoc-file=enum.c
@@ -586,8 +586,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def each_with_index: () { (Elem, Integer index) -> untyped } -> self
-                     | () -> ::Enumerator[[ Elem, Integer ], self]
+  def each_with_index: () { (E, Integer index) -> untyped } -> self
+                     | () -> ::Enumerator[[ E, Integer ], self]
 
   # <!--
   #   rdoc-file=enum.c
@@ -605,18 +605,18 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def each_with_object: [U] (U obj) { (Elem, U obj) -> untyped } -> U
-                      | [U] (U obj) -> ::Enumerator[[ Elem, U ], U]
+  def each_with_object: [U] (U obj) { (E, U obj) -> untyped } -> U
+                      | [U] (U obj) -> ::Enumerator[[ E, U ], U]
 
   # <!-- rdoc-file=enum.c -->
   # Returns an array containing the items in `self`:
   #
   #     (0..4).to_a # => [0, 1, 2, 3, 4]
   #
-  def entries: () -> ::Array[Elem]
+  def entries: () -> ::Array[E]
 
   def enum_for: (Symbol method, *untyped, **untyped) ?{ (?) -> Integer } -> Enumerator[untyped, untyped]
-              | () ?{ () -> Integer } -> Enumerator[Elem, self]
+              | () ?{ () -> Integer } -> Enumerator[E, self]
 
   %a{annotate:rdoc:skip}
   alias to_enum enum_for
@@ -639,8 +639,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #reject.
   #
-  def find_all: () { (Elem) -> boolish } -> ::Array[Elem]
-              | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def find_all: () { (E) -> boolish } -> ::Array[E]
+              | () -> ::Enumerator[E, ::Array[E]]
 
   # <!-- rdoc-file=enum.c -->
   # Returns an array containing elements selected by the block.
@@ -697,8 +697,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # With no argument and no block given, returns an Enumerator.
   #
   def find_index: (untyped value) -> Integer?
-                | () { (Elem) -> boolish } -> Integer?
-                | () -> ::Enumerator[Elem, Integer?]
+                | () { (E) -> boolish } -> Integer?
+                | () -> ::Enumerator[E, Integer?]
 
   # <!--
   #   rdoc-file=enum.c
@@ -723,8 +723,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     {foo: 1, bar: 1, baz: 2}.first(2) # => [[:foo, 1], [:bar, 1]]
   #     [].first(2)                       # => []
   #
-  def first: () -> Elem?
-           | (_ToInt n) -> ::Array[Elem]
+  def first: () -> E?
+           | (_ToInt n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -750,8 +750,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #grep_v.
   #
-  def grep: (untyped arg0) -> ::Array[Elem]
-          | [U] (untyped arg0) { (Elem arg0) -> U } -> ::Array[U]
+  def grep: (untyped arg0) -> ::Array[E]
+          | [U] (untyped arg0) { (E arg0) -> U } -> ::Array[U]
 
   # <!--
   #   rdoc-file=enum.c
@@ -777,8 +777,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #grep.
   #
-  def grep_v: (untyped) -> ::Array[Elem]
-            | [U] (untyped) { (Elem) -> U } -> ::Array[U]
+  def grep_v: (untyped) -> ::Array[E]
+            | [U] (untyped) { (E) -> U } -> ::Array[U]
 
   # <!--
   #   rdoc-file=enum.c
@@ -801,8 +801,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def group_by: [U] () { (Elem arg0) -> U } -> ::Hash[U, ::Array[Elem]]
-              | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def group_by: [U] () { (E arg0) -> U } -> ::Hash[U, ::Array[E]]
+              | () -> ::Enumerator[E, ::Array[E]]
 
   # <!-- rdoc-file=enum.c -->
   # Returns whether for any element <code>object == element</code>:
@@ -972,8 +972,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def inject: (untyped init, Symbol method) -> untyped
             | (Symbol method) -> untyped
-            | [A] (A initial) { (A, Elem) -> A } -> A
-            | () { (Elem, Elem) -> Elem } -> Elem
+            | [A] (A initial) { (A, E) -> A } -> A
+            | () { (E, E) -> E } -> E
 
   # <!--
   #   rdoc-file=enum.c
@@ -1030,10 +1030,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #min, #minmax, #max_by.
   #
-  def max: () -> Elem?
-         | () { (Elem arg0, Elem arg1) -> Integer } -> Elem?
-         | (Integer arg0) -> ::Array[Elem]
-         | (Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
+  def max: () -> E?
+         | () { (E arg0, E arg1) -> Integer } -> E?
+         | (Integer arg0) -> ::Array[E]
+         | (Integer arg0) { (E arg0, E arg1) -> Integer } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1068,10 +1068,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #max, #minmax, #min_by.
   #
-  def max_by: () -> ::Enumerator[Elem, Elem?]
-            | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
-            | (Integer arg0) -> ::Enumerator[Elem, ::Array[Elem]]
-            | (Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
+  def max_by: () -> ::Enumerator[E, E?]
+            | () { (E arg0) -> (Comparable | ::Array[untyped]) } -> E?
+            | (Integer arg0) -> ::Enumerator[E, ::Array[E]]
+            | (Integer arg0) { (E arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1128,10 +1128,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #min_by, #minmax, #max.
   #
-  def min: () -> Elem?
-         | () { (Elem arg0, Elem arg1) -> Integer } -> Elem?
-         | (Integer arg0) -> ::Array[Elem]
-         | (Integer arg0) { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
+  def min: () -> E?
+         | () { (E arg0, E arg1) -> Integer } -> E?
+         | (Integer arg0) -> ::Array[E]
+         | (Integer arg0) { (E arg0, E arg1) -> Integer } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1166,10 +1166,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #min, #minmax, #max_by.
   #
-  def min_by: () -> ::Enumerator[Elem, Elem?]
-            | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> Elem?
-            | (Integer arg0) -> ::Enumerator[Elem, ::Array[Elem]]
-            | (Integer arg0) { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
+  def min_by: () -> ::Enumerator[E, E?]
+            | () { (E arg0) -> (Comparable | ::Array[untyped]) } -> E?
+            | (Integer arg0) -> ::Enumerator[E, ::Array[E]]
+            | (Integer arg0) { (E arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1200,8 +1200,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #min, #max, #minmax_by.
   #
-  def minmax: () -> [ Elem?, Elem? ]
-            | () { (Elem arg0, Elem arg1) -> Integer } -> [ Elem?, Elem? ]
+  def minmax: () -> [ E?, E? ]
+            | () { (E arg0, E arg1) -> Integer } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1224,8 +1224,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #max_by, #minmax, #min_by.
   #
-  def minmax_by: () -> [ Elem?, Elem? ]
-               | () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> [ Elem?, Elem? ]
+  def minmax_by: () -> [ E?, E? ]
+               | () { (E arg0) -> (Comparable | ::Array[untyped]) } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1266,7 +1266,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def none?: () -> bool
            | (_Pattern) -> bool
-           | () { (Elem) -> boolish } -> bool
+           | () { (E) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=enum.c
@@ -1310,7 +1310,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   def one?: () -> bool
           | (_Pattern) -> bool
-          | () { (Elem) -> boolish } -> bool
+          | () { (E) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=enum.c
@@ -1339,8 +1339,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: Enumerable#group_by.
   #
-  def partition: () { (Elem) -> boolish } -> [ ::Array[Elem], ::Array[Elem] ]
-               | () -> ::Enumerator[Elem, [ ::Array[Elem], ::Array[Elem] ]]
+  def partition: () { (E) -> boolish } -> [ ::Array[E], ::Array[E] ]
+               | () -> ::Enumerator[E, [ ::Array[E], ::Array[E] ]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1359,8 +1359,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Related: #select.
   #
-  def reject: () { (Elem) -> boolish } -> ::Array[Elem]
-            | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def reject: () { (E) -> boolish } -> ::Array[E]
+            | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1386,8 +1386,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def reverse_each: () { (Elem arg0) -> untyped } -> void
-                  | () -> ::Enumerator[Elem]
+  def reverse_each: () { (E arg0) -> untyped } -> void
+                  | () -> ::Enumerator[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1420,8 +1420,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # See also #sort_by. It implements a Schwartzian transform which is useful when
   # key computation or comparison is expensive.
   #
-  def sort: () -> ::Array[Elem]
-          | () { (Elem arg0, Elem arg1) -> Integer } -> ::Array[Elem]
+  def sort: () -> ::Array[E]
+          | () { (E arg0, E arg1) -> Integer } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1501,8 +1501,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   #     ary.sort_by { ... }.reverse!
   #
-  def sort_by: () { (Elem arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[Elem]
-             | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def sort_by: () { (E arg0) -> (Comparable | ::Array[untyped]) } -> ::Array[E]
+             | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1517,7 +1517,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     h = {foo: 0, bar: 1, baz: 2, bat: 3}
   #     h.take(2) # => [[:foo, 0], [:bar, 1]]
   #
-  def take: (Integer n) -> ::Array[Elem]
+  def take: (Integer n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1534,8 +1534,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def take_while: () { (Elem) -> boolish } -> ::Array[Elem]
-                | () -> ::Enumerator[Elem, ::Array[Elem]]
+  def take_while: () { (E) -> boolish } -> ::Array[E]
+                | () -> ::Enumerator[E, ::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1557,7 +1557,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # block is not passed.
   #
   def to_h: () -> ::Hash[untyped, untyped]
-          | [T, U] () { (Elem) -> [ T, U ] } -> ::Hash[T, U]
+          | [T, U] () { (E) -> [ T, U ] } -> ::Hash[T, U]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1578,8 +1578,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def each_slice: (Integer n) { (::Array[Elem]) -> void } -> self
-                | (Integer n) -> ::Enumerator[::Array[Elem], self]
+  def each_slice: (Integer n) { (::Array[E]) -> void } -> self
+                | (Integer n) -> ::Enumerator[::Array[E], self]
 
   interface _NotFound[T]
     def call: () -> T
@@ -1607,10 +1607,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def find: () { (Elem) -> boolish } -> Elem?
-          | () -> ::Enumerator[Elem, Elem?]
-          | [T] (_NotFound[T] ifnone) { (Elem) -> boolish } -> (Elem | T)
-          | [T] (_NotFound[T] ifnone) -> ::Enumerator[Elem, Elem | T]
+  def find: () { (E) -> boolish } -> E?
+          | () -> ::Enumerator[E, E?]
+          | [T] (_NotFound[T] ifnone) { (E) -> boolish } -> (E | T)
+          | [T] (_NotFound[T] ifnone) -> ::Enumerator[E, E | T]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1631,8 +1631,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # Alias: #collect_concat.
   #
-  def flat_map: [U] () { (Elem) -> (Array[U] | U) } -> Array[U]
-              | () -> ::Enumerator[Elem, Array[untyped]]
+  def flat_map: [U] () { (E) -> (Array[U] | U) } -> Array[U]
+              | () -> ::Enumerator[E, Array[untyped]]
 
   # <!-- rdoc-file=enum.c -->
   # Returns an array of objects returned by the block.
@@ -1645,8 +1645,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def map: [U] () { (Elem arg0) -> U } -> ::Array[U]
-         | () -> ::Enumerator[Elem, ::Array[untyped]]
+  def map: [U] () { (E arg0) -> U } -> ::Array[U]
+         | () -> ::Enumerator[E, ::Array[untyped]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1821,7 +1821,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   #     (0..4).to_a # => [0, 1, 2, 3, 4]
   #
-  def to_a: () -> ::Array[Elem]
+  def to_a: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -1851,7 +1851,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     # show pythagorean triples less than 100
   #     p pythagorean_triples.take_while { |*, z| z < 100 }.force
   #
-  def lazy: () -> Enumerator::Lazy[Elem]
+  def lazy: () -> Enumerator::Lazy[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1872,8 +1872,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     a = %w[a b c d e e d c b a a b c d e]
   #     a.uniq {|c| c < 'c' }         # => ["a", "c"]
   #
-  def uniq: () -> ::Array[Elem]
-          | () { (Elem item) -> untyped } -> ::Array[Elem]
+  def uniq: () -> ::Array[E]
+          | () { (E item) -> untyped } -> ::Array[E]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1904,10 +1904,10 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     h.sum {|key, value| value.odd? ? value : 0 } # => 9
   #     ('a'..'f').sum('x') {|c| c < 'd' ? c : '' }  # => "xabc"
   #
-  def sum: () -> (Elem | Integer)
-         | [T] () { (Elem arg0) -> T } -> (Integer | T)
-         | [T] (?T arg0) -> (Elem | T)
-         | [U] (?U arg0) { (Elem arg0) -> U } -> U
+  def sum: () -> (E | Integer)
+         | [T] () { (E arg0) -> T } -> (Integer | T)
+         | [T] (?T arg0) -> (E | T)
+         | [U] (?U arg0) { (E arg0) -> U } -> U
 
   # <!--
   #   rdoc-file=enum.c
@@ -1924,8 +1924,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # When no block given, returns an Enumerator.
   #
-  def filter_map: [U] () { (Elem elem) -> (nil | false | U) } -> ::Array[U]
-                | () -> ::Enumerator[Elem, ::Array[untyped]]
+  def filter_map: [U] () { (E elem) -> (nil | false | U) } -> ::Array[U]
+                | () -> ::Enumerator[E, ::Array[untyped]]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -1937,7 +1937,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     e = (1..3).chain([4, 5])
   #     e.to_a #=> [1, 2, 3, 4, 5]
   #
-  def chain: [Elem2] (*_Each[Elem2] enumerables) -> ::Enumerator::Chain[Elem | Elem2]
+  def chain: [Elem2] (*_Each[Elem2] enumerables) -> ::Enumerator::Chain[E | Elem2]
 
   # <!--
   #   rdoc-file=enum.c
@@ -1983,7 +1983,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #         {foo: 'a', bar: 'b'}.tally(h) # => {[:foo, "a"]=>2, [:bar, "b"]=>2, [:foo, "c"]=>1, [:bar, "d"]=>1}
   #         {foo: 'c', bar: 'd'}.tally(h) # => {[:foo, "a"]=>2, [:bar, "b"]=>2, [:foo, "c"]=>2, [:bar, "d"]=>2}
   #
-  def tally: (?Hash[Elem, Integer] hash) -> ::Hash[Elem, Integer]
+  def tally: (?Hash[E, Integer] hash) -> ::Hash[E, Integer]
 
   # <!--
   #   rdoc-file=enum.c
@@ -2021,8 +2021,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def each_entry: () -> ::Enumerator[Elem, self]
-                | () { (Elem arg0) -> untyped } -> self
+  def each_entry: () -> ::Enumerator[E, self]
+                | () { (E arg0) -> untyped } -> self
 
   # <!--
   #   rdoc-file=enum.c
@@ -2088,9 +2088,9 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     [:a2, :b2, :c2]
   #     [:a3, :b3, :c3]
   #
-  def zip: [Elem2] (_Each[Elem2] enum) -> Array[[ Elem, Elem2? ]]
+  def zip: [Elem2] (_Each[Elem2] enum) -> Array[[ E, Elem2? ]]
          | (_Each[untyped], *_Each[untyped]) -> Array[Array[untyped]]
-         | [Elem2] (_Each[Elem2]) { ([ Elem, Elem2? ]) -> void } -> nil
+         | [Elem2] (_Each[Elem2]) { ([ E, Elem2? ]) -> void } -> nil
          | (_Each[untyped], *_Each[untyped]) { (Array[untyped]) -> void } -> nil
 
   # <!--
@@ -2197,8 +2197,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #       pp lines
   #     }
   #
-  def chunk: [U] () { (Elem elt) -> U } -> ::Enumerator[[ U, ::Array[Elem] ]]
-           | () -> ::Enumerator[Elem, ::Enumerator[[ untyped, ::Array[Elem] ]]]
+  def chunk: [U] () { (E elt) -> U } -> ::Enumerator[[ U, ::Array[E] ]]
+           | () -> ::Enumerator[E, ::Enumerator[[ untyped, ::Array[E] ]]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -2247,7 +2247,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Enumerable#slice_when does the same, except splitting when the block returns
   # `true` instead of `false`.
   #
-  def chunk_while: () { (Elem elt_before, Elem elt_after) -> boolish } -> ::Enumerator[::Array[Elem]]
+  def chunk_while: () { (E elt_before, E elt_after) -> boolish } -> ::Enumerator[::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -2309,7 +2309,7 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   # Enumerable#chunk_while does the same, except splitting when the block returns
   # `false` instead of `true`.
   #
-  def slice_when: () { (Elem elt_before, Elem elt_after) -> boolish } -> ::Enumerator[::Array[Elem]]
+  def slice_when: () { (E elt_before, E elt_after) -> boolish } -> ::Enumerator[::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -2344,8 +2344,8 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #     p e.map {|ll| ll[0...-1].map {|l| l.sub(/\\\n\z/, "") }.join + ll.last }
   #     #=>["foo\n", "barbaz\n", "\n", "qux\n"]
   #
-  def slice_after: (untyped pattern) -> ::Enumerator[::Array[Elem]]
-                 | () { (Elem elt) -> boolish } -> ::Enumerator[::Array[Elem]]
+  def slice_after: (untyped pattern) -> ::Enumerator[::Array[E]]
+                 | () { (E elt) -> boolish } -> ::Enumerator[::Array[E]]
 
   # <!--
   #   rdoc-file=enum.c
@@ -2501,6 +2501,6 @@ module Enumerable[unchecked out Elem] : _Each[Elem]
   #       }
   #     }
   #
-  def slice_before: (untyped pattern) -> ::Enumerator[::Array[Elem]]
-                  | () { (Elem elt) -> boolish } -> ::Enumerator[::Array[Elem]]
+  def slice_before: (untyped pattern) -> ::Enumerator[::Array[E]]
+                  | () { (E elt) -> boolish } -> ::Enumerator[::Array[E]]
 end

--- a/core/enumerator.rbs
+++ b/core/enumerator.rbs
@@ -125,14 +125,14 @@
 #     puts ext_each(o.to_enum) {|*x| puts x; [:b, *x] }
 #     # => [], [:b], [1], [:b, 1], [1, 2], [:b, 1, 2], 3
 #
-class Enumerator[unchecked out Elem, out Return = void] < Object
-  include Enumerable[Elem]
+class Enumerator[unchecked out E, out R = void] < Object
+  include Enumerable[E]
 
   # A convenience interface for `each` with optional block
   #
-  interface _Each[out E, out R]
-    def each: () { (E) -> void } -> R
-            | () -> Enumerator[E, R]
+  interface _Each[out T, out R]
+    def each: () { (T) -> void } -> R
+            | () -> Enumerator[T, R]
   end
 
   # <!--
@@ -211,7 +211,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   # When a block is given, calls the block with each N-element array generated and
   # returns `nil`.
   #
-  def self.product: [Elem] (*_EachEntry[Elem]) -> Product[Elem]
+  def self.product: [E] (*_EachEntry[E]) -> Product[E]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -248,7 +248,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     enum.each(:y, :z).equal?(enum)  #=> false
   #     enum.each(:y, :z) { |elm| elm } #=> :method_returned
   #
-  def each: () { (Elem arg0) -> untyped } -> Return
+  def each: () { (E arg0) -> untyped } -> R
           | () -> self
 
   # <!--
@@ -296,7 +296,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     e.next              # (7)
   #                         # (10)
   #
-  def feed: (Elem arg0) -> NilClass
+  def feed: (E arg0) -> NilClass
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -322,7 +322,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   # lazy fashion (see Enumerator#size). It can either be a value or a callable
   # object.
   #
-  def initialize: (?Integer arg0) { (Enumerator::Yielder arg0) -> Return } -> void
+  def initialize: (?Integer arg0) { (Enumerator::Yielder arg0) -> R } -> void
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -350,7 +350,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #
   # See class-level notes about external iterators.
   #
-  def next: () -> Elem
+  def next: () -> E
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -394,7 +394,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     #  yield nil        [nil]            nil
   #     #  yield [1, 2]     [[1, 2]]         [1, 2]
   #
-  def next_values: () -> ::Array[Elem]
+  def next_values: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -418,7 +418,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     p e.next   #=> 3
   #     p e.peek   #raises StopIteration
   #
-  def peek: () -> Elem
+  def peek: () -> E
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -448,7 +448,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     e.next
   #     p e.peek_values    # raises StopIteration
   #
-  def peek_values: () -> ::Array[Elem]
+  def peek_values: () -> ::Array[E]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -501,7 +501,7 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     e = (1..3).each + [4, 5]
   #     e.to_a #=> [1, 2, 3, 4, 5]
   #
-  def +: [Elem2] (::_Each[Elem2]) -> ::Enumerator::Chain[Elem | Elem2]
+  def +: [Elem2] (::_Each[Elem2]) -> ::Enumerator::Chain[E | Elem2]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -515,8 +515,8 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   # `offset`
   # :   the starting index to use
   #
-  def with_index: (?Integer offset) { (Elem arg0, Integer arg1) -> untyped } -> Return
-                | (?Integer offset) -> ::Enumerator[[ Elem, Integer ], Return]
+  def with_index: (?Integer offset) { (E arg0, Integer arg1) -> untyped } -> R
+                | (?Integer offset) -> ::Enumerator[[ E, Integer ], R]
 
   # <!-- rdoc-file=enumerator.c -->
   # Iterates the given block for each element with an arbitrary object, `obj`, and
@@ -541,17 +541,17 @@ class Enumerator[unchecked out Elem, out Return = void] < Object
   #     # => foo: 1
   #     # => foo: 2
   #
-  def with_object: [U] (U obj) { (Elem, U obj) -> untyped } -> U
-                 | [U] (U obj) -> ::Enumerator[[ Elem, U ], U]
+  def with_object: [U] (U obj) { (E, U obj) -> untyped } -> U
+                 | [U] (U obj) -> ::Enumerator[[ E, U ], U]
 end
 
 # <!-- rdoc-file=enumerator.c -->
 # Generator
 #
-class Enumerator::Generator[out Elem] < Object
-  include Enumerable[Elem]
+class Enumerator::Generator[out E] < Object
+  include Enumerable[E]
 
-  def each: () { (Elem) -> void } -> void
+  def each: () { (E) -> void } -> void
 end
 
 # <!-- rdoc-file=enumerator.c -->
@@ -620,7 +620,7 @@ end
 #     # This returns an array of items like a normal enumerator does.
 #     all_checked = active_items.select(&:checked)
 #
-class Enumerator::Lazy[out Elem, out Return = void] < Enumerator[Elem, Return]
+class Enumerator::Lazy[out E, out R = void] < Enumerator[E, R]
   # <!-- rdoc-file=enumerator.c -->
   # Expands `lazy` enumerator to an array. See Enumerable#to_a.
   #
@@ -632,7 +632,7 @@ class Enumerator::Lazy[out Elem, out Return = void] < Enumerator[Elem, Return]
   # -->
   # Like Enumerable#compact, but chains operation to be lazy-evaluated.
   #
-  def compact: () -> Enumerator::Lazy[Elem, Return]
+  def compact: () -> Enumerator::Lazy[E, R]
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -640,7 +640,7 @@ class Enumerator::Lazy[out Elem, out Return = void] < Enumerator[Elem, Return]
   # -->
   # Returns a non-lazy Enumerator converted from the lazy enumerator.
   #
-  def eager: () -> ::Enumerator[Elem, Return]
+  def eager: () -> ::Enumerator[E, R]
 end
 
 # <!-- rdoc-file=enumerator.c -->
@@ -675,7 +675,7 @@ end
 #
 # This type of objects can be created by Enumerable#chain and Enumerator#+.
 #
-class Enumerator::Chain[out Elem] < Enumerator[Elem, void]
+class Enumerator::Chain[out E] < Enumerator[E, void]
   # <!--
   #   rdoc-file=enumerator.c
   #   - Enumerator::Chain.new(*enums) -> enum
@@ -687,7 +687,7 @@ class Enumerator::Chain[out Elem] < Enumerator[Elem, void]
   #     e.to_a #=> [1, 2, 3, 4, 5]
   #     e.size #=> 5
   #
-  def initialize: (*_Each[Elem] enums) -> void
+  def initialize: (*_Each[E] enums) -> void
 
   # <!--
   #   rdoc-file=enumerator.c
@@ -700,6 +700,6 @@ class Enumerator::Chain[out Elem] < Enumerator[Elem, void]
   #
   # If no block is given, returns an enumerator.
   #
-  def each: () { (Elem) -> void } -> self
-          | () -> Enumerator[Elem, self]
+  def each: () { (E) -> void } -> self
+          | () -> Enumerator[E, self]
 end

--- a/core/enumerator/product.rbs
+++ b/core/enumerator/product.rbs
@@ -1,5 +1,5 @@
 %a{annotate:rdoc:skip}
-class Enumerator[unchecked out Elem, out Return = void]
+class Enumerator[unchecked out E, out R = void]
   # <!-- rdoc-file=enumerator.c -->
   # Enumerator::Product generates a Cartesian product of any number of enumerable
   # objects.  Iterating over the product of enumerable objects is roughly
@@ -30,7 +30,7 @@ class Enumerator[unchecked out Elem, out Return = void]
   #
   # This type of objects can be created by Enumerator.product.
   #
-  class Product[unchecked out Elem] < Enumerator[Array[Elem], Product[Elem]]
+  class Product[unchecked out E] < Enumerator[Array[E], Product[E]]
     # <!--
     #   rdoc-file=enumerator.c
     #   - Enumerator::Product.new(*enums) -> enum
@@ -42,7 +42,7 @@ class Enumerator[unchecked out Elem, out Return = void]
     #     e.to_a #=> [[1, 4], [1, 5], [2, 4], [2, 5], [3, 4], [3, 5]]
     #     e.size #=> 6
     #
-    def initialize: (*_EachEntry[Elem]) -> void
+    def initialize: (*_EachEntry[E]) -> void
 
     # <!--
     #   rdoc-file=enumerator.c
@@ -55,7 +55,7 @@ class Enumerator[unchecked out Elem, out Return = void]
     #
     # If no block is given, returns an enumerator.  Otherwise, returns self.
     #
-    def each: () { (Array[Elem]) -> void } -> self
+    def each: () { (Array[E]) -> void } -> self
 
     # <!--
     #   rdoc-file=enumerator.c
@@ -87,6 +87,6 @@ class Enumerator[unchecked out Elem, out Return = void]
 
     private
 
-    def initialize_copy: (Product[Elem]) -> void
+    def initialize_copy: (Product[E]) -> void
   end
 end

--- a/core/object_space/weak_key_map.rbs
+++ b/core/object_space/weak_key_map.rbs
@@ -57,7 +57,7 @@ module ObjectSpace
   # attributes always, but the values that aren't needed anymore wouldn't be
   # sitting in the cache forever.
   #
-  class WeakKeyMap[Key, Value]
+  class WeakKeyMap[K, V]
     # <!--
     #   rdoc-file=weakmap.c
     #   - map[key] -> value
@@ -66,7 +66,7 @@ module ObjectSpace
     #
     # If `key` is not found, returns `nil`.
     #
-    def []: (Key) -> Value?
+    def []: (K) -> V?
 
     # <!--
     #   rdoc-file=weakmap.c
@@ -80,7 +80,7 @@ module ObjectSpace
     # If the given `key` exists, replaces its value with the given `value`; the
     # ordering is not affected
     #
-    def []=: (Key, Value?) -> Value?
+    def []=: (K, V?) -> V?
 
     # <!--
     #   rdoc-file=weakmap.c
@@ -119,8 +119,8 @@ module ObjectSpace
     #     m = ObjectSpace::WeakKeyMap.new
     #     m.delete("nosuch") { |key| "Key #{key} not found" } # => "Key nosuch not found"
     #
-    def delete: (Key) -> Value?
-              | [T] (Key) { (Key) -> T } -> (Value | T)
+    def delete: (K) -> V?
+              | [T] (K) { (K) -> T } -> (V | T)
 
     # <!--
     #   rdoc-file=weakmap.c
@@ -141,7 +141,7 @@ module ObjectSpace
     #     copy = cache.getkey({amount: 1, currency: 'USD'})
     #     copy.object_id == value.object_id #=> true
     #
-    def getkey: (untyped) -> Key?
+    def getkey: (untyped) -> K?
 
     # <!--
     #   rdoc-file=weakmap.c
@@ -161,6 +161,6 @@ module ObjectSpace
     # -->
     # Returns `true` if `key` is a key in `self`, otherwise `false`.
     #
-    def key?: (Key) -> bool
+    def key?: (K) -> bool
   end
 end

--- a/core/range.rbs
+++ b/core/range.rbs
@@ -235,8 +235,8 @@
 #
 #     require 'json/add/range'
 #
-class Range[out Elem] < Object
-  include Enumerable[Elem]
+class Range[out E] < Object
+  include Enumerable[E]
 
   # <!--
   #   rdoc-file=range.c
@@ -260,8 +260,8 @@ class Range[out Elem] < Object
   #     (0..7) % 2 #=> ((0..7).%(2)) -- as expected
   #     0..7 % 2 #=> 0..1 -- parsed as 0..(7 % 2)
   #
-  def %: (Numeric | int n) -> Enumerator[Elem, self]
-       | (Numeric | int n) { (Elem element) -> void } -> self
+  def %: (Numeric | int n) -> Enumerator[E, self]
+       | (Numeric | int n) { (E element) -> void } -> self
 
   # <!--
   #   rdoc-file=range.c
@@ -345,7 +345,7 @@ class Range[out Elem] < Object
   #
   # Related: Range#first, Range#end.
   #
-  def begin: () -> Elem
+  def begin: () -> E
 
   # <!--
   #   rdoc-file=range.c
@@ -355,9 +355,9 @@ class Range[out Elem] < Object
   #
   # See [Binary Searching](rdoc-ref:language/bsearch.rdoc).
   #
-  def bsearch: () -> ::Enumerator[Elem, Elem?]
-             | () { (Elem) -> (true | false) } -> Elem?
-             | () { (Elem) -> ::Integer } -> Elem?
+  def bsearch: () -> ::Enumerator[E, E?]
+             | () { (E) -> (true | false) } -> E?
+             | () { (E) -> ::Integer } -> E?
 
   # <!--
   #   rdoc-file=range.c
@@ -500,8 +500,8 @@ class Range[out Elem] < Object
   #
   # With no block given, returns an enumerator.
   #
-  def each: () { (Elem arg0) -> untyped } -> self
-          | () -> ::Enumerator[Elem, self]
+  def each: () { (E arg0) -> untyped } -> self
+          | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=range.c
@@ -515,7 +515,7 @@ class Range[out Elem] < Object
   #
   # Related: Range#begin, Range#last.
   #
-  def end: () -> Elem
+  def end: () -> E
 
   # <!--
   #   rdoc-file=range.c
@@ -551,8 +551,8 @@ class Range[out Elem] < Object
   #
   #     (..4).first # Raises RangeError
   #
-  def first: () -> Elem
-           | (Integer n) -> ::Array[Elem]
+  def first: () -> E
+           | (Integer n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=range.c
@@ -605,7 +605,7 @@ class Range[out Elem] < Object
   #     Range.new('a', 'd').to_a        # => ["a", "b", "c", "d"]
   #     Range.new('a', 'd', true).to_a  # => ["a", "b", "c"]
   #
-  def initialize: (Elem from, Elem to, ?boolish exclude_end) -> void
+  def initialize: (E from, E to, ?boolish exclude_end) -> void
 
   # <!--
   #   rdoc-file=range.c
@@ -661,8 +661,8 @@ class Range[out Elem] < Object
   #
   #     (1..).last # Raises RangeError
   #
-  def last: () -> Elem
-          | (Integer n) -> ::Array[Elem]
+  def last: () -> E
+          | (Integer n) -> ::Array[E]
 
   # <!--
   #   rdoc-file=range.c
@@ -958,8 +958,8 @@ class Range[out Elem] < Object
   #
   # With no block given, returns an enumerator.
   #
-  def reverse_each: () { (Elem) -> void } -> self
-                  | () -> ::Enumerator[Elem, self]
+  def reverse_each: () { (E) -> void } -> self
+                  | () -> ::Enumerator[E, self]
 
   # <!--
   #   rdoc-file=range.c
@@ -1016,7 +1016,7 @@ class Range[out Elem] < Object
   #
   def count: () -> (Integer | Float)
            | (untyped) -> Integer
-           | () { (Elem) -> boolish } -> Integer
+           | () { (E) -> boolish } -> Integer
 
   # <!--
   #   rdoc-file=range.c
@@ -1096,10 +1096,10 @@ class Range[out Elem] < Object
   #     ('a'..'e').step { p _1 }
   #     # Default step 1; prints: a, b, c, d, e
   #
-  def step: (?Numeric | int) -> Enumerator[Elem, self]
-          | (?Numeric | int) { (Elem element) -> void } -> self
-          | (untyped) -> Enumerator[Elem, self]
-          | (untyped) { (Elem element) -> void } -> self
+  def step: (?Numeric | int) -> Enumerator[E, self]
+          | (?Numeric | int) { (E element) -> void } -> self
+          | (untyped) -> Enumerator[E, self]
+          | (untyped) { (E element) -> void } -> self
 
   # <!--
   #   rdoc-file=range.c

--- a/core/set.rbs
+++ b/core/set.rbs
@@ -738,7 +738,7 @@ class Set[unchecked out A]
 end
 
 %a{annotate:rdoc:skip}
-module Enumerable[unchecked out Elem]
+module Enumerable[unchecked out E]
   # <!--
   #   rdoc-file=prelude.rb
   #   - to_set(*args, &block)
@@ -746,6 +746,6 @@ module Enumerable[unchecked out Elem]
   # Makes a set from the enumerable object with given arguments. Passing arguments
   # to this method is deprecated.
   #
-  def to_set: () -> Set[Elem]
-            | [T] () { (Elem) -> T } -> Set[T]
+  def to_set: () -> Set[E]
+            | [T] () { (E) -> T } -> Set[T]
 end

--- a/core/struct.rbs
+++ b/core/struct.rbs
@@ -104,8 +104,8 @@
 # *   #inspect (aliased as #to_s): Returns a string representation of `self`.
 # *   #to_h: Returns a hash of the member name/value pairs in `self`.
 #
-class Struct[Elem]
-  include Enumerable[Elem]
+class Struct[E]
+  include Enumerable[E]
 
   # The types that can be used when "indexing" into a `Struct` via `[]`, `[]=`, `dig`, and
   # `deconstruct_keys`.
@@ -362,7 +362,7 @@ class Struct[Elem]
   #
   # Related: #members.
   #
-  def to_a: () -> Array[Elem]
+  def to_a: () -> Array[E]
 
   # <!--
   #   rdoc-file=struct.c
@@ -385,8 +385,8 @@ class Struct[Elem]
   #
   # Raises ArgumentError if the block returns an inappropriate value.
   #
-  def to_h: () -> Hash[Symbol, Elem]
-          | [K, V] () { (Symbol key, Elem value) -> [K, V] } -> Hash[K, V]
+  def to_h: () -> Hash[Symbol, E]
+          | [K, V] () { (Symbol key, E value) -> [K, V] } -> Hash[K, V]
 
   # <!-- rdoc-file=struct.c -->
   # Returns the values in `self` as an array:
@@ -441,8 +441,8 @@ class Struct[Elem]
   #
   # Related: #each_pair.
   #
-  def each: () -> Enumerator[Elem, self]
-          | () { (Elem value) -> void } -> self
+  def each: () -> Enumerator[E, self]
+          | () { (E value) -> void } -> self
 
   # <!--
   #   rdoc-file=struct.c
@@ -465,8 +465,8 @@ class Struct[Elem]
   #
   # Related: #each.
   #
-  def each_pair: () -> Enumerator[[Symbol, Elem], self]
-               | () { ([Symbol, Elem] key_value) -> void } -> self
+  def each_pair: () -> Enumerator[[Symbol, E], self]
+               | () { ([Symbol, E] key_value) -> void } -> self
 
   # <!--
   #   rdoc-file=struct.c
@@ -492,7 +492,7 @@ class Struct[Elem]
   #
   # Raises IndexError if `n` is out of range.
   #
-  def []: (index name_or_position) -> Elem
+  def []: (index name_or_position) -> E
 
   # <!--
   #   rdoc-file=struct.c
@@ -521,7 +521,7 @@ class Struct[Elem]
   #
   # Raises IndexError if `n` is out of range.
   #
-  def []=: (index name_or_position, Elem value) -> Elem
+  def []=: (index name_or_position, E value) -> E
 
   # <!--
   #   rdoc-file=struct.c
@@ -540,8 +540,8 @@ class Struct[Elem]
   #
   # With no block given, returns an Enumerator.
   #
-  def select: () -> Enumerator[Elem, Array[Elem]]
-            | () { (Elem value) -> boolish } -> Array[Elem]
+  def select: () -> Enumerator[E, Array[E]]
+            | () { (E value) -> boolish } -> Array[E]
 
   # <!-- rdoc-file=struct.c -->
   # With a block given, returns an array of values from `self` for which the block
@@ -591,7 +591,7 @@ class Struct[Elem]
   # Raises RangeError if any element of the range is negative and out of range;
   # see Array@Array+Indexes.
   #
-  def values_at: (*int | range[int?] positions) -> Array[Elem]
+  def values_at: (*int | range[int?] positions) -> Array[E]
 
   # <!--
   #   rdoc-file=struct.c
@@ -634,7 +634,7 @@ class Struct[Elem]
   #     f.dig(0, 0, :b, 0) # => 1
   #     f.dig(:b, 0) # => nil
   #
-  def dig: (index name_or_position) -> Elem
+  def dig: (index name_or_position) -> E
          | (index name_or_position, untyped, *untyped) -> untyped
 
   # <!-- rdoc-file=struct.c -->
@@ -664,5 +664,5 @@ class Struct[Elem]
   #     h = joe.deconstruct_keys(nil)
   #     h # => {:name=>"Joseph Smith, Jr.", :address=>"123 Maple, Anytown NC", :zip=>12345}
   #
-  def deconstruct_keys: (Array[index & Hash::_Key]? indices) -> Hash[index & Hash::_Key, Elem]
+  def deconstruct_keys: (Array[index & Hash::_Key]? indices) -> Hash[index & Hash::_Key, E]
 end

--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -1604,7 +1604,7 @@ end
 #
 #     consumer.join
 #
-class Thread::Queue[Elem = untyped] < Object
+class Thread::Queue[E = untyped] < Object
   # <!-- rdoc-file=thread_sync.c -->
   # Pushes the given `object` to the queue.
   #
@@ -1719,7 +1719,7 @@ class Thread::Queue[Elem = untyped] < Object
   # If `timeout` seconds have passed and no data is available `nil` is returned.
   # If `timeout` is `0` it returns immediately.
   #
-  def pop: (?boolish non_block, ?timeout: _ToF?) -> Elem?
+  def pop: (?boolish non_block, ?timeout: _ToF?) -> E?
 
   # <!--
   #   rdoc-file=thread_sync.c
@@ -1729,7 +1729,7 @@ class Thread::Queue[Elem = untyped] < Object
   # -->
   # Pushes the given `object` to the queue.
   #
-  def push: (Elem obj) -> void
+  def push: (E obj) -> void
 
   # <!--
   #   rdoc-file=thread_sync.rb
@@ -1750,7 +1750,7 @@ end
 #
 # See Thread::Queue for an example of how a Thread::SizedQueue works.
 #
-class Thread::SizedQueue[Elem = untyped] < Thread::Queue[Elem]
+class Thread::SizedQueue[E = untyped] < Thread::Queue[E]
   # <!--
   #   rdoc-file=thread_sync.rb
   #   - <<(object, non_block = false, timeout: nil)
@@ -1813,8 +1813,8 @@ class Thread::SizedQueue[Elem = untyped] < Thread::Queue[Elem]
   # If `timeout` seconds have passed and no space is available `nil` is returned.
   # If `timeout` is `0` it returns immediately. Otherwise it returns `self`.
   #
-  def push: (Elem obj, ?boolish non_block) -> void
-          | (Elem obj, timeout: _ToF?) -> self?
+  def push: (E obj, ?boolish non_block) -> void
+          | (E obj, timeout: _ToF?) -> self?
 end
 
 class ConditionVariable = Thread::ConditionVariable

--- a/docs/rbs_by_example.md
+++ b/docs/rbs_by_example.md
@@ -107,14 +107,14 @@ end
 For now, it's safe to ignore them, but they're included for completeness.
 
 ```rbs
-class Array[Elem]
+class Array[E]
   def *: (String) -> String
-       | (Integer) -> Array[Elem]
+       | (Integer) -> Array[E]
 end
 ```
 
 `Array`'s `*` method, when given a `String` returns a `String`. When given an
-`Integer`, it returns an `Array` of the same contained type `Elem` (in our example case, `Elem` corresponds to `Integer`).
+`Integer`, it returns an `Array` of the same contained type `E` (in our example case, `E` corresponds to `Integer`).
 
 ### Union types
 
@@ -150,9 +150,9 @@ end
 ```
 
 ```rbs
-class Enumerable[Elem]
-  def first: () -> Elem?
-           | (Integer) -> Array[Elem]
+class Enumerable[E]
+  def first: () -> E?
+           | (Integer) -> Array[E]
 end
 ```
 
@@ -160,12 +160,12 @@ end
 
 When called with no arguments, the return value will either be an instance of
 whatever type is contained in the enumerable, or `nil`. We represent that with
-the type variable `Elem`, and the `?` suffix nilable marker.
+the type variable `E`, and the `?` suffix nilable marker.
 
 When called with an `Integer` positional argument, the return value will be an
 `Array` of whatever type is contained.
 
-The `?` syntax is a convenient shorthand for a union with nil. An equivalent union type would be `(Elem | nil)`.
+The `?` syntax is a convenient shorthand for a union with nil. An equivalent union type would be `(E | nil)`.
 
 ### Keyword Arguments
 
@@ -222,9 +222,9 @@ end
 ```
 
 ```rbs
-class Array[Elem]
-  def filter: () { (Elem) -> boolish } -> ::Array[Elem]
-            | () -> ::Enumerator[Elem, ::Array[Elem]]
+class Array[E]
+  def filter: () { (E) -> boolish } -> ::Array[E]
+            | () -> ::Enumerator[E, ::Array[E]]
 end
 ```
 
@@ -264,13 +264,13 @@ a.collect.with_index {|x, i| x * i}
 ```
 
 ```rbs
-class Array[Elem]
-  def collect: [U] () { (Elem) -> U } -> Array[U]
-             | () -> Enumerator[Elem, Array[untyped]]
+class Array[E]
+  def collect: [U] () { (E) -> U } -> Array[U]
+             | () -> Enumerator[E, Array[untyped]]
 end
 ```
 
-Type variables can also be introduced in methods. Here, in `Array`'s `#collect` method, we introduce a type variable `U`. The block passed to `#collect` will receive a parameter of type `Elem`, and return a value of type `U`. Then `#collect` will return an `Array` of type `U`.
+Type variables can also be introduced in methods. Here, in `Array`'s `#collect` method, we introduce a type variable `U`. The block passed to `#collect` will receive a parameter of type `E`, and return a value of type `U`. Then `#collect` will return an `Array` of type `U`.
 
 In this example, the method receives its signature from the inferred return type of the passed block. When then block is absent, as in when the method returns an `Enumerator`, we can't infer the type, and so the return value of the enumerator can only be described as `Array[untyped]`.
 
@@ -284,9 +284,9 @@ In this example, the method receives its signature from the inferred return type
 ```
 
 ```rbs
-class Enumerable[Elem]
-  def partition: () { (Elem) -> boolish } -> [Array[Elem], Array[Elem]]
-               | () -> ::Enumerator[Elem, [Array[Elem], Array[Elem] ]]
+class Enumerable[E]
+  def partition: () { (E) -> boolish } -> [Array[E], Array[E]]
+               | () -> ::Enumerator[E, [Array[E], Array[E] ]]
 end
 ```
 
@@ -300,9 +300,9 @@ Tuples can be of any size, and they can have mixed types.
 ```
 
 ```rbs
-class Enumerable[Elem]
+class Enumerable[E]
   def to_h: () -> ::Hash[untyped, untyped]
-          | [T, U] () { (Elem) -> [T, U] } -> ::Hash[T, U]
+          | [T, U] () { (E) -> [T, U] } -> ::Hash[T, U]
 end
 ```
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -196,8 +196,8 @@ It is an alias of `top` type, and you can use `boolish` if we want to allow any 
 We can see an example at the definition of `Enumerable#find`:
 
 ```rbs
-module Enumerable[Elem, Return]
-  def find: () { (Elem) -> boolish } -> Elem?
+module Enumerable[E, R]
+  def find: () { (E) -> boolish } -> E?
 end
 ```
 

--- a/sig/shims/enumerable.rbs
+++ b/sig/shims/enumerable.rbs
@@ -1,5 +1,5 @@
-module Enumerable[unchecked out Elem] : _Each[Elem]
-  def each_slice: (2) { ([Elem, Elem]) -> void } -> void
-                | (2) -> Enumerator[[Elem, Elem], void]
+module Enumerable[unchecked out T] : _Each[T]
+  def each_slice: (2) { ([T, T]) -> void } -> void
+                | (2) -> Enumerator[[T, T], void]
                 | ...
 end

--- a/sig/shims/enumerable.rbs
+++ b/sig/shims/enumerable.rbs
@@ -1,5 +1,5 @@
-module Enumerable[unchecked out T] : _Each[T]
-  def each_slice: (2) { ([T, T]) -> void } -> void
-                | (2) -> Enumerator[[T, T], void]
+module Enumerable[unchecked out Elem] : _Each[Elem]
+  def each_slice: (2) { ([Elem, Elem]) -> void } -> void
+                | (2) -> Enumerator[[Elem, Elem], void]
                 | ...
 end

--- a/stdlib/abbrev/0/array.rbs
+++ b/stdlib/abbrev/0/array.rbs
@@ -1,5 +1,5 @@
 %a{annotate:rdoc:skip}
-class Array[unchecked out Elem]
+class Array[unchecked out E]
   # <!--
   #   rdoc-file=lib/abbrev.rb
   #   - abbrev(pattern = nil)

--- a/stdlib/csv/0/csv.rbs
+++ b/stdlib/csv/0/csv.rbs
@@ -2964,8 +2964,8 @@ end
 #     table['Name'] = ['Foo', 'Bar', 'Baz']
 #     table['Name'] # => ["Foo", "Bar", "Baz"]
 #
-class CSV::Table[out Elem] < Object
-  include Enumerable[Elem]
+class CSV::Table[out E] < Object
+  include Enumerable[E]
   extend Forwardable
 
   # <!--
@@ -3587,8 +3587,8 @@ class CSV::Table[out Elem] < Object
   # Returns a new Enumerator if no block is given:
   #     table.each # => #<Enumerator: #<CSV::Table mode:col row_count:4>:each>
   #
-  def each: () -> Enumerator[Elem, self]
-          | () { (Elem) -> void } -> self
+  def each: () -> Enumerator[E, self]
+          | () { (E) -> void } -> self
           | () { (*untyped) -> void } -> self
 
   def empty?: (*untyped args) { (*untyped) -> untyped } -> untyped
@@ -3758,7 +3758,7 @@ class CSV::Table[out Elem] < Object
 end
 
 %a{annotate:rdoc:skip}
-class Array[unchecked out Elem] < Object
+class Array[unchecked out E] < Object
   # Equivalent to CSV::generate_line(self, options)
   #
   #   ["CSV", "data"].to_csv

--- a/stdlib/json/0/json.rbs
+++ b/stdlib/json/0/json.rbs
@@ -1307,7 +1307,7 @@ class Hash[unchecked out K, unchecked out V]
 end
 
 %a{annotate:rdoc:skip}
-class Array[unchecked out Elem]
+class Array[unchecked out E]
   # Returns a JSON string containing a JSON array, that is generated from
   # this Array instance.
   # _state_ is a JSON::State object, that can also be used to configure the
@@ -1616,7 +1616,7 @@ class OpenStruct
 end
 
 %a{annotate:rdoc:skip}
-class Range[out Elem]
+class Range[out E]
   # <!--
   #   rdoc-file=ext/json/lib/json/add/range.rb
   #   - json_create(object)
@@ -1648,7 +1648,7 @@ class Range[out Elem]
   #     Range.json_create(y) # => 1...4
   #     Range.json_create(z) # => "a".."d"
   #
-  def as_json: (*untyped) -> Hash[String, String | [ Elem, Elem, bool ]]
+  def as_json: (*untyped) -> Hash[String, String | [ E, E, bool ]]
 
   # <!--
   #   rdoc-file=ext/json/lib/json/add/range.rb
@@ -1815,14 +1815,14 @@ class Set[unchecked out A]
 end
 
 %a{annotate:rdoc:skip}
-class Struct[Elem]
+class Struct[E]
   # <!--
   #   rdoc-file=ext/json/lib/json/add/struct.rb
   #   - json_create(object)
   # -->
   # See #as_json.
   #
-  def self.json_create: [Elem] (Hash[String, String | Array[Elem]] object) -> Struct[Elem]
+  def self.json_create: [E] (Hash[String, String | Array[E]] object) -> Struct[E]
 
   # <!--
   #   rdoc-file=ext/json/lib/json/add/struct.rb
@@ -1846,7 +1846,7 @@ class Struct[Elem]
   #     Struct::Customer.json_create(x)
   #     # => #<struct Struct::Customer name=nil, address=nil, zip=nil>
   #
-  def as_json: (*untyped) -> Hash[String, String | Array[Elem]]
+  def as_json: (*untyped) -> Hash[String, String | Array[E]]
 
   # <!--
   #   rdoc-file=ext/json/lib/json/add/struct.rb

--- a/stdlib/shellwords/0/shellwords.rbs
+++ b/stdlib/shellwords/0/shellwords.rbs
@@ -191,7 +191,7 @@ module Shellwords
 end
 
 %a{annotate:rdoc:skip}
-class Array[unchecked out Elem]
+class Array[unchecked out E]
   # <!--
   #   rdoc-file=lib/shellwords.rb
   #   - array.shelljoin => string

--- a/stdlib/tsort/0/cyclic.rbs
+++ b/stdlib/tsort/0/cyclic.rbs
@@ -1,5 +1,5 @@
 %a{annotate:rdoc:skip}
-module TSort[Node]
+module TSort[N]
   # <!-- rdoc-file=lib/tsort.rb -->
   # Exception class to be raised when a cycle is found.
   #

--- a/stdlib/tsort/0/interfaces.rbs
+++ b/stdlib/tsort/0/interfaces.rbs
@@ -1,20 +1,20 @@
 %a{annotate:rdoc:skip}
-module TSort[Node]
-  interface _Sortable[Node]
+module TSort[N]
+  interface _Sortable[N]
     # #tsort_each_node is used to iterate for all nodes over a graph.
     #
-    def tsort_each_node: () { (Node) -> void } -> void
+    def tsort_each_node: () { (N) -> void } -> void
 
     # #tsort_each_child is used to iterate for child nodes of node.
     #
-    def tsort_each_child: (Node) { (Node) -> void } -> void
+    def tsort_each_child: (N) { (N) -> void } -> void
   end
 
-  interface _EachNode[Node]
-    def call: () { (Node) -> void } -> void
+  interface _EachNode[N]
+    def call: () { (N) -> void } -> void
   end
 
-  interface _EachChild[Node]
-    def call: (Node) { (Node) -> void } -> void
+  interface _EachChild[N]
+    def call: (N) { (N) -> void } -> void
   end
 end

--- a/stdlib/tsort/0/tsort.rbs
+++ b/stdlib/tsort/0/tsort.rbs
@@ -113,7 +113,7 @@
 #     1.  Tarjan, "Depth First Search and Linear Graph Algorithms",
 # *SIAM Journal on Computing*, Vol. 1, No. 2, pp. 146-160, June 1972.
 #
-module TSort[Node] : TSort::_Sortable[Node]
+module TSort[N] : TSort::_Sortable[N]
   # <!--
   #   rdoc-file=lib/tsort.rb
   #   - each_strongly_connected_component(each_node, each_child) { |nodes| ... }
@@ -290,8 +290,8 @@ module TSort[Node] : TSort::_Sortable[Node]
   #     #   [2, 3]
   #     #   [1]
   #
-  def each_strongly_connected_component: () { (Array[Node]) -> void } -> void
-                                       | () -> Enumerator[Array[Node], void]
+  def each_strongly_connected_component: () { (Array[N]) -> void } -> void
+                                       | () -> Enumerator[Array[N], void]
 
   # <!--
   #   rdoc-file=lib/tsort.rb
@@ -323,8 +323,8 @@ module TSort[Node] : TSort::_Sortable[Node]
   #     #=> [4]
   #     #   [2, 3]
   #
-  def each_strongly_connected_component_from: (Node, ?untyped id_map, ?untyped stack) { (Array[Node]) -> void } -> void
-                                            | (Node, ?untyped id_map, ?untyped stack) -> Enumerator[Array[Node], void]
+  def each_strongly_connected_component_from: (N, ?untyped id_map, ?untyped stack) { (Array[N]) -> void } -> void
+                                            | (N, ?untyped id_map, ?untyped stack) -> Enumerator[Array[N], void]
 
   # <!--
   #   rdoc-file=lib/tsort.rb
@@ -349,7 +349,7 @@ module TSort[Node] : TSort::_Sortable[Node]
   #     graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
   #     p graph.strongly_connected_components #=> [[4], [2, 3], [1]]
   #
-  def strongly_connected_components: () -> Array[Array[Node]]
+  def strongly_connected_components: () -> Array[Array[N]]
 
   # <!--
   #   rdoc-file=lib/tsort.rb
@@ -376,7 +376,7 @@ module TSort[Node] : TSort::_Sortable[Node]
   #     graph = G.new({1=>[2], 2=>[3, 4], 3=>[2], 4=>[]})
   #     p graph.tsort # raises TSort::Cyclic
   #
-  def tsort: () -> Array[Node]
+  def tsort: () -> Array[N]
 
   # <!--
   #   rdoc-file=lib/tsort.rb
@@ -405,6 +405,6 @@ module TSort[Node] : TSort::_Sortable[Node]
   #     #   3
   #     #   1
   #
-  def tsort_each: () { (Node) -> void } -> void
-                | () -> Enumerator[Node, void]
+  def tsort_each: () { (N) -> void } -> void
+                | () -> Enumerator[N, void]
 end


### PR DESCRIPTION
TL;DR: This migrates RBS signatures to use single-characters instead of multiple charcaters.

RBS is a bit inconsistent about how generic variables (eg `Foo[X, Y]`) are named: Some of them are long (`Array[Elem]`, `Enumerable[Elem]`, `ObjectSpace::WeakMap[Key, Value]`), whereas some of them are short (`Hash[K, V]`, `Set[A]`, and most exceptions like `FrozenError[T]`, `KeyError[K, R]`.)

I talked with @soutaro about this, and he liked the idea of the one-charcater variables (which I'm also partial to—it's how most langauges work, and makes it easier to distinguish them from classnames). This PR implements that