### PR TITLE
Remove `logger` from sig dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -203,8 +203,8 @@ task :validate => :compile do
     args = ["-r", lib]
 
     if lib == "rbs"
-      args << "-r"
-      args << "prism"
+      args << "-r" << "prism"
+      args << "-r" << "logger"
     end
 
     sh "#{ruby} #{rbs} #{args.join(' ')} validate"

--- a/sig/manifest.yaml
+++ b/sig/manifest.yaml
@@ -1,5 +1,4 @@
 dependencies:
-  - name: logger
   - name: json
   - name: optparse
   - name: tsort


### PR DESCRIPTION
Because there is a dependency on `logger` via manifest.yaml, rbs_collection.lock.yaml is being generated to load the stdlib `logger` when reading signatures from the rbs-gem.

I removed `logger` from manifest.yaml and modify it to load signatures from gem_rbs_collection instead.