### PR TITLE
Add nullability annotations to AST pointer types

### DIFF
--- a/ext/rbs_extension/extconf.rb
+++ b/ext/rbs_extension/extconf.rb
@@ -16,6 +16,7 @@ append_cflags [
   '-Wimplicit-fallthrough',
   '-Wunused-result',
   '-Wc++-compat',
+  '-Wnullable-to-nonnull-conversion',
 ]
 
 if ENV['DEBUG']

--- a/include/rbs/ast.h
+++ b/include/rbs/ast.h
@@ -8,6 +8,7 @@
 #ifndef RBS__AST_H
 #define RBS__AST_H
 
+#include "rbs/defines.h"
 #include "rbs/util/rbs_allocator.h"
 #include "rbs/util/rbs_constant_pool.h"
 #include "string.h"
@@ -144,48 +145,48 @@ typedef struct rbs_node {
     rbs_location_range location;
 } rbs_node_t;
 
-const char *rbs_node_type_name(rbs_node_t *node);
+const char *RBS_NONNULL rbs_node_type_name(rbs_node_t *RBS_NONNULL node);
 
 /* rbs_node_list_node */
 
 typedef struct rbs_node_list_node {
-    rbs_node_t *node;
-    struct rbs_node_list_node *next;
+    rbs_node_t *RBS_NONNULL node;
+    struct rbs_node_list_node *RBS_NULLABLE next;
 } rbs_node_list_node_t;
 
 typedef struct rbs_node_list {
-    rbs_allocator_t *allocator;
-    rbs_node_list_node_t *head;
-    rbs_node_list_node_t *tail;
+    rbs_allocator_t *RBS_NONNULL allocator;
+    rbs_node_list_node_t *RBS_NULLABLE head;
+    rbs_node_list_node_t *RBS_NULLABLE tail;
     size_t length;
 } rbs_node_list_t;
 
-rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *);
+rbs_node_list_t *RBS_NONNULL rbs_node_list_new(rbs_allocator_t *RBS_NONNULL);
 
-void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node);
+void rbs_node_list_append(rbs_node_list_t *RBS_NONNULL list, rbs_node_t *RBS_NONNULL node);
 
 /* rbs_hash */
 
 typedef struct rbs_hash_node {
-    rbs_node_t *key;
-    rbs_node_t *value;
-    struct rbs_hash_node *next;
+    rbs_node_t *RBS_NONNULL key;
+    rbs_node_t *RBS_NONNULL value;
+    struct rbs_hash_node *RBS_NULLABLE next;
 } rbs_hash_node_t;
 
 typedef struct rbs_hash {
-    rbs_allocator_t *allocator;
-    rbs_hash_node_t *head;
-    rbs_hash_node_t *tail;
+    rbs_allocator_t *RBS_NONNULL allocator;
+    rbs_hash_node_t *RBS_NULLABLE head;
+    rbs_hash_node_t *RBS_NULLABLE tail;
     size_t length;
 } rbs_hash_t;
 
-rbs_hash_t *rbs_hash_new(rbs_allocator_t *);
+rbs_hash_t *RBS_NONNULL rbs_hash_new(rbs_allocator_t *RBS_NONNULL);
 
-void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value);
+void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs_node_t *RBS_NONNULL value);
 
-rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key);
+rbs_hash_node_t *RBS_NULLABLE rbs_hash_find(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key);
 
-rbs_node_t *rbs_hash_get(rbs_hash_t *hash, rbs_node_t *key);
+rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key);
 
 /* rbs_ast_node */
 
@@ -210,12 +211,12 @@ typedef struct rbs_ast_comment {
 typedef struct rbs_ast_declarations_class {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *type_params;
-    struct rbs_ast_declarations_class_super *super_class; /* Optional */
-    struct rbs_node_list *members;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL type_params;
+    struct rbs_ast_declarations_class_super *RBS_NULLABLE super_class;
+    struct rbs_node_list *RBS_NONNULL members;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range keyword_range;     /* Required */
     rbs_location_range name_range;        /* Required */
@@ -227,8 +228,8 @@ typedef struct rbs_ast_declarations_class {
 typedef struct rbs_ast_declarations_class_super {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -237,10 +238,10 @@ typedef struct rbs_ast_declarations_class_super {
 typedef struct rbs_ast_declarations_class_alias {
     rbs_node_t base;
 
-    struct rbs_type_name *new_name;
-    struct rbs_type_name *old_name;
-    struct rbs_ast_comment *comment; /* Optional */
-    struct rbs_node_list *annotations;
+    struct rbs_type_name *RBS_NONNULL new_name;
+    struct rbs_type_name *RBS_NONNULL old_name;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
+    struct rbs_node_list *RBS_NONNULL annotations;
 
     rbs_location_range keyword_range;  /* Required */
     rbs_location_range new_name_range; /* Required */
@@ -251,10 +252,10 @@ typedef struct rbs_ast_declarations_class_alias {
 typedef struct rbs_ast_declarations_constant {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node *type;
-    struct rbs_ast_comment *comment; /* Optional */
-    struct rbs_node_list *annotations;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
+    struct rbs_node_list *RBS_NONNULL annotations;
 
     rbs_location_range name_range;  /* Required */
     rbs_location_range colon_range; /* Required */
@@ -263,10 +264,10 @@ typedef struct rbs_ast_declarations_constant {
 typedef struct rbs_ast_declarations_global {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
-    struct rbs_ast_comment *comment; /* Optional */
-    struct rbs_node_list *annotations;
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
+    struct rbs_node_list *RBS_NONNULL annotations;
 
     rbs_location_range name_range;  /* Required */
     rbs_location_range colon_range; /* Required */
@@ -275,11 +276,11 @@ typedef struct rbs_ast_declarations_global {
 typedef struct rbs_ast_declarations_interface {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *type_params;
-    struct rbs_node_list *members;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL type_params;
+    struct rbs_node_list *RBS_NONNULL members;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range keyword_range;     /* Required */
     rbs_location_range name_range;        /* Required */
@@ -290,12 +291,12 @@ typedef struct rbs_ast_declarations_interface {
 typedef struct rbs_ast_declarations_module {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *type_params;
-    struct rbs_node_list *self_types;
-    struct rbs_node_list *members;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL type_params;
+    struct rbs_node_list *RBS_NONNULL self_types;
+    struct rbs_node_list *RBS_NONNULL members;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range keyword_range;     /* Required */
     rbs_location_range name_range;        /* Required */
@@ -308,8 +309,8 @@ typedef struct rbs_ast_declarations_module {
 typedef struct rbs_ast_declarations_module_self {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -318,10 +319,10 @@ typedef struct rbs_ast_declarations_module_self {
 typedef struct rbs_ast_declarations_module_alias {
     rbs_node_t base;
 
-    struct rbs_type_name *new_name;
-    struct rbs_type_name *old_name;
-    struct rbs_ast_comment *comment; /* Optional */
-    struct rbs_node_list *annotations;
+    struct rbs_type_name *RBS_NONNULL new_name;
+    struct rbs_type_name *RBS_NONNULL old_name;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
+    struct rbs_node_list *RBS_NONNULL annotations;
 
     rbs_location_range keyword_range;  /* Required */
     rbs_location_range new_name_range; /* Required */
@@ -332,11 +333,11 @@ typedef struct rbs_ast_declarations_module_alias {
 typedef struct rbs_ast_declarations_type_alias {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *type_params;
-    struct rbs_node *type;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL type_params;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range keyword_range;     /* Required */
     rbs_location_range name_range;        /* Required */
@@ -347,7 +348,7 @@ typedef struct rbs_ast_declarations_type_alias {
 typedef struct rbs_ast_directives_use {
     rbs_node_t base;
 
-    struct rbs_node_list *clauses;
+    struct rbs_node_list *RBS_NONNULL clauses;
 
     rbs_location_range keyword_range; /* Required */
 } rbs_ast_directives_use_t;
@@ -355,8 +356,8 @@ typedef struct rbs_ast_directives_use {
 typedef struct rbs_ast_directives_use_single_clause {
     rbs_node_t base;
 
-    struct rbs_type_name *type_name;
-    struct rbs_ast_symbol *new_name; /* Optional */
+    struct rbs_type_name *RBS_NONNULL type_name;
+    struct rbs_ast_symbol *RBS_NULLABLE new_name;
 
     rbs_location_range type_name_range; /* Required */
     rbs_location_range keyword_range;   /* Optional */
@@ -366,7 +367,7 @@ typedef struct rbs_ast_directives_use_single_clause {
 typedef struct rbs_ast_directives_use_wildcard_clause {
     rbs_node_t base;
 
-    struct rbs_namespace *rbs_namespace;
+    struct rbs_namespace *RBS_NONNULL rbs_namespace;
 
     rbs_location_range namespace_range; /* Required */
     rbs_location_range star_range;      /* Required */
@@ -381,11 +382,11 @@ typedef struct rbs_ast_integer {
 typedef struct rbs_ast_members_alias {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *new_name;
-    struct rbs_ast_symbol *old_name;
+    struct rbs_ast_symbol *RBS_NONNULL new_name;
+    struct rbs_ast_symbol *RBS_NONNULL old_name;
     enum rbs_alias_kind kind;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range keyword_range;  /* Required */
     rbs_location_range new_name_range; /* Required */
@@ -397,12 +398,12 @@ typedef struct rbs_ast_members_alias {
 typedef struct rbs_ast_members_attr_accessor {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
     rbs_attr_ivar_name_t ivar_name;
     enum rbs_attribute_kind kind;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
     enum rbs_attribute_visibility visibility;
 
     rbs_location_range keyword_range;    /* Required */
@@ -417,12 +418,12 @@ typedef struct rbs_ast_members_attr_accessor {
 typedef struct rbs_ast_members_attr_reader {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
     rbs_attr_ivar_name_t ivar_name;
     enum rbs_attribute_kind kind;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
     enum rbs_attribute_visibility visibility;
 
     rbs_location_range keyword_range;    /* Required */
@@ -437,12 +438,12 @@ typedef struct rbs_ast_members_attr_reader {
 typedef struct rbs_ast_members_attr_writer {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
     rbs_attr_ivar_name_t ivar_name;
     enum rbs_attribute_kind kind;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
     enum rbs_attribute_visibility visibility;
 
     rbs_location_range keyword_range;    /* Required */
@@ -457,9 +458,9 @@ typedef struct rbs_ast_members_attr_writer {
 typedef struct rbs_ast_members_class_instance_variable {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;  /* Required */
     rbs_location_range colon_range; /* Required */
@@ -469,9 +470,9 @@ typedef struct rbs_ast_members_class_instance_variable {
 typedef struct rbs_ast_members_class_variable {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;  /* Required */
     rbs_location_range colon_range; /* Required */
@@ -481,10 +482,10 @@ typedef struct rbs_ast_members_class_variable {
 typedef struct rbs_ast_members_extend {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;    /* Required */
     rbs_location_range keyword_range; /* Required */
@@ -494,10 +495,10 @@ typedef struct rbs_ast_members_extend {
 typedef struct rbs_ast_members_include {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;    /* Required */
     rbs_location_range keyword_range; /* Required */
@@ -507,9 +508,9 @@ typedef struct rbs_ast_members_include {
 typedef struct rbs_ast_members_instance_variable {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
-    struct rbs_node *type;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_ast_symbol *RBS_NONNULL name;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;  /* Required */
     rbs_location_range colon_range; /* Required */
@@ -519,11 +520,11 @@ typedef struct rbs_ast_members_instance_variable {
 typedef struct rbs_ast_members_method_definition {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
+    struct rbs_ast_symbol *RBS_NONNULL name;
     enum rbs_method_definition_kind kind;
-    struct rbs_node_list *overloads;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_node_list *RBS_NONNULL overloads;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
     bool overloading;
     enum rbs_method_definition_visibility visibility;
 
@@ -537,17 +538,17 @@ typedef struct rbs_ast_members_method_definition {
 typedef struct rbs_ast_members_method_definition_overload {
     rbs_node_t base;
 
-    struct rbs_node_list *annotations;
-    struct rbs_node *method_type;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_node *RBS_NONNULL method_type;
 } rbs_ast_members_method_definition_overload_t;
 
 typedef struct rbs_ast_members_prepend {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
-    struct rbs_node_list *annotations;
-    struct rbs_ast_comment *comment; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_ast_comment *RBS_NULLABLE comment;
 
     rbs_location_range name_range;    /* Required */
     rbs_location_range keyword_range; /* Required */
@@ -569,12 +570,12 @@ typedef struct rbs_ast_ruby_annotations_block_param_type_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range ampersand_location;
-    rbs_location_range name_location; /* Optional */
+    rbs_location_range name_location;
     rbs_location_range colon_location;
-    rbs_location_range question_location; /* Optional */
+    rbs_location_range question_location;
     rbs_location_range type_location;
-    struct rbs_node *type_;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL type_;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_block_param_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_class_alias_annotation {
@@ -582,16 +583,16 @@ typedef struct rbs_ast_ruby_annotations_class_alias_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range keyword_location;
-    struct rbs_type_name *type_name;
-    rbs_location_range type_name_location; /* Optional */
+    struct rbs_type_name *RBS_NONNULL type_name;
+    rbs_location_range type_name_location;
 } rbs_ast_ruby_annotations_class_alias_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_colon_method_type_annotation {
     rbs_node_t base;
 
     rbs_location_range prefix_location;
-    struct rbs_node_list *annotations;
-    struct rbs_node *method_type;
+    struct rbs_node_list *RBS_NONNULL annotations;
+    struct rbs_node *RBS_NONNULL method_type;
 } rbs_ast_ruby_annotations_colon_method_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_double_splat_param_type_annotation {
@@ -599,30 +600,30 @@ typedef struct rbs_ast_ruby_annotations_double_splat_param_type_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range star2_location;
-    rbs_location_range name_location; /* Optional */
+    rbs_location_range name_location;
     rbs_location_range colon_location;
-    struct rbs_node *param_type;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL param_type;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_double_splat_param_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_instance_variable_annotation {
     rbs_node_t base;
 
     rbs_location_range prefix_location;
-    struct rbs_ast_symbol *ivar_name;
+    struct rbs_ast_symbol *RBS_NONNULL ivar_name;
     rbs_location_range ivar_name_location;
     rbs_location_range colon_location;
-    struct rbs_node *type;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL type;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_instance_variable_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_method_types_annotation {
     rbs_node_t base;
 
     rbs_location_range prefix_location;
-    struct rbs_node_list *overloads;
-    rbs_location_range_list_t *vertical_bar_locations;
-    rbs_location_range dot3_location; /* Optional */
+    struct rbs_node_list *RBS_NONNULL overloads;
+    rbs_location_range_list_t *RBS_NONNULL vertical_bar_locations;
+    rbs_location_range dot3_location;
 } rbs_ast_ruby_annotations_method_types_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_module_alias_annotation {
@@ -630,8 +631,8 @@ typedef struct rbs_ast_ruby_annotations_module_alias_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range keyword_location;
-    struct rbs_type_name *type_name;
-    rbs_location_range type_name_location; /* Optional */
+    struct rbs_type_name *RBS_NONNULL type_name;
+    rbs_location_range type_name_location;
 } rbs_ast_ruby_annotations_module_alias_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_module_self_annotation {
@@ -640,19 +641,19 @@ typedef struct rbs_ast_ruby_annotations_module_self_annotation {
     rbs_location_range prefix_location;
     rbs_location_range keyword_location;
     rbs_location_range colon_location;
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
-    rbs_location_range open_bracket_location;  /* Optional */
-    rbs_location_range close_bracket_location; /* Optional */
-    rbs_location_range_list_t *args_comma_locations;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
+    rbs_location_range open_bracket_location;
+    rbs_location_range close_bracket_location;
+    rbs_location_range_list_t *RBS_NONNULL args_comma_locations;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_module_self_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_node_type_assertion {
     rbs_node_t base;
 
     rbs_location_range prefix_location;
-    struct rbs_node *type;
+    struct rbs_node *RBS_NONNULL type;
 } rbs_ast_ruby_annotations_node_type_assertion_t;
 
 typedef struct rbs_ast_ruby_annotations_param_type_annotation {
@@ -661,8 +662,8 @@ typedef struct rbs_ast_ruby_annotations_param_type_annotation {
     rbs_location_range prefix_location;
     rbs_location_range name_location;
     rbs_location_range colon_location;
-    struct rbs_node *param_type;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL param_type;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_param_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_return_type_annotation {
@@ -671,8 +672,8 @@ typedef struct rbs_ast_ruby_annotations_return_type_annotation {
     rbs_location_range prefix_location;
     rbs_location_range return_location;
     rbs_location_range colon_location;
-    struct rbs_node *return_type;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL return_type;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_return_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_skip_annotation {
@@ -680,7 +681,7 @@ typedef struct rbs_ast_ruby_annotations_skip_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range skip_location;
-    rbs_location_range comment_location; /* Optional */
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_skip_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_splat_param_type_annotation {
@@ -688,19 +689,19 @@ typedef struct rbs_ast_ruby_annotations_splat_param_type_annotation {
 
     rbs_location_range prefix_location;
     rbs_location_range star_location;
-    rbs_location_range name_location; /* Optional */
+    rbs_location_range name_location;
     rbs_location_range colon_location;
-    struct rbs_node *param_type;
-    rbs_location_range comment_location; /* Optional */
+    struct rbs_node *RBS_NONNULL param_type;
+    rbs_location_range comment_location;
 } rbs_ast_ruby_annotations_splat_param_type_annotation_t;
 
 typedef struct rbs_ast_ruby_annotations_type_application_annotation {
     rbs_node_t base;
 
     rbs_location_range prefix_location;
-    struct rbs_node_list *type_args;
+    struct rbs_node_list *RBS_NONNULL type_args;
     rbs_location_range close_bracket_location;
-    rbs_location_range_list_t *comma_locations;
+    rbs_location_range_list_t *RBS_NONNULL comma_locations;
 } rbs_ast_ruby_annotations_type_application_annotation_t;
 
 typedef struct rbs_ast_string {
@@ -712,11 +713,11 @@ typedef struct rbs_ast_string {
 typedef struct rbs_ast_type_param {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
+    struct rbs_ast_symbol *RBS_NONNULL name;
     enum rbs_type_param_variance variance;
-    struct rbs_node *upper_bound;  /* Optional */
-    struct rbs_node *lower_bound;  /* Optional */
-    struct rbs_node *default_type; /* Optional */
+    struct rbs_node *RBS_NULLABLE upper_bound;
+    struct rbs_node *RBS_NULLABLE lower_bound;
+    struct rbs_node *RBS_NULLABLE default_type;
     bool unchecked;
 
     rbs_location_range name_range;        /* Required */
@@ -730,9 +731,9 @@ typedef struct rbs_ast_type_param {
 typedef struct rbs_method_type {
     rbs_node_t base;
 
-    struct rbs_node_list *type_params;
-    struct rbs_node *type;
-    struct rbs_types_block *block; /* Optional */
+    struct rbs_node_list *RBS_NONNULL type_params;
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_types_block *RBS_NULLABLE block;
 
     rbs_location_range type_range;        /* Required */
     rbs_location_range type_params_range; /* Optional */
@@ -741,29 +742,29 @@ typedef struct rbs_method_type {
 typedef struct rbs_namespace {
     rbs_node_t base;
 
-    struct rbs_node_list *path;
+    struct rbs_node_list *RBS_NONNULL path;
     bool absolute;
 } rbs_namespace_t;
 
 typedef struct rbs_signature {
     rbs_node_t base;
 
-    struct rbs_node_list *directives;
-    struct rbs_node_list *declarations;
+    struct rbs_node_list *RBS_NONNULL directives;
+    struct rbs_node_list *RBS_NONNULL declarations;
 } rbs_signature_t;
 
 typedef struct rbs_type_name {
     rbs_node_t base;
 
-    struct rbs_namespace *rbs_namespace;
-    struct rbs_ast_symbol *name;
+    struct rbs_namespace *RBS_NONNULL rbs_namespace;
+    struct rbs_ast_symbol *RBS_NONNULL name;
 } rbs_type_name_t;
 
 typedef struct rbs_types_alias {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -818,16 +819,16 @@ typedef struct rbs_types_bases_void {
 typedef struct rbs_types_block {
     rbs_node_t base;
 
-    struct rbs_node *type;
+    struct rbs_node *RBS_NONNULL type;
     bool required;
-    struct rbs_node *self_type; /* Optional */
+    struct rbs_node *RBS_NULLABLE self_type;
 } rbs_types_block_t;
 
 typedef struct rbs_types_class_instance {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -836,8 +837,8 @@ typedef struct rbs_types_class_instance {
 typedef struct rbs_types_class_singleton {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -846,21 +847,21 @@ typedef struct rbs_types_class_singleton {
 typedef struct rbs_types_function {
     rbs_node_t base;
 
-    struct rbs_node_list *required_positionals;
-    struct rbs_node_list *optional_positionals;
-    struct rbs_node *rest_positionals; /* Optional */
-    struct rbs_node_list *trailing_positionals;
-    struct rbs_hash *required_keywords;
-    struct rbs_hash *optional_keywords;
-    struct rbs_node *rest_keywords; /* Optional */
-    struct rbs_node *return_type;
+    struct rbs_node_list *RBS_NONNULL required_positionals;
+    struct rbs_node_list *RBS_NONNULL optional_positionals;
+    struct rbs_node *RBS_NULLABLE rest_positionals;
+    struct rbs_node_list *RBS_NONNULL trailing_positionals;
+    struct rbs_hash *RBS_NONNULL required_keywords;
+    struct rbs_hash *RBS_NONNULL optional_keywords;
+    struct rbs_node *RBS_NULLABLE rest_keywords;
+    struct rbs_node *RBS_NONNULL return_type;
 } rbs_types_function_t;
 
 typedef struct rbs_types_function_param {
     rbs_node_t base;
 
-    struct rbs_node *type;
-    struct rbs_ast_symbol *name; /* Optional */
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_ast_symbol *RBS_NULLABLE name;
 
     rbs_location_range name_range; /* Optional */
 } rbs_types_function_param_t;
@@ -868,8 +869,8 @@ typedef struct rbs_types_function_param {
 typedef struct rbs_types_interface {
     rbs_node_t base;
 
-    struct rbs_type_name *name;
-    struct rbs_node_list *args;
+    struct rbs_type_name *RBS_NONNULL name;
+    struct rbs_node_list *RBS_NONNULL args;
 
     rbs_location_range name_range; /* Required */
     rbs_location_range args_range; /* Optional */
@@ -878,64 +879,64 @@ typedef struct rbs_types_interface {
 typedef struct rbs_types_intersection {
     rbs_node_t base;
 
-    struct rbs_node_list *types;
+    struct rbs_node_list *RBS_NONNULL types;
 } rbs_types_intersection_t;
 
 typedef struct rbs_types_literal {
     rbs_node_t base;
 
-    struct rbs_node *literal;
+    struct rbs_node *RBS_NONNULL literal;
 } rbs_types_literal_t;
 
 typedef struct rbs_types_optional {
     rbs_node_t base;
 
-    struct rbs_node *type;
+    struct rbs_node *RBS_NONNULL type;
 } rbs_types_optional_t;
 
 typedef struct rbs_types_proc {
     rbs_node_t base;
 
-    struct rbs_node *type;
-    struct rbs_types_block *block; /* Optional */
-    struct rbs_node *self_type;    /* Optional */
+    struct rbs_node *RBS_NONNULL type;
+    struct rbs_types_block *RBS_NULLABLE block;
+    struct rbs_node *RBS_NULLABLE self_type;
 } rbs_types_proc_t;
 
 typedef struct rbs_types_record {
     rbs_node_t base;
 
-    struct rbs_hash *all_fields;
+    struct rbs_hash *RBS_NONNULL all_fields;
 } rbs_types_record_t;
 
 typedef struct rbs_types_record_field_type {
     rbs_node_t base;
 
-    struct rbs_node *type;
+    struct rbs_node *RBS_NONNULL type;
     bool required;
 } rbs_types_record_field_type_t;
 
 typedef struct rbs_types_tuple {
     rbs_node_t base;
 
-    struct rbs_node_list *types;
+    struct rbs_node_list *RBS_NONNULL types;
 } rbs_types_tuple_t;
 
 typedef struct rbs_types_union {
     rbs_node_t base;
 
-    struct rbs_node_list *types;
+    struct rbs_node_list *RBS_NONNULL types;
 } rbs_types_union_t;
 
 typedef struct rbs_types_untyped_function {
     rbs_node_t base;
 
-    struct rbs_node *return_type;
+    struct rbs_node *RBS_NONNULL return_type;
 } rbs_types_untyped_function_t;
 
 typedef struct rbs_types_variable {
     rbs_node_t base;
 
-    struct rbs_ast_symbol *name;
+    struct rbs_ast_symbol *RBS_NONNULL name;
 } rbs_types_variable_t;
 
 typedef union rbs_ast_ruby_annotations {
@@ -955,84 +956,84 @@ typedef struct rbs_ast_symbol {
     rbs_constant_id_t constant_id;
 } rbs_ast_symbol_t;
 
-rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *, rbs_location_range, rbs_constant_pool_t *, rbs_constant_id_t);
+rbs_ast_symbol_t *RBS_NONNULL rbs_ast_symbol_new(rbs_allocator_t *RBS_NONNULL, rbs_location_range, rbs_constant_pool_t *RBS_NONNULL, rbs_constant_id_t);
 
-rbs_ast_annotation_t *rbs_ast_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string);
-rbs_ast_bool_t *rbs_ast_bool_new(rbs_allocator_t *allocator, rbs_location_range location, bool value);
-rbs_ast_comment_t *rbs_ast_comment_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string);
-rbs_ast_declarations_class_t *rbs_ast_declarations_class_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_ast_declarations_class_super_t *super_class, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
-rbs_ast_declarations_class_super_t *rbs_ast_declarations_class_super_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_ast_declarations_class_alias_t *rbs_ast_declarations_class_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range);
-rbs_ast_declarations_constant_t *rbs_ast_declarations_constant_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_declarations_global_t *rbs_ast_declarations_global_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_declarations_interface_t *rbs_ast_declarations_interface_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
-rbs_ast_declarations_module_t *rbs_ast_declarations_module_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *self_types, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
-rbs_ast_declarations_module_self_t *rbs_ast_declarations_module_self_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_ast_declarations_module_alias_t *rbs_ast_declarations_module_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range);
-rbs_ast_declarations_type_alias_t *rbs_ast_declarations_type_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_t *type, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range eq_range);
-rbs_ast_directives_use_t *rbs_ast_directives_use_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *clauses, rbs_location_range keyword_range);
-rbs_ast_directives_use_single_clause_t *rbs_ast_directives_use_single_clause_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *type_name, rbs_ast_symbol_t *new_name, rbs_location_range type_name_range);
-rbs_ast_directives_use_wildcard_clause_t *rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_namespace_t *rbs_namespace, rbs_location_range namespace_range, rbs_location_range star_range);
-rbs_ast_integer_t *rbs_ast_integer_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string_representation);
-rbs_ast_members_alias_t *rbs_ast_members_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *new_name, rbs_ast_symbol_t *old_name, enum rbs_alias_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range old_name_range);
-rbs_ast_members_attr_accessor_t *rbs_ast_members_attr_accessor_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_attr_reader_t *rbs_ast_members_attr_reader_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_attr_writer_t *rbs_ast_members_attr_writer_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_class_instance_variable_t *rbs_ast_members_class_instance_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_class_variable_t *rbs_ast_members_class_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_extend_t *rbs_ast_members_extend_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range);
-rbs_ast_members_include_t *rbs_ast_members_include_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range);
-rbs_ast_members_instance_variable_t *rbs_ast_members_instance_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range);
-rbs_ast_members_method_definition_t *rbs_ast_members_method_definition_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, enum rbs_method_definition_kind kind, rbs_node_list_t *overloads, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, bool overloading, enum rbs_method_definition_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range);
-rbs_ast_members_method_definition_overload_t *rbs_ast_members_method_definition_overload_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *annotations, rbs_node_t *method_type);
-rbs_ast_members_prepend_t *rbs_ast_members_prepend_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range);
-rbs_ast_members_private_t *rbs_ast_members_private_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_ast_members_public_t *rbs_ast_members_public_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_ast_ruby_annotations_block_param_type_annotation_t *rbs_ast_ruby_annotations_block_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range ampersand_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_location_range question_location, rbs_location_range type_location, rbs_node_t *type_, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_class_alias_annotation_t *rbs_ast_ruby_annotations_class_alias_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *type_name, rbs_location_range type_name_location);
-rbs_ast_ruby_annotations_colon_method_type_annotation_t *rbs_ast_ruby_annotations_colon_method_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *annotations, rbs_node_t *method_type);
-rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *rbs_ast_ruby_annotations_double_splat_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star2_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_instance_variable_annotation_t *rbs_ast_ruby_annotations_instance_variable_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_ast_symbol_t *ivar_name, rbs_location_range ivar_name_location, rbs_location_range colon_location, rbs_node_t *type, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_method_types_annotation_t *rbs_ast_ruby_annotations_method_types_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *overloads, rbs_location_range_list_t *vertical_bar_locations, rbs_location_range dot3_location);
-rbs_ast_ruby_annotations_module_alias_annotation_t *rbs_ast_ruby_annotations_module_alias_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *type_name, rbs_location_range type_name_location);
-rbs_ast_ruby_annotations_module_self_annotation_t *rbs_ast_ruby_annotations_module_self_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_location_range colon_location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range open_bracket_location, rbs_location_range close_bracket_location, rbs_location_range_list_t *args_comma_locations, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_node_type_assertion_t *rbs_ast_ruby_annotations_node_type_assertion_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_t *type);
-rbs_ast_ruby_annotations_param_type_annotation_t *rbs_ast_ruby_annotations_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_return_type_annotation_t *rbs_ast_ruby_annotations_return_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range return_location, rbs_location_range colon_location, rbs_node_t *return_type, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_skip_annotation_t *rbs_ast_ruby_annotations_skip_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range skip_location, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_splat_param_type_annotation_t *rbs_ast_ruby_annotations_splat_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location);
-rbs_ast_ruby_annotations_type_application_annotation_t *rbs_ast_ruby_annotations_type_application_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *type_args, rbs_location_range close_bracket_location, rbs_location_range_list_t *comma_locations);
-rbs_ast_string_t *rbs_ast_string_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string);
-rbs_ast_type_param_t *rbs_ast_type_param_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, enum rbs_type_param_variance variance, rbs_node_t *upper_bound, rbs_node_t *lower_bound, rbs_node_t *default_type, bool unchecked, rbs_location_range name_range);
-rbs_method_type_t *rbs_method_type_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *type_params, rbs_node_t *type, rbs_types_block_t *block, rbs_location_range type_range);
-rbs_namespace_t *rbs_namespace_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *path, bool absolute);
-rbs_signature_t *rbs_signature_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *directives, rbs_node_list_t *declarations);
-rbs_type_name_t *rbs_type_name_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_namespace_t *rbs_namespace, rbs_ast_symbol_t *name);
-rbs_types_alias_t *rbs_types_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_types_bases_any_t *rbs_types_bases_any_new(rbs_allocator_t *allocator, rbs_location_range location, bool todo);
-rbs_types_bases_bool_t *rbs_types_bases_bool_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_bottom_t *rbs_types_bases_bottom_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_class_t *rbs_types_bases_class_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_instance_t *rbs_types_bases_instance_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_nil_t *rbs_types_bases_nil_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_self_t *rbs_types_bases_self_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_top_t *rbs_types_bases_top_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_bases_void_t *rbs_types_bases_void_new(rbs_allocator_t *allocator, rbs_location_range location);
-rbs_types_block_t *rbs_types_block_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, bool required, rbs_node_t *self_type);
-rbs_types_class_instance_t *rbs_types_class_instance_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_types_class_singleton_t *rbs_types_class_singleton_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_types_function_t *rbs_types_function_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *required_positionals, rbs_node_list_t *optional_positionals, rbs_node_t *rest_positionals, rbs_node_list_t *trailing_positionals, rbs_hash_t *required_keywords, rbs_hash_t *optional_keywords, rbs_node_t *rest_keywords, rbs_node_t *return_type);
-rbs_types_function_param_t *rbs_types_function_param_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, rbs_ast_symbol_t *name);
-rbs_types_interface_t *rbs_types_interface_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range);
-rbs_types_intersection_t *rbs_types_intersection_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types);
-rbs_types_literal_t *rbs_types_literal_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *literal);
-rbs_types_optional_t *rbs_types_optional_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type);
-rbs_types_proc_t *rbs_types_proc_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, rbs_types_block_t *block, rbs_node_t *self_type);
-rbs_types_record_t *rbs_types_record_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_hash_t *all_fields);
-rbs_types_record_field_type_t *rbs_types_record_field_type_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, bool required);
-rbs_types_tuple_t *rbs_types_tuple_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types);
-rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types);
-rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *return_type);
-rbs_types_variable_t *rbs_types_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name);
+rbs_ast_annotation_t *RBS_NONNULL rbs_ast_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string);
+rbs_ast_bool_t *RBS_NONNULL rbs_ast_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool value);
+rbs_ast_comment_t *RBS_NONNULL rbs_ast_comment_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string);
+rbs_ast_declarations_class_t *RBS_NONNULL rbs_ast_declarations_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_ast_declarations_class_super_t *RBS_NULLABLE super_class, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
+rbs_ast_declarations_class_super_t *RBS_NONNULL rbs_ast_declarations_class_super_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_ast_declarations_class_alias_t *RBS_NONNULL rbs_ast_declarations_class_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range);
+rbs_ast_declarations_constant_t *RBS_NONNULL rbs_ast_declarations_constant_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_declarations_global_t *RBS_NONNULL rbs_ast_declarations_global_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_declarations_interface_t *RBS_NONNULL rbs_ast_declarations_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
+rbs_ast_declarations_module_t *RBS_NONNULL rbs_ast_declarations_module_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL self_types, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range);
+rbs_ast_declarations_module_self_t *RBS_NONNULL rbs_ast_declarations_module_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_ast_declarations_module_alias_t *RBS_NONNULL rbs_ast_declarations_module_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range);
+rbs_ast_declarations_type_alias_t *RBS_NONNULL rbs_ast_declarations_type_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range eq_range);
+rbs_ast_directives_use_t *RBS_NONNULL rbs_ast_directives_use_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL clauses, rbs_location_range keyword_range);
+rbs_ast_directives_use_single_clause_t *RBS_NONNULL rbs_ast_directives_use_single_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL type_name, rbs_ast_symbol_t *RBS_NULLABLE new_name, rbs_location_range type_name_range);
+rbs_ast_directives_use_wildcard_clause_t *RBS_NONNULL rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_location_range namespace_range, rbs_location_range star_range);
+rbs_ast_integer_t *RBS_NONNULL rbs_ast_integer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string_representation);
+rbs_ast_members_alias_t *RBS_NONNULL rbs_ast_members_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL new_name, rbs_ast_symbol_t *RBS_NONNULL old_name, enum rbs_alias_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range old_name_range);
+rbs_ast_members_attr_accessor_t *RBS_NONNULL rbs_ast_members_attr_accessor_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_attr_reader_t *RBS_NONNULL rbs_ast_members_attr_reader_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_attr_writer_t *RBS_NONNULL rbs_ast_members_attr_writer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_class_instance_variable_t *RBS_NONNULL rbs_ast_members_class_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_class_variable_t *RBS_NONNULL rbs_ast_members_class_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_extend_t *RBS_NONNULL rbs_ast_members_extend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range);
+rbs_ast_members_include_t *RBS_NONNULL rbs_ast_members_include_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range);
+rbs_ast_members_instance_variable_t *RBS_NONNULL rbs_ast_members_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range);
+rbs_ast_members_method_definition_t *RBS_NONNULL rbs_ast_members_method_definition_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_method_definition_kind kind, rbs_node_list_t *RBS_NONNULL overloads, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, bool overloading, enum rbs_method_definition_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range);
+rbs_ast_members_method_definition_overload_t *RBS_NONNULL rbs_ast_members_method_definition_overload_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type);
+rbs_ast_members_prepend_t *RBS_NONNULL rbs_ast_members_prepend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range);
+rbs_ast_members_private_t *RBS_NONNULL rbs_ast_members_private_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_ast_members_public_t *RBS_NONNULL rbs_ast_members_public_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_ast_ruby_annotations_block_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_block_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range ampersand_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_location_range question_location, rbs_location_range type_location, rbs_node_t *RBS_NONNULL type_, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_class_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_class_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NONNULL type_name, rbs_location_range type_name_location);
+rbs_ast_ruby_annotations_colon_method_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_colon_method_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type);
+rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_double_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star2_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_instance_variable_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_instance_variable_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_ast_symbol_t *RBS_NONNULL ivar_name, rbs_location_range ivar_name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL type, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_method_types_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_method_types_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL overloads, rbs_location_range_list_t *RBS_NONNULL vertical_bar_locations, rbs_location_range dot3_location);
+rbs_ast_ruby_annotations_module_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NONNULL type_name, rbs_location_range type_name_location);
+rbs_ast_ruby_annotations_module_self_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_self_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_location_range colon_location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range open_bracket_location, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL args_comma_locations, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_node_type_assertion_t *RBS_NONNULL rbs_ast_ruby_annotations_node_type_assertion_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_t *RBS_NONNULL type);
+rbs_ast_ruby_annotations_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_return_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_return_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range return_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL return_type, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_skip_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_skip_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range skip_location, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location);
+rbs_ast_ruby_annotations_type_application_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_type_application_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL type_args, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL comma_locations);
+rbs_ast_string_t *RBS_NONNULL rbs_ast_string_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string);
+rbs_ast_type_param_t *RBS_NONNULL rbs_ast_type_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_type_param_variance variance, rbs_node_t *RBS_NULLABLE upper_bound, rbs_node_t *RBS_NULLABLE lower_bound, rbs_node_t *RBS_NULLABLE default_type, bool unchecked, rbs_location_range name_range);
+rbs_method_type_t *RBS_NONNULL rbs_method_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_location_range type_range);
+rbs_namespace_t *RBS_NONNULL rbs_namespace_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL path, bool absolute);
+rbs_signature_t *RBS_NONNULL rbs_signature_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL directives, rbs_node_list_t *RBS_NONNULL declarations);
+rbs_type_name_t *RBS_NONNULL rbs_type_name_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_ast_symbol_t *RBS_NONNULL name);
+rbs_types_alias_t *RBS_NONNULL rbs_types_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_types_bases_any_t *RBS_NONNULL rbs_types_bases_any_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool todo);
+rbs_types_bases_bool_t *RBS_NONNULL rbs_types_bases_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_bottom_t *RBS_NONNULL rbs_types_bases_bottom_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_class_t *RBS_NONNULL rbs_types_bases_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_instance_t *RBS_NONNULL rbs_types_bases_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_nil_t *RBS_NONNULL rbs_types_bases_nil_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_self_t *RBS_NONNULL rbs_types_bases_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_top_t *RBS_NONNULL rbs_types_bases_top_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_bases_void_t *RBS_NONNULL rbs_types_bases_void_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
+rbs_types_block_t *RBS_NONNULL rbs_types_block_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required, rbs_node_t *RBS_NULLABLE self_type);
+rbs_types_class_instance_t *RBS_NONNULL rbs_types_class_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NONNULL return_type);
+rbs_types_function_param_t *RBS_NONNULL rbs_types_function_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_ast_symbol_t *RBS_NULLABLE name);
+rbs_types_interface_t *RBS_NONNULL rbs_types_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
+rbs_types_intersection_t *RBS_NONNULL rbs_types_intersection_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types);
+rbs_types_literal_t *RBS_NONNULL rbs_types_literal_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL literal);
+rbs_types_optional_t *RBS_NONNULL rbs_types_optional_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type);
+rbs_types_proc_t *RBS_NONNULL rbs_types_proc_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_node_t *RBS_NULLABLE self_type);
+rbs_types_record_t *RBS_NONNULL rbs_types_record_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_hash_t *RBS_NONNULL all_fields);
+rbs_types_record_field_type_t *RBS_NONNULL rbs_types_record_field_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required);
+rbs_types_tuple_t *RBS_NONNULL rbs_types_tuple_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types);
+rbs_types_union_t *RBS_NONNULL rbs_types_union_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types);
+rbs_types_untyped_function_t *RBS_NONNULL rbs_types_untyped_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL return_type);
+rbs_types_variable_t *RBS_NONNULL rbs_types_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name);
 
 #endif

--- a/include/rbs/defines.h
+++ b/include/rbs/defines.h
@@ -83,4 +83,17 @@
 #define RBS_ATTRIBUTE_UNUSED
 #endif
 
+/**
+ * Nullability annotations for pointer types.
+ * Clang supports _Nullable and _Nonnull to indicate whether a pointer may be NULL.
+ * On other compilers, these expand to nothing.
+ */
+#ifdef __clang__
+#define RBS_NULLABLE _Nullable
+#define RBS_NONNULL _Nonnull
+#else
+#define RBS_NULLABLE
+#define RBS_NONNULL
+#endif
+
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-const char *rbs_node_type_name(rbs_node_t *node) {
+const char *RBS_NONNULL rbs_node_type_name(rbs_node_t *RBS_NONNULL node) {
     switch (node->type) {
     case RBS_AST_ANNOTATION:
         return "RBS::AST::Annotation";
@@ -176,7 +176,7 @@ const char *rbs_node_type_name(rbs_node_t *node) {
 
 /* rbs_node_list */
 
-rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *allocator) {
+rbs_node_list_t *RBS_NONNULL rbs_node_list_new(rbs_allocator_t *RBS_NONNULL allocator) {
     rbs_node_list_t *list = rbs_allocator_alloc(allocator, rbs_node_list_t);
     *list = (rbs_node_list_t) {
         .allocator = allocator,
@@ -188,7 +188,7 @@ rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *allocator) {
     return list;
 }
 
-void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
+void rbs_node_list_append(rbs_node_list_t *RBS_NONNULL list, rbs_node_t *RBS_NONNULL node) {
     rbs_node_list_node_t *new_node = rbs_allocator_alloc(list->allocator, rbs_node_list_node_t);
     *new_node = (rbs_node_list_node_t) {
         .node = node,
@@ -208,7 +208,7 @@ void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
 
 /* rbs_hash */
 
-rbs_hash_t *rbs_hash_new(rbs_allocator_t *allocator) {
+rbs_hash_t *RBS_NONNULL rbs_hash_new(rbs_allocator_t *RBS_NONNULL allocator) {
     rbs_hash_t *hash = rbs_allocator_alloc(allocator, rbs_hash_t);
     *hash = (rbs_hash_t) {
         .allocator = allocator,
@@ -220,7 +220,7 @@ rbs_hash_t *rbs_hash_new(rbs_allocator_t *allocator) {
     return hash;
 }
 
-bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
+bool rbs_node_equal(rbs_node_t *RBS_NONNULL lhs, rbs_node_t *RBS_NONNULL rhs) {
     if (lhs == rhs) return true;
     if (lhs->type != rhs->type) return false;
 
@@ -239,7 +239,7 @@ bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
     }
 }
 
-rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key) {
+rbs_hash_node_t *RBS_NULLABLE rbs_hash_find(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {
     rbs_hash_node_t *current = hash->head;
 
     while (current != NULL) {
@@ -252,7 +252,7 @@ rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key) {
     return NULL;
 }
 
-void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value) {
+void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs_node_t *RBS_NONNULL value) {
     rbs_hash_node_t *existing_node = rbs_hash_find(hash, key);
     if (existing_node != NULL) {
         existing_node->value = value;
@@ -273,12 +273,12 @@ void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value) {
     }
 }
 
-rbs_node_t *rbs_hash_get(rbs_hash_t *hash, rbs_node_t *key) {
+rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {
     rbs_hash_node_t *node = rbs_hash_find(hash, key);
     return node ? node->value : NULL;
 }
 
-rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_constant_pool_t *constant_pool, rbs_constant_id_t constant_id) {
+rbs_ast_symbol_t *RBS_NONNULL rbs_ast_symbol_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_constant_pool_t *RBS_NONNULL constant_pool, rbs_constant_id_t constant_id) {
     rbs_ast_symbol_t *instance = rbs_allocator_alloc(allocator, rbs_ast_symbol_t);
 
     *instance = (rbs_ast_symbol_t) {
@@ -293,7 +293,7 @@ rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_ra
 }
 
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_annotation_t *rbs_ast_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string) {
+rbs_ast_annotation_t *RBS_NONNULL rbs_ast_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_annotation_t);
 
     *instance = (rbs_ast_annotation_t) {
@@ -307,7 +307,7 @@ rbs_ast_annotation_t *rbs_ast_annotation_new(rbs_allocator_t *allocator, rbs_loc
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_bool_t *rbs_ast_bool_new(rbs_allocator_t *allocator, rbs_location_range location, bool value) {
+rbs_ast_bool_t *RBS_NONNULL rbs_ast_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool value) {
     rbs_ast_bool_t *instance = rbs_allocator_alloc(allocator, rbs_ast_bool_t);
 
     *instance = (rbs_ast_bool_t) {
@@ -321,7 +321,7 @@ rbs_ast_bool_t *rbs_ast_bool_new(rbs_allocator_t *allocator, rbs_location_range 
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_comment_t *rbs_ast_comment_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string) {
+rbs_ast_comment_t *RBS_NONNULL rbs_ast_comment_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_comment_t *instance = rbs_allocator_alloc(allocator, rbs_ast_comment_t);
 
     *instance = (rbs_ast_comment_t) {
@@ -335,7 +335,7 @@ rbs_ast_comment_t *rbs_ast_comment_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_class_t *rbs_ast_declarations_class_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_ast_declarations_class_super_t *super_class, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
+rbs_ast_declarations_class_t *RBS_NONNULL rbs_ast_declarations_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_ast_declarations_class_super_t *RBS_NULLABLE super_class, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_class_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_t);
 
     *instance = (rbs_ast_declarations_class_t) {
@@ -359,7 +359,7 @@ rbs_ast_declarations_class_t *rbs_ast_declarations_class_new(rbs_allocator_t *al
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_class_super_t *rbs_ast_declarations_class_super_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_ast_declarations_class_super_t *RBS_NONNULL rbs_ast_declarations_class_super_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_ast_declarations_class_super_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_super_t);
 
     *instance = (rbs_ast_declarations_class_super_t) {
@@ -376,7 +376,7 @@ rbs_ast_declarations_class_super_t *rbs_ast_declarations_class_super_new(rbs_all
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_class_alias_t *rbs_ast_declarations_class_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
+rbs_ast_declarations_class_alias_t *RBS_NONNULL rbs_ast_declarations_class_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
     rbs_ast_declarations_class_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_alias_t);
 
     *instance = (rbs_ast_declarations_class_alias_t) {
@@ -397,7 +397,7 @@ rbs_ast_declarations_class_alias_t *rbs_ast_declarations_class_alias_new(rbs_all
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_constant_t *rbs_ast_declarations_constant_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_declarations_constant_t *RBS_NONNULL rbs_ast_declarations_constant_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_declarations_constant_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_constant_t);
 
     *instance = (rbs_ast_declarations_constant_t) {
@@ -416,7 +416,7 @@ rbs_ast_declarations_constant_t *rbs_ast_declarations_constant_new(rbs_allocator
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_global_t *rbs_ast_declarations_global_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_declarations_global_t *RBS_NONNULL rbs_ast_declarations_global_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_declarations_global_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_global_t);
 
     *instance = (rbs_ast_declarations_global_t) {
@@ -435,7 +435,7 @@ rbs_ast_declarations_global_t *rbs_ast_declarations_global_new(rbs_allocator_t *
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_interface_t *rbs_ast_declarations_interface_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
+rbs_ast_declarations_interface_t *RBS_NONNULL rbs_ast_declarations_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_interface_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_interface_t);
 
     *instance = (rbs_ast_declarations_interface_t) {
@@ -457,7 +457,7 @@ rbs_ast_declarations_interface_t *rbs_ast_declarations_interface_new(rbs_allocat
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_module_t *rbs_ast_declarations_module_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_list_t *self_types, rbs_node_list_t *members, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
+rbs_ast_declarations_module_t *RBS_NONNULL rbs_ast_declarations_module_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL self_types, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_module_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_t);
 
     *instance = (rbs_ast_declarations_module_t) {
@@ -482,7 +482,7 @@ rbs_ast_declarations_module_t *rbs_ast_declarations_module_new(rbs_allocator_t *
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_module_self_t *rbs_ast_declarations_module_self_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_ast_declarations_module_self_t *RBS_NONNULL rbs_ast_declarations_module_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_ast_declarations_module_self_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_self_t);
 
     *instance = (rbs_ast_declarations_module_self_t) {
@@ -499,7 +499,7 @@ rbs_ast_declarations_module_self_t *rbs_ast_declarations_module_self_new(rbs_all
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_module_alias_t *rbs_ast_declarations_module_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *new_name, rbs_type_name_t *old_name, rbs_ast_comment_t *comment, rbs_node_list_t *annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
+rbs_ast_declarations_module_alias_t *RBS_NONNULL rbs_ast_declarations_module_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
     rbs_ast_declarations_module_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_alias_t);
 
     *instance = (rbs_ast_declarations_module_alias_t) {
@@ -520,7 +520,7 @@ rbs_ast_declarations_module_alias_t *rbs_ast_declarations_module_alias_new(rbs_a
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_declarations_type_alias_t *rbs_ast_declarations_type_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *type_params, rbs_node_t *type, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range eq_range) {
+rbs_ast_declarations_type_alias_t *RBS_NONNULL rbs_ast_declarations_type_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range eq_range) {
     rbs_ast_declarations_type_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_type_alias_t);
 
     *instance = (rbs_ast_declarations_type_alias_t) {
@@ -542,7 +542,7 @@ rbs_ast_declarations_type_alias_t *rbs_ast_declarations_type_alias_new(rbs_alloc
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_directives_use_t *rbs_ast_directives_use_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *clauses, rbs_location_range keyword_range) {
+rbs_ast_directives_use_t *RBS_NONNULL rbs_ast_directives_use_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL clauses, rbs_location_range keyword_range) {
     rbs_ast_directives_use_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_t);
 
     *instance = (rbs_ast_directives_use_t) {
@@ -557,7 +557,7 @@ rbs_ast_directives_use_t *rbs_ast_directives_use_new(rbs_allocator_t *allocator,
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_directives_use_single_clause_t *rbs_ast_directives_use_single_clause_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *type_name, rbs_ast_symbol_t *new_name, rbs_location_range type_name_range) {
+rbs_ast_directives_use_single_clause_t *RBS_NONNULL rbs_ast_directives_use_single_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL type_name, rbs_ast_symbol_t *RBS_NULLABLE new_name, rbs_location_range type_name_range) {
     rbs_ast_directives_use_single_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_single_clause_t);
 
     *instance = (rbs_ast_directives_use_single_clause_t) {
@@ -575,7 +575,7 @@ rbs_ast_directives_use_single_clause_t *rbs_ast_directives_use_single_clause_new
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_directives_use_wildcard_clause_t *rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_namespace_t *rbs_namespace, rbs_location_range namespace_range, rbs_location_range star_range) {
+rbs_ast_directives_use_wildcard_clause_t *RBS_NONNULL rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_location_range namespace_range, rbs_location_range star_range) {
     rbs_ast_directives_use_wildcard_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_wildcard_clause_t);
 
     *instance = (rbs_ast_directives_use_wildcard_clause_t) {
@@ -591,7 +591,7 @@ rbs_ast_directives_use_wildcard_clause_t *rbs_ast_directives_use_wildcard_clause
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_integer_t *rbs_ast_integer_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string_representation) {
+rbs_ast_integer_t *RBS_NONNULL rbs_ast_integer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string_representation) {
     rbs_ast_integer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_integer_t);
 
     *instance = (rbs_ast_integer_t) {
@@ -605,7 +605,7 @@ rbs_ast_integer_t *rbs_ast_integer_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_alias_t *rbs_ast_members_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *new_name, rbs_ast_symbol_t *old_name, enum rbs_alias_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range old_name_range) {
+rbs_ast_members_alias_t *RBS_NONNULL rbs_ast_members_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL new_name, rbs_ast_symbol_t *RBS_NONNULL old_name, enum rbs_alias_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range old_name_range) {
     rbs_ast_members_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_alias_t);
 
     *instance = (rbs_ast_members_alias_t) {
@@ -628,7 +628,7 @@ rbs_ast_members_alias_t *rbs_ast_members_alias_new(rbs_allocator_t *allocator, r
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_attr_accessor_t *rbs_ast_members_attr_accessor_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_attr_accessor_t *RBS_NONNULL rbs_ast_members_attr_accessor_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_accessor_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_accessor_t);
 
     *instance = (rbs_ast_members_attr_accessor_t) {
@@ -655,7 +655,7 @@ rbs_ast_members_attr_accessor_t *rbs_ast_members_attr_accessor_new(rbs_allocator
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_attr_reader_t *rbs_ast_members_attr_reader_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_attr_reader_t *RBS_NONNULL rbs_ast_members_attr_reader_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_reader_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_reader_t);
 
     *instance = (rbs_ast_members_attr_reader_t) {
@@ -682,7 +682,7 @@ rbs_ast_members_attr_reader_t *rbs_ast_members_attr_reader_new(rbs_allocator_t *
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_attr_writer_t *rbs_ast_members_attr_writer_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_attr_writer_t *RBS_NONNULL rbs_ast_members_attr_writer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_writer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_writer_t);
 
     *instance = (rbs_ast_members_attr_writer_t) {
@@ -709,7 +709,7 @@ rbs_ast_members_attr_writer_t *rbs_ast_members_attr_writer_new(rbs_allocator_t *
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_class_instance_variable_t *rbs_ast_members_class_instance_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_class_instance_variable_t *RBS_NONNULL rbs_ast_members_class_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_class_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_instance_variable_t);
 
     *instance = (rbs_ast_members_class_instance_variable_t) {
@@ -728,7 +728,7 @@ rbs_ast_members_class_instance_variable_t *rbs_ast_members_class_instance_variab
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_class_variable_t *rbs_ast_members_class_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_class_variable_t *RBS_NONNULL rbs_ast_members_class_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_class_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_variable_t);
 
     *instance = (rbs_ast_members_class_variable_t) {
@@ -747,7 +747,7 @@ rbs_ast_members_class_variable_t *rbs_ast_members_class_variable_new(rbs_allocat
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_extend_t *rbs_ast_members_extend_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range) {
+rbs_ast_members_extend_t *RBS_NONNULL rbs_ast_members_extend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_extend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_extend_t);
 
     *instance = (rbs_ast_members_extend_t) {
@@ -767,7 +767,7 @@ rbs_ast_members_extend_t *rbs_ast_members_extend_new(rbs_allocator_t *allocator,
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_include_t *rbs_ast_members_include_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range) {
+rbs_ast_members_include_t *RBS_NONNULL rbs_ast_members_include_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_include_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_include_t);
 
     *instance = (rbs_ast_members_include_t) {
@@ -787,7 +787,7 @@ rbs_ast_members_include_t *rbs_ast_members_include_new(rbs_allocator_t *allocato
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_instance_variable_t *rbs_ast_members_instance_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, rbs_node_t *type, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range colon_range) {
+rbs_ast_members_instance_variable_t *RBS_NONNULL rbs_ast_members_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_instance_variable_t);
 
     *instance = (rbs_ast_members_instance_variable_t) {
@@ -806,7 +806,7 @@ rbs_ast_members_instance_variable_t *rbs_ast_members_instance_variable_new(rbs_a
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_method_definition_t *rbs_ast_members_method_definition_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, enum rbs_method_definition_kind kind, rbs_node_list_t *overloads, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, bool overloading, enum rbs_method_definition_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range) {
+rbs_ast_members_method_definition_t *RBS_NONNULL rbs_ast_members_method_definition_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_method_definition_kind kind, rbs_node_list_t *RBS_NONNULL overloads, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, bool overloading, enum rbs_method_definition_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range) {
     rbs_ast_members_method_definition_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_t);
 
     *instance = (rbs_ast_members_method_definition_t) {
@@ -831,7 +831,7 @@ rbs_ast_members_method_definition_t *rbs_ast_members_method_definition_new(rbs_a
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_method_definition_overload_t *rbs_ast_members_method_definition_overload_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *annotations, rbs_node_t *method_type) {
+rbs_ast_members_method_definition_overload_t *RBS_NONNULL rbs_ast_members_method_definition_overload_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type) {
     rbs_ast_members_method_definition_overload_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_overload_t);
 
     *instance = (rbs_ast_members_method_definition_overload_t) {
@@ -846,7 +846,7 @@ rbs_ast_members_method_definition_overload_t *rbs_ast_members_method_definition_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_prepend_t *rbs_ast_members_prepend_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_node_list_t *annotations, rbs_ast_comment_t *comment, rbs_location_range name_range, rbs_location_range keyword_range) {
+rbs_ast_members_prepend_t *RBS_NONNULL rbs_ast_members_prepend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_prepend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_prepend_t);
 
     *instance = (rbs_ast_members_prepend_t) {
@@ -866,7 +866,7 @@ rbs_ast_members_prepend_t *rbs_ast_members_prepend_new(rbs_allocator_t *allocato
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_private_t *rbs_ast_members_private_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_ast_members_private_t *RBS_NONNULL rbs_ast_members_private_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_ast_members_private_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_private_t);
 
     *instance = (rbs_ast_members_private_t) {
@@ -879,7 +879,7 @@ rbs_ast_members_private_t *rbs_ast_members_private_new(rbs_allocator_t *allocato
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_members_public_t *rbs_ast_members_public_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_ast_members_public_t *RBS_NONNULL rbs_ast_members_public_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_ast_members_public_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_public_t);
 
     *instance = (rbs_ast_members_public_t) {
@@ -892,7 +892,7 @@ rbs_ast_members_public_t *rbs_ast_members_public_new(rbs_allocator_t *allocator,
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_block_param_type_annotation_t *rbs_ast_ruby_annotations_block_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range ampersand_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_location_range question_location, rbs_location_range type_location, rbs_node_t *type_, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_block_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_block_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range ampersand_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_location_range question_location, rbs_location_range type_location, rbs_node_t *RBS_NONNULL type_, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_block_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_block_param_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_block_param_type_annotation_t) {
@@ -913,7 +913,7 @@ rbs_ast_ruby_annotations_block_param_type_annotation_t *rbs_ast_ruby_annotations
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_class_alias_annotation_t *rbs_ast_ruby_annotations_class_alias_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *type_name, rbs_location_range type_name_location) {
+rbs_ast_ruby_annotations_class_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_class_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NONNULL type_name, rbs_location_range type_name_location) {
     rbs_ast_ruby_annotations_class_alias_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_class_alias_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_class_alias_annotation_t) {
@@ -930,7 +930,7 @@ rbs_ast_ruby_annotations_class_alias_annotation_t *rbs_ast_ruby_annotations_clas
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_colon_method_type_annotation_t *rbs_ast_ruby_annotations_colon_method_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *annotations, rbs_node_t *method_type) {
+rbs_ast_ruby_annotations_colon_method_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_colon_method_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type) {
     rbs_ast_ruby_annotations_colon_method_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_colon_method_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_colon_method_type_annotation_t) {
@@ -946,7 +946,7 @@ rbs_ast_ruby_annotations_colon_method_type_annotation_t *rbs_ast_ruby_annotation
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *rbs_ast_ruby_annotations_double_splat_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star2_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_double_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star2_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_double_splat_param_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_double_splat_param_type_annotation_t) {
@@ -965,7 +965,7 @@ rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *rbs_ast_ruby_anno
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_instance_variable_annotation_t *rbs_ast_ruby_annotations_instance_variable_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_ast_symbol_t *ivar_name, rbs_location_range ivar_name_location, rbs_location_range colon_location, rbs_node_t *type, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_instance_variable_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_instance_variable_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_ast_symbol_t *RBS_NONNULL ivar_name, rbs_location_range ivar_name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_instance_variable_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_instance_variable_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_instance_variable_annotation_t) {
@@ -984,7 +984,7 @@ rbs_ast_ruby_annotations_instance_variable_annotation_t *rbs_ast_ruby_annotation
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_method_types_annotation_t *rbs_ast_ruby_annotations_method_types_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *overloads, rbs_location_range_list_t *vertical_bar_locations, rbs_location_range dot3_location) {
+rbs_ast_ruby_annotations_method_types_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_method_types_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL overloads, rbs_location_range_list_t *RBS_NONNULL vertical_bar_locations, rbs_location_range dot3_location) {
     rbs_ast_ruby_annotations_method_types_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_method_types_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_method_types_annotation_t) {
@@ -1001,7 +1001,7 @@ rbs_ast_ruby_annotations_method_types_annotation_t *rbs_ast_ruby_annotations_met
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_module_alias_annotation_t *rbs_ast_ruby_annotations_module_alias_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *type_name, rbs_location_range type_name_location) {
+rbs_ast_ruby_annotations_module_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NONNULL type_name, rbs_location_range type_name_location) {
     rbs_ast_ruby_annotations_module_alias_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_module_alias_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_module_alias_annotation_t) {
@@ -1018,7 +1018,7 @@ rbs_ast_ruby_annotations_module_alias_annotation_t *rbs_ast_ruby_annotations_mod
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_module_self_annotation_t *rbs_ast_ruby_annotations_module_self_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_location_range colon_location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range open_bracket_location, rbs_location_range close_bracket_location, rbs_location_range_list_t *args_comma_locations, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_module_self_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_self_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_location_range colon_location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range open_bracket_location, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL args_comma_locations, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_module_self_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_module_self_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_module_self_annotation_t) {
@@ -1040,7 +1040,7 @@ rbs_ast_ruby_annotations_module_self_annotation_t *rbs_ast_ruby_annotations_modu
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_node_type_assertion_t *rbs_ast_ruby_annotations_node_type_assertion_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_t *type) {
+rbs_ast_ruby_annotations_node_type_assertion_t *RBS_NONNULL rbs_ast_ruby_annotations_node_type_assertion_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_t *RBS_NONNULL type) {
     rbs_ast_ruby_annotations_node_type_assertion_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_node_type_assertion_t);
 
     *instance = (rbs_ast_ruby_annotations_node_type_assertion_t) {
@@ -1055,7 +1055,7 @@ rbs_ast_ruby_annotations_node_type_assertion_t *rbs_ast_ruby_annotations_node_ty
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_param_type_annotation_t *rbs_ast_ruby_annotations_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_param_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_param_type_annotation_t) {
@@ -1073,7 +1073,7 @@ rbs_ast_ruby_annotations_param_type_annotation_t *rbs_ast_ruby_annotations_param
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_return_type_annotation_t *rbs_ast_ruby_annotations_return_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range return_location, rbs_location_range colon_location, rbs_node_t *return_type, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_return_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_return_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range return_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL return_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_return_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_return_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_return_type_annotation_t) {
@@ -1091,7 +1091,7 @@ rbs_ast_ruby_annotations_return_type_annotation_t *rbs_ast_ruby_annotations_retu
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_skip_annotation_t *rbs_ast_ruby_annotations_skip_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range skip_location, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_skip_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_skip_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range skip_location, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_skip_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_skip_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_skip_annotation_t) {
@@ -1107,7 +1107,7 @@ rbs_ast_ruby_annotations_skip_annotation_t *rbs_ast_ruby_annotations_skip_annota
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_splat_param_type_annotation_t *rbs_ast_ruby_annotations_splat_param_type_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *param_type, rbs_location_range comment_location) {
+rbs_ast_ruby_annotations_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_splat_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_splat_param_type_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_splat_param_type_annotation_t) {
@@ -1126,7 +1126,7 @@ rbs_ast_ruby_annotations_splat_param_type_annotation_t *rbs_ast_ruby_annotations
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_ruby_annotations_type_application_annotation_t *rbs_ast_ruby_annotations_type_application_annotation_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *type_args, rbs_location_range close_bracket_location, rbs_location_range_list_t *comma_locations) {
+rbs_ast_ruby_annotations_type_application_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_type_application_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL type_args, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL comma_locations) {
     rbs_ast_ruby_annotations_type_application_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_type_application_annotation_t);
 
     *instance = (rbs_ast_ruby_annotations_type_application_annotation_t) {
@@ -1143,7 +1143,7 @@ rbs_ast_ruby_annotations_type_application_annotation_t *rbs_ast_ruby_annotations
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_string_t *rbs_ast_string_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_string_t string) {
+rbs_ast_string_t *RBS_NONNULL rbs_ast_string_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_string_t *instance = rbs_allocator_alloc(allocator, rbs_ast_string_t);
 
     *instance = (rbs_ast_string_t) {
@@ -1157,7 +1157,7 @@ rbs_ast_string_t *rbs_ast_string_new(rbs_allocator_t *allocator, rbs_location_ra
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_ast_type_param_t *rbs_ast_type_param_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name, enum rbs_type_param_variance variance, rbs_node_t *upper_bound, rbs_node_t *lower_bound, rbs_node_t *default_type, bool unchecked, rbs_location_range name_range) {
+rbs_ast_type_param_t *RBS_NONNULL rbs_ast_type_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_type_param_variance variance, rbs_node_t *RBS_NULLABLE upper_bound, rbs_node_t *RBS_NULLABLE lower_bound, rbs_node_t *RBS_NULLABLE default_type, bool unchecked, rbs_location_range name_range) {
     rbs_ast_type_param_t *instance = rbs_allocator_alloc(allocator, rbs_ast_type_param_t);
 
     *instance = (rbs_ast_type_param_t) {
@@ -1182,7 +1182,7 @@ rbs_ast_type_param_t *rbs_ast_type_param_new(rbs_allocator_t *allocator, rbs_loc
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_method_type_t *rbs_method_type_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *type_params, rbs_node_t *type, rbs_types_block_t *block, rbs_location_range type_range) {
+rbs_method_type_t *RBS_NONNULL rbs_method_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_location_range type_range) {
     rbs_method_type_t *instance = rbs_allocator_alloc(allocator, rbs_method_type_t);
 
     *instance = (rbs_method_type_t) {
@@ -1200,7 +1200,7 @@ rbs_method_type_t *rbs_method_type_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_namespace_t *rbs_namespace_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *path, bool absolute) {
+rbs_namespace_t *RBS_NONNULL rbs_namespace_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL path, bool absolute) {
     rbs_namespace_t *instance = rbs_allocator_alloc(allocator, rbs_namespace_t);
 
     *instance = (rbs_namespace_t) {
@@ -1215,7 +1215,7 @@ rbs_namespace_t *rbs_namespace_new(rbs_allocator_t *allocator, rbs_location_rang
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_signature_t *rbs_signature_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *directives, rbs_node_list_t *declarations) {
+rbs_signature_t *RBS_NONNULL rbs_signature_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL directives, rbs_node_list_t *RBS_NONNULL declarations) {
     rbs_signature_t *instance = rbs_allocator_alloc(allocator, rbs_signature_t);
 
     *instance = (rbs_signature_t) {
@@ -1230,7 +1230,7 @@ rbs_signature_t *rbs_signature_new(rbs_allocator_t *allocator, rbs_location_rang
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_type_name_t *rbs_type_name_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_namespace_t *rbs_namespace, rbs_ast_symbol_t *name) {
+rbs_type_name_t *RBS_NONNULL rbs_type_name_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_ast_symbol_t *RBS_NONNULL name) {
     rbs_type_name_t *instance = rbs_allocator_alloc(allocator, rbs_type_name_t);
 
     *instance = (rbs_type_name_t) {
@@ -1245,7 +1245,7 @@ rbs_type_name_t *rbs_type_name_new(rbs_allocator_t *allocator, rbs_location_rang
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_alias_t *rbs_types_alias_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_types_alias_t *RBS_NONNULL rbs_types_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_alias_t *instance = rbs_allocator_alloc(allocator, rbs_types_alias_t);
 
     *instance = (rbs_types_alias_t) {
@@ -1262,7 +1262,7 @@ rbs_types_alias_t *rbs_types_alias_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_any_t *rbs_types_bases_any_new(rbs_allocator_t *allocator, rbs_location_range location, bool todo) {
+rbs_types_bases_any_t *RBS_NONNULL rbs_types_bases_any_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool todo) {
     rbs_types_bases_any_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_any_t);
 
     *instance = (rbs_types_bases_any_t) {
@@ -1276,7 +1276,7 @@ rbs_types_bases_any_t *rbs_types_bases_any_new(rbs_allocator_t *allocator, rbs_l
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_bool_t *rbs_types_bases_bool_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_bool_t *RBS_NONNULL rbs_types_bases_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_bool_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bool_t);
 
     *instance = (rbs_types_bases_bool_t) {
@@ -1289,7 +1289,7 @@ rbs_types_bases_bool_t *rbs_types_bases_bool_new(rbs_allocator_t *allocator, rbs
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_bottom_t *rbs_types_bases_bottom_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_bottom_t *RBS_NONNULL rbs_types_bases_bottom_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_bottom_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bottom_t);
 
     *instance = (rbs_types_bases_bottom_t) {
@@ -1302,7 +1302,7 @@ rbs_types_bases_bottom_t *rbs_types_bases_bottom_new(rbs_allocator_t *allocator,
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_class_t *rbs_types_bases_class_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_class_t *RBS_NONNULL rbs_types_bases_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_class_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_class_t);
 
     *instance = (rbs_types_bases_class_t) {
@@ -1315,7 +1315,7 @@ rbs_types_bases_class_t *rbs_types_bases_class_new(rbs_allocator_t *allocator, r
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_instance_t *rbs_types_bases_instance_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_instance_t *RBS_NONNULL rbs_types_bases_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_instance_t);
 
     *instance = (rbs_types_bases_instance_t) {
@@ -1328,7 +1328,7 @@ rbs_types_bases_instance_t *rbs_types_bases_instance_new(rbs_allocator_t *alloca
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_nil_t *rbs_types_bases_nil_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_nil_t *RBS_NONNULL rbs_types_bases_nil_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_nil_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_nil_t);
 
     *instance = (rbs_types_bases_nil_t) {
@@ -1341,7 +1341,7 @@ rbs_types_bases_nil_t *rbs_types_bases_nil_new(rbs_allocator_t *allocator, rbs_l
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_self_t *rbs_types_bases_self_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_self_t *RBS_NONNULL rbs_types_bases_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_self_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_self_t);
 
     *instance = (rbs_types_bases_self_t) {
@@ -1354,7 +1354,7 @@ rbs_types_bases_self_t *rbs_types_bases_self_new(rbs_allocator_t *allocator, rbs
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_top_t *rbs_types_bases_top_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_top_t *RBS_NONNULL rbs_types_bases_top_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_top_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_top_t);
 
     *instance = (rbs_types_bases_top_t) {
@@ -1367,7 +1367,7 @@ rbs_types_bases_top_t *rbs_types_bases_top_new(rbs_allocator_t *allocator, rbs_l
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_bases_void_t *rbs_types_bases_void_new(rbs_allocator_t *allocator, rbs_location_range location) {
+rbs_types_bases_void_t *RBS_NONNULL rbs_types_bases_void_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_void_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_void_t);
 
     *instance = (rbs_types_bases_void_t) {
@@ -1380,7 +1380,7 @@ rbs_types_bases_void_t *rbs_types_bases_void_new(rbs_allocator_t *allocator, rbs
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_block_t *rbs_types_block_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, bool required, rbs_node_t *self_type) {
+rbs_types_block_t *RBS_NONNULL rbs_types_block_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required, rbs_node_t *RBS_NULLABLE self_type) {
     rbs_types_block_t *instance = rbs_allocator_alloc(allocator, rbs_types_block_t);
 
     *instance = (rbs_types_block_t) {
@@ -1396,7 +1396,7 @@ rbs_types_block_t *rbs_types_block_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_class_instance_t *rbs_types_class_instance_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_types_class_instance_t *RBS_NONNULL rbs_types_class_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_class_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_instance_t);
 
     *instance = (rbs_types_class_instance_t) {
@@ -1413,7 +1413,7 @@ rbs_types_class_instance_t *rbs_types_class_instance_new(rbs_allocator_t *alloca
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_class_singleton_t *rbs_types_class_singleton_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_class_singleton_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_singleton_t);
 
     *instance = (rbs_types_class_singleton_t) {
@@ -1430,7 +1430,7 @@ rbs_types_class_singleton_t *rbs_types_class_singleton_new(rbs_allocator_t *allo
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_function_t *rbs_types_function_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *required_positionals, rbs_node_list_t *optional_positionals, rbs_node_t *rest_positionals, rbs_node_list_t *trailing_positionals, rbs_hash_t *required_keywords, rbs_hash_t *optional_keywords, rbs_node_t *rest_keywords, rbs_node_t *return_type) {
+rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NONNULL return_type) {
     rbs_types_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_t);
 
     *instance = (rbs_types_function_t) {
@@ -1451,7 +1451,7 @@ rbs_types_function_t *rbs_types_function_new(rbs_allocator_t *allocator, rbs_loc
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_function_param_t *rbs_types_function_param_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, rbs_ast_symbol_t *name) {
+rbs_types_function_param_t *RBS_NONNULL rbs_types_function_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_ast_symbol_t *RBS_NULLABLE name) {
     rbs_types_function_param_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_param_t);
 
     *instance = (rbs_types_function_param_t) {
@@ -1467,7 +1467,7 @@ rbs_types_function_param_t *rbs_types_function_param_new(rbs_allocator_t *alloca
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_interface_t *rbs_types_interface_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_type_name_t *name, rbs_node_list_t *args, rbs_location_range name_range) {
+rbs_types_interface_t *RBS_NONNULL rbs_types_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_interface_t *instance = rbs_allocator_alloc(allocator, rbs_types_interface_t);
 
     *instance = (rbs_types_interface_t) {
@@ -1484,7 +1484,7 @@ rbs_types_interface_t *rbs_types_interface_new(rbs_allocator_t *allocator, rbs_l
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_intersection_t *rbs_types_intersection_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types) {
+rbs_types_intersection_t *RBS_NONNULL rbs_types_intersection_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_intersection_t *instance = rbs_allocator_alloc(allocator, rbs_types_intersection_t);
 
     *instance = (rbs_types_intersection_t) {
@@ -1498,7 +1498,7 @@ rbs_types_intersection_t *rbs_types_intersection_new(rbs_allocator_t *allocator,
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_literal_t *rbs_types_literal_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *literal) {
+rbs_types_literal_t *RBS_NONNULL rbs_types_literal_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL literal) {
     rbs_types_literal_t *instance = rbs_allocator_alloc(allocator, rbs_types_literal_t);
 
     *instance = (rbs_types_literal_t) {
@@ -1512,7 +1512,7 @@ rbs_types_literal_t *rbs_types_literal_new(rbs_allocator_t *allocator, rbs_locat
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_optional_t *rbs_types_optional_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type) {
+rbs_types_optional_t *RBS_NONNULL rbs_types_optional_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type) {
     rbs_types_optional_t *instance = rbs_allocator_alloc(allocator, rbs_types_optional_t);
 
     *instance = (rbs_types_optional_t) {
@@ -1526,7 +1526,7 @@ rbs_types_optional_t *rbs_types_optional_new(rbs_allocator_t *allocator, rbs_loc
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_proc_t *rbs_types_proc_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, rbs_types_block_t *block, rbs_node_t *self_type) {
+rbs_types_proc_t *RBS_NONNULL rbs_types_proc_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_node_t *RBS_NULLABLE self_type) {
     rbs_types_proc_t *instance = rbs_allocator_alloc(allocator, rbs_types_proc_t);
 
     *instance = (rbs_types_proc_t) {
@@ -1542,7 +1542,7 @@ rbs_types_proc_t *rbs_types_proc_new(rbs_allocator_t *allocator, rbs_location_ra
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_record_t *rbs_types_record_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_hash_t *all_fields) {
+rbs_types_record_t *RBS_NONNULL rbs_types_record_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_hash_t *RBS_NONNULL all_fields) {
     rbs_types_record_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_t);
 
     *instance = (rbs_types_record_t) {
@@ -1556,7 +1556,7 @@ rbs_types_record_t *rbs_types_record_new(rbs_allocator_t *allocator, rbs_locatio
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_record_field_type_t *rbs_types_record_field_type_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *type, bool required) {
+rbs_types_record_field_type_t *RBS_NONNULL rbs_types_record_field_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required) {
     rbs_types_record_field_type_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_field_type_t);
 
     *instance = (rbs_types_record_field_type_t) {
@@ -1571,7 +1571,7 @@ rbs_types_record_field_type_t *rbs_types_record_field_type_new(rbs_allocator_t *
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_tuple_t *rbs_types_tuple_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types) {
+rbs_types_tuple_t *RBS_NONNULL rbs_types_tuple_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_tuple_t *instance = rbs_allocator_alloc(allocator, rbs_types_tuple_t);
 
     *instance = (rbs_types_tuple_t) {
@@ -1585,7 +1585,7 @@ rbs_types_tuple_t *rbs_types_tuple_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_list_t *types) {
+rbs_types_union_t *RBS_NONNULL rbs_types_union_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_union_t *instance = rbs_allocator_alloc(allocator, rbs_types_union_t);
 
     *instance = (rbs_types_union_t) {
@@ -1599,7 +1599,7 @@ rbs_types_union_t *rbs_types_union_new(rbs_allocator_t *allocator, rbs_location_
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_node_t *return_type) {
+rbs_types_untyped_function_t *RBS_NONNULL rbs_types_untyped_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL return_type) {
     rbs_types_untyped_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_untyped_function_t);
 
     *instance = (rbs_types_untyped_function_t) {
@@ -1613,7 +1613,7 @@ rbs_types_untyped_function_t *rbs_types_untyped_function_new(rbs_allocator_t *al
     return instance;
 }
 #line 140 "prism/templates/src/ast.c.erb"
-rbs_types_variable_t *rbs_types_variable_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_ast_symbol_t *name) {
+rbs_types_variable_t *RBS_NONNULL rbs_types_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name) {
     rbs_types_variable_t *instance = rbs_allocator_alloc(allocator, rbs_types_variable_t);
 
     *instance = (rbs_types_variable_t) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -3324,11 +3324,7 @@ bool rbs_parse_signature(rbs_parser_t *parser, rbs_signature_t **signature) {
         rbs_ast_directives_use_t *use_node;
         CHECK_PARSE(parse_use_directive(parser, &use_node));
 
-        if (use_node == NULL) {
-            rbs_node_list_append(dirs, NULL);
-        } else {
-            rbs_node_list_append(dirs, (rbs_node_t *) use_node);
-        }
+        rbs_node_list_append(dirs, (rbs_node_t *) use_node);
     }
 
     while (parser->next_token.type != pEOF) {

--- a/templates/include/rbs/ast.h.erb
+++ b/templates/include/rbs/ast.h.erb
@@ -1,6 +1,7 @@
 #ifndef RBS__AST_H
 #define RBS__AST_H
 
+#include "rbs/defines.h"
 #include "rbs/util/rbs_allocator.h"
 #include "rbs/util/rbs_constant_pool.h"
 #include "string.h"
@@ -38,48 +39,48 @@ typedef struct rbs_node {
     rbs_location_range location;
 } rbs_node_t;
 
-const char *rbs_node_type_name(rbs_node_t *node);
+const char *RBS_NONNULL rbs_node_type_name(rbs_node_t *RBS_NONNULL node);
 
 /* rbs_node_list_node */
 
 typedef struct rbs_node_list_node {
-    rbs_node_t *node;
-    struct rbs_node_list_node *next;
+    rbs_node_t *RBS_NONNULL node;
+    struct rbs_node_list_node *RBS_NULLABLE next;
 } rbs_node_list_node_t;
 
 typedef struct rbs_node_list {
-    rbs_allocator_t *allocator;
-    rbs_node_list_node_t *head;
-    rbs_node_list_node_t *tail;
+    rbs_allocator_t *RBS_NONNULL allocator;
+    rbs_node_list_node_t *RBS_NULLABLE head;
+    rbs_node_list_node_t *RBS_NULLABLE tail;
     size_t length;
 } rbs_node_list_t;
 
-rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *);
+rbs_node_list_t *RBS_NONNULL rbs_node_list_new(rbs_allocator_t *RBS_NONNULL);
 
-void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node);
+void rbs_node_list_append(rbs_node_list_t *RBS_NONNULL list, rbs_node_t *RBS_NONNULL node);
 
 /* rbs_hash */
 
 typedef struct rbs_hash_node {
-    rbs_node_t *key;
-    rbs_node_t *value;
-    struct rbs_hash_node *next;
+    rbs_node_t *RBS_NONNULL key;
+    rbs_node_t *RBS_NONNULL value;
+    struct rbs_hash_node *RBS_NULLABLE next;
 } rbs_hash_node_t;
 
 typedef struct rbs_hash {
-    rbs_allocator_t *allocator;
-    rbs_hash_node_t *head;
-    rbs_hash_node_t *tail;
+    rbs_allocator_t *RBS_NONNULL allocator;
+    rbs_hash_node_t *RBS_NULLABLE head;
+    rbs_hash_node_t *RBS_NULLABLE tail;
     size_t length;
 } rbs_hash_t;
 
-rbs_hash_t *rbs_hash_new(rbs_allocator_t *);
+rbs_hash_t *RBS_NONNULL rbs_hash_new(rbs_allocator_t *RBS_NONNULL);
 
-void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value);
+void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs_node_t *RBS_NONNULL value);
 
-rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key);
+rbs_hash_node_t *RBS_NULLABLE rbs_hash_find(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key);
 
-rbs_node_t *rbs_hash_get(rbs_hash_t *hash, rbs_node_t *key);
+rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key);
 
 /* rbs_ast_node */
 
@@ -89,9 +90,11 @@ typedef struct <%= node.c_name %> {
 
     <%- node.fields.each do |field| -%>
         <%- if field.type.is_a?(RBS::Template::NodeType) -%>
-    struct <%= field.type.c_name %> *<%= field.c_name %>;  <%= field.optional? ? "/* Optional */" : "" %>
+    struct <%= field.type.c_name %> *<%= field.optional? ? "RBS_NULLABLE" : "RBS_NONNULL" %> <%= field.c_name %>;
+        <%- elsif field.type.pointer? -%>
+    <%= field.type.c_type_name %><%= field.optional? ? "RBS_NULLABLE" : "RBS_NONNULL" %> <%= field.c_name %>;
         <%- else -%>
-    <%= field.type.c_type_name %> <%= field.c_name %>;   <%= field.optional? ? "/* Optional */" : "" %>
+    <%= field.type.c_type_name %> <%= field.c_name %>;
         <%- end -%>
     <%- end -%>
     <%- if node.locations -%>
@@ -120,10 +123,10 @@ typedef struct rbs_ast_symbol {
     rbs_constant_id_t constant_id;
 } rbs_ast_symbol_t;
 
-rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *, rbs_location_range, rbs_constant_pool_t *, rbs_constant_id_t);
+rbs_ast_symbol_t *RBS_NONNULL rbs_ast_symbol_new(rbs_allocator_t *RBS_NONNULL, rbs_location_range, rbs_constant_pool_t *RBS_NONNULL, rbs_constant_id_t);
 
 <%- nodes.each do |node| -%>
-<%= node.c_name %>_t *<%= node.c_constructor_function_name %>(<%= node.constructor_params.join(", ") %>);
+<%= node.c_name %>_t *RBS_NONNULL <%= node.c_constructor_function_name %>(<%= node.constructor_params.join(", ") %>);
 <%- end -%>
 
 #endif

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-const char *rbs_node_type_name(rbs_node_t *node) {
+const char *RBS_NONNULL rbs_node_type_name(rbs_node_t *RBS_NONNULL node) {
     switch (node->type) {
     <%- nodes.each do |node| -%>
     case <%= node.c_node_enum_name %>:
@@ -19,7 +19,7 @@ const char *rbs_node_type_name(rbs_node_t *node) {
 
 /* rbs_node_list */
 
-rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *allocator) {
+rbs_node_list_t *RBS_NONNULL rbs_node_list_new(rbs_allocator_t *RBS_NONNULL allocator) {
     rbs_node_list_t *list = rbs_allocator_alloc(allocator, rbs_node_list_t);
     *list = (rbs_node_list_t) {
         .allocator = allocator,
@@ -31,7 +31,7 @@ rbs_node_list_t *rbs_node_list_new(rbs_allocator_t *allocator) {
     return list;
 }
 
-void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
+void rbs_node_list_append(rbs_node_list_t *RBS_NONNULL list, rbs_node_t *RBS_NONNULL node) {
     rbs_node_list_node_t *new_node = rbs_allocator_alloc(list->allocator, rbs_node_list_node_t);
     *new_node = (rbs_node_list_node_t) {
         .node = node,
@@ -51,7 +51,7 @@ void rbs_node_list_append(rbs_node_list_t *list, rbs_node_t *node) {
 
 /* rbs_hash */
 
-rbs_hash_t *rbs_hash_new(rbs_allocator_t *allocator) {
+rbs_hash_t *RBS_NONNULL rbs_hash_new(rbs_allocator_t *RBS_NONNULL allocator) {
     rbs_hash_t *hash = rbs_allocator_alloc(allocator, rbs_hash_t);
     *hash = (rbs_hash_t) {
         .allocator = allocator,
@@ -63,7 +63,7 @@ rbs_hash_t *rbs_hash_new(rbs_allocator_t *allocator) {
     return hash;
 }
 
-bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
+bool rbs_node_equal(rbs_node_t *RBS_NONNULL lhs, rbs_node_t *RBS_NONNULL rhs) {
     if (lhs == rhs) return true;
     if (lhs->type != rhs->type) return false;
 
@@ -82,7 +82,7 @@ bool rbs_node_equal(rbs_node_t *lhs, rbs_node_t *rhs) {
     }
 }
 
-rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key) {
+rbs_hash_node_t *RBS_NULLABLE rbs_hash_find(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {
     rbs_hash_node_t *current = hash->head;
 
     while (current != NULL) {
@@ -95,7 +95,7 @@ rbs_hash_node_t *rbs_hash_find(rbs_hash_t *hash, rbs_node_t *key) {
     return NULL;
 }
 
-void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value) {
+void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs_node_t *RBS_NONNULL value) {
     rbs_hash_node_t *existing_node = rbs_hash_find(hash, key);
     if (existing_node != NULL) {
         existing_node->value = value;
@@ -116,12 +116,12 @@ void rbs_hash_set(rbs_hash_t *hash, rbs_node_t *key, rbs_node_t *value) {
     }
 }
 
-rbs_node_t *rbs_hash_get(rbs_hash_t *hash, rbs_node_t *key) {
+rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {
     rbs_hash_node_t *node = rbs_hash_find(hash, key);
     return node ? node->value : NULL;
 }
 
-rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_range location, rbs_constant_pool_t *constant_pool, rbs_constant_id_t constant_id) {
+rbs_ast_symbol_t *RBS_NONNULL rbs_ast_symbol_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_constant_pool_t *RBS_NONNULL constant_pool, rbs_constant_id_t constant_id) {
     rbs_ast_symbol_t *instance = rbs_allocator_alloc(allocator, rbs_ast_symbol_t);
 
     *instance = (rbs_ast_symbol_t) {
@@ -137,7 +137,7 @@ rbs_ast_symbol_t *rbs_ast_symbol_new(rbs_allocator_t *allocator, rbs_location_ra
 
 <%- nodes.each do |node| -%>
 #line <%= __LINE__ + 1 %> "prism/templates/src/<%= File.basename(__FILE__) %>"
-<%= node.c_type_name %> *<%= node.c_constructor_function_name %>(<%= node.constructor_params.join(", ") %>) {
+<%= node.c_type_name %> *RBS_NONNULL <%= node.c_constructor_function_name %>(<%= node.constructor_params.join(", ") %>) {
     <%= node.c_type_name %> *instance = rbs_allocator_alloc(allocator, <%= node.c_type_name %>);
 
     *instance = (<%= node.c_type_name %>) {

--- a/templates/template.rb
+++ b/templates/template.rb
@@ -14,16 +14,20 @@ module RBS
 
     class Type
       attr_reader :name #: String
-      
+
       attr_reader :c_name #: String
-      
+
       def initialize(name:, c_name:)
         @name = name
         @c_name = c_name
       end
-      
+
       def c_type_name
         c_name
+      end
+
+      def pointer? #: bool
+        c_type_name.end_with?("*")
       end
     end
 
@@ -132,9 +136,14 @@ module RBS
       end
     end
 
-    FunctionParam = Data.define(:type, :name) do
+    FunctionParam = Data.define(:type, :name, :nullable) do
       def to_s
-        "#{type.c_type_name} #{name}"
+        if !nullable.nil? && type.pointer?
+          annotation = nullable ? "RBS_NULLABLE" : "RBS_NONNULL"
+          "#{type.c_type_name}#{annotation} #{name}"
+        else
+          "#{type.c_type_name} #{name}"
+        end
       end
     end
 
@@ -364,10 +373,13 @@ module RBS
           end
 
           constructor_params = [
-            FunctionParam.new(Type.new(name: "allocator", c_name: "rbs_allocator_t *"), "allocator"),
-            FunctionParam.new(types.fetch("rbs_location_range"), "location"),
-            *fields.map { FunctionParam.new(_1.type, _1.c_name) },
-            *locations&.select(&:required?)&.map { FunctionParam.new(types.fetch("rbs_location_range"), _1.attribute_name) },
+            FunctionParam.new(Type.new(name: "allocator", c_name: "rbs_allocator_t *"), "allocator", false),
+            FunctionParam.new(types.fetch("rbs_location_range"), "location", nil),
+            *fields.map {
+              nullable = _1.type.pointer? ? _1.optional? : nil
+              FunctionParam.new(_1.type, _1.c_name, nullable)
+            },
+            *locations&.select(&:required?)&.map { FunctionParam.new(types.fetch("rbs_location_range"), _1.attribute_name, nil) },
           ]
 
           Node.new(node, fields, locations, constructor_params)


### PR DESCRIPTION
## Summary
This PR adds Clang nullability annotations (`_Nullable` and `_Nonnull`) to pointer types throughout the RBS AST header and implementation files. These annotations help static analysis tools and IDEs better understand which pointers can be NULL and which cannot.

## Key Changes

- **Added nullability macros** (`RBS_NULLABLE` and `RBS_NONNULL`) in `include/rbs/defines.h` that expand to Clang's `_Nullable` and `_Nonnull` attributes on Clang, and to nothing on other compilers for compatibility

- **Annotated struct fields** across all AST node types with appropriate nullability markers:
  - Required pointer fields marked with `RBS_NONNULL`
  - Optional pointer fields marked with `RBS_NULLABLE`
  - Examples include class declarations, method definitions, type parameters, and various annotation types

- **Annotated function signatures** for all AST constructor and utility functions:
  - Return types annotated (e.g., `rbs_node_list_t *RBS_NONNULL`)
  - Parameter types annotated (e.g., `rbs_allocator_t *RBS_NONNULL`)
  - Functions like `rbs_hash_find()` and `rbs_hash_get()` marked as returning `RBS_NULLABLE` since they can return NULL

- **Updated template files** (`templates/template.rb` and `templates/include/rbs/ast.h.erb`) to generate nullability annotations automatically for constructor parameters based on whether fields are optional or required

## Implementation Details

- The nullability annotations are conditionally compiled using `#ifdef __clang__` to ensure compatibility with non-Clang compilers
- Constructor parameters for pointer types are annotated based on the field's optional status: optional fields use `RBS_NULLABLE`, required fields use `RBS_NONNULL`
- The template system was enhanced to track nullability information for function parameters and generate appropriate annotations

https://claude.ai/code/session_013XvhPzhCAZGQ9qniMY1YQY