### PR TITLE
Suppress spurious warning for non-gem stdlib libraries

### DIFF
--- a/lib/rbs/collection/config/lockfile_generator.rb
+++ b/lib/rbs/collection/config/lockfile_generator.rb
@@ -21,6 +21,17 @@ module RBS
           "pstore" => nil,
         }
 
+        NONGEM_STDLIBS = Set[
+          "cgi-escape",
+          "coverage",
+          "monitor",
+          "objspace",
+          "pathname",
+          "pty",
+          "ripper",
+          "socket",
+        ]
+
         class GemfileLockMismatchError < StandardError
           def initialize(expected:, actual:)
             @expected = expected
@@ -168,7 +179,9 @@ module RBS
               end
             end
           else
-            RBS.logger.warn "Cannot find `#{name}` gem. Using incorrect Bundler context? (#{definition.lockfile})"
+            unless NONGEM_STDLIBS.include?(name)
+              RBS.logger.warn "Cannot find `#{name}` gem. Using incorrect Bundler context? (#{definition.lockfile})"
+            end
           end
         end
 

--- a/sig/collection/config/lockfile_generator.rbs
+++ b/sig/collection/config/lockfile_generator.rbs
@@ -6,6 +6,8 @@ module RBS
         #
         ALUMNI_STDLIBS: Hash[String, String?]
 
+        NONGEM_STDLIBS: Set[String]
+
         class GemfileLockMismatchError < StandardError
           @expected: Pathname
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1491,6 +1491,54 @@ Processing `lib`...
     end
   end
 
+  def test_collection_install__nongem_stdlib_no_warning
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        dir.join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources:
+            - name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+
+          path: #{dir.join('gem_rbs_collection')}
+
+          gems:
+          - name: socket
+          - name: pathname
+        YAML
+
+        bundle_install('ast', 'logger', 'tsort')
+
+        # First install creates the lockfile with socket as stdlib
+        _stdout, stderr = run_rbs_collection("install", bundler: true)
+
+        lockfile = RBS::Collection::Config::Lockfile.from_lockfile(
+          lockfile_path: dir + "rbs_collection.lock.yaml",
+          data: YAML.safe_load((dir + "rbs_collection.lock.yaml").read)
+        )
+
+        assert_instance_of RBS::Collection::Sources::Stdlib, lockfile.gems["socket"][:source]
+        assert_instance_of RBS::Collection::Sources::Stdlib, lockfile.gems["pathname"][:source]
+
+        # Second install with existing lockfile should not warn about nongem stdlibs
+        _stdout, stderr = run_rbs_collection("install", bundler: true)
+
+        refute_match(/Cannot find `socket` gem/, stderr)
+        refute_match(/Cannot find `pathname` gem/, stderr)
+
+        lockfile = RBS::Collection::Config::Lockfile.from_lockfile(
+          lockfile_path: dir + "rbs_collection.lock.yaml",
+          data: YAML.safe_load((dir + "rbs_collection.lock.yaml").read)
+        )
+
+        assert_instance_of RBS::Collection::Sources::Stdlib, lockfile.gems["socket"][:source]
+        assert_instance_of RBS::Collection::Sources::Stdlib, lockfile.gems["pathname"][:source]
+      end
+    end
+  end
+
   def test_collection_install__set_pathname__manifest
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do


### PR DESCRIPTION
## Summary
- Add `NONGEM_STDLIBS` constant listing standard libraries that are not distributed as gems (e.g., `socket`, `pathname`, `monitor`) but have type definitions in `stdlib/`
- Skip the "Cannot find `<name>` gem" warning for these libraries during `rbs collection install`
- Add test to verify no warning is emitted when non-gem stdlibs are in the lockfile

## Problem

When `rbs_collection.yaml` includes non-gem standard libraries like `socket`, running `rbs collection install` a second time (with an existing lockfile) emits a misleading warning:

```
Cannot find `socket` gem. Using incorrect Bundler context?
```

This happens because with an existing lockfile, `assign_gem` takes the `existing_lockfile` code path, bypassing stdlib detection via `find_source`. It then checks `gem_hash` (Bundler's specs) which naturally doesn't include non-gem libraries, triggering the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)