### PR TITLE
Support `def self.method_name` singleton method in inline parser

### DIFF
--- a/lib/rbs/ast/ruby/members.rb
+++ b/lib/rbs/ast/ruby/members.rb
@@ -549,15 +549,25 @@ module RBS
 
           attr_reader :name
           attr_reader :node
+          attr_reader :kind
           attr_reader :method_type
           attr_reader :leading_comment
 
-          def initialize(buffer, name, node, method_type, leading_comment)
+          def initialize(buffer, name, node, method_type, leading_comment, kind: :instance)
             super(buffer)
             @name = name
             @node = node
+            @kind = kind
             @method_type = method_type
             @leading_comment = leading_comment
+          end
+
+          def singleton?
+            kind == :singleton
+          end
+
+          def instance?
+            kind == :instance
           end
 
           def location
@@ -583,6 +593,7 @@ module RBS
           def type_fingerprint
             [
               "members/def",
+              kind.to_s,
               name.to_s,
               method_type.type_fingerprint,
               leading_comment&.as_comment&.string

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -143,12 +143,14 @@ module RBS
                   decl.members.each do |member|
                     case member
                     when AST::Ruby::Members::DefMember
-                      build_method(
-                        methods,
-                        type,
-                        member: member,
-                        accessibility: :public
-                      )
+                      if member.instance?
+                        build_method(
+                          methods,
+                          type,
+                          member: member,
+                          accessibility: :public
+                        )
+                      end
                     when AST::Ruby::Members::AttrReaderMember, AST::Ruby::Members::AttrWriterMember, AST::Ruby::Members::AttrAccessorMember
                       build_ruby_attribute(methods, type, member: member, accessibility: :public)
                     end
@@ -180,6 +182,10 @@ module RBS
                   when AST::Members::Alias
                     if member.kind == :singleton
                       build_alias(methods, type, member: member)
+                    end
+                  when AST::Ruby::Members::DefMember
+                    if member.singleton?
+                      build_method(methods, type, member: member, accessibility: :public)
                     end
                   end
                 end

--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -795,7 +795,8 @@ module RBS
           member.name,
           member.node,
           member.method_type.map_type_name {|name, _, _| absolute_type_name(resolver, nil, name, context: context) },
-          member.leading_comment
+          member.leading_comment,
+          kind: member.kind
         )
       when AST::Ruby::Members::IncludeMember
         resolved_annotation = member.annotation&.map_type_name {|name, _, _| absolute_type_name(resolver, nil, name, context: context) }

--- a/lib/rbs/inline_parser.rb
+++ b/lib/rbs/inline_parser.rb
@@ -202,13 +202,15 @@ module RBS
       def visit_def_node(node)
         return if skip_node?(node)
 
-        if node.receiver
+        if node.receiver && !node.receiver.is_a?(Prism::SelfNode)
           diagnostics << Diagnostic::NotImplementedYet.new(
             rbs_location(node.receiver.location),
-            "Singleton method definition is not supported yet"
+            "Method definition with non-self receiver is not supported"
           )
           return
         end
+
+        kind = node.receiver ? :singleton : :instance #: :singleton | :instance
 
         case current = current_module
         when AST::Ruby::Declarations::ClassDecl, AST::Ruby::Declarations::ModuleDecl
@@ -223,7 +225,7 @@ module RBS
           method_type, leading_unuseds, trailing_unused = AST::Ruby::Members::MethodTypeAnnotation.build(leading_block, trailing_block, [], node)
           report_unused_annotation(trailing_unused, *leading_unuseds)
 
-          defn = AST::Ruby::Members::DefMember.new(buffer, node.name, node, method_type, leading_block)
+          defn = AST::Ruby::Members::DefMember.new(buffer, node.name, node, method_type, leading_block, kind: kind)
           current.members << defn
 
           # Skip other comments in `def` node

--- a/sig/ast/ruby/members.rbs
+++ b/sig/ast/ruby/members.rbs
@@ -84,10 +84,15 @@ module RBS
 
           attr_reader name: Symbol
           attr_reader node: Prism::DefNode
+          attr_reader kind: :instance | :singleton
           attr_reader method_type: MethodTypeAnnotation
           attr_reader leading_comment: CommentBlock?
 
-          def initialize: (Buffer, Symbol name, Prism::DefNode node, MethodTypeAnnotation, CommentBlock? leading_comment) -> void
+          def initialize: (Buffer, Symbol name, Prism::DefNode node, MethodTypeAnnotation, CommentBlock? leading_comment, ?kind: :instance | :singleton) -> void
+
+          def singleton?: () -> bool
+
+          def instance?: () -> bool
 
           def location: () -> Location
 

--- a/test/rbs/inline_parser_test.rb
+++ b/test/rbs/inline_parser_test.rb
@@ -125,18 +125,195 @@ class RBS::InlineParserTest < Test::Unit::TestCase
     assert_empty result.declarations
   end
 
-  def test_error__def__singleton
+  def test_parse__def__singleton
     result = parse(<<~RUBY)
       module Foo
         def self.foo; end
       end
     RUBY
 
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :foo, member.name
+        assert_predicate member, :singleton?
+        refute_predicate member, :instance?
+        assert_equal :singleton, member.kind
+      end
+    end
+  end
+
+  def test_parse__def__singleton__colon_type
+    result = parse(<<~RUBY)
+      class Foo
+        #: () -> void
+        def self.hello
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :hello, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__def__singleton__rbs_annotation
+    result = parse(<<~RUBY)
+      class Foo
+        # @rbs () -> void
+        def self.hello
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :hello, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__def__singleton__with_params
+    result = parse(<<~RUBY)
+      class Foo
+        # @rbs n: Integer
+        # @rbs return: Integer
+        def self.double(n)
+          n * 2
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :double, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["(Integer n) -> Integer"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__def__singleton__mixed_with_instance
+    result = parse(<<~RUBY)
+      class Foo
+        #: () -> void
+        def self.class_method
+        end
+
+        #: () -> String
+        def instance_method
+          ""
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 2, decl.members.size
+
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :class_method, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+
+      decl.members[1].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :instance_method, member.name
+        assert_predicate member, :instance?
+        assert_equal ["() -> String"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__def__singleton__skip
+    result = parse(<<~RUBY)
+      class Foo
+        # @rbs skip
+        def self.skipped_method
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_error__def__singleton__non_self_receiver
+    result = parse(<<~RUBY)
+      module Foo
+        def other_obj.foo; end
+      end
+    RUBY
+
     assert_equal 1, result.diagnostics.size
     assert_any!(result.diagnostics) do |diagnostic|
       assert_instance_of RBS::InlineParser::Diagnostic::NotImplementedYet, diagnostic
-      assert_equal "self", diagnostic.location.source
-      assert_equal "Singleton method definition is not supported yet", diagnostic.message
+      assert_equal "other_obj", diagnostic.location.source
+      assert_equal "Method definition with non-self receiver is not supported", diagnostic.message
+    end
+  end
+
+  def test_parse__def__singleton__in_module
+    result = parse(<<~RUBY)
+      module Foo
+        #: () -> void
+        def self.module_method
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :module_method, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__def__instance_method_kind
+    result = parse(<<~RUBY)
+      class Foo
+        def instance_method; end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :instance_method, member.name
+        assert_predicate member, :instance?
+        refute_predicate member, :singleton?
+        assert_equal :instance, member.kind
+      end
     end
   end
 


### PR DESCRIPTION
Previously, the inline parser emitted a diagnostic error for any method definition with a receiver (`def self.foo`, `def obj.foo`, etc.) and skipped processing it entirely. This meant that singleton methods defined with `def self.method_name` could not have their type annotations recognized.

This change adds support for `def self.method_name` by:

- Checking `Prism::SelfNode` specifically in `visit_def_node` and only rejecting non-self receivers (e.g., `def obj.foo`)
- Adding a `kind` attribute (`:instance` | `:singleton`) to `DefMember` to distinguish between instance and singleton methods
- Propagating `kind` through `Environment#resolve_type_names`
- Routing singleton `DefMember`s to `build_singleton` in `MethodBuilder`

All existing inline annotation formats (`#:`, `# @rbs`, `# @rbs param:`) work with singleton methods as well.

## In addition

Could you also add the appropriate milestone to this PR? I do not have permission to set milestones from the GitHub UI. If this PR does not need one, please add the `no-milestone` label instead.