### PR TITLE
Fix rbs test use cases

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1061,7 +1061,7 @@ EOB
       env_hash = {
         'RUBYOPT' => "#{ENV['RUBYOPT']} -rrbs/test/setup",
         'RBS_TEST_OPT' => test_opt(options),
-        'RBS_TEST_LOGLEVEL' => %w(DEBUG INFO WARN ERROR FATAL)[RBS.logger_level || 5] || "UNKNOWN",
+        'RBS_TEST_LOGLEVEL' => RBS.logger_level || "UNKNOWN",
         'RBS_TEST_SAMPLE_SIZE' => sample_size,
         'RBS_TEST_DOUBLE_SUITE' => double_suite,
         'RBS_TEST_UNCHECKED_CLASSES' => (unchecked_classes.join(',') unless unchecked_classes.empty?),

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1044,6 +1044,22 @@ Processing `lib`...
   def test_test
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
+      dir.join('foo.rb').write(<<~RB)
+      class Foo
+        def foo(*)
+        end
+      end
+
+      module Bar
+        class Baz
+          def foo
+          end
+        end
+      end
+
+      # violates type definition
+      Foo.new.foo(1)
+      RB
       dir.join('foo.rbs').write(<<~RBS)
         class Foo
           def foo: () -> void
@@ -1059,10 +1075,12 @@ Processing `lib`...
       with_cli do |cli|
         # `exit` is a common shell built-in command.
         assert_rbs_test_no_errors(cli, dir, %w(--target ::Foo exit))
+        assert_rbs_test_no_errors(cli, dir, %w(--target ::Foo exit), %w(--log-level debug))
 
         refute_cli_success cli.run(%w(test))
         refute_cli_success cli.run(%W(-I #{dir} test))
         refute_cli_success cli.run(%W(-I #{dir} test --target ::Foo))
+        refute_cli_success cli.run(%W(-I #{dir} test --target ::Foo ruby #{dir}/foo.rb))
       end
     end
   end
@@ -1715,8 +1733,8 @@ Processing `lib`...
     end
   end
 
-  def assert_rbs_test_no_errors cli, dir, arg_array
-    args = ['-I', dir.to_s, 'test', *arg_array]
+  def assert_rbs_test_no_errors cli, dir, arg_array, env_array = []
+    args = ['-I', dir.to_s, *env_array, 'test', *arg_array]
     exit_status = cli.run(args)
     assert_instance_of Integer, exit_status
     assert_predicate exit_status, :zero?


### PR DESCRIPTION
In the process of porting usage of rbs runtime checks via env vars onto `rbs test` in the `httpx` repository, there were some setbacks that were addressed by these fixes:

* using `--log-level` wasn't working
* manifest.yaml (a recommendation of RBS docs for libs) isn't being used when running tests from the lib repo. this fixes it by searching for a "manifest.yaml" file in the sig dirs.
* I initially added a test to support RBS_TEST_RAISE via a --raise parameter, only to find out that it's now raising by default. I left the test around, but if you think it's not adding much, lmk and I can remove it.