### PR TITLE
Convert character offset to byte offset in parse_inline_*_annotation

### DIFF
--- a/lib/rbs/parser_aux.rb
+++ b/lib/rbs/parser_aux.rb
@@ -121,12 +121,14 @@ module RBS
 
     def self.parse_inline_leading_annotation(source, range, variables: [])
       buf = buffer(source)
-      _parse_inline_leading_annotation(buf, range.begin || 0, range.end || buf.last_position, variables)
+      byte_range = byte_range(range, buf.content)
+      _parse_inline_leading_annotation(buf, byte_range.begin || 0, byte_range.end || buf.content.bytesize, variables)
     end
 
     def self.parse_inline_trailing_annotation(source, range, variables: [])
       buf = buffer(source)
-      _parse_inline_trailing_annotation(buf, range.begin || 0, range.end || buf.last_position, variables)
+      byte_range = byte_range(range, buf.content)
+      _parse_inline_trailing_annotation(buf, byte_range.begin || 0, byte_range.end || buf.content.bytesize, variables)
     end
 
     def self.byte_range(char_range, content)

--- a/test/rbs/inline_annotation_parsing_test.rb
+++ b/test/rbs/inline_annotation_parsing_test.rb
@@ -559,4 +559,28 @@ class RBS::InlineAnnotationParsingTest < Test::Unit::TestCase
       Parser.parse_inline_leading_annotation("@rbs module-self: foo", 0...)
     end
   end
+
+  def test_parse__trailing_assertion__multibyte_offset
+    buffer = Buffer.new(name: Pathname("test.rb"), content: "日本語\n: String")
+
+    Parser.parse_inline_trailing_annotation(buffer, 4...12).tap do |annot|
+      assert_instance_of AST::Ruby::Annotations::NodeTypeAssertion, annot
+      assert_equal ": String", annot.location.source
+      assert_equal ":", annot.prefix_location.source
+      assert_equal "String", annot.type.location.source
+    end
+  end
+
+  def test_parse__leading_annotation__multibyte_offset
+    buffer = Buffer.new(name: Pathname("test.rb"), content: "日本語のコメント\n@rbs return: String -- 戻り値の説明")
+
+    Parser.parse_inline_leading_annotation(buffer, 9...).tap do |annot|
+      assert_instance_of AST::Ruby::Annotations::ReturnTypeAnnotation, annot
+      assert_equal "@rbs return: String -- 戻り値の説明", annot.location.source
+      assert_equal "return", annot.return_location.source
+      assert_equal ":", annot.colon_location.source
+      assert_equal "String", annot.return_type.location.source
+      assert_equal "-- 戻り値の説明", annot.comment_location.source
+    end
+  end
 end


### PR DESCRIPTION

## Summary

- `parse_inline_*_annotation` were skipped during the byte-offset migration (#2863), causing parse errors on multibyte content.
- Apply the existing `byte_range` helper to convert offsets, matching the pattern used by `parse_type` etc.

See the commit message for details.

## Refs

- Fixes #2944
- Related: #2863

## Test plan

- [x] Multibyte regression tests added
- [x] `bundle exec rake test` — 938 tests, 7643 assertions, 0 failures, 0 errors
