### PR TITLE
Speed up RBS::InlineParser on large sources with non-ASCII characters

### DIFF
--- a/lib/rbs/ast/ruby/comment_block.rb
+++ b/lib/rbs/ast/ruby/comment_block.rb
@@ -25,8 +25,8 @@ module RBS
 
             offsets << tuple
 
-            start_char = comment.location.start_character_offset + tuple[1]
-            end_char = comment.location.end_character_offset
+            start_char = source_buffer.character_offset(comment.location.start_offset) + tuple[1]
+            end_char = source_buffer.character_offset(comment.location.end_offset)
             ranges << (start_char ... end_char)
           end
 
@@ -53,7 +53,7 @@ module RBS
 
         def line_starts
           offsets.map do |comment, prefix_size|
-            comment.location.start_character_offset + prefix_size
+            comment_buffer.character_offset(comment.location.start_offset) + prefix_size
           end
         end
 

--- a/lib/rbs/ast/ruby/comment_block.rb
+++ b/lib/rbs/ast/ruby/comment_block.rb
@@ -15,6 +15,7 @@ module RBS
           prefix_str = "# "
 
           ranges = [] #: Array[Range[Integer]]
+          byte_ranges = [] #: Array[Range[Integer]]
 
           comments.each do |comment|
             tuple = [comment, 2] #: [Prism::Comment, Integer]
@@ -28,9 +29,10 @@ module RBS
             start_char = source_buffer.character_offset(comment.location.start_offset) + tuple[1]
             end_char = source_buffer.character_offset(comment.location.end_offset)
             ranges << (start_char ... end_char)
+            byte_ranges << ((comment.location.start_offset + tuple[1]) ... comment.location.end_offset)
           end
 
-          @comment_buffer = source_buffer.sub_buffer(lines: ranges)
+          @comment_buffer = source_buffer.sub_buffer(lines: ranges, byte_lines_hint: byte_ranges)
         end
 
         def leading?

--- a/lib/rbs/ast/ruby/helpers/location_helper.rb
+++ b/lib/rbs/ast/ruby/helpers/location_helper.rb
@@ -6,7 +6,7 @@ module RBS
       module Helpers
         module LocationHelper
           def rbs_location(location)
-            Location.new(buffer, location.start_character_offset, location.end_character_offset)
+            Location.new(buffer, buffer.character_offset(location.start_offset), buffer.character_offset(location.end_offset))
           end
         end
       end

--- a/lib/rbs/buffer.rb
+++ b/lib/rbs/buffer.rb
@@ -87,11 +87,36 @@ module RBS
       "#<RBS::Buffer:#{__id__} @name=#{name}, @content=#{content.bytesize} bytes, @lines=#{ranges.size} lines,>"
     end
 
+    def character_offset(byte_offset)
+      top = top_buffer
+      return top.character_offset(byte_offset) unless top.equal?(self)
+
+      keys, vals = (@character_offset_cache ||= [[0], [0]])
+
+      idx = keys.bsearch_index { |k| k > byte_offset }
+      lo = idx ? idx - 1 : keys.size - 1
+
+      base_byte = keys[lo]
+      base_char = vals[lo]
+      delta = byte_offset - base_byte
+      return base_char if delta == 0
+
+      result = base_char + (content.byteslice(base_byte, delta) or raise).length
+
+      if base_byte == keys[-1]
+        keys << byte_offset
+        vals << result
+      end
+
+      result
+    end
+
     def rbs_location(location, loc2=nil)
+      top = top_buffer
       if loc2
-        Location.new(self.top_buffer, location.start_character_offset, loc2.end_character_offset)
+        Location.new(top, character_offset(location.start_offset), character_offset(loc2.end_offset))
       else
-        Location.new(self.top_buffer, location.start_character_offset, location.end_character_offset)
+        Location.new(top, character_offset(location.start_offset), character_offset(location.end_offset))
       end
     end
 

--- a/lib/rbs/buffer.rb
+++ b/lib/rbs/buffer.rb
@@ -120,17 +120,29 @@ module RBS
       end
     end
 
-    def sub_buffer(lines:)
+    def sub_buffer(lines:, byte_lines_hint: nil)
       buf = +""
-      lines.each_with_index do |range, index|
-        start_pos = range.begin
-        end_pos = range.end
-        slice = content[start_pos...end_pos] or raise
-        if slice.include?("\n")
-          raise "Line #{index + 1} cannot contain newline character."
+
+      if byte_lines_hint
+        byte_lines_hint.each_with_index do |range, index|
+          slice = content.byteslice(range.begin, range.end - range.begin) or raise
+          if slice.include?("\n")
+            raise "Line #{index + 1} cannot contain newline character."
+          end
+          buf << slice
+          buf << "\n"
         end
-        buf << slice
-        buf << "\n"
+      else
+        lines.each_with_index do |range, index|
+          start_pos = range.begin
+          end_pos = range.end
+          slice = content[start_pos...end_pos] or raise
+          if slice.include?("\n")
+            raise "Line #{index + 1} cannot contain newline character."
+          end
+          buf << slice
+          buf << "\n"
+        end
       end
 
       buf.chomp!

--- a/sig/buffer.rbs
+++ b/sig/buffer.rbs
@@ -60,6 +60,19 @@ module RBS
     def rbs_location: (Prism::Location) -> Location
                     | (Prism::Location, Prism::Location) -> Location
 
+    # Translate a byte offset (into the top buffer's source) to a character offset.
+    #
+    # Resolution is delegated to the top buffer, which keeps a sparse cache of
+    # resolved (byte, char) pairs so successive calls scan only the delta from the
+    # nearest cached pair. Amortizes to O(content_size) across all calls; a single
+    # call is one byteslice + length.
+    #
+    def character_offset: (Integer byte_offset) -> Integer
+
+    # Sparse cache backing `#character_offset`: a pair `[byte_keys, char_values]`
+    # kept in ascending byte order to support binary search.
+    @character_offset_cache: [Array[Integer], Array[Integer]]?
+
     # Construct a buffer from substrings of this buffer.
     #
     # The returned buffer contains lines from given ranges.

--- a/sig/buffer.rbs
+++ b/sig/buffer.rbs
@@ -88,7 +88,12 @@ module RBS
     # buffer.sub_buffer(lines: [5..7])          # => Raises an error because the range contains newline
     # ```
     #
-    %a{pure} def sub_buffer: (lines: Array[Range[Integer]]) -> Buffer
+    # `byte_lines_hint:` is an optional performance hint: byte ranges corresponding
+    # to `lines:`. When provided, slicing uses `byteslice` (O(slice_size) per line)
+    # instead of `content[char_range]`, which on a multi-byte string is O(content_size)
+    # per call. Result is identical either way.
+    #
+    %a{pure} def sub_buffer: (lines: Array[Range[Integer]], ?byte_lines_hint: Array[Range[Integer]]?) -> Buffer
 
     %a{pure} def parent_buffer: () -> Buffer?
 


### PR DESCRIPTION
## Problem

`RBS::InlineParser.parse` is quadratic in source size when the source contains
any non-ASCII byte. On stripe-ruby's
[`rbi/stripe.rbi`](https://raw.githubusercontent.com/stripe/stripe-ruby/refs/heads/master/rbi/stripe.rbi)
(167k lines / 8.8MB, 472 non-ASCII chars), parsing takes **153s**.

## Cause

1. `Prism::Location#start_character_offset` = `byteslice(0, byte_offset).length`
   walks the source from byte 0 on every call → O(comments × source_size).
   Prism's `ASCIISource` shortcut bypasses this, but a single non-ASCII byte
   anywhere disables it.
2. `Buffer#sub_buffer` slices via `content[char_range]`. On a multi-byte
   string, `String#[]` walks bytes from the start counting characters →
   O(source_size) per call.

## Solution

Two commits confined to `RBS::Buffer`. Public API only grows by one method
and one optional keyword.

1. `Buffer#character_offset(byte_offset)` with a sparse cache on the top
   buffer. Successive calls amortize to O(content_size); single calls match
   the original cost.
2. `Buffer#sub_buffer(lines:, byte_lines_hint:)` optional keyword. Callers
   that already know byte ranges (Prism provides them directly) get
   O(slice_size) slicing.

| Measurement                            | Before  | After    | Speedup  |
|----------------------------------------|---------|----------|----------|
| `RBS::InlineParser.parse` (full)       | 153.2s  | 0.83s    | **184x** |
|  ↳ `CommentAssociation.build`          | 55.0s   | 0.17s    | 323x     |
|  ↳ visit phase remainder               | 98.2s   | 0.66s    | 149x     |
| Reference: `Prism.parse` (lower bound) | 0.24s   | —        | —        |

ASCII-only or small files (<1k lines) show no measurable regression.

## Reproduction

```bash
curl -sSLO https://raw.githubusercontent.com/stripe/stripe-ruby/refs/heads/master/rbi/stripe.rbi
ruby -Ilib -rrbs -e '
  src = File.read("stripe.rbi")
  prism = Prism.parse(src)
  buffer = RBS::Buffer.new(name: "stripe.rbi", content: src)
  t = Time.now
  RBS::InlineParser.parse(buffer, prism)
  puts "%.3fs" % (Time.now - t)
'
```
