### PR TITLE
ci: skip Gemfile.lock BUNDLED WITH on ruby-head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,6 +63,9 @@ jobs:
         if: ${{ contains(matrix.ruby, 'head') }}
         run: |
           bundle config set force_ruby_platform true
+      - name: Ignore Gemfile.lock's BUNDLED WITH on ruby-head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: bundle config set --local version system
       - name: Skip installing type checkers
         if: ${{ ! contains(matrix.job, 'typecheck_test') }}
         run: |
@@ -106,6 +109,9 @@ jobs:
         if: ${{ contains(matrix.ruby, 'head') }}
         run: |
           bundle config set force_ruby_platform true
+      - name: Ignore Gemfile.lock's BUNDLED WITH on ruby-head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: bundle config set --local version system
       - name: bin/setup
         run: |
           bin/setup
@@ -140,6 +146,9 @@ jobs:
         if: ${{ contains(matrix.ruby, 'head') }}
         run: |
           bundle config set force_ruby_platform true
+      - name: Ignore Gemfile.lock's BUNDLED WITH on ruby-head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: bundle config set --local version system
       - name: bin/setup
         run: |
           bin/setup

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,9 @@ jobs:
             bundled_gems = JSON.parse(res)["gems"].map{_1["gem"]}
             system "gem uninstall #{bundled_gems.join(" ")} --force", exception: true
           '
+      - name: Ignore Gemfile.lock's BUNDLED WITH on dev Ruby
+        if: ${{ matrix.ruby == 'ucrt' || matrix.ruby == 'mswin' }}
+        run: bundle config set --local version system
       - name: bundle install
         run: |
           bundle config set without profilers libs


### PR DESCRIPTION
## Summary

- The Ruby / Ruby on Windows / C99_compile / clang_compile workflows have been failing on `ruby-head` (and the `ucrt` / `mswin` dev builds on Windows) with `NameError: private constant Pathname::SEPARATOR_PAT referenced` raised from `Bundler::Source::Path#generate_bin`.
- Root cause: `Pathname::SEPARATOR_PAT` became a private constant on ruby-head (4.1.0.dev). Every released bundler up to **4.0.11** still references it. Because `Gemfile.lock` pins `BUNDLED WITH 4.0.1`, the bundler 4.1.0.dev that ships with ruby-head downgrades itself to 4.0.1 before running and then crashes.
- The upstream fix is rubygems/rubygems#9529 ("Use `Pathname#absolute?`", merged 2026-05-07) — but it has not landed in any released bundler yet, so simply bumping `BUNDLED WITH` would not help.
- This PR adds `bundle config set --local version system` for ruby-head / ucrt / mswin only. That tells bundler to use the system-installed bundler instead of the one pinned in `Gemfile.lock`, avoiding the forced downgrade to 4.0.1. Stable Ruby versions are unaffected because `Gemfile.lock` is untouched.

Once a fixed bundler (4.0.12 or 4.1.0) is released, run `bundle update --bundler` to bump `BUNDLED WITH` in both `Gemfile.lock` and `steep/Gemfile.lock`, and revert these workaround steps.

## Test plan

- [ ] `Ruby` workflow: `test (head, ...)` jobs go green
- [ ] `Ruby` workflow: `C99_compile (head)` goes green
- [ ] `Ruby` workflow: `clang_compile (head)` goes green
- [ ] `Ruby on Windows` workflow: `compile (ucrt)` and `compile (mswin)` go green
- [ ] No regression on stable Ruby versions (`3.2` / `3.3` / `3.4` / `4.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)