### PR TITLE
ci: declare workflow-level `contents: read` on 6 test/lint workflows

### DIFF
--- a/.github/workflows/c-check.yml
+++ b/.github/workflows/c-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request: {}
   merge_group: {}
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, milestoned, demilestoned, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,6 +7,9 @@ on:
   pull_request: {}
   merge_group: {}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,9 @@ on:
 env:
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: cargo:test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,6 +7,9 @@ on:
   pull_request: {}
   merge_group: {}
 
+permissions:
+  contents: read
+
 jobs:
   steep:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,9 @@ on:
   pull_request: {}
   merge_group: {}
 
+permissions:
+  contents: read
+
 jobs:
   compile:
     runs-on: "windows-latest"


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 6 workflows in `.github/workflows/` that don't actually need any write scope:

- `c-check.yml`: C-extension build check.
- `milestone.yml`: PR milestone enforcer. The `actions/github-script` step only reads `context.payload.pull_request` and calls `core.setFailed` / `core.info`; no `github.rest.*` API call.
- `ruby.yml`: Ruby test matrix.
- `rust.yml`: Rust parser build.
- `typecheck.yml`: steep typecheck.
- `windows.yml`: Windows test job.

Left implicit on purpose:

- `bundle-update.yml` does `git push`, `gh pr create`, and `gh pr merge --auto`.
- `comments.yml` needs comment-write scope.

Both need write scopes that are best declared by a maintainer.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.