### PR TITLE
Deprecate prototype runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This is only a starting point, and you should edit the output to match your sign
 
 - `rb` generates from just the available Ruby code
 - `rbi` generates from Sorbet RBI
-- `runtime` generates from runtime API
+- `runtime` generates from runtime API (**deprecated**; see [#2841](https://github.com/ruby/rbs/issues/2841))
 
 ## Library
 

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -77,6 +77,8 @@ module RBS
       attr_accessor :outline
 
       def initialize(patterns:, env:, merge:, todo: false, owners_included: [])
+        Kernel.warn("RBS::Prototype::Runtime is deprecated. See https://github.com/ruby/rbs/issues/2841")
+
         @patterns = patterns
         @decls = nil
         @modules = {}


### PR DESCRIPTION
Deprecate `RBS::Prototype::Runtime` per the direction confirmed by @soutaro in https://github.com/ruby/rbs/issues/2841#issuecomment-discussion.

`RBS::Prototype::Runtime.new` now emits a deprecation warning via `Kernel.warn`, and the README marks `runtime` accordingly.

Refs: #2841

Generated with [Claude Code](https://claude.com/claude-code)