### PR TITLE
Update `StringScanner` signatures to match strscan 3.1.6

### DIFF
--- a/stdlib/strscan/0/string_scanner.rbs
+++ b/stdlib/strscan/0/string_scanner.rbs
@@ -498,7 +498,7 @@ class StringScanner
   # scanner[0]           # => nil
   # scanner[1]           # => nil
   #
-  def []: (Integer) -> String?
+  def []: (Integer | String | Symbol) -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c

--- a/stdlib/strscan/0/string_scanner.rbs
+++ b/stdlib/strscan/0/string_scanner.rbs
@@ -625,7 +625,7 @@ class StringScanner
   #     scanner.check(/nope/)          # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def check: (Regexp) -> String?
+  def check: (Regexp | String) -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -673,7 +673,7 @@ class StringScanner
   #     scanner.check_until(/nope/)    # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def check_until: (Regexp) -> String
+  def check_until: (Regexp | String) -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -760,7 +760,7 @@ class StringScanner
   #     scanner.exist?(/nope/)         # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def exist?: (Regexp) -> Integer?
+  def exist?: (Regexp | String) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -913,7 +913,7 @@ class StringScanner
   #     scanner.match?(/nope/)         # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def match?: (Regexp) -> Integer?
+  def match?: (Regexp | String) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -975,6 +975,29 @@ class StringScanner
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
+  #   - named_captures -> hash
+  # -->
+  # Returns the array of captured match values at indexes (1..)
+  # if the most recent match attempt succeeded, or nil otherwise;
+  # see [Captured Match Values](rdoc-ref:StringScanner@Captured+Match+Values):
+  #     scanner = StringScanner.new('Fri Dec 12 1975 14:39')
+  # scanner.named_captures # => {}
+  #
+  # pattern = /(?<wday>\w+) (?<month>\w+) (?<day>\d+) /
+  # scanner.match?(pattern)
+  # scanner.named_captures # => {"wday"=>"Fri", "month"=>"Dec", "day"=>"12"}
+  #
+  # scanner.string = 'nope'
+  # scanner.match?(pattern)
+  # scanner.named_captures # => {"wday"=>nil, "month"=>nil, "day"=>nil}
+  #
+  # scanner.match?(/nosuch/)
+  # scanner.named_captures # => {}
+  #
+  def named_captures: () -> Hash[String, String?]
+
+  # <!--
+  #   rdoc-file=ext/strscan/strscan.c
   #   - peek(length) -> substring
   # -->
   # Returns the substring <code>string[pos, length]</code>;
@@ -987,6 +1010,17 @@ class StringScanner
   # scanner.peek(3)   # => ""
   #
   def peek: (Integer) -> String
+
+  # <!--
+  #   rdoc-file=ext/strscan/strscan.c
+  #   - peek_byte()
+  # -->
+  # Peeks at the current byte and returns it as an integer.
+  #
+  #     s = StringScanner.new('ab')
+  #     s.peek_byte         # => 97
+  #
+  def peek_byte: () -> Integer?
 
   # <!-- rdoc-file=ext/strscan/strscan.c -->
   # call-seq:
@@ -1092,7 +1126,7 @@ class StringScanner
   # scanner.match?(/nope/) # => nil
   # scanner.post_match     # => nil
   #
-  def post_match: () -> String
+  def post_match: () -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1112,7 +1146,7 @@ class StringScanner
   # scanner.exist?(/nope/) # => nil
   # scanner.pre_match      # => nil
   #
-  def pre_match: () -> String
+  def pre_match: () -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1134,7 +1168,7 @@ class StringScanner
   # # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def reset: () -> void
+  def reset: () -> self
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1235,7 +1269,16 @@ class StringScanner
   #     scanner.scan(/nope/)           # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def scan: (Regexp) -> String?
+  def scan: (Regexp | String) -> String?
+
+  # <!--
+  #   rdoc-file=ext/strscan/strscan.c
+  #   - scan_byte -> integer_byte
+  # -->
+  # Scans one byte and returns it as an integer. This method is not multibyte
+  # character sensitive. See also: #getch.
+  #
+  def scan_byte: () -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1247,7 +1290,22 @@ class StringScanner
   #
   # "full" means "#scan with full parameters".
   #
-  def scan_full: (Regexp pattern, bool advance_pointer_p, bool return_string_p) -> untyped
+  def scan_full: (Regexp | String pattern, bool advance_pointer_p, bool return_string_p) -> (String | Integer)?
+
+  # <!--
+  #   rdoc-file=ext/strscan/lib/strscan/strscan.rb
+  #   - scan_integer(base: 10)
+  # -->
+  # If `base` isn't provided or is `10`, then it is equivalent to calling
+  # <code>#scan</code> with a `[+-]?d+` pattern, and returns an Integer or nil.
+  #
+  # If `base` is `16`, then it is equivalent to calling <code>#scan</code> with a
+  # `[+-]?(0x)?[0-9a-fA-F]+` pattern, and returns an Integer or nil.
+  #
+  # The scanned string must be encoded with an ASCII compatible encoding,
+  # otherwise Encoding::CompatibilityError will be raised.
+  #
+  def scan_integer: (?base: Integer) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1300,7 +1358,7 @@ class StringScanner
   #     scanner.scan_until(/nope/)     # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def scan_until: (Regexp) -> String?
+  def scan_until: (Regexp | String) -> String?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1311,7 +1369,7 @@ class StringScanner
   # `return_string_p` is true, otherwise returns the number of bytes advanced.
   # This method does affect the match register.
   #
-  def search_full: (Regexp pattern, bool advance_pointer_p, bool return_string_p) -> untyped
+  def search_full: (Regexp | String pattern, bool advance_pointer_p, bool return_string_p) -> (String | Integer)?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1331,7 +1389,7 @@ class StringScanner
   # scanner.match?(/nope/)              # => nil
   # scanner.size                        # => nil
   #
-  def size: () -> Integer
+  def size: () -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1379,7 +1437,7 @@ class StringScanner
   # scanner.skip(/nope/)            # => nil
   # match_values_cleared?(scanner)  # => true
   #
-  def skip: (Regexp) -> Integer?
+  def skip: (Regexp | String) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1427,7 +1485,7 @@ class StringScanner
   #     scanner.skip_until(/nope/)     # => nil
   # match_values_cleared?(scanner) # => true
   #
-  def skip_until: (Regexp) -> Integer?
+  def skip_until: (Regexp | String) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1501,7 +1559,7 @@ class StringScanner
   # #   rest_size: 0
   # match_values_cleared?(scanner) # => true
   #
-  def terminate: () -> void
+  def terminate: () -> self
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1532,7 +1590,7 @@ class StringScanner
   # match_values_cleared?(scanner) # => true
   # scanner.unscan                 # Raises StringScanner::Error.
   #
-  def unscan: () -> void
+  def unscan: () -> self
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c
@@ -1547,7 +1605,7 @@ class StringScanner
   # scanner.values_at(*0..3)               # => ["Fri Dec 12 ", "Fri", "Dec", "12"]
   # scanner.values_at(*%i[wday month day]) # => ["Fri", "Dec", "12"]
   #
-  def values_at: (*Integer) -> Array[String]?
+  def values_at: (*Integer | String | Symbol) -> Array[String]?
 
   private
 
@@ -1570,7 +1628,7 @@ class StringScanner
   # #   rest:      "foobarbaz"
   # #   rest_size: 9
   #
-  def initialize: (String, ?bool dup, ?fixed_anchor: bool) -> untyped
+  def initialize: (String, ?fixed_anchor: bool) -> void
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c

--- a/stdlib/strscan/0/string_scanner.rbs
+++ b/stdlib/strscan/0/string_scanner.rbs
@@ -1290,7 +1290,8 @@ class StringScanner
   #
   # "full" means "#scan with full parameters".
   #
-  def scan_full: (Regexp | String pattern, bool advance_pointer_p, bool return_string_p) -> (String | Integer)?
+  def scan_full: (Regexp | String pattern, bool advance_pointer_p, true return_string_p) -> String?
+               | (Regexp | String pattern, bool advance_pointer_p, false return_string_p) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/lib/strscan/strscan.rb
@@ -1369,7 +1370,8 @@ class StringScanner
   # `return_string_p` is true, otherwise returns the number of bytes advanced.
   # This method does affect the match register.
   #
-  def search_full: (Regexp | String pattern, bool advance_pointer_p, bool return_string_p) -> (String | Integer)?
+  def search_full: (Regexp | String pattern, bool advance_pointer_p, true return_string_p) -> String?
+                 | (Regexp | String pattern, bool advance_pointer_p, false return_string_p) -> Integer?
 
   # <!--
   #   rdoc-file=ext/strscan/strscan.c


### PR DESCRIPTION
`StringScanner#[]` accepts a capture-group name as a String or Symbol in addition to an Integer index — the method's own RD doc in this file documents and demonstrates it ("`specifier` symbol or string. returns the named subgroup", with `scanner[:wday]` / `scanner['wday']` examples). The signature only listed `Integer`, so named-capture lookups type-check as an argument error.

see https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1705-L1715

---

## Update StringScanner signatures to match strscan 3.1.6

The follow-up commit aligns the rest of `StringScanner` with strscan 3.1.6 (bundled with Ruby 4.0): it widens the matcher arguments to accept `String` patterns, corrects several return types, and adds methods introduced in recent releases. The table lists one method per row; the pattern-matching methods that share a single C helper are described below it.

| Ruby Method | Change | C function |
|-------------|--------|------------|
| `[]` | Accept a capture-group name (`Integer` → `Integer \| String \| Symbol`) | [`strscan_aref`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1695-L1726) |
| `initialize` | Drop the obsolete `dup` parameter; return type `void` | [`strscan_initialize`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L254-L282) |
| `named_captures` | New method (`() -> Hash[String, String?]`) | [`strscan_named_captures`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L2176-L2189) |
| `peek_byte` | New method (`() -> Integer?`) | [`strscan_peek_byte`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1173-L1183) |
| `post_match` | Return type `String` → `String?` | [`strscan_post_match`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1917-L1927) |
| `pre_match` | Return type `String` → `String?` | [`strscan_pre_match`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1880-L1890) |
| `reset` | Return type `void` → `self` | [`strscan_reset`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L364-L373) |
| `scan_byte` | New method (`() -> Integer?`) | [`strscan_scan_byte`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1148-L1165) |
| `scan_integer` | New method (`(?base: Integer) -> Integer?`) | [`lib/strscan/strscan.rb`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/lib/strscan/strscan.rb#L4-L24) |
| `size` | Return type `Integer` → `Integer?` | [`strscan_size`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1752-L1760) |
| `terminate` | Return type `void` → `self` | [`strscan_terminate`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L380-L389) |
| `unscan` | Return type `void` → `self` | [`strscan_unscan`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1399-L1410) |
| `values_at` | Accept capture-group names (`*Integer` → `*Integer \| String \| Symbol`) | [`strscan_values_at`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L1837-L1853) |

### Pattern-matching methods

`check`, `check_until`, `exist?`, `match?`, `scan`, `scan_until`, `skip`, `skip_until`, `scan_full`, and `search_full` are not listed individually above because they all dispatch through the shared helper [`strscan_do_scan`](https://github.com/ruby/ruby/blob/v4.0.5/ext/strscan/strscan.c#L689-L755). That helper accepts both `Regexp` and `String` patterns, so the first parameter of each method is widened from `Regexp` to `Regexp | String`. It also produces their results, so the return types are corrected at the same time: `check_until` to `String?`, and `scan_full` / `search_full` from `untyped` to `(String | Integer)?`.

Removal of the obsolete methods (`clear`, `empty?`, `getbyte`, `peep`, `restsize`) is intentionally out of scope here and handled separately in #2961.