### PR TITLE
Fix `Resolv#initialize` signature: array of resolvers + `use_ipv6:`

### DIFF
--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -134,7 +134,7 @@ class Resolv
   # DNS resolver.  If `resolvers` is a hash, uses the hash as configuration for
   # the DNS resolver.
   #
-  def initialize: (?Resolv::Hosts | Resolv::DNS resolvers) -> untyped
+  def initialize: (?(Array[Resolv::Hosts | Resolv::DNS] | Hash[Symbol, untyped])? resolvers, ?use_ipv6: bool?) -> untyped
 end
 
 # <!-- rdoc-file=lib/resolv.rb -->


### PR DESCRIPTION
`Resolv#initialize` took `?Resolv::Hosts | Resolv::DNS resolvers`, which is wrong on two counts, both visible in this file's own RD doc (`new(resolvers=..., use_ipv6: ...)`):

- `resolvers` is the resolver *list*, not a single resolver — Ruby's implementation iterates it (`@resolvers.each`). Passing one resolver object fails at runtime. It accepts an Array of resolver objects, a Hash (used as DNS-resolver configuration, per the doc), or nil.
- the `use_ipv6:` keyword was missing from the signature entirely.

See https://github.com/ruby/ruby/blob/v4.0.5/lib/resolv.rb#L82-L100