### PR TITLE
Update the target Ruby version notes to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ end
 
 ## The Target Version
 
-* The standard library signatures targets the latest release of Ruby. (`3.2` as of 2023.)
-* The library code targets non-EOL versions of Ruby. (`>= 3.0` as of 2023.)
+* The standard library signatures targets the [latest release of Ruby](https://www.ruby-lang.org/en/downloads/branches/). (`4.0` as of 2026.)
+* The library code targets [non-EOL versions of Ruby](https://www.ruby-lang.org/en/downloads/branches/). (`>= 3.3` as of 2026.)
 
 ## Installation
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,8 @@
 The RBS repository contains the type definitions of Core API and Standard Libraries.
 There are some discussions whether if it is the best to have them in this repository, but we have them and continue updating the files meanwhile.
 
-The target version of the bundled type definitions is the latest _release_ of Ruby -- `3.1` as of January 2022.
+The target version of the bundled type definitions is the [latest _release_ of Ruby](https://www.ruby-lang.org/en/downloads/branches/) -- `4.0` as of 2026.
+Note, however, that the CI currently retains the tests on Ruby 3.2 as well.
 
 **The core API** type definitions are in `core` directory.
 You will find the familiar class names in the directory, like `string.rbs` or `array.rbs`.


### PR DESCRIPTION
## Summary

The "target version" notes in `README.md` and `docs/CONTRIBUTING.md` still referred to Ruby `3.1` / `3.2` (dated 2022/2023). This refreshes them:

- Update the version numbers to the latest release (`4.0`, `>= 3.3` for non-EOL, as of 2026).
- Link "latest release of Ruby" / "non-EOL versions of Ruby" to the official [Ruby branches page](https://www.ruby-lang.org/en/downloads/branches/) so the supported versions stay verifiable instead of going stale.
- Note in `CONTRIBUTING.md` that the CI matrix currently still retains Ruby 3.2.

## Test plan

- [x] Documentation-only change; no code affected.