### PR TITLE
Split socket/SSLSocket nonblock methods into `exception:` overloads

### DIFF
--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -9342,8 +9342,8 @@ module OpenSSL
       # Writes *string* to the SSL connection in a non-blocking manner.  Raises an
       # SSLError if writing would block.
       #
-      def syswrite_nonblock: (_ToS string, ?exception: true) -> Integer
-                           | (_ToS string, exception: false) -> (Integer | :wait_readable | :wait_writable | nil)
+      def syswrite_nonblock: (string, ?exception: true) -> Integer
+                           | (string, exception: false) -> (Integer | :wait_readable | :wait_writable)
 
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/ssl.rb

--- a/stdlib/openssl/0/openssl.rbs
+++ b/stdlib/openssl/0/openssl.rbs
@@ -9332,7 +9332,8 @@ module OpenSSL
       # Reads *length* bytes from the SSL connection.  If a pre-allocated *buffer* is
       # provided the data will be written into it.
       #
-      def sysread_nonblock: (*untyped) -> untyped
+      def sysread_nonblock: (Integer length, ?String buffer, ?exception: true) -> String
+                          | (Integer length, ?String buffer, exception: false) -> (String | :wait_readable | :wait_writable | nil)
 
       # <!--
       #   rdoc-file=ext/openssl/ossl_ssl.c
@@ -9341,7 +9342,8 @@ module OpenSSL
       # Writes *string* to the SSL connection in a non-blocking manner.  Raises an
       # SSLError if writing would block.
       #
-      def syswrite_nonblock: (*untyped) -> untyped
+      def syswrite_nonblock: (_ToS string, ?exception: true) -> Integer
+                           | (_ToS string, exception: false) -> (Integer | :wait_readable | :wait_writable | nil)
 
       # <!--
       #   rdoc-file=ext/openssl/lib/openssl/ssl.rb

--- a/stdlib/socket/0/basic_socket.rbs
+++ b/stdlib/socket/0/basic_socket.rbs
@@ -330,8 +330,8 @@ class BasicSocket < IO
   # ### See
   # *   Socket#recvfrom
   #
-  def recv_nonblock: (Integer maxlen, ?Integer flags, ?String buf, ?exception: true) -> String
-                   | (Integer maxlen, ?Integer flags, ?String buf, exception: false) -> (String | :wait_readable)
+  def recv_nonblock: (Integer maxlen, ?Integer flags, ?String buf, ?exception: true) -> String?
+                   | (Integer maxlen, ?Integer flags, ?String buf, exception: false) -> (String | :wait_readable | nil)
 
   # <!--
   #   rdoc-file=ext/socket/lib/socket.rb
@@ -402,8 +402,8 @@ class BasicSocket < IO
   # recvmsg_nonblock should not raise an IO::WaitReadable exception, but return
   # the symbol <code>:wait_readable</code> instead.
   #
-  def recvmsg_nonblock: (?Integer dlen, ?Integer flags, ?Integer clen, ?exception: true, ?scm_rights: boolish) -> [ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ]
-                      | (?Integer dlen, ?Integer flags, ?Integer clen, exception: false, ?scm_rights: boolish) -> ([ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ] | :wait_readable)
+  def recvmsg_nonblock: (?Integer dlen, ?Integer flags, ?Integer clen, ?exception: true, ?scm_rights: boolish) -> [ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ]?
+                      | (?Integer dlen, ?Integer flags, ?Integer clen, exception: false, ?scm_rights: boolish) -> ([ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ] | :wait_readable | nil)
 
   # <!--
   #   rdoc-file=ext/socket/basicsocket.c

--- a/stdlib/socket/0/basic_socket.rbs
+++ b/stdlib/socket/0/basic_socket.rbs
@@ -330,7 +330,8 @@ class BasicSocket < IO
   # ### See
   # *   Socket#recvfrom
   #
-  def recv_nonblock: (Integer maxlen, ?Integer flags, ?String buf, ?exception: boolish) -> (String | :wait_readable)
+  def recv_nonblock: (Integer maxlen, ?Integer flags, ?String buf, ?exception: true) -> String
+                   | (Integer maxlen, ?Integer flags, ?String buf, exception: false) -> (String | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/lib/socket.rb
@@ -401,7 +402,8 @@ class BasicSocket < IO
   # recvmsg_nonblock should not raise an IO::WaitReadable exception, but return
   # the symbol <code>:wait_readable</code> instead.
   #
-  def recvmsg_nonblock: (?Integer dlen, ?Integer flags, ?Integer clen, ?exception: boolish, ?scm_rights: boolish) -> ([ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ] | :wait_readable)
+  def recvmsg_nonblock: (?Integer dlen, ?Integer flags, ?Integer clen, ?exception: true, ?scm_rights: boolish) -> [ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ]
+                      | (?Integer dlen, ?Integer flags, ?Integer clen, exception: false, ?scm_rights: boolish) -> ([ String, Addrinfo, Integer?, Array[Socket::AncillaryData] ] | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/basicsocket.c
@@ -489,7 +491,8 @@ class BasicSocket < IO
   # sendmsg_nonblock should not raise an IO::WaitWritable exception, but return
   # the symbol <code>:wait_writable</code> instead.
   #
-  def sendmsg_nonblock: (String mesg, ?Integer flags, ?Addrinfo | String dest_sockaddr, *Socket::AncillaryData controls, ?exception: boolish) -> (Integer | :wait_writable)
+  def sendmsg_nonblock: (String mesg, ?Integer flags, ?Addrinfo | String dest_sockaddr, *Socket::AncillaryData controls, ?exception: true) -> Integer
+                      | (String mesg, ?Integer flags, ?Addrinfo | String dest_sockaddr, *Socket::AncillaryData controls, exception: false) -> (Integer | :wait_writable)
 
   # <!--
   #   rdoc-file=ext/socket/basicsocket.c

--- a/stdlib/socket/0/socket.rbs
+++ b/stdlib/socket/0/socket.rbs
@@ -1365,8 +1365,8 @@ class Socket < BasicSocket
   # ### See
   # *   Socket#recvfrom
   #
-  def recvfrom_nonblock: (Integer maxlen, ?Integer flags, ?untyped outbuf, ?exception: true) -> [ String, Addrinfo ]
-                       | (Integer maxlen, ?Integer flags, ?untyped outbuf, exception: false) -> ([ String, Addrinfo ] | :wait_readable)
+  def recvfrom_nonblock: (Integer maxlen, ?Integer flags, ?untyped outbuf, ?exception: true) -> [ String, Addrinfo ]?
+                       | (Integer maxlen, ?Integer flags, ?untyped outbuf, exception: false) -> ([ String, Addrinfo ] | :wait_readable | nil)
 
   # <!--
   #   rdoc-file=ext/socket/socket.c

--- a/stdlib/socket/0/socket.rbs
+++ b/stdlib/socket/0/socket.rbs
@@ -851,7 +851,8 @@ class Socket < BasicSocket
   # ### See
   # *   Socket#accept
   #
-  def accept_nonblock: (?exception: boolish) -> ([ Socket, Addrinfo ] | :wait_readable)
+  def accept_nonblock: (?exception: true) -> [ Socket, Addrinfo ]
+                     | (exception: false) -> ([ Socket, Addrinfo ] | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/socket.c
@@ -1105,7 +1106,8 @@ class Socket < BasicSocket
   # ### See
   # *   Socket#connect
   #
-  def connect_nonblock: (untyped addr, ?exception: untyped) -> (Integer | :wait_writable)
+  def connect_nonblock: (untyped addr, ?exception: true) -> Integer
+                      | (untyped addr, exception: false) -> (Integer | :wait_writable)
 
   # <!--
   #   rdoc-file=ext/socket/lib/socket.rb
@@ -1363,7 +1365,8 @@ class Socket < BasicSocket
   # ### See
   # *   Socket#recvfrom
   #
-  def recvfrom_nonblock: (Integer maxlen, ?Integer flags, ?untyped outbuf, ?exception: boolish) -> ([ String, Addrinfo ] | :wait_readable)
+  def recvfrom_nonblock: (Integer maxlen, ?Integer flags, ?untyped outbuf, ?exception: true) -> [ String, Addrinfo ]
+                       | (Integer maxlen, ?Integer flags, ?untyped outbuf, exception: false) -> ([ String, Addrinfo ] | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/socket.c

--- a/stdlib/socket/0/tcp_server.rbs
+++ b/stdlib/socket/0/tcp_server.rbs
@@ -78,7 +78,8 @@ class TCPServer < TCPSocket
   # *   TCPServer#accept
   # *   Socket#accept
   #
-  def accept_nonblock: (?exception: boolish) -> (TCPSocket | :wait_readable)
+  def accept_nonblock: (?exception: true) -> TCPSocket
+                     | (exception: false) -> (TCPSocket | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/tcpserver.c

--- a/stdlib/socket/0/udp_socket.rbs
+++ b/stdlib/socket/0/udp_socket.rbs
@@ -86,8 +86,8 @@ class UDPSocket < IPSocket
   # ### See
   # *   Socket#recvfrom
   #
-  def recvfrom_nonblock: (Integer len, ?Integer flag, ?String outbuf, ?exception: true) -> [ String, [ String, Integer, String, String ] ]
-                       | (Integer len, ?Integer flag, ?String outbuf, exception: false) -> ([ String, [ String, Integer, String, String ] ] | :wait_readable)
+  def recvfrom_nonblock: (Integer len, ?Integer flag, ?String outbuf, ?exception: true) -> [ String, [ String, Integer, String, String ] ]?
+                       | (Integer len, ?Integer flag, ?String outbuf, exception: false) -> ([ String, [ String, Integer, String, String ] ] | :wait_readable | nil)
 
   # <!--
   #   rdoc-file=ext/socket/udpsocket.c

--- a/stdlib/socket/0/udp_socket.rbs
+++ b/stdlib/socket/0/udp_socket.rbs
@@ -86,7 +86,8 @@ class UDPSocket < IPSocket
   # ### See
   # *   Socket#recvfrom
   #
-  def recvfrom_nonblock: (Integer len, ?Integer flag, ?String outbuf, ?exception: boolish) -> [ String, [ String, Integer, String, String ] ]
+  def recvfrom_nonblock: (Integer len, ?Integer flag, ?String outbuf, ?exception: true) -> [ String, [ String, Integer, String, String ] ]
+                       | (Integer len, ?Integer flag, ?String outbuf, exception: false) -> ([ String, [ String, Integer, String, String ] ] | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/udpsocket.c

--- a/stdlib/socket/0/unix_server.rbs
+++ b/stdlib/socket/0/unix_server.rbs
@@ -56,7 +56,8 @@ class UNIXServer < UNIXSocket
   # *   UNIXServer#accept
   # *   Socket#accept
   #
-  def accept_nonblock: (?exception: boolish) -> (UNIXSocket | :wait_readable)
+  def accept_nonblock: (?exception: true) -> UNIXSocket
+                     | (exception: false) -> (UNIXSocket | :wait_readable)
 
   # <!--
   #   rdoc-file=ext/socket/unixserver.c


### PR DESCRIPTION
## Summary

The non-blocking socket methods (and OpenSSL `SSLSocket` equivalents) take an `exception:` keyword that selects the return value: the normal result when `exception: true` (the default), or a `:wait_readable` / `:wait_writable` symbol when `exception: false`. The signatures expressed this with a single `?exception: boolish` parameter and a union return type (or plain `untyped`), so the symbol leaked into the result type even when `exception:` was not passed.

This splits each method into `true` / `false` literal overloads so the return type reflects the argument — the same treatment applied to `StringScanner#scan_full` / `#search_full` in #2959.

| Ruby Method | Change | C function |
|-------------|--------|------------|
| `BasicSocket#recv_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_recvfrom_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L249-L324) |
| `BasicSocket#recvmsg_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_bsock_recvmsg_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/ancdata.c#L1695-L1699) |
| `BasicSocket#sendmsg_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_writable`) | [`rsock_bsock_sendmsg_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/ancdata.c#L1323-L1328) |
| `OpenSSL::SSL::SSLSocket#sysread_nonblock` | Replace `(*untyped) -> untyped` with `true`/`false` overloads (`false` → `… \| :wait_readable \| :wait_writable \| nil`) | [`ossl_ssl_read_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/openssl/ossl_ssl.c#L2085-L2089) |
| `OpenSSL::SSL::SSLSocket#syswrite_nonblock` | Replace `(*untyped) -> untyped` with `true`/`false` overloads (`false` → `… \| :wait_readable \| :wait_writable \| nil`) | [`ossl_ssl_write_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/openssl/ossl_ssl.c#L2201-L2209) |
| `Socket#accept_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_accept_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L669-L695) |
| `Socket#connect_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_writable`) | [`sock_connect_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/socket.c#L410-L438) |
| `Socket#recvfrom_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_recvfrom_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L249-L324) |
| `TCPServer#accept_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_accept_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L669-L695) |
| `UDPSocket#recvfrom_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_recvfrom_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L249-L324) |
| `UNIXServer#accept_nonblock` | Split `exception:` into `true`/`false` overloads (`false` → `… \| :wait_readable`) | [`rsock_s_accept_nonblock`](https://github.com/ruby/ruby/blob/v4.0.5/ext/socket/init.c#L669-L695) |

## Out of scope

- The OpenSSL `read_nonblock`, `write_nonblock`, `connect_nonblock`, and `accept_nonblock` methods already use `true`/`false` overloads — no change needed.
- `read_nonblock` / `write_nonblock` are not redefined under `stdlib/socket`; they inherit the core `IO` signatures, which already have the overloads.
- `PTY.check(pid, raise)` is a related parameter-driven return type (`raise: true` can only return `nil`), but it belongs to a different method family rather than non-blocking I/O; left for a separate change.

## Test plan

- [x] `bundle exec rbs -r socket validate`
- [x] `bundle exec rbs -r openssl validate`
- [x] `bundle exec rubocop stdlib/socket/0/ stdlib/openssl/0/openssl.rbs`