### PR TITLE
Split parameter-driven return types into overloads

### DIFF
--- a/core/thread.rbs
+++ b/core/thread.rbs
@@ -1719,7 +1719,8 @@ class Thread::Queue[E = untyped] < Object
   # If `timeout` seconds have passed and no data is available `nil` is returned.
   # If `timeout` is `0` it returns immediately.
   #
-  def pop: (?boolish non_block, ?timeout: _ToF?) -> E?
+  def pop: (?false non_block, ?timeout: _ToF?) -> E?
+         | (true non_block) -> E
 
   # <!--
   #   rdoc-file=thread_sync.c

--- a/stdlib/bigdecimal/0/big_decimal.rbs
+++ b/stdlib/bigdecimal/0/big_decimal.rbs
@@ -1238,7 +1238,8 @@ module Kernel
   # Raises an exception if `value` evaluates to a Float and `digits` is larger
   # than Float::DIG + 1.
   #
-  def self?.BigDecimal: (real | string | BigDecimal initial, ?int digits, ?exception: bool) -> BigDecimal
+  def self?.BigDecimal: (real | string | BigDecimal initial, ?int digits, ?exception: true) -> BigDecimal
+                      | (real | string | BigDecimal initial, ?int digits, exception: false) -> BigDecimal?
 end
 
 %a{annotate:rdoc:skip}


### PR DESCRIPTION
## Summary

Several methods have a boolean-ish argument that deterministically selects the return type. Following the same approach as `StringScanner#scan_full` (#2959) and the non-blocking socket methods (#2963), this expresses each with literal `true`/`false` overloads instead of a single signature with a loose union return.

| Ruby Method | Change | Implementation |
|-------------|--------|----------------|
| `Kernel#BigDecimal` | `exception: false` returns `nil` on a conversion failure: `(?exception: true) -> BigDecimal` / `(exception: false) -> BigDecimal?` | [ruby/bigdecimal](https://github.com/ruby/bigdecimal) |
| `Thread::Queue#pop` | `non_block: true` raises `ThreadError` when the queue is empty, so it never returns `nil`: `(?false non_block, ?timeout: _ToF?) -> E?` / `(true non_block) -> E` | [`Queue#pop`](https://github.com/ruby/ruby/blob/v4.0.5/thread_sync.rb#L71-L76) |

Notes:

- `Thread::Queue#pop`'s `(true)` overload omits `timeout:` because passing both `non_block` and `timeout:` raises `ArgumentError`. `SizedQueue#pop` inherits this signature, and `deq` / `shift` are aliases, so they are covered automatically.

## Out of scope

- `PTY.check` was initially included, but reverted: its `raise` argument is `boolish` — the implementation uses `RTEST`, so any truthy value works, and the `stdlib_test` exercises this by passing the Symbol `:true`. Literal `true`/`false` overloads cannot represent that, so it stays `(Integer pid, ?boolish raise) -> Process::Status?`.
- `Kernel#system` was initially included, but reverted per review feedback: it has complex arguments and the precise return type (`exception: true -> TrueClass`) does not pay for the maintenance cost of duplicating that long signature across two overloads.
- The `RBS::Collection::Sources::Git#setup!` partial-clone cleanup that was previously bundled here was identified on this PR's CI run and has been moved to its own PR: #2978.

## Test plan

- [x] `bundle exec rbs -r bigdecimal validate`
- [x] `bundle exec rbs validate`
- [x] `bundle exec rake stdlib_test`
- [x] `bundle exec rubocop core/thread.rbs stdlib/bigdecimal/0/big_decimal.rbs`