### PR TITLE
Replace deterministic `untyped` return types with concrete types

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1399,7 +1399,8 @@ class IO < Object
   #
   #     AA
   #
-  def putc: (Numeric | String object) -> (Numeric | String)
+  def putc: (real) -> real
+          | (String) -> String
 
   # <!--
   #   rdoc-file=io.c

--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1417,7 +1417,8 @@ class IO < Object
   #
   #     AA
   #
-  def putc: (Numeric | String object) -> (Numeric | String)
+  def putc: (real) -> real
+          | (String) -> String
 
   # <!--
   #   rdoc-file=io.c

--- a/stdlib/erb/0/erb.rbs
+++ b/stdlib/erb/0/erb.rbs
@@ -619,7 +619,7 @@ class ERB
   # It's good practice to choose a variable name that begins with an underscore:
   # <code>'_'</code>.
   #
-  def initialize: (String, ?eoutvar: String, ?trim_mode: Integer | String | NilClass) -> untyped
+  def initialize: (String, ?eoutvar: String, ?trim_mode: Integer | String | NilClass) -> void
 
   # <!-- rdoc-file=lib/erb.rb -->
   # Returns the Ruby code that, when executed, generates the result;
@@ -702,7 +702,7 @@ class ERB
   # Like #result, but prints the result string (instead of returning it);
   # returns `nil`.
   #
-  def run: (?Binding) -> untyped
+  def run: (?Binding) -> nil
 
   # <!--
   #   rdoc-file=lib/erb.rb
@@ -746,7 +746,7 @@ class ERB
   # class MyClass; include MyModule; end
   # MyClass.new.render('foo', 123)                      # => "foo 123"
   #
-  def def_method: (Module, String, ?String) -> untyped
+  def def_method: (Module, String, ?String) -> Symbol
 
   # <!--
   #   rdoc-file=lib/erb.rb
@@ -913,7 +913,7 @@ class ERB
     # define *methodname* as instance method of current module, using ERB object or
     # eRuby file
     #
-    def self.def_erb_method: (String methodname, (String | ERB) erb_or_fname) -> untyped
+    def self.def_erb_method: (String methodname, (String | ERB) erb_or_fname) -> Symbol
   end
 
   # <!-- rdoc-file=lib/erb/util.rb -->

--- a/stdlib/monitor/0/monitor.rbs
+++ b/stdlib/monitor/0/monitor.rbs
@@ -111,7 +111,7 @@ class Monitor
   #   - wait_for_cond(p1, p2)
   # -->
   #
-  def wait_for_cond: (::MonitorMixin::ConditionVariable, Numeric? timeout) -> untyped
+  def wait_for_cond: (::MonitorMixin::ConditionVariable, Numeric? timeout) -> bool
 end
 
 # <!-- rdoc-file=ext/monitor/lib/monitor.rb -->
@@ -334,7 +334,7 @@ class MonitorMixin::ConditionVariable
   # If `timeout` is given, this method returns after `timeout` seconds passed,
   # even if no other thread doesn't signal.
   #
-  def wait: (?Numeric? timeout) -> untyped
+  def wait: (?Numeric? timeout) -> bool
 
   # <!--
   #   rdoc-file=ext/monitor/lib/monitor.rb
@@ -342,7 +342,7 @@ class MonitorMixin::ConditionVariable
   # -->
   # Calls wait repeatedly until the given block yields a truthy value.
   #
-  def wait_until: () { () -> boolish } -> untyped
+  def wait_until: () { () -> boolish } -> nil
 
   # <!--
   #   rdoc-file=ext/monitor/lib/monitor.rb
@@ -350,7 +350,7 @@ class MonitorMixin::ConditionVariable
   # -->
   # Calls wait repeatedly while the given block yields a truthy value.
   #
-  def wait_while: () { () -> boolish } -> untyped
+  def wait_while: () { () -> boolish } -> nil
 
   private
 

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -1271,7 +1271,8 @@ class StringIO
   # -->
   # See IO#putc.
   #
-  def putc: (Numeric | String arg0) -> (Numeric | String)
+  def putc: (real) -> real
+          | (String) -> String
 
   def puts: (*untyped arg0) -> nil
 

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -1271,7 +1271,7 @@ class StringIO
   # -->
   # See IO#putc.
   #
-  def putc: (Numeric | String arg0) -> untyped
+  def putc: (Numeric | String arg0) -> (Numeric | String)
 
   def puts: (*untyped arg0) -> nil
 

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -1272,7 +1272,8 @@ class StringIO
   # -->
   # See IO#putc.
   #
-  def putc: (Numeric | String arg0) -> (Numeric | String)
+  def putc: (real) -> real
+          | (String) -> String
 
   def puts: (*untyped arg0) -> nil
 

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -1272,7 +1272,7 @@ class StringIO
   # -->
   # See IO#putc.
   #
-  def putc: (Numeric | String arg0) -> untyped
+  def putc: (Numeric | String arg0) -> (Numeric | String)
 
   def puts: (*untyped arg0) -> nil
 

--- a/stdlib/zlib/0/gzip_file.rbs
+++ b/stdlib/zlib/0/gzip_file.rbs
@@ -143,7 +143,7 @@ module Zlib
     # `flush` method.  While `sync` mode is `true`, the compression ratio decreases
     # sharply.
     #
-    def sync=: (boolish) -> untyped
+    def sync=: (boolish) -> boolish
 
     # <!--
     #   rdoc-file=ext/zlib/zlib.c

--- a/stdlib/zlib/0/gzip_writer.rbs
+++ b/stdlib/zlib/0/gzip_writer.rbs
@@ -125,7 +125,8 @@ module Zlib
     # -->
     # Same as IO.
     #
-    def putc: (Numeric | String arg0) -> (Numeric | String)
+    def putc: (real) -> real
+            | (String) -> String
 
     # <!--
     #   rdoc-file=ext/zlib/zlib.c

--- a/stdlib/zlib/0/gzip_writer.rbs
+++ b/stdlib/zlib/0/gzip_writer.rbs
@@ -125,7 +125,7 @@ module Zlib
     # -->
     # Same as IO.
     #
-    def putc: (Numeric | String arg0) -> untyped
+    def putc: (Numeric | String arg0) -> (Numeric | String)
 
     # <!--
     #   rdoc-file=ext/zlib/zlib.c


### PR DESCRIPTION
## Summary

Several methods were typed `-> untyped` even though the implementation makes the return value deterministic. This replaces those with concrete types.

| Ruby Method | `untyped` → | Basis |
|-------------|-------------|-------|
| `Zlib::GzipFile#sync=` | `boolish` | setter returns its argument |
| `MonitorMixin::ConditionVariable#wait_for_cond` | `bool` | C implementation returns `Qtrue` / `Qfalse` |
| `MonitorMixin::ConditionVariable#wait` | `bool` | delegates to `#wait_for_cond` |
| `MonitorMixin::ConditionVariable#wait_until` | `nil` | body is an `until` loop expression |
| `MonitorMixin::ConditionVariable#wait_while` | `nil` | body is a `while` loop expression |
| `ERB#run` | `nil` | `print self.result(b)` — `print` returns `nil` |
| `ERB#initialize` | `void` | constructor |
| `ERB#def_method` | `Symbol` | `module_eval { eval("def …\nend") }` returns the method name |
| `ERB::DefMethod.def_erb_method` | `Symbol` | delegates to `ERB#def_method` |

### `putc`

`IO#putc`, `StringIO#putc`, and `Zlib::GzipWriter#putc` return their argument. They were typed `-> untyped` (`StringIO` / `GzipWriter`) or `(Numeric | String) -> (Numeric | String)` (`IO`); this types them as `(real) -> real | (String) -> String` so the return type tracks the argument. `real` is also more precise than `Numeric` — `putc` does not accept `Complex`. (`IO#putc` was not `untyped`, but is aligned here for consistency since the others document themselves as "Same as IO".)

## Out of scope

- `ObjectSpace.internal_super_of` — although the doc says it returns "Class or Module", it actually returns the internal super entry, which can be a `T_ICLASS` object. That is not a real `Module`, so `untyped` is the correct type (the `stdlib_test` for it confirms this). Left unchanged.
- The `core/class.rbs` (`allocate`, `new`) and `core/struct.rbs` (`self.new`) `untyped` → `instance` proposals were left out: `Class#new` is special-cased by the type checker, and `Struct.new(:a, :b)` returns a new struct *class* (not an instance), so `instance` would be incorrect there.

## Test plan

- [x] `bundle exec rbs validate`
- [x] `bundle exec rbs -r stringio -r zlib -r monitor -r erb validate`
- [x] `bundle exec rake stdlib_test`
- [x] `bundle exec rubocop` on the changed files