### PR TITLE
Correct core/stdlib signatures to match Ruby 4.0

### DIFF
--- a/core/io.rbs
+++ b/core/io.rbs
@@ -1231,6 +1231,24 @@ class IO < Object
   def ioctl: (Integer integer_cmd, String | Integer argument) -> Integer
 
   # <!--
+  #   rdoc-file=ext/etc/etc.c
+  #   - pathconf(name)       ->  Integer
+  # -->
+  # Returns pathname configuration variable using fpathconf().
+  #
+  # *name* should be a constant under `Etc` which begins with `PC_`.
+  #
+  # The return value is an integer or nil. nil means indefinite limit.
+  # (fpathconf() returns -1 but errno is not set.)
+  #
+  #     require 'etc'
+  #     IO.pipe {|r, w|
+  #       p w.pathconf(Etc::PC_PIPE_BUF) #=> 4096
+  #     }
+  #
+  def pathconf: (Integer name) -> Integer?
+
+  # <!--
   #   rdoc-file=io.c
   #   - isatty -> true or false
   # -->

--- a/stdlib/digest/0/digest.rbs
+++ b/stdlib/digest/0/digest.rbs
@@ -303,7 +303,7 @@ module Digest::Instance
   # uninitialized.  Do not call this method from outside.  Use #digest!() instead,
   # which ensures that internal data be reset for security reasons.
   #
-  def finish: () -> self
+  def finish: () -> String
 end
 
 # <!-- rdoc-file=ext/digest/digest.c -->
@@ -319,7 +319,7 @@ class Digest::Class
   # Returns the base64 encoded hash value of a given *string*.  The return value
   # is properly padded with '=' and contains no line feeds.
   #
-  def self.base64digest: (string str) -> String
+  def self.base64digest: (string str, *untyped args) -> String
 
   # <!--
   #   rdoc-file=ext/digest/bubblebabble/bubblebabble.c
@@ -327,7 +327,7 @@ class Digest::Class
   # -->
   # Returns the BubbleBabble encoded hash value of a given *string*.
   #
-  def self.bubblebabble: (string) -> String
+  def self.bubblebabble: (string, *untyped) -> String
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -338,7 +338,7 @@ class Digest::Class
   # any, are passed through to the constructor and the *string* is passed to
   # #digest().
   #
-  def self.digest: (string) -> String
+  def self.digest: (string, *untyped) -> String
 
   # <!--
   #   rdoc-file=ext/digest/lib/digest.rb
@@ -350,7 +350,7 @@ class Digest::Class
   #     p Digest::SHA256.file("X11R6.8.2-src.tar.bz2").hexdigest
   #     # => "f02e3c85572dc9ad7cb77c2a638e3be24cc1b5bea9fdbb0b0299c9668475c534"
   #
-  def self.file: (string name) -> instance
+  def self.file: (string name, *untyped args) -> instance
 
   # <!--
   #   rdoc-file=ext/digest/digest.c
@@ -359,7 +359,7 @@ class Digest::Class
   # Returns the hex-encoded hash value of a given *string*.  This is almost
   # equivalent to Digest.hexencode(Digest::Class.new(*parameters).digest(string)).
   #
-  def self.hexdigest: (string) -> String
+  def self.hexdigest: (string, *untyped) -> String
 
   private
 

--- a/stdlib/etc/0/etc.rbs
+++ b/stdlib/etc/0/etc.rbs
@@ -295,7 +295,7 @@ module Etc
   #     Etc.sysconf(Etc::SC_ARG_MAX) #=> 2097152
   #     Etc.sysconf(Etc::SC_LOGIN_NAME_MAX) #=> 256
   #
-  def self?.sysconf: (::Integer p1) -> ::Integer
+  def self?.sysconf: (::Integer p1) -> ::Integer?
 
   # <!--
   #   rdoc-file=ext/etc/etc.c
@@ -318,7 +318,7 @@ module Etc
   # -->
   # Returns system temporary directory; typically "/tmp".
   #
-  def self?.systmpdir: () -> ::String
+  def self?.systmpdir: () -> ::String?
 
   # <!--
   #   rdoc-file=ext/etc/etc.c
@@ -709,7 +709,8 @@ module Etc
     #     Etc::Group.collect {|g| g.name}
     #     Etc::Group.select {|g| !g.mem.empty?}
     #
-    def self.each: () -> untyped
+    def self.each: () { (::Etc::Group) -> void } -> singleton(::Etc::Group)
+                 | () -> ::Enumerator[::Etc::Group]
 
     def self.inspect: () -> untyped
 
@@ -817,7 +818,8 @@ module Etc
     #     Etc::Passwd.collect {|u| u.gecos}
     #     Etc::Passwd.collect {|u| u.gecos}
     #
-    def self.each: () -> untyped
+    def self.each: () { (::Etc::Passwd) -> void } -> singleton(::Etc::Passwd)
+                 | () -> ::Enumerator[::Etc::Passwd]
 
     def self.inspect: () -> untyped
 
@@ -827,9 +829,17 @@ module Etc
 
     def self.new: (*untyped) -> untyped
 
+    def age: () -> Integer
+
+    def age=: (Integer new_age) -> void
+
     def change: () -> Integer
 
     def change=: (Integer new_change) -> void
+
+    def comment: () -> String
+
+    def comment=: (String new_comment) -> void
 
     def dir: () -> String
 
@@ -854,6 +864,10 @@ module Etc
     def passwd: () -> String
 
     def passwd=: (String new_passwd) -> void
+
+    def quota: () -> Integer
+
+    def quota=: (Integer new_quota) -> void
 
     def shell: () -> String
 

--- a/stdlib/stringio/0/stringio.rbs
+++ b/stdlib/stringio/0/stringio.rbs
@@ -560,7 +560,8 @@ class StringIO
   #
   # Related: StringIO.new.
   #
-  def self.open: [U] (?String string, ?String? mode) { (StringIO arg) -> U } -> U
+  def self.open: (?String string, ?String? mode) -> StringIO
+               | [U] (?String string, ?String? mode) { (StringIO arg) -> U } -> U
 
   def <<: (untyped arg0) -> self
 
@@ -970,7 +971,7 @@ class StringIO
   # -->
   # Raises NotImplementedError.
   #
-  def fcntl: (Integer integer_cmd, String | Integer arg) -> Integer
+  def fcntl: (*untyped) -> bot
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
@@ -994,7 +995,7 @@ class StringIO
   # -->
   # Returns 0; for compatibility with IO.
   #
-  def fsync: () -> Integer?
+  def fsync: () -> Integer
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
@@ -1190,7 +1191,7 @@ class StringIO
   # -->
   # Returns `nil`; for compatibility with IO.
   #
-  def internal_encoding: () -> Encoding
+  def internal_encoding: () -> nil
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
@@ -1207,7 +1208,7 @@ class StringIO
   #     strio = StringIO.new(nil, 'w+')
   #     strio.external_encoding # => nil
   #
-  def external_encoding: () -> Encoding
+  def external_encoding: () -> Encoding?
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
@@ -1283,7 +1284,16 @@ class StringIO
   #
   def read: (?int? length, ?string outbuf) -> String?
 
-  def read_nonblock: (int len, ?string buf) -> String
+  # <!--
+  #   rdoc-file=ext/stringio/stringio.c
+  #   - pread(maxlen, offset)             -> string
+  #   - pread(maxlen, offset, out_string) -> string
+  # -->
+  # See IO#pread.
+  #
+  def pread: (Integer maxlen, Integer offset, ?String outbuf) -> String
+
+  def read_nonblock: (int len, ?string buf, ?exception: bool) -> String?
 
   def readbyte: () -> Integer
 
@@ -1360,6 +1370,16 @@ class StringIO
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
+  #   - strio.set_encoding_by_bom  => strio or nil
+  # -->
+  # Sets the encoding according to the BOM (Byte Order Mark) in the string.
+  #
+  # Returns `self` if the BOM is found, otherwise +nil.
+  #
+  def set_encoding_by_bom: () -> Encoding?
+
+  # <!--
+  #   rdoc-file=ext/stringio/stringio.c
   #   - string -> string
   # -->
   # Returns underlying string:
@@ -1429,7 +1449,7 @@ class StringIO
   #
   def sync=: (boolish) -> bool
 
-  def sysread: (Integer maxlen, String outbuf) -> String
+  def sysread: (Integer maxlen, ?String outbuf) -> String
 
   def syswrite: (String arg0) -> Integer
 
@@ -1472,7 +1492,7 @@ class StringIO
   # Pushes back ("unshifts") a character or integer onto the stream; see
   # [Character IO](rdoc-ref:IO@Character+IO).
   #
-  def ungetc: (String arg0) -> nil
+  def ungetc: (String | Integer arg0) -> nil
 
   # <!--
   #   rdoc-file=ext/stringio/stringio.c
@@ -1484,6 +1504,8 @@ class StringIO
   # a string using `to_s`. Returns the number of bytes written.  See IO#write.
   #
   def write: (*_ToS) -> Integer
+
+  def write_nonblock: (_ToS s, ?exception: bool) -> Integer
 
   # This is a deprecated alias for #each_byte.
   #


### PR DESCRIPTION
## Summary

Several core/stdlib signatures were inaccurate against the Ruby 4.0 implementation. This corrects them.

| Ruby Method | Change |
|-------------|--------|
| `IO#pathconf` | Add the method — `(Integer name) -> Integer?` |
| `Digest::Instance#finish` | Return `String`, not `self` |
| `Digest::Class.digest` / `.hexdigest` / `.bubblebabble` | Accept trailing `*args` (passed through to the constructor) |
| `Digest::Class.file` / `.base64digest` | Accept trailing `*args` |
| `Etc.sysconf` | Return type is nilable — `-> Integer?` |
| `Etc.systmpdir` | Return type is nilable — `-> String?` |
| `Etc::Group.each` / `Etc::Passwd.each` | Add block / `Enumerator` overloads instead of `-> untyped` |
| `Etc::Passwd` | Add the `age`, `comment`, and `quota` members (with their setters) |
| `StringIO.open` | Add the non-block overload — `(?String, ?String?) -> StringIO` |
| `StringIO#fcntl` | Always raises `NotImplementedError` — return `bot` |
| `StringIO#fsync` | Always returns `0` — `-> Integer` (not `Integer?`) |
| `StringIO#internal_encoding` | Always returns `nil` |
| `StringIO#external_encoding` | Return type is nilable — `-> Encoding?` |
| `StringIO#pread` | Add the method |
| `StringIO#read_nonblock` | Accept `exception:`; return type is nilable |
| `StringIO#write_nonblock` | Add the method |
| `StringIO#sysread` | `outbuf` is optional |
| `StringIO#ungetc` | Also accepts an `Integer` |
| `StringIO#set_encoding_by_bom` | Add the method |

## Notes

- `Monitor#wait_for_cond` / `MonitorMixin::ConditionVariable#wait` (`-> bool`) are intentionally excluded here — they are covered by #2966.
- rdoc comments for the newly added methods match `rbs annotate` output (`confirm_annotation`).

## Test plan

- [x] `bundle exec rbs validate`
- [x] `bundle exec rbs -r digest -r etc -r stringio validate`
- [x] `bundle exec rubocop core/io.rbs stdlib/digest/0/digest.rbs stdlib/etc/0/etc.rbs stdlib/stringio/0/stringio.rbs`