### PR TITLE
Support `class << self` in inline parser

### DIFF
--- a/lib/rbs/inline_parser.rb
+++ b/lib/rbs/inline_parser.rb
@@ -40,6 +40,9 @@ module RBS
       MixinNonConstantModule = _ = Class.new(Base)
       AttributeNonSymbolName = _ = Class.new(Base)
       ClassModuleAliasDeclarationMissingTypeName = _ = Class.new(Base)
+      NestedSingletonScope = _ = Class.new(Base)
+      TopLevelSingletonScope = _ = Class.new(Base)
+      NonSelfSingletonScope = _ = Class.new(Base)
     end
 
     def self.parse(buffer, prism)
@@ -63,6 +66,7 @@ module RBS
       def initialize(result)
         @result = result
         @module_nesting = []
+        @singleton_class_depth = 0
         @comments = CommentAssociation.build(result.buffer, result.prism_result)
       end
 
@@ -164,17 +168,65 @@ module RBS
         visit_class_or_module_body(module_decl, node)
       end
 
-      def visit_class_or_module_body(decl, node)
-        push_module_nesting(decl) do
-          visit_child_nodes(node)
+      def visit_singleton_class_node(node)
+        return if skip_node?(node)
 
-          node.child_nodes.each do |child_node|
-            if child_node
-              comments.each_enclosed_block(child_node) do |block|
-                report_unused_block(block)
+        if in_singleton_class?
+          diagnostics << Diagnostic::NestedSingletonScope.new(
+            rbs_location(node.class_keyword_loc),
+            "Nested `class << self` opens the singleton class of a singleton class, which has no representation in RBS"
+          )
+          return
+        end
+
+        unless node.expression.is_a?(Prism::SelfNode)
+          diagnostics << Diagnostic::NonSelfSingletonScope.new(
+            rbs_location(node.expression.location),
+            "Non-self expression in `class << ...` opens an anonymous singleton class, which has no representation in RBS"
+          )
+          return
+        end
+
+        unless current_module
+          diagnostics << Diagnostic::TopLevelSingletonScope.new(
+            rbs_location(node.class_keyword_loc),
+            "Top-level `class << self` opens the singleton class of `main`, which has no representation in RBS"
+          )
+          return
+        end
+
+        @singleton_class_depth += 1
+        begin
+          visit_child_nodes(node)
+        ensure
+          @singleton_class_depth -= 1
+        end
+      end
+
+      def in_singleton_class?
+        @singleton_class_depth > 0
+      end
+
+      def visit_class_or_module_body(decl, node)
+        # Entering a new class/module body establishes a fresh metaclass context;
+        # any singleton_class_depth from an enclosing `class << self` does not apply here.
+        saved_depth = @singleton_class_depth
+        @singleton_class_depth = 0
+
+        begin
+          push_module_nesting(decl) do
+            visit_child_nodes(node)
+
+            node.child_nodes.each do |child_node|
+              if child_node
+                comments.each_enclosed_block(child_node) do |block|
+                  report_unused_block(block)
+                end
               end
             end
           end
+        ensure
+          @singleton_class_depth = saved_depth
         end
 
         comments.each_enclosed_block(node) do |block|
@@ -210,7 +262,23 @@ module RBS
           return
         end
 
-        kind = node.receiver ? :singleton : :instance #: :singleton | :instance
+        if in_singleton_class? && node.receiver
+          diagnostics << Diagnostic::NestedSingletonScope.new(
+            rbs_location(node.receiver.location),
+            "Method definition with self receiver inside `class << self` targets the singleton class of a singleton class, which has no representation in RBS"
+          )
+          # Consume the leading block so the annotation isn't re-reported as UnusedInlineAnnotation;
+          # the NestedSingletonScope diagnostic above is the only diagnostic for this construct.
+          comments.leading_block!(node)
+          return
+        end
+
+        kind =
+          if in_singleton_class?
+            :singleton
+          else
+            node.receiver ? :singleton : :instance
+          end #: :singleton | :instance
 
         case current = current_module
         when AST::Ruby::Declarations::ClassDecl, AST::Ruby::Declarations::ModuleDecl
@@ -247,12 +315,28 @@ module RBS
         when :include, :extend, :prepend
           return if skip_node?(node)
 
+          if in_singleton_class?
+            diagnostics << Diagnostic::NotImplementedYet.new(
+              rbs_location(node.message_loc || node.location),
+              "Mixin call inside `class << self` is not supported"
+            )
+            return
+          end
+
           case current = current_module
           when AST::Ruby::Declarations::ClassDecl, AST::Ruby::Declarations::ModuleDecl
             parse_mixin_call(node)
           end
         when :attr_reader, :attr_writer, :attr_accessor
           return if skip_node?(node)
+
+          if in_singleton_class?
+            diagnostics << Diagnostic::NotImplementedYet.new(
+              rbs_location(node.message_loc || node.location),
+              "Attribute definition inside `class << self` is not supported"
+            )
+            return
+          end
 
           case current = current_module
           when AST::Ruby::Declarations::ClassDecl, AST::Ruby::Declarations::ModuleDecl

--- a/sig/inline_parser.rbs
+++ b/sig/inline_parser.rbs
@@ -61,6 +61,15 @@ module RBS
       class ClassModuleAliasDeclarationMissingTypeName < Base
       end
 
+      class NestedSingletonScope < Base
+      end
+
+      class TopLevelSingletonScope < Base
+      end
+
+      class NonSelfSingletonScope < Base
+      end
+
       type t = NotImplementedYet
              | NonConstantClassName | NonConstantModuleName | NonConstantSuperClassName
              | TopLevelMethodDefinition | TopLevelAttributeDefinition
@@ -69,12 +78,17 @@ module RBS
              | AttributeNonSymbolName
              | NonConstantConstantDeclaration
              | ClassModuleAliasDeclarationMissingTypeName
+             | NestedSingletonScope
+             | TopLevelSingletonScope
+             | NonSelfSingletonScope
     end
 
     def self.parse: (Buffer, Prism::ParseResult) -> Result
 
     class Parser < Prism::Visitor
       type module_context = Declarations::ClassDecl | Declarations::ModuleDecl
+
+      @singleton_class_depth: Integer
 
       include AST::Ruby::Helpers::ConstantHelper
 
@@ -111,6 +125,10 @@ module RBS
       def report_unused_block: (AST::Ruby::CommentBlock) -> void
 
       def visit_class_or_module_body: (module_context, Prism::ClassNode | Prism::ModuleNode) -> void
+
+      def visit_singleton_class_node: (Prism::SingletonClassNode) -> void
+
+      def in_singleton_class?: () -> bool
 
       private
 

--- a/test/rbs/inline_parser_test.rb
+++ b/test/rbs/inline_parser_test.rb
@@ -2275,4 +2275,374 @@ COMMENT
 
     assert_empty result.declarations
   end
+
+  def test_parse__class_singleton_class__def
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          #: () -> void
+          def hello; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 1, decl.members.size
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :hello, member.name
+        assert_predicate member, :singleton?
+        refute_predicate member, :instance?
+        assert_equal :singleton, member.kind
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__rbs_annotation
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          # @rbs () -> void
+          def hello; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :hello, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__mixed_with_instance
+    result = parse(<<~RUBY)
+      class Foo
+        #: () -> String
+        def instance_method
+          ""
+        end
+
+        class << self
+          #: () -> void
+          def class_method; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 2, decl.members.size
+
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :instance_method, member.name
+        assert_predicate member, :instance?
+      end
+
+      decl.members[1].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :class_method, member.name
+        assert_predicate member, :singleton?
+        assert_equal ["() -> void"], member.overloads.map { _1.method_type.to_s }
+      end
+    end
+  end
+
+  def test_error__class_singleton_class__def_self
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          def self.nested; end
+        end
+      end
+    RUBY
+
+    assert_equal 1, result.diagnostics.size
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NestedSingletonScope, diagnostic
+      assert_equal "Method definition with self receiver inside `class << self` targets the singleton class of a singleton class, which has no representation in RBS", diagnostic.message
+    end
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_error__class_singleton_class__nested_singleton_class
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          class << self
+            def deep; end
+          end
+        end
+      end
+    RUBY
+
+    assert_equal 1, result.diagnostics.size
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NestedSingletonScope, diagnostic
+      assert_equal "Nested `class << self` opens the singleton class of a singleton class, which has no representation in RBS", diagnostic.message
+    end
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_error__class_singleton_class__include
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          include M
+        end
+      end
+    RUBY
+
+    assert_equal 1, result.diagnostics.size
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NotImplementedYet, diagnostic
+      assert_equal "Mixin call inside `class << self` is not supported", diagnostic.message
+    end
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_error__class_singleton_class__attr_reader
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          attr_reader :x
+        end
+      end
+    RUBY
+
+    assert_equal 1, result.diagnostics.size
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NotImplementedYet, diagnostic
+      assert_equal "Attribute definition inside `class << self` is not supported", diagnostic.message
+    end
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_parse__class_singleton_class__constant_flatten
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          BAR = 1 #: Integer
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 1, decl.members.size
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Declarations::ConstantDecl, member
+        assert_equal "BAR", member.constant_name.to_s
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__nested_class_flatten
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          class Inner; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 1, decl.members.size
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Declarations::ClassDecl, member
+        assert_equal "Inner", member.class_name.to_s
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__nested_module_flatten
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          module Inner; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_equal 1, decl.members.size
+      decl.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Declarations::ModuleDecl, member
+        assert_equal "Inner", member.module_name.to_s
+      end
+    end
+  end
+
+  def test_error__class_singleton_class__non_self_expression
+    result = parse(<<~RUBY)
+      class Foo
+        OBJ = Object.new
+        class << OBJ
+          def hello; end
+        end
+      end
+    RUBY
+
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NonSelfSingletonScope, diagnostic
+      assert_equal "Non-self expression in `class << ...` opens an anonymous singleton class, which has no representation in RBS", diagnostic.message
+    end
+
+    result.declarations[0].tap do |decl|
+      refute decl.members.any? { |m| m.is_a?(RBS::AST::Ruby::Members::DefMember) && m.name == :hello }
+    end
+  end
+
+  def test_error__class_singleton_class__top_level
+    result = parse(<<~RUBY)
+      class << self
+        def hello; end
+      end
+    RUBY
+
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::TopLevelSingletonScope, diagnostic
+      assert_equal "Top-level `class << self` opens the singleton class of `main`, which has no representation in RBS", diagnostic.message
+    end
+
+    assert_empty result.declarations
+  end
+
+  def test_parse__class_singleton_class__skip
+    result = parse(<<~RUBY)
+      class Foo
+        # @rbs skip
+        class << self
+          def hello; end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      assert_empty decl.members
+    end
+  end
+
+  def test_parse__class_singleton_class__nested_class_resets_singleton_context
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          class Inner
+            #: () -> void
+            def m; end
+          end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      inner = decl.members.find { _1.is_a?(RBS::AST::Ruby::Declarations::ClassDecl) }
+      refute_nil inner
+      inner.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :m, member.name
+        assert_predicate member, :instance?
+        refute_predicate member, :singleton?
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__nested_module_resets_singleton_context
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          module Inner
+            #: () -> void
+            def m; end
+          end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      inner = decl.members.find { _1.is_a?(RBS::AST::Ruby::Declarations::ModuleDecl) }
+      refute_nil inner
+      inner.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :m, member.name
+        assert_predicate member, :instance?
+      end
+    end
+  end
+
+  def test_parse__class_singleton_class__inner_class_own_singleton_is_independent
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          class Inner
+            class << self
+              #: () -> Integer
+              def baz; 42; end
+            end
+          end
+        end
+      end
+    RUBY
+
+    assert_empty result.diagnostics
+
+    result.declarations[0].tap do |decl|
+      inner = decl.members.find { _1.is_a?(RBS::AST::Ruby::Declarations::ClassDecl) }
+      refute_nil inner
+      inner.members[0].tap do |member|
+        assert_instance_of RBS::AST::Ruby::Members::DefMember, member
+        assert_equal :baz, member.name
+        assert_predicate member, :singleton?
+      end
+    end
+  end
+
+  def test_error__class_singleton_class__def_self_with_leading_annotation_single_diagnostic
+    result = parse(<<~RUBY)
+      class Foo
+        class << self
+          #: () -> void
+          def self.nested; end
+        end
+      end
+    RUBY
+
+    assert_equal 1, result.diagnostics.size
+    assert_any!(result.diagnostics) do |diagnostic|
+      assert_instance_of RBS::InlineParser::Diagnostic::NestedSingletonScope, diagnostic
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add `class << self` support to the inline parser.

## Approach

Follow Steep's interpretation of `class << self`: preserve the lexical
nesting (`module_nesting`, `class_name`) through `class << self` and
rebind only the implied "kind" of methods being defined. A flag
`@singleton_class_depth` tracks whether the current visit position is
inside a `class << self` body. It is reset on entry to a nested
class/module body, because `self` rebinds at class boundaries and
singleton context does not cross them.

## Behavior

Inside `class << self` of a named class:

| construct | result |
| --- | --- |
| `def x` | singleton method of the enclosing class (`Foo.x`) |
| `class Inner` | flattened to `Foo::Inner` (lexical resolution) |
| `module Inner` | flattened to `Foo::Inner` |
| `FOO = 1` | flattened to `Foo::FOO` |

The flatten matches the only representation RBS can express — RBS has
no syntax for constants on a singleton class, so this is what Ruby and
Steep also produce via lexical lookup.

## Diagnostics

RBS has no notation for the singleton class of a singleton class, an
anonymous singleton class, or constants attached to a singleton class.
Three new diagnostics flag those gaps:

- `NestedSingletonScope` — nested `class << self`, and `def self.x`
  inside `class << self` (both target the singleton of a singleton)
- `TopLevelSingletonScope` — `class << self` at top level (opens the
  singleton class of `main`)
- `NonSelfSingletonScope` — `class << expr` for non-`self` `expr`
  (opens an anonymous singleton class)

## Out of scope

Mixin (`include` / `extend` / `prepend`) and attribute (`attr_*`)
calls inside `class << self` remain `NotImplementedYet`. They have
RBS-representable equivalents (`extend M` and `attr_reader self.x:`)
but the conversion requires extending the member data model and is
deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)