### PR TITLE
Fix lexer infinite loop / abort on invalid UTF-8 byte

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "net-smtp"
 gem 'csv'
 gem 'ostruct'
 gem 'pstore'
+gem "timeout"
 
 group :minitest do
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,7 @@ DEPENDENCIES
   steep!
   tempfile
   test-unit
+  timeout
 
 BUNDLED WITH
   4.0.1

--- a/src/lexstate.c
+++ b/src/lexstate.c
@@ -134,7 +134,11 @@ bool rbs_next_char(rbs_lexer_t *lexer, unsigned int *codepoint, size_t *byte_len
 
     *byte_len = lexer->encoding->char_width((const uint8_t *) start, (ptrdiff_t) (lexer->string.end - start));
 
-    if (*byte_len == 1) {
+    if (*byte_len == 0) {
+        // Avoid infinite loop on invalid bytes.
+        *byte_len = 1;
+        *codepoint = (unsigned int) (unsigned char) *start;
+    } else if (*byte_len == 1) {
         *codepoint = (unsigned int) *start;
     } else {
         *codepoint = 12523; // Dummy data for "ル" from "ルビー" (Ruby) in Unicode

--- a/test/rbs/parser_test.rb
+++ b/test/rbs/parser_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "timeout"
 
 class RBS::ParserTest < Test::Unit::TestCase
   def buffer(source)
@@ -1027,5 +1028,23 @@ class RBS::ParserTest < Test::Unit::TestCase
     assert_equal [:kEND, 'end', 53...56], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
     assert_equal [:tTRIVIA, "\n", 56...57], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
     assert_equal [:pEOF, '', 57...57], tokens.shift.then { |t| [t[0], t[1].source, t[1].range] }
+  end
+
+  def test_invalid_utf8_byte_in_comment_does_not_hang
+    # Regression: invalid UTF-8 byte in a comment used to loop forever in the lexer.
+    source = "# \xC2".dup.force_encoding(Encoding::UTF_8)
+    Timeout.timeout(5) do
+      RBS::Parser._parse_signature(buffer(source), 0, source.bytesize)
+    end
+  end
+
+  def test_invalid_utf8_byte_at_top_level_raises
+    # Regression: invalid UTF-8 byte at top level used to trip RBS_ASSERT in the C extension.
+    source = "\xFF".dup.force_encoding(Encoding::UTF_8)
+    Timeout.timeout(5) do
+      assert_raises(RBS::ParsingError) do
+        RBS::Parser._parse_signature(buffer(source), 0, source.bytesize)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`rbs_next_char` left `byte_len = 0` when the active encoding's `char_width()` rejected a byte. Depending on where the byte appeared, the lexer either:

- looped forever inside a comment (GVL held, `SIGINT` ineffective), or
- tripped `RBS_ASSERT(current_character_bytes > 0, ...)` in `rbs_skip` at top level and called `exit(1)`.

This PR makes `rbs_next_char` advance one byte in that case so the lexer always makes progress; the invalid byte then flows into the usual parser error path.

## Reproducer

```ruby
buf = RBS::Buffer.new(content: "# \xC2".force_encoding("UTF-8"), name: "x.rbs")
RBS::Parser._parse_signature(buf, 0, buf.content.bytesize)
# hangs forever; only `kill -9` stops the process
```

## Fix

`src/lexstate.c` (`rbs_next_char`): when `encoding->char_width()` returns `0`, treat the byte as a 1-byte garbage character and advance one byte. The lexer's invariant "cursor advances by at least one byte per step" is now preserved on every code path. Valid UTF-8 input is unaffected because `char_width()` never returns `0` for valid sequences.

---

This PR description was written by [Claude Code](https://claude.com/claude-code).