### PR TITLE
Clean up partial clone before falling back to full clone

### DIFF
--- a/lib/rbs/collection/sources/git.rb
+++ b/lib/rbs/collection/sources/git.rb
@@ -140,6 +140,12 @@ module RBS
                 # git v2.27.0 or greater
                 git 'clone', '--filter=blob:none', remote, git_dir.to_s, chdir: nil
               rescue CommandError
+                # The failed `--filter=blob:none` clone may leave behind a
+                # partial repository (e.g. when the server returned an error
+                # mid-clone), which would cause the fallback `git clone` to
+                # fail with "destination path ... already exists and is not
+                # an empty directory". Clean it up before retrying.
+                FileUtils.rm_rf(git_dir)
                 git 'clone', remote, git_dir.to_s, chdir: nil
               end
             end


### PR DESCRIPTION
## Summary

`RBS::Collection::Sources::Git#setup!` falls back to a non-filtered `git clone` when the `--filter=blob:none` variant fails. If the partial clone left a non-empty directory (e.g. the server returned `HTTP 502` mid-clone), the retry fails with `destination path ... already exists and is not an empty directory`. Remove the partial clone before retrying so the fallback can proceed.

## Reproduction

Observed on the CI run of #2965 (`bundle exec rake test` — `test_collection_install`). The failing job log is at <https://github.com/ruby/rbs/actions/runs/26512049136/job/78078808477?pr=2965>:

```
$ git clone --filter=blob:none https://github.com/ruby/gem_rbs_collection.git /home/runner/.cache/rbs/...
error: RPC failed; HTTP 502 curl 22 The requested URL returned error: 502
fatal: expected 'packfile'
fatal: could not fetch ... from promisor remote
warning: Clone succeeded, but checkout failed.
$ git clone https://github.com/ruby/gem_rbs_collection.git /home/runner/.cache/rbs/...
fatal: destination path '/home/runner/.cache/rbs/...' already exists and is not an empty directory.
```

The first clone left `.git/` etc. in the cache directory, and the fallback `git clone` cannot reuse a non-empty target.

## Fix

In the `rescue CommandError` branch of `Git#setup!`, remove the partial clone with `FileUtils.rm_rf(git_dir)` before invoking the fallback `git clone`. `fileutils` is already required in this file.

```ruby
rescue CommandError
  FileUtils.rm_rf(git_dir)
  git 'clone', remote, git_dir.to_s, chdir: nil
end
```

## Test plan

- [ ] CI — the partial-clone case is hard to reproduce locally because it depends on an `HTTP 502` from `github.com` mid-clone; the patch matches the failure observed on the test runner.