### PR TITLE
Narrow Resolv::DNS resource methods by typeclass

### DIFF
--- a/stdlib/resolv/0/resolv.rbs
+++ b/stdlib/resolv/0/resolv.rbs
@@ -218,9 +218,37 @@ class Resolv::DNS
   # Iterates over all `typeclass` DNS resources for `name`.  See #getresource for
   # argument details.
   #
-  def each_resource: (dns_name name, singleton(Resolv::DNS::Query) typeclass) { (Resolv::DNS::Resource) -> void } -> void
+  def each_resource: (dns_name name, singleton(Resolv::DNS::Resource::IN::A) typeclass) { (Resolv::DNS::Resource::IN::A) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::AAAA) typeclass) { (Resolv::DNS::Resource::IN::AAAA) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::CNAME) typeclass) { (Resolv::DNS::Resource::IN::CNAME) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::HINFO) typeclass) { (Resolv::DNS::Resource::IN::HINFO) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::LOC) typeclass) { (Resolv::DNS::Resource::IN::LOC) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::MINFO) typeclass) { (Resolv::DNS::Resource::IN::MINFO) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::MX) typeclass) { (Resolv::DNS::Resource::IN::MX) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::NS) typeclass) { (Resolv::DNS::Resource::IN::NS) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::PTR) typeclass) { (Resolv::DNS::Resource::IN::PTR) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::SOA) typeclass) { (Resolv::DNS::Resource::IN::SOA) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::SRV) typeclass) { (Resolv::DNS::Resource::IN::SRV) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::TXT) typeclass) { (Resolv::DNS::Resource::IN::TXT) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::IN::WKS) typeclass) { (Resolv::DNS::Resource::IN::WKS) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Resource::Generic) typeclass) { (Resolv::DNS::Resource::Generic) -> void } -> void
+                   | (dns_name name, singleton(Resolv::DNS::Query) typeclass) { (Resolv::DNS::Resource) -> void } -> void
 
-  def extract_resources: (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Query) typeclass) { (Resolv::DNS::Resource) -> void } -> void
+  def extract_resources: (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::A) typeclass) { (Resolv::DNS::Resource::IN::A) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::AAAA) typeclass) { (Resolv::DNS::Resource::IN::AAAA) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::CNAME) typeclass) { (Resolv::DNS::Resource::IN::CNAME) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::HINFO) typeclass) { (Resolv::DNS::Resource::IN::HINFO) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::LOC) typeclass) { (Resolv::DNS::Resource::IN::LOC) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::MINFO) typeclass) { (Resolv::DNS::Resource::IN::MINFO) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::MX) typeclass) { (Resolv::DNS::Resource::IN::MX) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::NS) typeclass) { (Resolv::DNS::Resource::IN::NS) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::PTR) typeclass) { (Resolv::DNS::Resource::IN::PTR) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::SOA) typeclass) { (Resolv::DNS::Resource::IN::SOA) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::SRV) typeclass) { (Resolv::DNS::Resource::IN::SRV) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::TXT) typeclass) { (Resolv::DNS::Resource::IN::TXT) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::IN::WKS) typeclass) { (Resolv::DNS::Resource::IN::WKS) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Resource::Generic) typeclass) { (Resolv::DNS::Resource::Generic) -> void } -> void
+                       | (Resolv::DNS::Message msg, dns_name name, singleton(Resolv::DNS::Query) typeclass) { (Resolv::DNS::Resource) -> void } -> void
 
   # <!--
   #   rdoc-file=lib/resolv.rb
@@ -299,7 +327,21 @@ class Resolv::DNS
   # Returned resource is represented as a Resolv::DNS::Resource instance, i.e.
   # Resolv::DNS::Resource::IN::A.
   #
-  def getresource: (dns_name name, singleton(Resolv::DNS::Query) typeclass) -> Resolv::DNS::Resource
+  def getresource: (dns_name name, singleton(Resolv::DNS::Resource::IN::A) typeclass) -> Resolv::DNS::Resource::IN::A
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::AAAA) typeclass) -> Resolv::DNS::Resource::IN::AAAA
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::CNAME) typeclass) -> Resolv::DNS::Resource::IN::CNAME
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::HINFO) typeclass) -> Resolv::DNS::Resource::IN::HINFO
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::LOC) typeclass) -> Resolv::DNS::Resource::IN::LOC
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::MINFO) typeclass) -> Resolv::DNS::Resource::IN::MINFO
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::MX) typeclass) -> Resolv::DNS::Resource::IN::MX
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::NS) typeclass) -> Resolv::DNS::Resource::IN::NS
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::PTR) typeclass) -> Resolv::DNS::Resource::IN::PTR
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::SOA) typeclass) -> Resolv::DNS::Resource::IN::SOA
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::SRV) typeclass) -> Resolv::DNS::Resource::IN::SRV
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::TXT) typeclass) -> Resolv::DNS::Resource::IN::TXT
+                 | (dns_name name, singleton(Resolv::DNS::Resource::IN::WKS) typeclass) -> Resolv::DNS::Resource::IN::WKS
+                 | (dns_name name, singleton(Resolv::DNS::Resource::Generic) typeclass) -> Resolv::DNS::Resource::Generic
+                 | (dns_name name, singleton(Resolv::DNS::Query) typeclass) -> Resolv::DNS::Resource
 
   # <!--
   #   rdoc-file=lib/resolv.rb
@@ -308,7 +350,21 @@ class Resolv::DNS
   # Looks up all `typeclass` DNS resources for `name`.  See #getresource for
   # argument details.
   #
-  def getresources: (dns_name name, singleton(Resolv::DNS::Query) typeclass) -> Array[Resolv::DNS::Resource]
+  def getresources: (dns_name name, singleton(Resolv::DNS::Resource::IN::A) typeclass) -> Array[Resolv::DNS::Resource::IN::A]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::AAAA) typeclass) -> Array[Resolv::DNS::Resource::IN::AAAA]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::CNAME) typeclass) -> Array[Resolv::DNS::Resource::IN::CNAME]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::HINFO) typeclass) -> Array[Resolv::DNS::Resource::IN::HINFO]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::LOC) typeclass) -> Array[Resolv::DNS::Resource::IN::LOC]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::MINFO) typeclass) -> Array[Resolv::DNS::Resource::IN::MINFO]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::MX) typeclass) -> Array[Resolv::DNS::Resource::IN::MX]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::NS) typeclass) -> Array[Resolv::DNS::Resource::IN::NS]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::PTR) typeclass) -> Array[Resolv::DNS::Resource::IN::PTR]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::SOA) typeclass) -> Array[Resolv::DNS::Resource::IN::SOA]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::SRV) typeclass) -> Array[Resolv::DNS::Resource::IN::SRV]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::TXT) typeclass) -> Array[Resolv::DNS::Resource::IN::TXT]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::IN::WKS) typeclass) -> Array[Resolv::DNS::Resource::IN::WKS]
+                  | (dns_name name, singleton(Resolv::DNS::Resource::Generic) typeclass) -> Array[Resolv::DNS::Resource::Generic]
+                  | (dns_name name, singleton(Resolv::DNS::Query) typeclass) -> Array[Resolv::DNS::Resource]
 
   def lazy_initialize: () -> untyped
 


### PR DESCRIPTION
## Summary

`Resolv::DNS#getresource` / `#getresources` / `#each_resource` / `#extract_resources` accept a typeclass argument (`Resolv::DNS::Resource::IN::MX`, `IN::A`, `IN::AAAA`, …) that fully determines the returned resource subclass. The current signatures return the upper bound `Resolv::DNS::Resource`, dropping that information — so callers using subclass-specific methods like `MX#exchange` have to downcast.

This adds per-subclass overloads for the leaf `Resolv::DNS::Resource::IN::*` types and `Resolv::DNS::Resource::Generic`, with the previous wide signature kept as the trailing fallback (which also covers `Resource::ANY` and other classes under `Resolv::DNS::Query`).

## Motivation

A typical caller pattern, from Mastodon (`app/validators/email_mx_validator.rb:49`):

```ruby
records = dns.getresources(domain, Resolv::DNS::Resource::IN::MX).to_a.map { |e| e.exchange.to_s }
```

`#exchange` is defined on `Resolv::DNS::Resource::MX` (inherited by `IN::MX`), not on the base `Resolv::DNS::Resource`. Under the existing signature, `e` is typed `Resolv::DNS::Resource` and `.exchange` does not resolve.

## Approach considered

A bounded generic would be the cleanest shape:

```rbs
def getresources: [T < Resolv::DNS::Resource] (dns_name name, singleton(T) typeclass) -> Array[T]
```

but RBS does not currently accept a type variable inside `singleton(...)`:

```
ERROR -- rbs: Could not find ::T (RBS::NoTypeFoundError)
    def getresources: [T < Resolv::DNS::Resource] (dns_name name, singleton(T) typeclass) -> Array[T]
                                                                  ^^^^^^^^^^^^
```

Falling back to per-subclass overloads — verbose but the precision is concentrated in the four methods.

## Change

For each of the four methods, 15 overloads:

- 13 leaf `Resolv::DNS::Resource::IN::{A, AAAA, CNAME, HINFO, LOC, MINFO, MX, NS, PTR, SOA, SRV, TXT, WKS}` overloads — narrowed return / block-parameter type.
- 1 `Resolv::DNS::Resource::Generic` overload — narrowed return / block-parameter type.
- 1 trailing wide `singleton(Resolv::DNS::Query)` fallback — keeps the previous behaviour for `Resolv::DNS::Resource::ANY`, the non-`IN` resource bases (`MX`, `NS`, `CNAME`, `DomainName`, `SOA`, `MINFO`, `HINFO`, `LOC`, `TXT`), and any other `Query` subclass.

| Ruby Method | Implementation |
|-------------|----------------|
| `Resolv::DNS#getresource` | [`Resolv::DNS#getresource`](https://github.com/ruby/ruby/blob/v4.0.5/lib/resolv.rb#L508) |
| `Resolv::DNS#getresources` | [`Resolv::DNS#getresources`](https://github.com/ruby/ruby/blob/v4.0.5/lib/resolv.rb#L517) |
| `Resolv::DNS#each_resource` | [`Resolv::DNS#each_resource`](https://github.com/ruby/ruby/blob/v4.0.5/lib/resolv.rb#L527) |
| `Resolv::DNS#extract_resources` | [`Resolv::DNS#extract_resources`](https://github.com/ruby/ruby/blob/v4.0.5/lib/resolv.rb#L606) |

## Out of scope

- `Resolv::DNS#fetch_resource` also accepts a typeclass argument, but its block yields `(Message, Name)` rather than a `Resource`, so it does not benefit from the same narrowing.

## Test plan

- [x] `bundle exec rbs -r resolv validate`
- [x] `bundle exec ruby -Ilib bin/test_runner.rb test/stdlib/resolv/DNS_test.rb` (67 tests pass)