### PR TITLE
Expose rbs_parse_inline_{leading,trailing}_annotation in ruby-rbs-sys

### DIFF
--- a/rust/ruby-rbs-sys/build.rs
+++ b/rust/ruby-rbs-sys/build.rs
@@ -162,6 +162,8 @@ fn generate_bindings(include_path: &Path) -> Result<bindgen::Bindings, Box<dyn E
         .allowlist_function("rbs_parse_signature")
         .allowlist_function("rbs_parser_free")
         .allowlist_function("rbs_parser_new")
+        .allowlist_function("rbs_parse_inline_leading_annotation")
+        .allowlist_function("rbs_parse_inline_trailing_annotation")
         // String functions
         .allowlist_function("rbs_string_new")
         // Location functions


### PR DESCRIPTION
Add `rbs_parse_inline_leading_annotation` and `rbs_parse_inline_trailing_annotation` to the bindgen allowlist in `build.rs`