### PR TITLE
feat: load local dependencies from manifest.yaml

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -49,6 +49,14 @@ module RBS
       case
       when path
         dirs << path
+
+        # search for manifest.yaml
+        if path.directory? && (manifest = path.each_entry.find { |s| s.basename.to_s == "manifest.yaml" })
+          local_lib = RBS::Collection::Sources::Local.new(path: path, base_directory: Pathname.pwd)
+          local_lib.dependencies_of("", "")&.each do |dep|
+            add(library: dep['name'], version: nil)
+          end
+        end
       when library
         if libs.add?(Library.new(name: library, version: version)) && resolve_dependencies
           resolve_dependencies(library: library, version: version)

--- a/test/rbs/environment_loader_test.rb
+++ b/test/rbs/environment_loader_test.rb
@@ -82,6 +82,22 @@ end
     end
   end
 
+    def test_loading_stdlib_via_manifest
+    mktmpdir do |path|
+      path.join("manifest.yaml").write(<<-RBS)
+dependencies:
+ - name: uri
+    RBS
+      loader = EnvironmentLoader.new
+      loader.add(path: path)
+
+      env = Environment.new
+      loader.load(env: env)
+
+      assert_operator env.class_decls, :key?, RBS::TypeName.parse("::URI")
+    end
+  end
+
   def test_loading_library_from_gem_repo
     mktmpdir do |path|
       (path + "gems").mkdir


### PR DESCRIPTION
this circumvents the need to be explicit about what to require via RBS_TEST_OPT when a manifest.yaml is already present (as it's considered a recommendation for gems as per the collection.md doc page).