### PR TITLE
Update `Array`

### DIFF
--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1397,7 +1397,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def concat: (*::Array[E] arrays) -> self
+  def concat: (*array[E] other_arrays) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2750,7 +2750,7 @@ class Array[unchecked out E]
   # Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def pop: () -> E?
-         | (int n) -> ::Array[E]
+         | (int count) -> Array[E]
 
   # <!-- rdoc-file=array.c -->
   # Prepends the given `objects` to `self`:
@@ -2838,7 +2838,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def push: (*E obj) -> self
+  def push: (*E objects) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3001,7 +3001,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def reverse: () -> ::Array[E]
+  def reverse: () -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3015,7 +3015,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def reverse!: () -> ::Array[E]
+  def reverse!: () -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3133,7 +3133,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def rotate: (?int count) -> ::Array[E]
+  def rotate: (?int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3305,7 +3305,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def shift: %a{implicitly-returns-nil} () -> E
-           | (int n) -> ::Array[E]
+           | (int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.rb
@@ -3746,7 +3746,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def to_a: () -> ::Array[E]
+  def to_a: () -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3902,7 +3902,7 @@ class Array[unchecked out E]
   # Related: Array#shift; see also [Methods for
   # Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def unshift: (*E obj) -> self
+  def unshift: (*E objects) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -4124,7 +4124,7 @@ class Array[unchecked out E]
   #
   def |: [T] (array[T] other_array) -> Array[E | T] # TODO: where E: _Eql[T]
 
-  def freeze: ->__todo__
+  def freeze: () -> self
   alias detect find
 
   private

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1120,7 +1120,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def all?: () -> bool
-          | (_Pattern[E] pattern) -> bool
+          | (RBS::Ops::_CaseEqual[E, boolish] pattern) -> bool
           | () { (E element) -> boolish } -> bool
 
   # <!--
@@ -1162,7 +1162,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def any?: () -> bool
-          | (_Pattern[E] pattern) -> bool
+          | (RBS::Ops::_CaseEqual[E, boolish] pattern) -> bool
           | () { (E element) -> boolish } -> bool
 
   # <!-- rdoc-file=array.c -->
@@ -2664,7 +2664,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def none?: () -> bool
-           | (_Pattern[E] pattern) -> bool
+           | (RBS::Ops::_CaseEqual[E, boolish] pattern) -> bool
            | () { (E element) -> boolish } -> bool
 
   # <!--
@@ -2703,7 +2703,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def one?: () -> bool
-          | (_Pattern[E] pattern) -> bool
+          | (RBS::Ops::_CaseEqual[E, boolish] pattern) -> bool
           | () { (E element) -> boolish } -> bool
 
   # <!--
@@ -4191,12 +4191,12 @@ class Array[unchecked out E]
   alias initialize_copy replace
 end
 
-%a{deprecated: Use Array::_Rand}
+%a{deprecated: Use Array::_Rand, or make your own}
 interface _Rand
   def rand: (Integer max) -> Integer
 end
 
-# %a{deprecated: Use RBS::Ops::_Matches[E, boolish]}
+%a{deprecated: Use RBS::Ops::_CaseEqual[E, boolish]}
 interface Array::_Pattern[T]
   def ===: (T) -> bool
 end

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -3570,8 +3570,8 @@ class Array[unchecked out E]
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def slice!: %a{implicitly-returns-nil} (int index) -> E
-            | (int start, int length) -> ::Array[E]?
-            | (::Range[::Integer] range) -> ::Array[E]?
+            | (int start, int length) -> Array[E]?
+            | (range[int?] range) -> Array[E]?
 
   # <!--
   #   rdoc-file=array.c
@@ -3685,8 +3685,7 @@ class Array[unchecked out E]
   # *   Array#sum method may not respect method redefinition of "+" methods such
   #     as Integer#+.
   #
-  def sum: (?untyped init) -> untyped
-         | (?untyped init) { (E e) -> untyped } -> untyped
+  def sum: (?untyped init) ?{ (E e) -> untyped } -> untyped # This would be usable if we had `where E < Complex`, etc
 
   # <!--
   #   rdoc-file=array.c
@@ -4100,10 +4099,14 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def zip: [U] (_Each[U] arg) -> Array[[ E, U? ]]
-         | (_Each[untyped] arg, *_Each[untyped] args) -> Array[Array[untyped]]
-         | [U] (_Each[U] arg) { ([ E, U? ]) -> void } -> nil
-         | (_Each[untyped] arg, *_Each[untyped] args) { (Array[untyped]) -> void } -> nil
+  def zip: () -> Array[[ E ]]
+         | [X] (_Each[X] iterable) -> Array[[ E, X? ]]
+         | [X, Y] (_Each[X] iterable1, _Each[Y] iterable2) -> Array[[ E, X?, Y? ]]
+         | [U] (*_Each[U] iterables) -> Array[Array[E | U?]]
+         | () { ([ E ]) -> void } -> nil
+         | [X] (_Each[X] iterable) { ([ E, X? ]) -> void } -> nil
+         | [X, Y] (_Each[X] iterable1, _Each[Y] iterable2) { ([ E, X?, Y? ]) -> void } -> nil
+         | [U] (*_Each[U] iterables) { (Array[E | U?]) -> void } -> nil
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -648,7 +648,7 @@ class Array[unchecked out E]
   #
   def self.try_convert: [A < Array[U], U] (A array) -> A
                       | [U] (array[U] ary) -> Array[U]
-                      | [U] (untyped) -> Array[U]?
+                      | (untyped) -> Array[untyped]?
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -666,7 +666,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def &: (::Array[untyped] | _ToAry[untyped]) -> ::Array[E]
+  def &: (array[untyped] other_array) -> Array[E] # TODO: `where E: _Eql?[T]`
 
   # <!--
   #   rdoc-file=array.c
@@ -684,8 +684,8 @@ class Array[unchecked out E]
   #
   #     [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {foo: 0}"
   #
-  def *: (string str) -> ::String
-       | (int int) -> ::Array[E]
+  def *: (string string_separator) -> String # TODO: where E: _ToS
+       | (int n) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -699,7 +699,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def +: [U] (_ToAry[U]) -> ::Array[E | U]
+  def +: [U] (array[U] other_array) -> Array[E | U]
 
   # <!--
   #   rdoc-file=array.c
@@ -717,7 +717,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def -: (_ToAry[untyped]) -> ::Array[E]
+  def -: (array[untyped] other_array) -> Array[E]  # TODO: `where E: _Eql?[T]`
 
   # <!--
   #   rdoc-file=array.c
@@ -733,7 +733,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def <<: (E) -> self
+  def <<: (E object) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -772,7 +772,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Comparing](rdoc-ref:Array@Methods+for+Comparing).
   #
-  def <=>: (untyped) -> ::Integer?
+  def <=>: (untyped) -> Integer? # Until we can do `where E: RBS::Ops::_Compare`, this is always going to return `Integer?~
 
   # <!--
   #   rdoc-file=array.c
@@ -921,8 +921,8 @@ class Array[unchecked out E]
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
   def []: %a{implicitly-returns-nil} (int index) -> E
-        | (int start, int length) -> ::Array[E]?
-        | (::Range[::Integer?] range) -> ::Array[E]?
+        | (int start, int length) -> Array[E]?
+        | (range[int] range) -> Array[E]?
 
   # <!--
   #   rdoc-file=array.c
@@ -1070,13 +1070,11 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def []=: (int index, E obj) -> E
-         | (int start, int length, E obj) -> E
-         | (int start, int length, ::Array[E]) -> ::Array[E]
-         | (int start, int length, nil) -> nil
-         | (::Range[::Integer?], E obj) -> E
-         | (::Range[::Integer?], ::Array[E]) -> ::Array[E]
-         | (::Range[::Integer?], nil) -> nil
+  def []=: (int index, E object) -> E
+         | [T < _ToAry[E]] (range[int?] range, T array) -> T
+         | (range[int?] range, E object) -> E
+         | [T < _ToAry[E]] (int start, int length, T array) -> T
+         | (int start, int length, E object) -> E
 
   # <!--
   #   rdoc-file=array.c
@@ -4111,7 +4109,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def |: [T] (::Array[T] other_ary) -> ::Array[E | T]
+  def |: [T] (array[T] other_array) -> Array[E | T] # TODO: where E: _Eql[T]
 
   def freeze: ->__todo__
   alias detect find

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2543,10 +2543,10 @@ class Array[unchecked out E]
   #
   def max: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
          | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero } -> E
-         | %a{implicitly-returns-nil} () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> E
+         | %a{implicitly-returns-nil} %a{warning: returning `nil` will always raise at runtime} () { (E a, E b) -> Comparable::_CompareToZero? } -> E
          | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
          | (int count) { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
-         | (int count) %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
+         | %a{warning: returning `nil` will always raise at runtime} (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2598,10 +2598,10 @@ class Array[unchecked out E]
   #
   def min: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
          | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero } -> E
-         | %a{implicitly-returns-nil} () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> E
+         | %a{implicitly-returns-nil} %a{warning: returning `nil` will always raise at runtime} () { (E a, E b) -> Comparable::_CompareToZero? } -> E
          | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
          | (int count) { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
-         | (int count) %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
+         | %a{warning: returning `nil` will always raise at runtime} (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
 
   # <!--
@@ -2628,7 +2628,7 @@ class Array[unchecked out E]
   #
   def minmax: () -> [ E?, E? ] # where E: Comparable::_WithSpaceshipOperator
             | () { (E a, E b) -> Comparable::_CompareToZero } -> [ E?, E? ]
-            | () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ]
+            | %a{warning: returning `nil` will always raise at runtime} () { (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=array.c
@@ -4196,6 +4196,7 @@ interface _Rand
   def rand: (Integer max) -> Integer
 end
 
+# %a{deprecated: Use RBS::Ops::_Matches[E, boolish]}
 interface Array::_Pattern[T]
   def ===: (T) -> bool
 end

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2542,9 +2542,11 @@ class Array[unchecked out E]
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
   def max: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
-         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: `?`
+         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero } -> E
+         | %a{implicitly-returns-nil} () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> E
          | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
-         | (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: `?`
+         | (int count) { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
+         | (int count) %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2595,9 +2597,11 @@ class Array[unchecked out E]
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
   def min: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
-         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: `?`
+         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero } -> E
+         | %a{implicitly-returns-nil} () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> E
          | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
-         | (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: `?`
+         | (int count) { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
+         | (int count) %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
 
   # <!--
@@ -2623,7 +2627,8 @@ class Array[unchecked out E]
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
   def minmax: () -> [ E?, E? ] # where E: Comparable::_WithSpaceshipOperator
-            | () { (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ] # TODO: `?`
+            | () { (E a, E b) -> Comparable::_CompareToZero } -> [ E?, E? ]
+            | () %a{warning: returning `nil` will always raise at runtime} { (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=array.c
@@ -3680,7 +3685,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def sort_by!: () { (E element) -> Comparable::_WithSpaceshipOperator } -> self # TODO: use RBS::Ops
+  def sort_by!: () { (E element) -> Comparable::_WithSpaceshipOperator } -> self
+              | %a{warning: returning `nil` will always raise at runtime} () { (E element) -> Comparable::_WithSpaceshipOperator? } -> self
               | () -> Enumerator[E, self]
 
   # <!--

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2511,10 +2511,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def max: %a{implicitly-returns-nil} () -> E
-         | %a{implicitly-returns-nil} () { (E a, E b) -> ::Integer? } -> E
-         | (int n) -> ::Array[E]
-         | (int n) { (E a, E b) -> ::Integer? } -> ::Array[E]
+  def max: %a{implicitly-returns-nil} () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: where `E: Comparable::_WithSpaceshipOperator`
+         | (int count) ?{ (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: i dont think these shoudl have `?` in _CompareToZero. But it would make signatures nicer?
 
   # <!--
   #   rdoc-file=array.c
@@ -2564,7 +2562,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  alias min max
+  def min: %a{implicitly-returns-nil} () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: where `E: Comparable::_WithSpaceshipOperator`
+         | (int count) ?{ (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2588,8 +2587,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def minmax: () -> [ E?, E? ]
-            | () { (E a, E b) -> ::Integer? } -> [ E?, E? ]
+  def minmax: () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ]
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -3466,9 +3466,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def slice: %a{implicitly-returns-nil} (int index) -> E
-           | (int start, int length) -> ::Array[E]?
-           | (::Range[::Integer] range) -> ::Array[E]?
+  alias slice []
 
   # <!--
   #   rdoc-file=array.c
@@ -4115,6 +4113,9 @@ class Array[unchecked out E]
   #
   def |: [T] (::Array[T] other_ary) -> ::Array[E | T]
 
+  def freeze: ->__todo__
+  alias detect find
+
   private
 
   # <!--
@@ -4132,7 +4133,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def initialize_copy: (self other_ary) -> void
+  alias initialize_copy replace
 end
 
 interface _Rand

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -549,6 +549,12 @@
 class Array[unchecked out E]
   include Enumerable[E]
 
+  # Interface for random number generations; used with `Array#shuffle`, `Array#shuffle!`, and `Array#sample`.
+  interface _Rand
+    # Generate a random number up to, but excluding, `max`
+    def rand: (Integer max) -> int
+  end
+
   # <!--
   #   rdoc-file=array.c
   #   - Array.new -> new_empty_array
@@ -1810,7 +1816,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def fetch_values: (*int indexes) -> self
+  def fetch_values: (*int indexes) -> Array[E]
+                  | [I < _ToInt, T] (*I indexes) { (I index) -> T } -> Array[E | T]
 
   # <!--
   #   rdoc-file=array.c
@@ -2116,7 +2123,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def first: %a{implicitly-returns-nil} () -> E
-           | (int n) -> ::Array[E]
+           | (int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -2411,7 +2418,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
   def last: %a{implicitly-returns-nil} () -> E
-          | (int n) -> ::Array[E]
+          | (int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3212,8 +3219,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def sample: %a{implicitly-returns-nil} (?random: _Rand rng) -> E
-            | (int n, ?random: _Rand rng) -> ::Array[E]
+  def sample: %a{implicitly-returns-nil} (?random: _Rand) -> E
+            | (int count, ?random: _Rand) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3322,7 +3329,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def shuffle: (?random: _Rand rng) -> ::Array[E]
+  def shuffle: (?random: _Rand) -> Array[E]
 
   # <!--
   #   rdoc-file=array.rb
@@ -3346,7 +3353,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def shuffle!: (?random: _Rand rng) -> self
+  def shuffle!: (?random: _Rand) -> self
 
   # <!-- rdoc-file=array.c -->
   # Returns the count of elements in `self`:
@@ -4140,6 +4147,7 @@ class Array[unchecked out E]
   alias initialize_copy replace
 end
 
+%a{deprecated: Use Array::_Rand}
 interface _Rand
   def rand: (::Integer max) -> ::Integer
 end

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2157,7 +2157,7 @@ class Array[unchecked out E]
   # Related: Array#flatten!; see also [Methods for
   # Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def flatten: (?int level) -> ::Array[untyped]
+  def flatten: (?int? level) -> Array[untyped]
 
   # <!--
   #   rdoc-file=array.c
@@ -2193,7 +2193,7 @@ class Array[unchecked out E]
   # Related: Array#flatten; see also [Methods for
   # Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def flatten!: (?int level) -> self?
+  def flatten!: (?int? level) -> self?
 
   # <!--
   #   rdoc-file=array.c
@@ -2223,7 +2223,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def include?: (top object) -> bool
+  def include?: (top object) -> bool # TODO: E: _Equals
 
   # <!-- rdoc-file=array.c -->
   # Returns the zero-based integer index of a specified element, or `nil`.
@@ -2371,7 +2371,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def join: (?string separator) -> String
+  def join: (?string? separator) -> String # TODO: where E: _ToS
 
   # <!--
   #   rdoc-file=array.c
@@ -2813,10 +2813,14 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def product: () -> ::Array[[ E ]]
-             | [X] (::Array[X] other_ary) -> ::Array[[ E, X ]]
-             | [X, Y] (::Array[X] other_ary1, ::Array[Y] other_ary2) -> ::Array[[ E, X, Y ]]
-             | [U] (*::Array[U] other_arys) -> ::Array[::Array[E | U]]
+  def product: () -> Array[[ E ]]
+             | () { ([E] combination) -> void } -> self
+             | [X] (array[X] other_ary) -> Array[[ E, X ]]
+             | [X] (array[X] other_ary) { ([E, X] combination) -> void } -> self
+             | [X, Y] (array[X] other_ary1, array[Y] other_ary2) -> Array[[ E, X, Y ]]
+             | [X, Y] (array[X] other_ary1, array[Y] other_ary2) { ([E, X, Y] combination) -> void } -> self
+             | [U] (*array[U] other_arys) -> Array[Array[E | U]]
+             | [U] (*array[U] other_arys) { (Array[E | U] combination) -> void } -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3702,7 +3706,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def take: (int n) -> ::Array[E]
+  def take: (int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1233,7 +1233,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch: () { (E element) -> (Numeric | bool?) } -> E?
+  def bsearch: () { (E element) -> bool? } -> E?
+             | () { (E element) -> Numeric? } -> E?
              | () -> Enumerator[E, E?]
 
   # <!--
@@ -1248,7 +1249,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch_index: () { (E element) -> (Numeric | bool?) } -> Integer?
+  def bsearch_index: () { (E element) -> bool? } -> Integer?
+                   | () { (E element) -> Numeric? } -> Integer?
                    | () -> Enumerator[E, Integer?]
 
   # <!--

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1996,11 +1996,10 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def fill: (E obj) -> self
-          | (E obj, int? start, ?int? length) -> self
-          | (E obj, ::Range[::Integer] range) -> self
-          | (?int? start, ?int? length) { (::Integer index) -> E } -> self
-          | (::Range[::Integer] range) { (::Integer index) -> E } -> self
+  def fill: (E obj, ?int? start, ?int? length) -> self
+          | (E obj, range[int?] range) -> self
+          | (?int? start, ?int? length) { (Integer index) -> E } -> self
+          | (range[int?] range) { (Integer index) -> E } -> self
 
   # <!-- rdoc-file=array.c -->
   # With a block given, calls the block with each element of `self`; returns a new
@@ -2286,7 +2285,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def insert: (int index, *E obj) -> self
+  def insert: (int index, *E objects) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2317,7 +2316,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def intersect?: (_ToAry[untyped]) -> bool
+  def intersect?: (array[untyped] other_array) -> bool # Todo: where E: _Eql
 
   # <!--
   #   rdoc-file=array.c
@@ -2339,7 +2338,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def intersection: (*::Array[untyped] | _ToAry[untyped] other_ary) -> ::Array[E]
+  def intersection: (*array[untyped] other_arrays) -> Array[E] # Todo: where E: _Eql
 
   # <!--
   #   rdoc-file=array.c
@@ -3607,8 +3606,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def sort: () -> ::Array[E]
-          | () { (E a, E b) -> ::Integer } -> ::Array[E]
+  def sort: () ?{ (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3619,8 +3617,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def sort!: () -> self
-           | () { (E a, E b) -> ::Integer } -> self
+  def sort!: () ?{ (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3832,7 +3829,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def union: [T] (*array[T] other_arrays) -> Array[T | E]
+  def union: [T] (*array[T] other_arrays) -> Array[T | E] # TODO: where E: _Eql
 
   # <!--
   #   rdoc-file=array.c
@@ -3858,8 +3855,7 @@ class Array[unchecked out E]
   #
   # Related: [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def uniq: () -> ::Array[E]
-          | () { (E item) -> untyped } -> ::Array[E]
+  def uniq: () ?{ (E element) -> Hash::_Key } -> Array[E] # TODO: E: Hash::_Key
 
   # <!--
   #   rdoc-file=array.c
@@ -3887,8 +3883,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def uniq!: () -> self?
-           | () { (E) -> untyped } -> self?
+  def uniq!: () ?{ (E element) -> Hash::_Key } -> self? # TODO: E: Hash::_Key
 
   # <!--
   #   rdoc-file=array.c
@@ -4011,7 +4006,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def values_at: (*int | ::Range[::Integer] selector) -> ::Array[E?]
+  def values_at: (*int | range[int?] selector) -> Array[E?]
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -546,7 +546,7 @@
 #     given block.
 #
 %a{annotate:rdoc:source:from=array.c}
-class Array[unchecked out E] < Object
+class Array[unchecked out E]
   include Enumerable[E]
 
   # <!--
@@ -603,10 +603,10 @@ class Array[unchecked out E] < Object
   # Related: see [Methods for Creating an
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
-  def initialize: () -> void
-                | (::Array[E] ary) -> void
-                | (int size, ?E val) -> void
-                | (int size) { (::Integer index) -> E } -> void
+  def initialize: () -> void # TODO: technically array has a `Array.new` defined. do we use that?
+                | (array[E] ary) -> void
+                | (int size, ?E default_value) -> void
+                | (int size) { (int index) -> E } -> void
 
   # <!--
   #   rdoc-file=array.c
@@ -621,7 +621,7 @@ class Array[unchecked out E] < Object
   # Related: see [Methods for Creating an
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
-  def self.[]: [U] (*U) -> ::Array[U]
+  def self.[]: [U] (*U) -> Array[U] # TODO: this technically returns a subclass. How do we want to do that?
 
   # <!--
   #   rdoc-file=array.c
@@ -640,7 +640,9 @@ class Array[unchecked out E] < Object
   # Related: see [Methods for Creating an
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
-  def self.try_convert: [U] (untyped) -> ::Array[U]?
+  def self.try_convert: [A < Array[U], U] (A array) -> A
+                      | [U] (array[U] ary) -> Array[U]
+                      | [U] (untyped) -> Array[U]?
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -2989,7 +2989,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def replace: (::Array[E]) -> self
+  def replace: (array[E] other_array) -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3781,7 +3781,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
   def to_h: () -> Hash[untyped, untyped]
-          | [T, S] () { (E) -> [ T, S ] } -> Hash[T, S]
+          | [K, V] () { (E element) -> Hash::_Pair[K, V] } -> Hash[K, V]
 
   # <!-- rdoc-file=array.c -->
   # Returns the new string formed by calling method <code>#inspect</code> on each
@@ -3808,7 +3808,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def transpose: () -> ::Array[::Array[untyped]]
+  def transpose: () -> Array[Array[untyped]]
 
   # <!--
   #   rdoc-file=array.c
@@ -3831,7 +3831,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def union: [T] (*::Array[T] other_arys) -> ::Array[T | E]
+  def union: [T] (*array[T] other_arrays) -> Array[T | E]
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -609,7 +609,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Creating an
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
-  def initialize: () -> void # TODO: technically array has a `Array.new` defined. do we use that?
+  def initialize: () -> void
                 | (array[E] ary) -> void
                 | (int size, ?E default_value) -> void
                 | (int size) { (int index) -> E } -> void
@@ -627,7 +627,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Creating an
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
-  def self.[]: [U] (*U) -> Array[U] # TODO: this technically returns a subclass. How do we want to do that?
+  def self.[]: [U] (*U) -> Array[U] # this technically returns a subclass, but `instance(self)` isn't a thing
 
   # <!--
   #   rdoc-file=array.c
@@ -672,7 +672,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def &: (array[untyped] other_array) -> Array[E] # TODO: `where E: _Eql?[T]`
+  def &: (array[untyped] other_array) -> Array[E] # where E: _Eql?[T]
 
   # <!--
   #   rdoc-file=array.c
@@ -690,8 +690,8 @@ class Array[unchecked out E]
   #
   #     [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {foo: 0}"
   #
-  def *: (string string_separator) -> String # TODO: where E: _ToS
-       | (int n) -> Array[E]
+  def *: (string string_separator) -> String # where E: _ToS
+       | (int n) -> Array[E] # where E: _ToS
 
   # <!--
   #   rdoc-file=array.c
@@ -723,7 +723,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def -: (array[untyped] other_array) -> Array[E] # TODO: `where E: _Eql?[T]`
+  def -: (array[untyped] other_array) -> Array[E] # where E: _Eql?[T]
 
   # <!--
   #   rdoc-file=array.c
@@ -1195,7 +1195,7 @@ class Array[unchecked out E]
   # Related: Array#rassoc; see also [Methods for
   # Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def assoc: (untyped object) -> Array[untyped]? # TODO: where `E: _ToAry[X]`, and object: _Equal
+  def assoc: (untyped object) -> Array[untyped]? # where E: _ToAry[X], object: _Equal
 
   # <!--
   #   rdoc-file=array.c
@@ -1365,7 +1365,7 @@ class Array[unchecked out E]
   # Related: Array#compact!; see also [Methods for
   # Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def compact: () -> Array[E] # TODO: it'd be nice if there was a way to do `Array[E - nil]`
+  def compact: () -> Array[E] # it'd be nice if there was a way to do `Array[E - nil]`
 
   # <!--
   #   rdoc-file=array.c
@@ -1426,7 +1426,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
   def count: () ?{ (E element) -> boolish } -> Integer
-           | (untyped object) -> Integer # TODO: where E: _Equal
+           | (untyped object) -> Integer # where E: RBS::Ops::_Equal
 
   # <!--
   #   rdoc-file=array.c
@@ -1505,7 +1505,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def delete: (untyped object) -> E? # TODO: _Comparable
+  def delete: (untyped object) -> E? # where E: _Comparable
             | [S, T] (S object) { (S object) -> T } -> (E | T)
 
   # <!--
@@ -2104,7 +2104,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def find_index: (untyped object) -> Integer? # TODO: _Equal
+  def find_index: (untyped object) -> Integer? # where E: RBS::Ops::_Equal
                 | () { (E element) -> boolish } -> Integer?
                 | () -> Enumerator[E, Integer?]
 
@@ -2239,7 +2239,7 @@ class Array[unchecked out E]
   #     ['a', 'b'].hash == ['a', 'c'].hash # => false
   #     ['a', 'b'].hash == ['a'].hash      # => false
   #
-  def hash: () -> Integer # TODO: where `E: _Hash`
+  def hash: () -> Integer # where E: _Hash
 
   # <!--
   #   rdoc-file=array.c
@@ -2254,7 +2254,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def include?: (top object) -> bool # TODO: E: _Equals
+  def include?: (untyped object) -> bool # where E: RBS::Ops::_Equals
 
   # <!-- rdoc-file=array.c -->
   # Returns the zero-based integer index of a specified element, or `nil`.
@@ -2332,7 +2332,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def inspect: () -> String # TODO: where E: _Inspect
+  def inspect: () -> String # where E: _Inspect
 
   # <!--
   #   rdoc-file=array.c
@@ -2348,7 +2348,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def intersect?: (array[untyped] other_array) -> bool # Todo: where E: _Eql
+  def intersect?: (array[untyped] other_array) -> bool # where E: _Eql?
 
   # <!--
   #   rdoc-file=array.c
@@ -2370,7 +2370,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def intersection: (*array[untyped] other_arrays) -> Array[E] # Todo: where E: _Eql
+  def intersection: (*array[untyped] other_arrays) -> Array[E] # where E: _Eql?
 
   # <!--
   #   rdoc-file=array.c
@@ -2402,7 +2402,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def join: (?string? separator) -> String # TODO: where E: _ToS
+  def join: (?string? separator) -> String # where E: _ToS
 
   # <!--
   #   rdoc-file=array.c
@@ -2541,8 +2541,10 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def max: %a{implicitly-returns-nil} () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: where `E: Comparable::_WithSpaceshipOperator`
-         | (int count) ?{ (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: i dont think these shoudl have `?` in _CompareToZero. But it would make signatures nicer?
+  def max: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
+         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: `?`
+         | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
+         | (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: `?`
 
   # <!--
   #   rdoc-file=array.c
@@ -2592,8 +2594,11 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def min: %a{implicitly-returns-nil} () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: where `E: Comparable::_WithSpaceshipOperator`
-         | (int count) ?{ (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
+  def min: %a{implicitly-returns-nil} () -> E # where E: Comparable::_WithSpaceshipOperator
+         | %a{implicitly-returns-nil} () { (E a, E b) -> Comparable::_CompareToZero? } -> E # TODO: `?`
+         | (int count) -> Array[E] # where E: Comparable::_WithSpaceshipOperator
+         | (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E] # TODO: `?`
+
 
   # <!--
   #   rdoc-file=array.c
@@ -2617,7 +2622,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def minmax: () ?{ (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ]
+  def minmax: () -> [ E?, E? ] # where E: Comparable::_WithSpaceshipOperator
+            | () { (E a, E b) -> Comparable::_CompareToZero? } -> [ E?, E? ] # TODO: `?`
 
   # <!--
   #   rdoc-file=array.c
@@ -2888,7 +2894,7 @@ class Array[unchecked out E]
   # Related: Array#assoc; see also [Methods for
   # Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def rassoc: (untyped object) -> Array[untyped]? # TODO: where `E: _ToAry[X]`, and object: _Equal
+  def rassoc: (untyped object) -> Array[untyped]? # where E: _ToAry, object: _Equal
 
   # <!--
   #   rdoc-file=array.c
@@ -3128,7 +3134,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def rindex: (untyped object) -> Integer? # TODO: _Equal
+  def rindex: (untyped object) -> Integer? # where E: _Equal
             | () { (E element) -> boolish } -> Integer?
             | () -> Enumerator[E, Integer?]
 
@@ -3638,7 +3644,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def sort: () ?{ (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
+  def sort: () -> Array[E] # where E: Comparable::_WithSpaceshipOperator
+          | () { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3649,7 +3656,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def sort!: () ?{ (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
+  def sort!: () -> self # where E: Comparable::_WithSpaceshipOperator
+           | () { (E a, E b) -> Comparable::_CompareToZero } -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -3860,7 +3868,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def union: [T] (*array[T] other_arrays) -> Array[T | E] # TODO: where E: _Eql
+  def union: [T] (*array[T] other_arrays) -> Array[T | E] # where E: _Eql?[T]
 
   # <!--
   #   rdoc-file=array.c
@@ -3886,7 +3894,8 @@ class Array[unchecked out E]
   #
   # Related: [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def uniq: () ?{ (E element) -> Hash::_Key } -> Array[E] # TODO: E: Hash::_Key
+  def uniq: () -> Array[E] # where E: Hash::_Key
+          | () { (E element) -> Hash::_Key } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3914,7 +3923,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def uniq!: () ?{ (E element) -> Hash::_Key } -> self? # TODO: E: Hash::_Key
+  def uniq!: () -> self? # where E: Hash::_Key
+           | () { (E element) -> Hash::_Key } -> self?
 
   # <!--
   #   rdoc-file=array.c
@@ -4153,7 +4163,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def |: [T] (array[T] other_array) -> Array[E | T] # TODO: where E: _Eql[T]
+  def |: [T] (array[T] other_array) -> Array[E | T] # where E: _Eql?[T]
 
   private
 

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1189,7 +1189,7 @@ class Array[unchecked out E]
   # Related: Array#rassoc; see also [Methods for
   # Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def assoc: (untyped) -> ::Array[untyped]?
+  def assoc: (untyped object) -> Array[untyped]? # TODO: where `E: _ToAry[X]`, and object: _Equal
 
   # <!--
   #   rdoc-file=array.c
@@ -1360,7 +1360,7 @@ class Array[unchecked out E]
   # Related: Array#compact!; see also [Methods for
   # Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def compact: () -> ::Array[E]
+  def compact: () -> Array[E] # TODO: it'd be nice if there was a way to do `Array[E - nil]`
 
   # <!--
   #   rdoc-file=array.c
@@ -2202,7 +2202,7 @@ class Array[unchecked out E]
   #     ['a', 'b'].hash == ['a', 'c'].hash # => false
   #     ['a', 'b'].hash == ['a'].hash      # => false
   #
-  def hash: () -> ::Integer
+  def hash: () -> Integer # TODO: where `E: _Hash`
 
   # <!--
   #   rdoc-file=array.c
@@ -2295,7 +2295,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def inspect: () -> String
+  def inspect: () -> String # TODO: where E: _Inspect
 
   # <!--
   #   rdoc-file=array.c
@@ -2849,7 +2849,7 @@ class Array[unchecked out E]
   # Related: Array#assoc; see also [Methods for
   # Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  alias rassoc assoc
+  def rassoc: (untyped object) -> Array[untyped]? # TODO: where `E: _ToAry[X]`, and object: _Equal
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -610,9 +610,9 @@ class Array[unchecked out E]
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
   def initialize: () -> void
-                | (array[E] ary) -> void
+                | (array[E] array) -> void
                 | (int size, ?E default_value) -> void
-                | (int size) { (int index) -> E } -> void
+                | (int size) { (Integer index) -> E } -> void
 
   # <!--
   #   rdoc-file=array.c
@@ -778,7 +778,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Comparing](rdoc-ref:Array@Methods+for+Comparing).
   #
-  def <=>: (untyped) -> Integer? # Until we can do `where E: RBS::Ops::_Compare`, this is always going to return `Integer?~
+  def <=>: (untyped) -> Integer? # Until we can do `where E: RBS::Ops::_Compare`, this is always going to return `Integer?`
 
   # <!--
   #   rdoc-file=array.c
@@ -2603,7 +2603,6 @@ class Array[unchecked out E]
          | (int count) { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
          | %a{warning: returning `nil` will always raise at runtime} (int count) { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
-
   # <!--
   #   rdoc-file=array.c
   #   - minmax -> array
@@ -3651,6 +3650,7 @@ class Array[unchecked out E]
   #
   def sort: () -> Array[E] # where E: Comparable::_WithSpaceshipOperator
           | () { (E a, E b) -> Comparable::_CompareToZero } -> Array[E]
+          | %a{warning: returning `nil` will always raise at runtime} () { (E a, E b) -> Comparable::_CompareToZero? } -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -3663,6 +3663,7 @@ class Array[unchecked out E]
   #
   def sort!: () -> self # where E: Comparable::_WithSpaceshipOperator
            | () { (E a, E b) -> Comparable::_CompareToZero } -> self
+           | %a{warning: returning `nil` will always raise at runtime} () { (E a, E b) -> Comparable::_CompareToZero? } -> self
 
   # <!--
   #   rdoc-file=array.c

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1115,7 +1115,7 @@ class Array[unchecked out E]
   #
   def all?: () -> bool
           | (_Pattern[E] pattern) -> bool
-          | () { (E obj) -> boolish } -> bool
+          | () { (E element) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=array.c
@@ -1155,7 +1155,9 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  alias any? all?
+  def any?: () -> bool
+          | (_Pattern[E] pattern) -> bool
+          | () { (E element) -> boolish } -> bool
 
   # <!-- rdoc-file=array.c -->
   # Appends each argument in `objects` to `self`; returns `self`:
@@ -2615,7 +2617,9 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  alias none? all?
+  def none?: () -> bool
+           | (_Pattern[E] pattern) -> bool
+           | () { (E element) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=array.c
@@ -2652,7 +2656,9 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  alias one? none?
+  def one?: () -> bool
+          | (_Pattern[E] pattern) -> bool
+          | () { (E element) -> boolish } -> bool
 
   # <!--
   #   rdoc-file=pack.rb

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -1426,9 +1426,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def count: () -> ::Integer
-           | (E obj) -> ::Integer
-           | () { (E) -> boolish } -> ::Integer
+  def count: () ?{ (E element) -> boolish } -> Integer
+           | (untyped object) -> Integer # TODO: where E: _Equal
 
   # <!--
   #   rdoc-file=array.c
@@ -1507,8 +1506,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def delete: (E obj) -> E?
-            | [S, T] (S obj) { (S) -> T } -> (E | T)
+  def delete: (untyped object) -> E? # TODO: _Comparable
+            | [S, T] (S object) { (S object) -> T } -> (E | T)
 
   # <!--
   #   rdoc-file=array.c
@@ -1576,7 +1575,7 @@ class Array[unchecked out E]
   # Related: Array#-; see also [Methods for
   # Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def difference: (*::Array[untyped] arrays) -> ::Array[E]
+  def difference: (*array[untyped] other_arrays) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -1596,8 +1595,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def dig: (int idx) -> E?
-         | (int idx, untyped, *untyped) -> untyped
+  def dig: (int index) -> E?
+         | (int index, untyped, *untyped) -> untyped
 
   # <!--
   #   rdoc-file=array.c
@@ -1616,7 +1615,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def drop: (int n) -> ::Array[E]
+  def drop: (int count) -> Array[E]
 
   # <!--
   #   rdoc-file=array.c
@@ -1779,7 +1778,7 @@ class Array[unchecked out E]
   #
   def fetch: (int index) -> E
            | [T] (int index, T default) -> (E | T)
-           | [T] (int index) { (int index) -> T } -> (E | T)
+           | [I < _ToInt, T] (I index) { (I index) -> T } -> (E | T)
 
   # <!--
   #   rdoc-file=array.rb

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -723,7 +723,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def -: (array[untyped] other_array) -> Array[E]  # TODO: `where E: _Eql?[T]`
+  def -: (array[untyped] other_array) -> Array[E] # TODO: `where E: _Eql?[T]`
 
   # <!--
   #   rdoc-file=array.c
@@ -1233,9 +1233,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch: () -> ::Enumerator[E, E?]
-             | () { (E) -> (true | false) } -> E?
-             | () { (E) -> ::Integer } -> E?
+  def bsearch: () { (E element) -> (Numeric | bool?) } -> E?
+             | () -> Enumerator[E, E?]
 
   # <!--
   #   rdoc-file=array.c
@@ -1249,8 +1248,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def bsearch_index: () { (E) -> (true | false) } -> ::Integer?
-                   | () { (E) -> ::Integer } -> ::Integer?
+  def bsearch_index: () { (E element) -> (Numeric | bool?) } -> Integer?
+                   | () -> Enumerator[E, Integer?]
 
   # <!--
   #   rdoc-file=array.c
@@ -1284,8 +1283,8 @@ class Array[unchecked out E]
   # Related: #collect!; see also [Methods for
   # Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def collect: [U] () { (E item) -> U } -> ::Array[U]
-             | () -> ::Enumerator[E, ::Array[untyped]]
+  def collect: [T] () { (E item) -> T } -> Array[T]
+             | () -> Enumerator[E, Array[untyped]]
 
   # <!--
   #   rdoc-file=array.c
@@ -1305,8 +1304,8 @@ class Array[unchecked out E]
   # Related: #collect; see also [Methods for
   # Converting](rdoc-ref:Array@Methods+for+Converting).
   #
-  def collect!: () { (E item) -> E } -> self
-              | () -> ::Enumerator[E, self]
+  def collect!: () { (E element) -> E } -> self
+              | () -> Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1350,8 +1349,8 @@ class Array[unchecked out E]
   # Related: Array#permutation; see also [Methods for
   # Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def combination: (int n) { (::Array[E]) -> void } -> self
-                 | (int n) -> ::Enumerator[::Array[E], self]
+  def combination: (int count) { (Array[E] combination) -> void } -> self
+                 | (int count) -> Enumerator[Array[E], self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1461,8 +1460,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def cycle: (?int? n) { (E) -> void } -> nil
-           | (?int? n) -> ::Enumerator[E, nil]
+  def cycle: (?int? n) { (E element) -> void } -> nil
+           | (?int? n) -> Enumerator[E, nil]
 
   # <!--
   #   rdoc-file=array.c
@@ -1555,7 +1554,24 @@ class Array[unchecked out E]
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def delete_if: () { (E item) -> boolish } -> self
-               | () -> ::Enumerator[E, self]
+               | () -> Enumerator[E, self]
+
+  # <!-- rdoc-file=array.c -->
+  # Returns the first element for which the block returns a truthy value.
+  #
+  # With a block given, calls the block with successive elements of the array;
+  # returns the first element for which the block returns a truthy value:
+  #
+  #     [1, 3, 5].find {|element| element > 2}                # => 3
+  #
+  # If no such element is found, calls `if_none_proc` and returns its return
+  # value.
+  #
+  #     [1, 3, 5].find(proc {-1}) {|element| element > 12} # => -1
+  #
+  # With no block given, returns an Enumerator.
+  #
+  alias detect find
 
   # <!--
   #   rdoc-file=array.c
@@ -1634,8 +1650,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def drop_while: () { (E obj) -> boolish } -> ::Array[E]
-                | () -> ::Enumerator[E, ::Array[E]]
+  def drop_while: () { (E element) -> boolish } -> Array[E]
+                | () -> Enumerator[E, Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -1668,8 +1684,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def each: () -> ::Enumerator[E, self]
-          | () { (E item) -> void } -> self
+  def each: () { (E element) -> void } -> self
+          | () -> Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1703,8 +1719,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def each_index: () { (::Integer index) -> void } -> self
-                | () -> ::Enumerator[::Integer, self]
+  def each_index: () { (Integer index) -> void } -> self
+                | () -> Enumerator[Integer, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -1996,8 +2012,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def fill: (E obj, ?int? start, ?int? length) -> self
-          | (E obj, range[int?] range) -> self
+  def fill: (E object, ?int? start, ?int? length) -> self
+          | (E object, range[int?] range) -> self
           | (?int? start, ?int? length) { (Integer index) -> E } -> self
           | (range[int?] range) { (Integer index) -> E } -> self
 
@@ -2014,8 +2030,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def filter: () { (E item) -> boolish } -> ::Array[E]
-            | () -> ::Enumerator[E, ::Array[E]]
+  alias filter select
 
   # <!-- rdoc-file=array.c -->
   # With a block given, calls the block with each element of `self`; removes from
@@ -2032,8 +2047,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def filter!: () { (E item) -> boolish } -> self?
-             | () -> ::Enumerator[E, self?]
+  alias filter! select!
 
   # <!--
   #   rdoc-file=array.c
@@ -2055,9 +2069,9 @@ class Array[unchecked out E]
   # With no block given, returns an Enumerator.
   #
   def find: () { (E) -> boolish } -> E?
-          | () -> ::Enumerator[E, E?]
-          | [T] (Enumerable::_NotFound[T] ifnone) { (E) -> boolish } -> (E | T)
-          | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[E, E | T]
+          | () -> Enumerator[E, E?]
+          | [T] (Enumerable::_NotFound[T]? ifnone) { (E) -> boolish } -> (E | T)
+          | [T] (Enumerable::_NotFound[T]? ifnone) -> Enumerator[E, E | T]
 
   # <!--
   #   rdoc-file=array.c
@@ -2090,9 +2104,9 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def find_index: (untyped obj) -> ::Integer?
-                | () { (E item) -> boolish } -> ::Integer?
-                | () -> ::Enumerator[E, ::Integer?]
+  def find_index: (untyped object) -> Integer? # TODO: _Equal
+                | () { (E element) -> boolish } -> Integer?
+                | () -> Enumerator[E, Integer?]
 
   # <!--
   #   rdoc-file=array.rb
@@ -2193,6 +2207,24 @@ class Array[unchecked out E]
   # Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
   def flatten!: (?int? level) -> self?
+
+  # <!--
+  #   rdoc-file=array.c
+  #   - freeze -> self
+  # -->
+  # Freezes `self` (if not already frozen); returns `self`:
+  #
+  #     a = []
+  #     a.frozen? # => false
+  #     a.freeze
+  #     a.frozen? # => true
+  #
+  # No further changes may be made to `self`; raises FrozenError if a change is
+  # attempted.
+  #
+  # Related: Kernel#frozen?.
+  #
+  def freeze: () -> self
 
   # <!--
   #   rdoc-file=array.c
@@ -2387,8 +2419,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def keep_if: () { (E item) -> boolish } -> self
-             | () -> ::Enumerator[E, self]
+  def keep_if: () { (E element) -> boolish } -> self
+             | () -> Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.rb
@@ -2430,7 +2462,7 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def length: () -> ::Integer
+  def length: () -> Integer
 
   # <!-- rdoc-file=array.c -->
   # With a block given, calls the block with each element of `self`; returns a new
@@ -2713,8 +2745,8 @@ class Array[unchecked out E]
   #
   # Related: [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def permutation: (?int n) -> ::Enumerator[::Array[E], ::Array[E]]
-                 | (?int n) { (::Array[E] p) -> void } -> ::Array[E]
+  def permutation: (?int? count) { (Array[E] permutation) -> void } -> self
+                 | (?int? count) -> Enumerator[Array[E], self]
 
   # <!--
   #   rdoc-file=array.c
@@ -2896,7 +2928,7 @@ class Array[unchecked out E]
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
   def reject!: () { (E item) -> boolish } -> self?
-             | () -> ::Enumerator[E, self?]
+             | () -> Enumerator[E, self?]
 
   # <!--
   #   rdoc-file=array.c
@@ -2935,8 +2967,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def repeated_combination: (int n) { (::Array[E] c) -> void } -> self
-                          | (int n) -> ::Enumerator[::Array[E], self]
+  def repeated_combination: (int size) { (Array[E] combination) -> void } -> self
+                          | (int size) -> Enumerator[Array[E], self]
 
   # <!--
   #   rdoc-file=array.c
@@ -2975,8 +3007,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Combining](rdoc-ref:Array@Methods+for+Combining).
   #
-  def repeated_permutation: (int n) { (::Array[E] p) -> void } -> self
-                          | (int n) -> ::Enumerator[::Array[E], self]
+  def repeated_permutation: (int size) { (Array[E] permutation) -> void } -> self
+                          | (int size) -> Enumerator[Array[E], self]
 
   # <!-- rdoc-file=array.c -->
   # Replaces the elements of `self` with the elements of `other_array`, which must
@@ -3039,8 +3071,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Iterating](rdoc-ref:Array@Methods+for+Iterating).
   #
-  def reverse_each: () { (E item) -> void } -> self
-                  | () -> ::Enumerator[E, self]
+  def reverse_each: () { (E element) -> void } -> self
+                  | () -> Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -3063,9 +3095,9 @@ class Array[unchecked out E]
   # With no block given, returns an Enumerator.
   #
   def rfind: () { (E) -> boolish } -> E?
-           | () -> ::Enumerator[E, E?]
-           | [T] (Enumerable::_NotFound[T] ifnone) { (E) -> boolish } -> (E | T)
-           | [T] (Enumerable::_NotFound[T] ifnone) -> ::Enumerator[E, E | T]
+           | () -> Enumerator[E, E?]
+           | [T] (Enumerable::_NotFound[T]? ifnone) { (E) -> boolish } -> (E | T)
+           | [T] (Enumerable::_NotFound[T]? ifnone) -> Enumerator[E, E | T]
 
   # <!--
   #   rdoc-file=array.c
@@ -3096,9 +3128,9 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Querying](rdoc-ref:Array@Methods+for+Querying).
   #
-  def rindex: (untyped obj) -> ::Integer?
-            | () { (E item) -> boolish } -> ::Integer?
-            | () -> ::Enumerator[E, ::Integer?]
+  def rindex: (untyped object) -> Integer? # TODO: _Equal
+            | () { (E element) -> boolish } -> Integer?
+            | () -> Enumerator[E, Integer?]
 
   # <!--
   #   rdoc-file=array.c
@@ -3241,8 +3273,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def select: () { (E item) -> boolish } -> ::Array[E]
-            | () -> ::Enumerator[E, ::Array[E]]
+  def select: () { (E element) -> boolish } -> Array[E]
+            | () -> Enumerator[E, Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -3265,8 +3297,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Deleting](rdoc-ref:Array@Methods+for+Deleting).
   #
-  def select!: () { (E item) -> boolish } -> self?
-             | () -> ::Enumerator[E, self?]
+  def select!: () { (E element) -> boolish } -> self?
+             | () -> Enumerator[E, self?]
 
   # <!--
   #   rdoc-file=array.c
@@ -3640,8 +3672,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Assigning](rdoc-ref:Array@Methods+for+Assigning).
   #
-  def sort_by!: [U] () { (E obj) -> U } -> ::Array[E]
-              | () -> ::Enumerator[E, ::Array[E]]
+  def sort_by!: () { (E element) -> Comparable::_WithSpaceshipOperator } -> self # TODO: use RBS::Ops
+              | () -> Enumerator[E, self]
 
   # <!--
   #   rdoc-file=array.c
@@ -3724,8 +3756,8 @@ class Array[unchecked out E]
   #
   # Related: see [Methods for Fetching](rdoc-ref:Array@Methods+for+Fetching).
   #
-  def take_while: () { (E obj) -> boolish } -> ::Array[E]
-                | () -> ::Enumerator[E, ::Array[E]]
+  def take_while: () { (E element) -> boolish } -> Array[E]
+                | () -> Enumerator[E, Array[E]]
 
   # <!--
   #   rdoc-file=array.c
@@ -4123,9 +4155,6 @@ class Array[unchecked out E]
   #
   def |: [T] (array[T] other_array) -> Array[E | T] # TODO: where E: _Eql[T]
 
-  def freeze: () -> self
-  alias detect find
-
   private
 
   # <!--
@@ -4148,7 +4177,7 @@ end
 
 %a{deprecated: Use Array::_Rand}
 interface _Rand
-  def rand: (::Integer max) -> ::Integer
+  def rand: (Integer max) -> Integer
 end
 
 interface Array::_Pattern[T]

--- a/core/array.rbs
+++ b/core/array.rbs
@@ -647,7 +647,7 @@ class Array[unchecked out E]
   # Array](rdoc-ref:Array@Methods+for+Creating+an+Array).
   #
   def self.try_convert: [A < Array[U], U] (A array) -> A
-                      | [U] (array[U] ary) -> Array[U]
+                      | [U] (array[U] ary) -> Array[U]?
                       | (untyped) -> Array[untyped]?
 
   # <!--

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -56,6 +56,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   class ArraySubclass < Array
   end
 
+  class RngGen
+    def rand(max) = ToInt.new(Random.new.rand(max))
+  end
+
   def test_op_and
     with_array [1r, 1i] do |other|
       assert_send_type  '(array[untyped]) -> Array[Rational]',
@@ -334,7 +338,21 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_fetch_values
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :fetch_values
+    assert_send_type  '() { (Integer) -> void } -> Array[Rational]',
+                      [1r, 2r], :fetch_values do end
+
+    with_int 1 do |index1|
+      with_int 2 do |index2|
+        assert_send_type  '(*int) -> Array[Rational]',
+                          [1r, 2r, 3r], :fetch_values, index1, index2
+        assert_send_type  '[I < _ToInt] (*I) { (I) -> void } -> Array[Rational]',
+                          [1r, 2r, 3r], :fetch_values, index1, index2 do fail end
+        assert_send_type  '[I < _ToInt] (*I) { (I) -> Complex } -> Array[Rational | Complex]',
+                          [1r, 2r], :fetch_values, index1, index2 do |x| x.to_int.i end
+      end
+    end
   end
 
   def test_fill
@@ -358,7 +376,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_first
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [], :first
+    assert_send_type  '() -> Rational',
+                      [1r, 2r], :first
+
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [], :first, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :first, count
+    end
   end
 
   def test_flatten
@@ -412,7 +440,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_last
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [], :last
+    assert_send_type  '() -> Rational',
+                      [1r, 2r], :last
+
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [], :last, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :last, count
+    end
   end
 
   def test_length(method: :length)
@@ -500,7 +538,22 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_sample
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [], :sample
+    assert_send_type  '(random: Array::_Rand) -> nil',
+                      [], :sample, random: RngGen.new
+
+    assert_send_type  '() -> Rational',
+                      [1r, 2r, 3r], :sample
+    assert_send_type  '(random: Array::_Rand) -> Rational',
+                      [1r, 2r, 3r], :sample, random: RngGen.new
+
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r, 3r], :sample, count
+      assert_send_type  '(int, random: Array::_Rand) -> Array[Rational]',
+                        [1r, 2r, 3r], :sample, count, random: RngGen.new
+    end
   end
 
   def test_select(method: :select)
@@ -524,11 +577,19 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_shuffle
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r], :shuffle
+
+    assert_send_type  '(random: Array::_Rand) -> Array[Rational]',
+                      [1r, 2r, 3r], :shuffle, random: RngGen.new
   end
 
   def test_shuffle!
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r], :shuffle!
+
+    assert_send_type  '(random: Array::_Rand) -> Array[Rational]',
+                      [1r, 2r, 3r], :shuffle!, random: RngGen.new
   end
 
   def test_slice!

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -3,7 +3,7 @@ require_relative "test_helper"
 class ArraySingletonTest < Test::Unit::TestCase
   include TestHelper
 
-  testing 'singleton(::Array)'
+  testing 'singleton(Array)'
 
   def test_new
     assert_send_type '() -> Array[untyped]',
@@ -51,990 +51,461 @@ end
 class ArrayInstanceTest < Test::Unit::TestCase
   include TestHelper
 
-  testing "::Array[::Integer]"
+  testing 'Array[Rational]'
 
-  def test_and
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :&, [2,3,4]
-    assert_send_type "(ToArray) -> Array[Integer]",
-                     [1,2,3], :&, ToArray.new(:a, :b, :c)
+  def test_op_and
+    omit 'todo'
   end
 
-  def test_mul
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1], :*, 3
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1], :*, ToInt.new(3)
-    assert_send_type "(String) -> String",
-                     [1], :*, ","
-    assert_send_type "(ToStr) -> String",
-                     [1], :*, ToStr.new(",")
+  def test_op_mul
+    omit 'todo'
   end
 
-  def test_plus
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :+, [4,5,6]
-    assert_send_type "(Array[String]) -> Array[Integer | String]",
-                     [1,2,3], :+, ["4", "5", "6"]
-    assert_send_type "(ToArray) -> Array[Integer | String]",
-                     [1,2,3], :+, ToArray.new("a")
-
-    refute_send_type "(Enum) -> Array[Integer | String]",
-                     [1,2,3], :+, Enum.new("a")
-  end
-
-  def test_minus
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :-, [4,5,6]
-    assert_send_type "(ToArray) -> Array[Integer | String]",
-                     [1,2,3], :-, ToArray.new("a")
-
-    refute_send_type "(Enum) -> Array[Integer]",
-                     [1,2,3], :-, Enum.new("a")
-  end
-
-  def test_lshift
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :<<, 4
-  end
-
-  def test_aref
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :[], 0
-    assert_send_type "(Integer) -> nil",
-                     [1,2,3], :[], 1000
-    assert_send_type "(Float) -> Integer",
-                     [1,2,3], :[], 0.1
-    assert_send_type "(ToInt) -> Integer",
-                     [1], :[], ToInt.new(0)
-
-    assert_send_type "(Integer, ToInt) -> Array[Integer]",
-                     [1,2,3], :[], 0, ToInt.new(2)
-    assert_send_type "(Integer, ToInt) -> nil",
-                     [1,2,3], :[], 4, ToInt.new(2)
-
-    assert_send_type "(Range[Integer]) -> Array[Integer]",
-                     [1,2,3], :[], 0...1
-    assert_send_type "(Range[Integer]) -> nil",
-                     [1,2,3], :[], 5..8
-    assert_send_type "(Range[Integer?]) -> Array[Integer]",
-                     [1,2,3], :[], 0...nil
-  end
-
-  def test_aupdate
-    assert_send_type "(Integer, Integer) -> Integer",
-                     [1,2,3], :[]=, 0, 0
-
-    assert_send_type "(Integer, ToInt, Integer) -> Integer",
-                     [1,2,3], :[]=, 0, ToInt.new(2), -1
-    assert_send_type "(Integer, ToInt, Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :[]=, 0, ToInt.new(2), [-1]
-    assert_send_type "(Integer, ToInt, nil) -> nil",
-                     [1,2,3], :[]=, 0, ToInt.new(2), nil
-
-    assert_send_type "(Range[Integer], Integer) -> Integer",
-                     [1,2,3], :[]=, 0..2, -1
-    assert_send_type "(Range[Integer], Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :[]=, 0...2, [-1]
-    assert_send_type "(Range[Integer], nil) -> nil",
-                     [1,2,3], :[]=, 0...2, nil
-    assert_send_type "(Range[Integer?], Integer) -> Integer",
-                     [1,2,3], :[]=, 0..nil, -1
-  end
-
-  def test_all?
-    assert_send_type "() -> bool",
-                     [1,2,3], :all?
-    assert_send_type "(singleton(Integer)) -> bool",
-                     [1,2,3], :all?, Integer
-    assert_send_type "() { (Integer) -> bool } -> bool",
-                     [1,2,3], :all? do true end
-  end
-
-  def test_any?
-    assert_send_type "() -> bool",
-                     [1,2,3], :any?
-    assert_send_type "(singleton(Integer)) -> bool",
-                     [1,2,3], :any?, Integer
-    assert_send_type "() { (Integer) -> bool } -> bool",
-                     [1,2,3], :any? do true end
-  end
-
-  def test_assoc
-    assert_send_type "(Integer) -> nil",
-                     [1,2,3], :assoc, 0
-  end
-
-  def test_at
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :at, 0
-    assert_send_type "(ToInt) -> Integer",
-                     [1,2,3], :at, ToInt.new(0)
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :at, ToInt.new(-5)
-  end
-
-  def test_bsearch
-    assert_send_type "() -> Enumerator[Integer]", [0,1,2,3,4],
-                     :bsearch
-
-    assert_send_type "() { (Integer) -> (true | false) } -> Integer",
-                     [0,1,2,3,4], :bsearch do |x| x > 2 end
-    assert_send_type "() { (Integer) -> (true | false) } -> nil",
-                     [0,1,2,3,4], :bsearch do |x| x > 8 end
-
-    assert_send_type "() { (Integer) -> Integer } -> Integer",
-                     [0,1,2,3,4], :bsearch do |x| 3 <=> x end
-    assert_send_type "() { (Integer) -> Integer } -> nil",
-                     [0,1,2,3,4], :bsearch do |x| 8 <=> x end
-
-  end
-
-  def test_bsearch_index
-    assert_send_type "() { (Integer) -> (true | false) } -> Integer",
-                     [0,1,2,3,4], :bsearch_index do |x| x > 2 end
-    assert_send_type "() { (Integer) -> (true | false) } -> nil",
-                     [0,1,2,3,4], :bsearch_index do |x| x > 8 end
-
-    assert_send_type "() { (Integer) -> Integer } -> Integer",
-                     [0,1,2,3,4], :bsearch_index do |x| 3 <=> x end
-    assert_send_type "() { (Integer) -> Integer } -> nil",
-                     [0,1,2,3,4], :bsearch_index do |x| 8 <=> x end
-  end
-
-  def test_llear
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :clear
-  end
-
-  def test_collect
-    assert_send_type "() { (Integer) -> String } -> Array[String]",
-                     [1,2,3], :collect do |x| x.to_s end
-    assert_send_type "() -> Enumerator[Integer, Array[untyped]]",
-                     [1,2,3], :collect
-  end
-
-  def test_collect!
-    assert_send_type "() { (Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :collect! do |x| x+1 end
-  end
-
-  def test_combination
-    assert_send_type "(Integer) -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :combination, 3
-    assert_send_type "(ToInt) -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :combination, ToInt.new(3)
-
-    assert_send_type "(Integer) { (Array[Integer]) -> void } -> Array[Integer]",
-                     [1,2,3], :combination, 3 do end
-    assert_send_type "(ToInt) { (Array[Integer]) -> void } -> Array[Integer]",
-                     [1,2,3], :combination, ToInt.new(3) do end
-  end
-
-  def test_compact
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :compact
-    assert_send_type "() -> nil",
-                     [1,2,3], :compact!
-  end
-
-  def test_concat
-    assert_send_type "(Array[Integer], Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :concat, [4,5,6], [7,8,9]
-    assert_send_type "(Array[Integer], Array[Integer]) -> Array[Integer]",
-                     Class.new(Array).new, :concat, [4,5,6], [7,8,9]
-  end
-
-  def test_count
-    assert_send_type "() -> Integer",
-                     [1,2,3], :count
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :count, 1
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :count do |x| x.odd? end
-  end
-
-  def test_cycle
-    assert_send_type(
-      "() { (Integer) -> void } -> nil",
-      [1,2,3], :cycle, &proc { break_from_block }
-    )
-
-    assert_send_type "(Integer) { (Integer) -> void } -> nil",
-                     [1,2,3], :cycle, 3 do end
-    assert_send_type "(ToInt) { (Integer) -> void } -> nil",
-                     [1,2,3], :cycle, ToInt.new(2) do end
-  end
-
-  def test_deconstruct
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :deconstruct
-  end
-
-  def test_delete
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :delete, 2
-
-    assert_send_type "(Integer) { (Integer) -> String } -> Integer",
-                     [1,2,3], :delete, 2 do "" end
-    assert_send_type "(Symbol) { (Symbol) -> String } -> String",
-                     [1,2,3], :delete, :foo do "" end
-  end
-
-  def test_delete_at
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :delete_at, 2
-    assert_send_type "(Integer) -> nil",
-                     [1,2,3], :delete_at, 100
-
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :delete_at, ToInt.new(300)
-  end
-
-  def test_delete_if
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :delete_if do |x| x.odd? end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :delete_if
-  end
-
-  def test_difference
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :difference, [2]
-  end
-
-  def test_dig
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :dig, 1
-    assert_send_type "(Integer) -> nil",
-                     [1,2,3], :dig, 10
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :dig, ToInt.new(10)
-  end
-
-  def test_drop
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :drop, 2
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :drop, ToInt.new(2)
-  end
-
-  def test_drop_while
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :drop_while do false end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :drop_while
-  end
-
-  def test_each
-    assert_send_type "() { (Integer) -> void } -> Array[Integer]",
-                     [1,2,3], :each do end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :each
-  end
-
-  def test_each_index
-    assert_send_type "() { (Integer) -> void } -> Array[String]",
-                     ['1','2','3'], :each_index do end
-    assert_send_type "() -> Enumerator[Integer, Array[String]]",
-                     ['1','2','3'], :each_index
-  end
-
-  def test_empty?
-    assert_send_type "() -> bool",
-                     [1,2,3], :empty?
-  end
-
-  def test_fetch
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :fetch, 1
-    assert_send_type "(ToInt) -> Integer",
-                     [1,2,3], :fetch, ToInt.new(1)
-
-    assert_send_type "(ToInt, String) -> Integer",
-                     [1,2,3], :fetch, ToInt.new(1), "foo"
-    assert_send_type "(ToInt, String) -> String",
-                     [1,2,3], :fetch, ToInt.new(10), "foo"
-
-    assert_send_type "(Integer) { (Integer) -> Symbol } -> Integer",
-                     [1,2,3], :fetch, 1 do :hello end
-    assert_send_type "(Integer) { (Integer) -> Symbol } -> Symbol",
-                     [1,2,3], :fetch, 10 do :hello end
-  end
-
-  def test_fetch_values
-    if_ruby("3.4"...) do
-      with_int(1) do |one|
-        with_int(2) do |two|
-          assert_send_type(
-            "(int, int) -> Array[Symbol]",
-            [:a, :b, :c], :fetch_values, one, two
-          )
-        end
-      end
-      assert_send_type(
-        "() -> Array[Symbol]",
-        [:a, :b, :c], :fetch_values
-      )
-    end
-  end
-
-  def test_fill
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :fill, 0
-
-    assert_send_type "(Integer, nil) -> Array[Integer]",
-                     [1,2,3], :fill, 0, nil
-    assert_send_type "(Integer, ToInt) -> Array[Integer]",
-                     [1,2,3], :fill, 0, ToInt.new(1)
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :fill, 0, 1
-    assert_send_type "(Integer, Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :fill, 0, 1, 2
-    assert_send_type "(Integer, ToInt, ToInt) -> Array[Integer]",
-                     [1,2,3], :fill, 0, ToInt.new(1), ToInt.new(2)
-    assert_send_type "(Integer, Integer, nil) -> Array[Integer]",
-                     [1,2,3], :fill, 0, 1, nil
-
-    assert_send_type "(Integer, Range[Integer]) -> Array[Integer]",
-                     [1,2,3], :fill, 0, 1..2
-
-    assert_send_type "() { (Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :fill do |i| i * 10 end
-    assert_send_type "(ToInt, ToInt) { (Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :fill, ToInt.new(0), ToInt.new(2) do |i| i * 10 end
-    assert_send_type "(Range[Integer]) { (Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :fill, 0..2 do |i| i * 10 end
-  end
-
-  def test_filter
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :filter do |i| i < 1 end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :filter
-  end
-
-  def test_filter!
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :filter! do |i| i < 0 end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :filter! do |i| i > 0 end
-
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]?]",
-                     [1,2,3], :filter!
-  end
-
-  def test_find
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :find, &->(i) { i.odd? }
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [0,2], :find, &->(i) { i.odd? }
-    assert_send_type "(Enumerable::_NotFound[String]) { (Integer) -> bool } -> String",
-                     [0,2], :find, -> { "" }, &->(i) { i.odd? }
-
-    assert_send_type "() -> Enumerator[Integer, Integer?]",
-                     [1,2,3], :find
-    assert_send_type "(Enumerable::_NotFound[String]) -> Enumerator[Integer, Integer | String | nil]",
-                     [0,2], :find, -> { "" }
-  end
-
-  def test_find_index
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :find_index, 1
-    assert_send_type "(String) -> nil",
-                     [1,2,3], :find_index, "0"
-
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :find_index do |i| i.odd? end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :find_index do |i| i < 0 end
-
-    assert_send_type "() -> Enumerator[Integer, Integer?]",
-                     [1,2,3], :find_index
-  end
-
-  def test_first
-    assert_send_type "() -> Integer",
-                     [1,2,3], :first
-    assert_send_type "() -> nil",
-                     [], :first
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :first, 2
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :first, ToInt.new(2)
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :first, 0
-  end
-
-  def test_flatten
-    assert_send_type "() -> Array[untyped]",
-                     [1,2,3], :flatten
-    assert_send_type "(Integer) -> Array[untyped]",
-                     [1,2,3], :flatten, 3
-    assert_send_type "(ToInt) -> Array[untyped]",
-                     [1,2,3], :flatten, ToInt.new(3)
-  end
-
-  def test_flatten!
-    assert_send_type "() -> Array[untyped]?",
-                     [1,2,3], :flatten!
-    assert_send_type "(Integer) -> Array[untyped]?",
-                     [1,2,3], :flatten!, 3
-    assert_send_type "(ToInt) -> Array[untyped]?",
-                     [1,2,3], :flatten!, ToInt.new(3)
-  end
-
-  def test_include?
-    assert_send_type "(Integer) -> bool",
-                     [1,2,3], :include?, 1
-  end
-
-  def test_index
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :index, 1
-    assert_send_type "(String) -> nil",
-                     [1,2,3], :index, "0"
-
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :index do |i| i.odd? end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :index do |i| i < 0 end
-
-    assert_send_type "() -> Enumerator[Integer, Integer?]",
-                     [1,2,3], :index
-  end
-
-  def test_insert
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :insert, 0, 10
-    assert_send_type "(ToInt, Integer, Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :insert, ToInt.new(0), 10, 20, 30
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :insert, 0
-  end
-
-  def test_intersect?
-    assert_send_type(
-      "(Array[Integer]) -> bool",
-      [1,2,3], :intersect?, [0]
-    )
-    assert_send_type(
-      "(ToArray[Integer]) -> bool",
-      [1,2,3], :intersect?, ToArray.new([0, 1])
-    )
-  end
-
-  def test_intersection
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :intersection, [2,3,4]
-    assert_send_type "(Array[Integer], Array[String], ToArray) -> Array[Integer]",
-                     [1,2,3], :intersection, [2,3,4], ["a"], ToArray.new(true, false)
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :intersection
-  end
-
-  def test_join
-    assert_send_type "() -> String",
-                     [1,2,3], :join
-
-    assert_send_type "(String) -> String",
-                     [1,2,3], :join, ","
-    assert_send_type "(ToStr) -> String",
-                     [1,2,3], :join, ToStr.new(",")
-  end
-
-  def test_keep_if
-    assert_send_type "() { (Integer) -> false } -> Array[Integer]",
-                     [1,2,3], :keep_if do false end
-    assert_send_type "() { (Integer) -> true } -> Array[Integer]",
-                     [1,2,3], :keep_if do true end
-
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :keep_if
-  end
-
-  def test_last
-    assert_send_type "() -> Integer",
-                     [1,2,3], :last
-    assert_send_type "() -> nil",
-                     [], :last
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :last, 2
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :last, ToInt.new(0)
-  end
-
-  def test_length
-    assert_send_type "() -> Integer",
-                     [1,2,3], :length
-  end
-
-  def test_map
-    assert_send_type "() { (Integer) -> String } -> Array[String]",
-                     [1,2,3], :map do |x| x.to_s end
-    assert_send_type "() -> Enumerator[Integer, Array[untyped]]",
-                     [1,2,3], :map
-  end
-
-  def test_map!
-    assert_send_type "() { (Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :map! do |x| x+1 end
-  end
-
-  def test_max
-    assert_send_type "() -> Integer",
-                     [1,2,3], :max
-    assert_send_type "() -> nil",
-                     [], :max
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :max, 1
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [], :max, ToInt.new(1)
-
-    assert_send_type "() { (Integer, Integer) -> Integer } -> Integer",
-                     [1,2,3], :max do |_, _| 1 end
-    assert_send_type "() { (Integer, Integer) -> Integer } -> nil",
-                     [], :max do |_, _| 0 end
-
-    assert_send_type "(ToInt) { (Integer, Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :max, ToInt.new(2) do |_, _| 0 end
-    refute_send_type "(Integer) { (Integer, Integer) -> ToInt } -> Array[Integer]",
-                     [1,2,3], :max, 2 do |_, _| ToInt.new(0) end
-  end
-
-  def test_minmax
-    assert_send_type "() -> [Integer, Integer]",
-                     [1,2,3], :minmax
-    assert_send_type "() -> [Integer, Integer]",
-                     [1], :minmax
-    assert_send_type "() -> [nil, nil]",
-                     [], :minmax
-
-    assert_send_type "() { (Integer, Integer) -> Integer } -> [Integer, Integer]",
-                     [1, 2], :minmax do |_, _| 0 end
-  end
-
-  def test_none?
-    assert_send_type "() -> bool",
-                     [1,2,3], :none?
-    assert_send_type "(singleton(String)) -> bool",
-                     [1,2,3], :none?, String
-    assert_send_type "() { (Integer) -> bool } -> bool",
-                     [1,2,3], :none? do |x| x.even? end
-  end
-
-  def test_one?
-    assert_send_type "() -> bool",
-                     [1,2,3], :one?
-    assert_send_type "(singleton(String)) -> bool",
-                     [1,2,3], :one?, String
-    assert_send_type "() { (Integer) -> bool } -> bool",
-                     [1,2,3], :one? do |x| x.even? end
-  end
-
-  def test_pack
-    assert_send_type "(String) -> String",
-                     [1,2,3], :pack, "ccc"
-    assert_send_type "(ToStr) -> String",
-                     [1,2,3], :pack, ToStr.new("ccc")
-
-    assert_send_type "(String, buffer: String) -> String",
-                     [1,2,3], :pack, "ccc", buffer: +""
-    assert_send_type "(String, buffer: nil) -> String",
-                     [1,2,3], :pack, "ccc", buffer: nil
-    refute_send_type "(ToStr, buffer: ToStr) -> String",
-                     [1,2,3], :pack, ToStr.new("ccc"), buffer: ToStr.new("")
-  end
-
-  def test_permutation
-    assert_send_type "(Integer) -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :permutation, 2
-    assert_send_type "() -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :permutation
-
-
-    assert_send_type "(Integer) { (Array[Integer]) -> void } -> Array[Integer]",
-                     [1,2,3], :permutation, 2 do end
-    assert_send_type "() { (Array[Integer]) -> void } -> Array[Integer]",
-                     [1,2,3], :permutation do end
-  end
-
-  def test_pop
-    assert_send_type "() -> Integer",
-                     [1,2,3], :pop
-    assert_send_type "() -> nil",
-                     [], :pop
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :pop, 1
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :pop, ToInt.new(2)
-  end
-
-  def test_product
-    assert_send_type "() -> Array[[Integer]]",
-                     [1,2,3], :product
-    assert_send_type "(Array[String]) -> Array[[Integer, String]]",
-                     [1,2,3], :product, ["a", "b"]
-    assert_send_type "(Array[String], Array[Symbol]) -> Array[[Integer, String, Symbol]]",
-                     [1,2,3], :product, ["a", "b"], [:a, :b]
-    assert_send_type "(Array[String], Array[Symbol], Array[true | false]) -> Array[Array[Integer | interned | true | false]]",
-                     [1,2,3], :product, ["a", "b"], [:a, :b], [true, false]
-  end
-
-  def test_push
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :push
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :push, 4, 5
-  end
-
-  def test_rassoc
-    assert_send_type "(String) -> nil",
-                     [1,2,3], :rassoc, "3"
-  end
-
-  def test_reject
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :reject do |x| x.odd? end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :reject
-  end
-
-  def test_reject!
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :reject! do |x| x.odd? end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :reject! do |x| x == "" end
-
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]?]",
-                     [1,2,3], :reject!
-  end
-
-  def test_repeated_combination
-    assert_send_type "(ToInt) { (Array[Integer]) -> nil } -> Array[Integer]",
-                     [1,2,3], :repeated_combination, ToInt.new(2) do end
-    assert_send_type "(ToInt) -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :repeated_combination, ToInt.new(2)
-  end
-
-  def test_repeated_permutation
-    assert_send_type "(ToInt) { (Array[Integer]) -> nil } -> Array[Integer]",
-                     [1,2,3], :repeated_permutation, ToInt.new(2) do end
-    assert_send_type "(ToInt) -> Enumerator[Array[Integer], Array[Integer]]",
-                     [1,2,3], :repeated_permutation, ToInt.new(2)
-  end
-
-  def test_replace
-    assert_send_type "(Array[Integer]) -> Array[Integer]",
-                     [1,2,3], :replace, [2,3,4]
-  end
-
-  def test_reverse
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :reverse
-  end
-
-  def test_reverse!
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :reverse!
-  end
-
-  def test_reverse_each
-    assert_send_type "() { (Integer) -> nil } -> Array[Integer]",
-                     [1,2,3], :reverse_each do end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [2,3,4], :reverse_each
-  end
-
-  def test_rfind
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :rfind, &->(i) { i.odd? }
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [0,2], :rfind, &->(i) { i.odd? }
-    assert_send_type "(Enumerable::_NotFound[String]) { (Integer) -> bool } -> String",
-                     [0,2], :rfind, -> { "" }, &->(i) { i.odd? }
-
-    assert_send_type "() -> Enumerator[Integer, Integer?]",
-                     [1,2,3], :rfind
-    assert_send_type "(Enumerable::_NotFound[String]) -> Enumerator[Integer, Integer | String | nil]",
-                     [0,2], :rfind, -> { "" }
-  end
-
-  def test_rindex
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :rindex, 1
-    assert_send_type "(String) -> nil",
-                     [1,2,3], :rindex, "0"
-
-    assert_send_type "() { (Integer) -> bool } -> Integer",
-                     [1,2,3], :rindex do |i| i.odd? end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :rindex do |i| i < 0 end
-
-    assert_send_type "() -> Enumerator[Integer, Integer?]",
-                     [1,2,3], :rindex
-  end
-
-  def test_rotate
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :rotate
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :rotate, 3
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :rotate, ToInt.new(2)
-  end
-
-  def test_rotate!
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :rotate!
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :rotate!, 3
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :rotate!, ToInt.new(2)
-  end
-
-  def test_sample
-    assert_send_type "() -> Integer",
-                     [1,2,3], :sample
-    assert_send_type "() -> nil",
-                     [], :sample
-    assert_send_type "(random: Random) -> Integer",
-                     [1,2,3], :sample, random: Random.new(1)
-    assert_send_type "(random: Rand) -> Integer",
-                     [1,2,3], :sample, random: Rand.new
-
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :sample, 2
-    assert_send_type "(ToInt, random: Random) -> Array[Integer]",
-                     [1,2,3], :sample, ToInt.new(2), random: Random.new(2)
-    assert_send_type "(ToInt, random: Rand) -> Array[Integer]",
-                     [1,2,3], :sample, ToInt.new(2), random: Rand.new
+  def test_op_add
+    omit 'todo'
   end
 
-  def test_select
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :select do |i| i < 1 end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :select
+  def test_op_sub
+    omit 'todo'
   end
 
-  def test_select!
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :select! do |i| i < 1 end
-    assert_send_type "() { (Integer) -> bool } -> nil",
-                     [1,2,3], :select! do true end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]?]",
-                     [1,2,3], :select!
+  def test_op_lsh
+    omit 'todo'
   end
 
-  def test_shift
-    assert_send_type "() -> Integer",
-                     [1,2,3], :shift
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :shift, ToInt.new(1)
-    assert_send_type "() -> nil",
-                     [], :shift
+  def test_op_cmp
+    omit 'todo'
   end
 
-  def test_shuffle
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :shuffle
-    assert_send_type "(random: Random) -> Array[Integer]",
-                     [1,2,3], :shuffle, random: Random.new(2)
-    assert_send_type "(random: Rand) -> Array[Integer]",
-                     [1,2,3], :shuffle, random: Rand.new
+  def test_op_eq
+    omit 'todo'
   end
 
-  def test_shuffle!
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :shuffle!
-    assert_send_type "(random: Random) -> Array[Integer]",
-                     [1,2,3], :shuffle!, random: Random.new(2)
-    assert_send_type "(random: Rand) -> Array[Integer]",
-                     [1,2,3], :shuffle!, random: Rand.new
+  def test_op_aref(method: :[])
+    omit 'todo'
   end
 
   def test_slice
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :slice, 1
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :slice, ToInt.new(11)
+    test_op_aref(method: :slice)
+  end
 
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :slice, 1, 2
-    assert_send_type "(ToInt, ToInt) -> nil",
-                     [1,2,3], :slice, ToInt.new(10), ToInt.new(2)
+  def test_op_aset
+    omit 'todo'
+  end
 
-    assert_send_type "(Range[Integer]) -> Array[Integer]",
-                     [1,2,3], :slice, 1...2
-    assert_send_type "(Range[Integer]) -> nil",
-                     [1,2,3], :slice, 11...21
+  def test_all?
+    omit 'todo'
+  end
+
+  def test_assoc
+    omit 'todo'
+  end
+
+  def test_at
+    omit 'todo'
+  end
+
+  def test_bsearch
+    omit 'todo'
+  end
+
+  def test_bsearch_index
+    omit 'todo'
+  end
+
+  def test_clear
+    omit 'todo'
+  end
+
+  def test_collect(method: :collect)
+    omit 'todo'
+  end
+
+  def test_map
+    test_collect(method: :map)
+  end
+
+  def test_collect!(method: :collect!)
+    omit 'todo'
+  end
+
+  def test_map!
+    test_collect!(method: :map!)
+  end
+
+  def test_combination
+    omit 'todo'
+  end
+
+  def test_compact
+    omit 'todo'
+  end
+
+  def test_compact!
+    omit 'todo'
+  end
+
+  def test_concat
+    omit 'todo'
+  end
+
+  def test_count
+    omit 'todo'
+  end
+
+  def test_cycle
+    omit 'todo'
+  end
+
+  def test_deconstruct
+    omit 'todo'
+  end
+
+  def test_delete
+    omit 'todo'
+  end
+
+  def test_delete_at
+    omit 'todo'
+  end
+
+  def test_delete_if
+    omit 'todo'
+  end
+
+  def test_difference
+    omit 'todo'
+  end
+
+  def test_dig
+    omit 'todo'
+  end
+
+  def test_drop
+    omit 'todo'
+  end
+
+  def test_drop_while
+    omit 'todo'
+  end
+
+  def test_each
+    omit 'todo'
+  end
+
+  def test_each_index
+    omit 'todo'
+  end
+
+  def test_empty?
+    omit 'todo'
+  end
+
+  def test_eql?
+    omit 'todo'
+  end
+
+  def test_fetch
+    omit 'todo'
+  end
+
+  def test_fetch_values
+    omit 'todo'
+  end
+
+  def test_fill
+    omit 'todo'
+  end
+
+  def test_find(method: :find)
+    omit 'todo'
+  end
+
+  def test_detect
+    test_find(method: :detect)
+  end
+
+  def test_find_index(method: :find_index)
+    omit 'todo'
+  end
+
+  def test_index
+    test_find_index(method: :index)
+  end
+
+  def test_first
+    omit 'todo'
+  end
+
+  def test_flatten
+    omit 'todo'
+  end
+
+  def test_flatten!
+    omit 'todo'
+  end
+
+  def test_hash
+    omit 'todo'
+  end
+
+  def test_include?
+    omit 'todo'
+  end
+
+  def test_insert
+    omit 'todo'
+  end
+
+  def test_inspect(method: :inspect)
+    omit 'todo'
+  end
+
+  def test_to_s
+    test_inspect(method: :to_s)
+  end
+
+  def test_intersect?
+    omit 'todo'
+  end
+
+  def test_intersection
+    omit 'todo'
+  end
+
+  def test_join
+    omit 'todo'
+  end
+
+  def test_keep_if
+    omit 'todo'
+  end
+
+  def test_last
+    omit 'todo'
+  end
+
+  def test_length(method: :length)
+    omit 'todo'
+  end
+
+  def test_size
+    test_length(method: :size)
+  end
+
+  def test_max
+    omit 'todo'
+  end
+
+  def test_minmax
+    omit 'todo'
+  end
+
+  def test_pack
+    omit 'todo'
+  end
+
+  def test_permutation
+    omit 'todo'
+  end
+
+  def test_pop
+    omit 'todo'
+  end
+
+  def test_product
+    omit 'todo'
+  end
+
+  def test_push(method: :push)
+    omit 'todo'
+  end
+
+  def test_append
+    test_push(method: :append)
+  end
+
+  def test_reject!
+    omit 'todo'
+  end
+
+  def test_repeated_combination
+    omit 'todo'
+  end
+
+  def test_repeated_permutation
+    omit 'todo'
+  end
+
+  def test_replace(method: :replace)
+    omit 'todo'
+  end
+
+  def test_reverse
+    omit 'todo'
+  end
+
+  def test_reverse!
+    omit 'todo'
+  end
+
+  def test_reverse_each
+    omit 'todo'
+  end
+
+  def test_rfind
+    omit 'todo'
+  end
+
+  def test_rindex
+    omit 'todo'
+  end
+
+  def test_rotate
+    omit 'todo'
+  end
+
+  def test_rotate!
+    omit 'todo'
+  end
+
+  def test_sample
+    omit 'todo'
+  end
+
+  def test_select(method: :select)
+    omit 'todo'
+  end
+
+  def test_filter
+    test_select(method: :filter)
+  end
+
+  def test_select!(method: :select!)
+    omit 'todo'
+  end
+
+  def test_filter!
+    test_select(method: :filter!)
+  end
+
+  def test_shift
+    omit 'todo'
+  end
+
+  def test_shuffle
+    omit 'todo'
+  end
+
+  def test_shuffle!
+    omit 'todo'
   end
 
   def test_slice!
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :slice!, 1
-    assert_send_type "(ToInt) -> nil",
-                     [1,2,3], :slice!, ToInt.new(11)
-
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :slice!, 1, 2
-    assert_send_type "(ToInt, ToInt) -> nil",
-                     [1,2,3], :slice!, ToInt.new(10), ToInt.new(2)
-
-    assert_send_type "(Range[Integer]) -> Array[Integer]",
-                     [1,2,3], :slice!, 1...2
-    assert_send_type "(Range[Integer]) -> nil",
-                     [1,2,3], :slice!, 11...21
+    omit 'todo'
   end
 
   def test_sort
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :sort
-
-    assert_send_type "() { (Integer, Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :sort do |a, b| b <=> a end
-
-    refute_send_type "() { (Integer, Integer) -> nil } -> Array[Integer]",
-                     [1,2,3], :sort do end
+    omit 'todo'
   end
 
   def test_sort!
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :sort!
-
-    assert_send_type "() { (Integer, Integer) -> Integer } -> Array[Integer]",
-                     [1,2,3], :sort! do |a, b| b <=> a end
-
-    refute_send_type "() { (Integer, Integer) -> nil } -> Array[Integer]",
-                     [1,2,3], :sort! do end
+    omit 'todo'
   end
 
   def test_sort_by!
-    assert_send_type "() { (Integer) -> String } -> Array[Integer]",
-                     [1,2,3], :sort_by! do |x| x.to_s end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :sort_by!
+    omit 'todo'
   end
 
   def test_sum
-    assert_send_type "() -> Integer",
-                     [1,2,3], :sum
-    assert_send_type "(Integer) -> Integer",
-                     [1,2,3], :sum, 2
-
-    assert_send_type "(String) { (Integer) -> String } -> String",
-                     [1,2,3], :sum, "**" do |x| x.to_s end
+    omit 'todo'
   end
 
   def test_take
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :take, 2
-    assert_send_type "(ToInt) -> Array[Integer]",
-                     [1,2,3], :take, ToInt.new(2)
+    omit 'todo'
   end
 
   def test_take_while
-    assert_send_type "() { (Integer) -> bool } -> Array[Integer]",
-                     [1,2,3], :take_while do |x| x < 2 end
-    assert_send_type "() -> Enumerator[Integer, Array[Integer]]",
-                     [1,2,3], :take_while
+    omit 'todo'
   end
 
   def test_to_a
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :to_a
+    omit 'todo'
   end
 
   def test_to_ary
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :to_ary
+    omit 'todo'
   end
 
   def test_to_h
-    testing "::Array[[::String, ::Integer]]" do
-      assert_send_type "() -> Hash[String, Integer]",
-                       [["foo", 1], ["bar", 2]], :to_h
-    end
-
-    assert_send_type "() { (Integer) -> [Symbol, String] } -> Hash[Symbol, String]",
-                     [1,2,3], :to_h do |i| [:"s#{i}", i.to_s ] end
+    omit 'todo'
   end
 
   def test_transpose
-    testing "::Array[[::String, ::Integer]]" do
-      assert_send_type "() -> [Array[String], Array[Integer]]",
-                       [["foo", 1], ["bar", 2]], :transpose
-    end
+    omit 'todo'
   end
 
   def test_union
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :union
-    assert_send_type "(Array[Symbol]) -> Array[Integer | Symbol]",
-                     [1,2,3], :union, [:x, :y, :z]
+    omit 'todo'
   end
 
   def test_uniq
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :uniq
-    assert_send_type "() { (Integer) -> String } -> Array[Integer]",
-                     [1,2,3], :uniq do |i| i.to_s end
+    omit 'todo'
   end
 
   def test_uniq!
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3,1], :uniq!
-    assert_send_type "() -> nil",
-                     [1,2,3], :uniq!
-    assert_send_type "() { (Integer) -> String } -> Array[Integer]",
-                     [1,2,3, 1], :uniq! do |i| i.to_s end
-    assert_send_type "() { (Integer) -> String } -> nil",
-                     [1,2,3], :uniq! do |i| i.to_s end
+    omit 'todo'
   end
 
-  def test_unshift
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :unshift
-    assert_send_type "(Integer, Integer) -> Array[Integer]",
-                     [1,2,3], :unshift, 4, 5
+  def test_unshift(method: :unshift)
+    omit 'todo'
+  end
+
+  def test_prepend
+    test_unshift(method: :prepend)
   end
 
   def test_values_at
-    assert_send_type "() -> Array[Integer]",
-                     [1,2,3], :values_at
-    assert_send_type "(Integer) -> Array[Integer]",
-                     [1,2,3], :values_at, 2
-    assert_send_type "(ToInt, Integer) -> Array[Integer?]",
-                     [1,2,3], :values_at, ToInt.new(2), 3
-    assert_send_type "(ToInt, Range[Integer]) -> Array[Integer?]",
-                     [1,2,3], :values_at, ToInt.new(2), 0..1
+    omit 'todo'
   end
 
   def test_zip
-    assert_send_type "(Array[String]) -> Array[[Integer, String?]]",
-                     [1,2,3], :zip, ["a", "b"]
-    assert_send_type "(Array[String]) -> Array[[Integer, String]]",
-                     [1,2,3], :zip, ["a", "b", "c", "d"]
-    assert_send_type "(Array[String], Array[Symbol]) -> Array[Array[untyped]]",
-                     [1,2,3], :zip, ["a", "b"], [:foo, :bar]
-
-    assert_send_type "(Array[String]) { ([Integer, String?]) -> true } -> nil",
-                     [1,2,3], :zip, ["a", "b"] do true end
-
-    assert_send_type(
-      "(::_Each[String]) -> Array[[Integer, String?]]",
-      [1,2,3], :zip, Each.new("a", "b")
-    )
+    omit 'todo'
   end
 
-  def test_vbar
-    assert_send_type "(Array[String]) -> Array[Integer | String]",
-                     [1,2,3], :|, ["x", "y"]
+  def test_op_or
+    omit 'todo'
+  end
+
+  def test_initialize_copy
+    test_replace(method: :initialize_copy)
+  end
+
+  def test_any?
+    omit 'todo'
+  end
+
+  def test_min
+    omit 'todo'
+  end
+
+  def test_none?
+    omit 'todo'
+  end
+
+  def test_one?
+    omit 'todo'
+  end
+
+  def test_prepend
+    omit 'todo'
+  end
+
+  def test_rassoc
+    omit 'todo'
+  end
+
+  def test_reject
+    omit 'todo'
   end
 end

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -60,6 +60,13 @@ class ArrayInstanceTest < Test::Unit::TestCase
     def rand(max) = ToInt.new(Random.new.rand(max))
   end
 
+  class ComparableToZero
+    def self.for(x, y) = (x <=> y)&.then { |cmp| new(cmp) }
+    def initialize(cmp) = @cmp = cmp
+    def <(x) = 0.equal?(x) ? @cmp < x : fail
+    def >(x) = 0.equal?(x) ? @cmp > x : fail
+  end
+
   def test_op_and
     with_array [1r, 1i] do |other|
       assert_send_type  '(array[untyped]) -> Array[Rational]',
@@ -475,11 +482,52 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_max
-    omit 'todo'
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() -> nil',
+                      [], :max
+    assert_send_type  '() -> Rational',
+                      ary, :max
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> Rational',
+                      ary, :max do |a, b| ComparableToZero.for(a, b) end
+
+    with_int 3 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        ary, :max, count
+      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero? } -> Array[Rational]',
+                        ary, :max, count do |a, b| ComparableToZero.for(a, b) end
+    end
+  end
+
+  def test_min
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() -> nil',
+                      [], :min
+    assert_send_type  '() -> Rational',
+                      ary, :min
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> Rational',
+                      ary, :min do |a, b| ComparableToZero.for(a, b) end
+
+    with_int 3 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        ary, :min, count
+      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero? } -> Array[Rational]',
+                        ary, :min, count do |a, b| ComparableToZero.for(a, b) end
+    end
   end
 
   def test_minmax
-    omit 'todo'
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() -> [nil, nil]',
+                      [], :minmax
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> [nil, nil]',
+                      [], :minmax do end
+    assert_send_type  '() -> [Rational, Rational]',
+                      ary, :minmax
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> [Rational, Rational]',
+                      ary, :minmax do |a, b| ComparableToZero.for(a, b) end
   end
 
   def test_pack
@@ -769,10 +817,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
   def test_initialize_copy
     assert_visibility :private, :initialize_copy
     test_replace(method: :initialize_copy)
-  end
-
-  def test_min
-    omit 'todo'
   end
 
   def test_none?

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -73,6 +73,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
     def eql?(other) = HashKey === other && @key.eql?(other.key)
   end
 
+  def with_each(*eles)
+    yield Each.new(*eles)
+  end
+
   def test_op_and
     with_array [1r, 1i] do |other|
       assert_send_type  '(array[untyped]) -> Array[Rational]',
@@ -897,7 +901,26 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_slice!
-    omit 'todo -- non-enumerable'
+    with_int 1 do |index|
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r], :slice!, index
+      assert_send_type  '(int) -> nil',
+                        [1r], :slice!, index
+    end
+
+    with_int 2 do |start|
+      with_int 1 do |length|
+        assert_send_type  '(int, int) -> Array[Rational]',
+                          [1r, 2r, 3r], :slice!, start, length
+        assert_send_type  '(int, int) -> nil',
+                          [1r], :slice!, start, length
+      end
+    end
+
+    with_range with_int(2).and_nil, with_int(1).and_nil do |range|
+      assert_send_type  '(range[int?]) -> Array[Rational]?',
+                        [1r, 2r, 3r], :slice!, range
+    end
   end
 
   def test_sort
@@ -923,7 +946,33 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_sum
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> untyped',
+                      [1, 2r, 3.0, 4i], :sum
+
+    with 5, 6r, 7.0, 8i do |init|
+      assert_send_type  '(untyped) -> untyped',
+                        [1, 2r, 3.0, 4i], :sum, init
+    end
+
+    assert_send_type  '() { (Rational) -> untyped } -> untyped',
+                      [1r, 2r, 3r], :sum do |ele| ele.i end
+
+    with 5, 6r, 7.0, 8i do |init|
+      assert_send_type  '(untyped) { (Rational) -> untyped } -> untyped',
+                        [1r, 2r, 3r], :sum, init do |ele| ele.i end
+    end
+
+    # Test an extremely esoteric edgecase, which any updates to the signature will have to allow for
+    outer = BlankSlate.new
+    def outer.+(rhs)
+      inner = BlankSlate.new
+      ::Kernel.instance_method(:instance_variable_set).bind_call(inner, :@rhs, rhs)
+      def inner.+(rhs) = [:innermost, @rhs, rhs]
+      inner
+    end
+
+    assert_send_type  '(untyped) -> [:innermost, 1, 2]',
+                      [1, 2], :sum, outer
   end
 
   def test_take
@@ -1031,7 +1080,31 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_zip
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[[Rational]]',
+                      [1r, 2r, 3r], :zip
+    assert_send_type  '() { ([Rational]) -> void } -> nil',
+                      [1r, 2r, 3r], :zip do end
+
+    with_each 1, 2 do |iter1|
+      assert_send_type  '(_Each[Integer]) -> Array[[Rational, Integer?]]',
+                        [1r, 2r, 3r], :zip, iter1
+      assert_send_type  '(_Each[Integer]) { ([Rational, Integer?]) -> void } -> nil',
+                        [1r, 2r, 3r], :zip, iter1 do end
+
+      with_each 1i, 2i do |iter2|
+        assert_send_type  '(_Each[Integer], _Each[Complex]) -> Array[[Rational, Integer?, Complex?]]',
+                          [1r, 2r, 3r], :zip, iter1, iter2
+        assert_send_type  '(_Each[Integer], _Each[Complex]) { ([Rational, Integer?, Complex?]) -> void } -> nil',
+                          [1r, 2r, 3r], :zip, iter1, iter2 do end
+
+        with_each 1.0, 2.0 do |iter3|
+          assert_send_type  '(*_Each[Integer | Complex | Float]) -> Array[Array[Rational | Integer | Complex | Float | nil]]',
+                            [1r, 2r, 3r], :zip, iter1, iter2, iter3
+          assert_send_type  '(*_Each[Integer | Complex | Float]) { (Array[Rational | Integer | Complex | Float | nil]) -> void } -> nil',
+                            [1r, 2r, 3r], :zip, iter1, iter2, iter3 do end
+        end
+      end
+    end
   end
 
   def test_op_or

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -271,7 +271,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_concat
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :concat
+    with_array 3r do |array1|
+      assert_send_type  '(*array[Rational]) -> Array[Rational]',
+                        [1r, 2r], :concat, array1
+
+      with_array 4r do |array2|
+        assert_send_type  '(*array[Rational]) -> Array[Rational]',
+                          [1r, 2r], :concat, array1, array2
+      end
+    end
   end
 
   def test_count
@@ -294,7 +304,7 @@ class ArrayInstanceTest < Test::Unit::TestCase
     omit 'todo'
   end
 
-  def test_delete_if
+  def test_delete_if(method: :delete_if)
     omit 'todo'
   end
 
@@ -454,7 +464,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_length(method: :length)
-    omit 'todo'
+    assert_send_type  '() -> Integer',
+                      [], method
+    assert_send_type  '() -> Integer',
+                      [1r, 2r], method
   end
 
   def test_size
@@ -478,7 +491,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_pop
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [], :pop
+    assert_send_type  '() -> Rational',
+                      [1r], :pop
+
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r, 3r], :pop, count
+    end
   end
 
   def test_product
@@ -486,7 +507,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_push(method: :push)
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], method
+    assert_send_type  '(*Rational) -> Array[Rational]',
+                      [1r], method, 2r
+    assert_send_type  '(*Rational) -> Array[Rational]',
+                      [1r], method, 2r, 3r
   end
 
   def test_append
@@ -510,11 +536,21 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_reverse
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [], :reverse
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], :reverse
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :reverse
   end
 
   def test_reverse!
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [], :reverse!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], :reverse!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :reverse!
   end
 
   def test_reverse_each
@@ -530,11 +566,37 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_rotate
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [], :rotate
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], :rotate
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :rotate
+    with_int 1 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [], :rotate, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r], :rotate, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :rotate, count
+    end
   end
 
   def test_rotate!
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [], :rotate!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], :rotate!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :rotate!
+    with_int 1 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [], :rotate!, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r], :rotate!, count
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :rotate!, count
+    end
   end
 
   def test_sample
@@ -573,7 +635,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_shift
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [], :shift
+    assert_send_type  '() -> Rational',
+                      [1r], :shift
+
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r, 3r], :shift, count
+    end
   end
 
   def test_shuffle
@@ -621,11 +691,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_to_a
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :to_a
+    assert_send_type  '() -> Array[Rational]',
+                      ArraySubclass.new([1r, 2r]), :to_a
   end
 
   def test_to_ary
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :to_ary
+    assert_send_type  '() -> ArrayInstanceTest::ArraySubclass[Rational]',
+                      ArraySubclass.new([1r, 2r]), :to_ary
   end
 
   def test_to_h
@@ -649,7 +725,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_unshift(method: :unshift)
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r], method
+    assert_send_type  '(*Rational) -> Array[Rational]',
+                      [1r], method, 0r
+    assert_send_type  '(*Rational) -> Array[Rational]',
+                      [1r], method, -1r, 0r
   end
 
   def test_prepend
@@ -701,10 +782,6 @@ class ArrayInstanceTest < Test::Unit::TestCase
                      [1r, 2r, 3r], :one? do :true end
   end
 
-  def test_prepend
-    omit 'todo'
-  end
-
   def test_rassoc
     with_untyped.and 1r, :a, 'b' do |object|
       next unless defined? object.==
@@ -714,6 +791,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_reject
-    omit 'todo'
+    test_delete_if(method: :reject)
+  end
+
+  def test_freeze
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :freeze
   end
 end

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -56,15 +56,21 @@ class ArrayInstanceTest < Test::Unit::TestCase
   class ArraySubclass < Array
   end
 
-  class RngGen
-    def rand(max) = ToInt.new(Random.new.rand(max))
+  class RngGen < BlankSlate
+    def rand(max) = ::RBS::UnitTest::Convertibles::ToInt.new(::Random.new.rand(max))
   end
 
-  class ComparableToZero
-    def self.for(x, y) = (x <=> y)&.then { |cmp| new(cmp) }
+  class ComparableToZero < BlankSlate
     def initialize(cmp) = @cmp = cmp
     def <(x) = 0.equal?(x) ? @cmp < x : fail
     def >(x) = 0.equal?(x) ? @cmp > x : fail
+  end
+
+  class HashKey < BlankSlate
+    protected attr_reader :key
+    def initialize(key) = @key = key
+    def hash = @key.hash
+    def eql?(other) = HashKey === other && @key.eql?(other.key)
   end
 
   def test_op_and
@@ -441,7 +447,35 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_fill
-    omit 'todo -- non-enumerable'
+    assert_send_type  '(Rational) -> Array[Rational]',
+                      [1r, 2r, 3r, 4r], :fill, 2r
+    with_int(1).and_nil do |start|
+      assert_send_type  '(Rational, int?) -> Array[Rational]',
+                        [1r, 2r, 3r, 4r], :fill, 2r, start
+
+      with_int(3).and_nil do |length|
+        assert_send_type  '(Rational, int?, int?) -> Array[Rational]',
+                          [1r, 2r, 3r, 4r], :fill, 2r, start, length
+      end
+    end
+
+    with_range with_int(1).and_nil, with_int(3).and_nil do |range|
+      assert_send_type  '(Rational, range[int?]) -> Array[Rational]',
+                        [1r, 2r, 3r, 4r], :fill, 2r, range
+    end
+
+    assert_send_type  '() { (Integer) -> Rational } -> Array[Rational]',
+                      [1r, 2r, 3r, 4r], :fill do 1r end
+
+    with_int(1).and_nil do |start|
+      assert_send_type  '(int?) { (Integer) -> Rational } -> Array[Rational]',
+                        [1r, 2r, 3r, 4r], :fill, start do 1r end
+
+      with_int(3).and_nil do |length|
+        assert_send_type  '(int?, int?) { (Integer) -> Rational } -> Array[Rational]',
+                          [1r, 2r, 3r, 4r], :fill, start, length do 1r end
+      end
+    end
   end
 
   def test_find(method: :find)
@@ -514,7 +548,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_insert
-    omit 'todo -- non-enumerable'
+    with_int 1 do |index|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r, 3r], :insert, index
+      assert_send_type  '(int, *Rational) -> Array[Rational]',
+                        [1r, 2r, 3r], :insert, index, 3r, 4r
+    end
   end
 
   def test_inspect(method: :inspect)
@@ -529,11 +568,27 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_intersect?
-    omit 'todo -- non-enumerable'
+    with_array 1r, 3r do |array|
+      assert_send_type  '(array[untyped]) -> bool',
+                        [1r, 2r, 3r], :intersect?, array
+    end
+
+    with_array :a, :b do |array|
+      assert_send_type  '(array[untyped]) -> bool',
+                        [1r, 2r, 3r], :intersect?, array
+    end
   end
 
   def test_intersection
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r], :intersection
+
+    with_array 1r, 2r, 4r do |array1|
+      with_array 1, 2, 4 do |array2|
+        assert_send_type  '(*array[untyped]) -> Array[Rational]',
+                          [1r, 2r, 3r], :intersection, array1, array2
+      end
+    end
   end
 
   def test_join
@@ -582,14 +637,14 @@ class ArrayInstanceTest < Test::Unit::TestCase
                       [], :max
     assert_send_type  '() -> Rational',
                       ary, :max
-    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> Rational',
-                      ary, :max do |a, b| ComparableToZero.for(a, b) end
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> Rational',
+                      ary, :max do |a, b| ComparableToZero.new(a <=> b) end
 
     with_int 3 do |count|
       assert_send_type  '(int) -> Array[Rational]',
                         ary, :max, count
-      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero? } -> Array[Rational]',
-                        ary, :max, count do |a, b| ComparableToZero.for(a, b) end
+      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero } -> Array[Rational]',
+                        ary, :max, count do |a, b| ComparableToZero.new(a <=> b) end
     end
   end
 
@@ -600,14 +655,14 @@ class ArrayInstanceTest < Test::Unit::TestCase
                       [], :min
     assert_send_type  '() -> Rational',
                       ary, :min
-    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> Rational',
-                      ary, :min do |a, b| ComparableToZero.for(a, b) end
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> Rational',
+                      ary, :min do |a, b| ComparableToZero.new(a <=> b) end
 
     with_int 3 do |count|
       assert_send_type  '(int) -> Array[Rational]',
                         ary, :min, count
-      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero? } -> Array[Rational]',
-                        ary, :min, count do |a, b| ComparableToZero.for(a, b) end
+      assert_send_type  '(int) { (Rational, Rational) -> Comparable::_CompareToZero } -> Array[Rational]',
+                        ary, :min, count do |a, b| ComparableToZero.new(a <=> b) end
     end
   end
 
@@ -616,12 +671,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
 
     assert_send_type  '() -> [nil, nil]',
                       [], :minmax
-    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> [nil, nil]',
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> [nil, nil]',
                       [], :minmax do end
     assert_send_type  '() -> [Rational, Rational]',
                       ary, :minmax
-    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero? } -> [Rational, Rational]',
-                      ary, :minmax do |a, b| ComparableToZero.for(a, b) end
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> [Rational, Rational]',
+                      ary, :minmax do |a, b| ComparableToZero.new(a <=> b) end
   end
 
   def test_pack
@@ -846,11 +901,21 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_sort
-    omit 'todo -- non-enumerable'
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() -> Array[Rational]',
+                      ary, :sort
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> Array[Rational]',
+                      ary, :sort do |a, b| ComparableToZero.new(a <=> b) end
   end
 
   def test_sort!
-    omit 'todo -- non-enumerable'
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() -> Array[Rational]',
+                      ary, :sort!
+    assert_send_type  '() { (Rational, Rational) -> Comparable::_CompareToZero } -> Array[Rational]',
+                      ary, :sort! do |a, b| ComparableToZero.new(a <=> b) end
   end
 
   def test_sort_by!
@@ -906,15 +971,34 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_union
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :union
+
+    with_array 2r, 3r do |array1|
+      with_array 1, :a, 'b' do |array2|
+        assert_send_type  '[T] (*array[T]) -> Array[Rational | T]',
+                          [1r, 2r], :union, array1, array2
+      end
+    end
+
   end
 
   def test_uniq
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r, 2r, 1r], :uniq
+    assert_send_type  '() { (Rational) -> Hash::_Key } -> Array[Rational]',
+                      [1r, 2r, 3r, 2r, 1r], :uniq do |x| HashKey.new x end
   end
 
   def test_uniq!
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> nil',
+                      [1r, 2r, 3r], :uniq!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r, 2r, 1r], :uniq!
+    assert_send_type  '() { (Rational) -> Hash::_Key } -> nil',
+                      [1r, 2r, 3r], :uniq! do |x| HashKey.new x end
+    assert_send_type  '() { (Rational) -> Hash::_Key } -> Array[Rational]',
+                      [1r, 2r, 3r, 2r, 1r], :uniq! do |x| HashKey.new x end
   end
 
   def test_unshift(method: :unshift)
@@ -931,7 +1015,19 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_values_at
-    omit 'todo -- non-enumerable'
+    ary = 10.times.map { |x| Rational(x) }
+
+    assert_send_type  '() -> Array[Rational]',
+                      ary, :values_at
+
+    with_int 3 do |index1|
+      with_int 99999 do |index2|
+        with_range with_int(3).and_nil, with_int(-2).and_nil do |range|
+          assert_send_type  '(*int | range[int?]) -> Array[Rational?]',
+                            ary, :values_at, index1, index2, range
+        end
+      end
+    end
   end
 
   def test_zip

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -202,11 +202,21 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_assoc
-    omit 'todo'
+    with_untyped.and 1r, :a, 'b' do |object|
+      next unless defined? object.==
+
+      assert_send_type  '(untyped) -> Array[untyped]?',
+                        [{foo: 3}, [1r, 1i], [:a, :b, :c], ['b']], :assoc, object
+    end
   end
 
   def test_at
-    omit 'todo'
+    with_int 1 do |index|
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r], :at, index
+      assert_send_type  '(int) -> nil',
+                        [1r], :at, index
+    end
   end
 
   def test_bsearch
@@ -218,7 +228,8 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_clear
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :clear
   end
 
   def test_collect(method: :collect)
@@ -242,11 +253,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_compact
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, 3r], :compact
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, nil, 3r], :compact
   end
 
   def test_compact!
-    omit 'todo'
+    assert_send_type  '() -> nil',
+                      [1r, 2r, 3r], :compact!
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r, nil, 3r], :compact!
   end
 
   def test_concat
@@ -302,7 +319,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_empty?
-    omit 'todo'
+    assert_send_type  '() -> bool',
+                      [], :empty?
+    assert_send_type  '() -> bool',
+                      [1r], :empty?
   end
 
   def test_eql?
@@ -350,7 +370,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_hash
-    omit 'todo'
+    assert_send_type  '() -> Integer',
+                      [], :hash
+    assert_send_type  '() -> Integer',
+                      [1r, 2r], :hash
   end
 
   def test_include?
@@ -362,7 +385,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_inspect(method: :inspect)
-    omit 'todo'
+    assert_send_type  '() -> String',
+                      [], method
+    assert_send_type  '() -> String',
+                      [1r, 2r], method
   end
 
   def test_to_s
@@ -619,7 +645,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_rassoc
-    omit 'todo'
+    with_untyped.and 1r, :a, 'b' do |object|
+      next unless defined? object.==
+      assert_send_type  '(untyped) -> Array[untyped]?',
+                        [{foo: 3}, [1r, 1i], [:a, :b, :c], ['b']], :rassoc, object
+    end
   end
 
   def test_reject

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -441,7 +441,7 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_fill
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_find(method: :find)
@@ -475,11 +475,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_flatten
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_flatten!
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_hash
@@ -490,11 +490,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_include?
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_insert
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_inspect(method: :inspect)
@@ -509,15 +509,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_intersect?
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_intersection
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_join
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_keep_if
@@ -629,7 +629,7 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_product
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_push(method: :push)
@@ -792,15 +792,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_slice!
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_sort
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_sort!
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_sort_by!
@@ -808,11 +808,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_sum
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_take
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_take_while
@@ -853,15 +853,15 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_union
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_uniq
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_uniq!
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_unshift(method: :unshift)
@@ -878,11 +878,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_values_at
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_zip
-    omit 'todo'
+    omit 'todo -- non-enumerable'
   end
 
   def test_op_or

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -241,11 +241,51 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_bsearch
-    omit 'todo'
+    ary = [0r, 4r, 7r, 10r, 12r]
+
+    # Bool-based approach
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Rational',
+                      ary, :bsearch do |ele| ele >= 2 ? true : nil end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch do |ele| ele >= 100 ? true : nil end
+
+    # Numeric-based approach
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Rational',
+                      ary, :bsearch do |ele| ele <=> 7 end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Rational',
+                      ary, :bsearch do |ele| 7.0 - ele end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch do |ele| ele <=> 100 end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch do |ele| 100.0 - ele end
+
+    # Enumerator
+    assert_send_type  '() -> Enumerator[Rational, Rational?]',
+                      ary, :bsearch
   end
 
   def test_bsearch_index
-    omit 'todo'
+    ary = [0r, 4r, 7r, 10r, 12r]
+
+    # Bool-based approach
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Integer',
+                      ary, :bsearch_index do |ele| ele >= 2 ? true : nil end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch_index do |ele| ele >= 100 ? true : nil end
+
+    # Numeric-based approach
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Integer',
+                      ary, :bsearch_index do |ele| ele <=> 7 end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> Integer',
+                      ary, :bsearch_index do |ele| 7.0 - ele end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch_index do |ele| ele <=> 100 end
+    assert_send_type  '() { (Rational) -> (Numeric | bool?) } -> nil',
+                      ary, :bsearch_index do |ele| 100.0 - ele end
+
+    # Enumerator
+    assert_send_type  '() -> Enumerator[Rational, Integer?]',
+                      ary, :bsearch_index
   end
 
   def test_clear
@@ -254,7 +294,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_collect(method: :collect)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> Complex } -> Array[Complex]',
+                      [1r, 2r, 3r], method do |ele| Complex(ele) end
+    assert_send_type  '() -> Enumerator[Rational, Array[untyped]]',
+                      [1r, 2r, 3r], method
   end
 
   def test_map
@@ -262,7 +305,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_collect!(method: :collect!)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> Rational } -> Array[Rational]',
+                      [1r, 2r, 3r], method do |ele| ele + 1 end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [], method
   end
 
   def test_map!
@@ -270,7 +316,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_combination
-    omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) { (Array[Rational]) -> void } -> Array[Rational]',
+                        [1r, 2r, 3r], :combination, count do end
+      assert_send_type  '(int) -> Enumerator[Array[Rational], Array[Rational]]',
+                        [1r, 2r, 3r], :combination, count
+    end
   end
 
   def test_compact
@@ -317,7 +368,24 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_cycle
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> void } -> nil',
+                      [1r, 2r, 3r], :cycle do break_from_block end
+
+    # Unfortunately you can't test the enumerator branch because it'll infinitely loop
+    raise unless [1r, 2r, 3r].cycle.instance_of? Enumerator
+
+    with_int(2).and_nil do |count|
+      assert_send_type  '(int?) { (Rational) -> void } -> nil',
+                        [1r, 2r, 3r], :cycle, count do break_from_block end
+
+      if nil === count
+        raise unless [1r, 2r, 3r].cycle(test_count).instance_of? Enumerator
+        next
+      end
+
+      assert_send_type  '(int) -> Enumerator[Rational, nil]',
+                        [1r, 2r, 3r], :cycle, count
+    end
   end
 
   def test_deconstruct
@@ -348,7 +416,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_delete_if(method: :delete_if)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], method do |ele| ele > 2 ? :truthy : nil end
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], method do false end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]?]',
+                      [], method
   end
 
   def test_difference
@@ -390,15 +463,24 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_drop_while
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], :take_while do |ele| ele >= 2 ? :truthy : nil end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], :take_while
   end
 
   def test_each
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> void } -> Array[Rational]',
+                      [1r, 2r, 3r], :each do end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], :each
   end
 
   def test_each_index
-    omit 'todo'
+    assert_send_type  '() { (Integer) -> void } -> Array[Rational]',
+                      [1r, 2r, 3r], :each_index do end
+    assert_send_type  '() -> Enumerator[Integer, Array[Rational]]',
+                      [1r, 2r, 3r], :each_index
   end
 
   def test_empty?
@@ -483,7 +565,19 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_find(method: :find)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Rational',
+                      [1r, 2r, 3r], method do it > 2 ? :truthy : nil end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], method do false end
+    assert_send_type  '() -> Enumerator[Rational, Rational?]',
+                      [1r, 2r, 3r], method
+
+    assert_send_type  '(Enumerable::_NotFound[String]) { (Rational) -> boolish } -> Rational',
+                      [1r, 2r, 3r], method, ->{ "" } do it > 2 ? :truthy : nil end
+    assert_send_type  '(Enumerable::_NotFound[String]) { (Rational) -> boolish } -> String',
+                      [1r, 2r, 3r], method, ->{ "" } do false end
+    assert_send_type  '(Enumerable::_NotFound[String]) -> Enumerator[Rational, Rational | String]',
+                      [1r, 2r, 3r], method, ->{ "" }
   end
 
   def test_detect
@@ -491,7 +585,19 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_find_index(method: :find_index)
-    omit 'todo'
+    with_untyped.and 2r do |untyped|
+      next unless defined? untyped.==
+      assert_send_type  '(untyped) -> Integer?',
+                        [1r, 2r, 3r], method, untyped
+    end
+
+    assert_send_type  '() { (Rational) -> boolish } -> Integer',
+                      [1r, 2r, 3r], method do :true end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], method do false end
+
+    assert_send_type  '() -> Enumerator[Rational, Integer?]',
+                      [1r, 2r, 3r], method
   end
 
   def test_index
@@ -606,7 +712,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_keep_if
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], :keep_if do |ele| ele > 2 ? :truthy : nil end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], :keep_if
   end
 
   def test_last
@@ -698,7 +807,26 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_permutation
-    omit 'todo'
+    assert_send_type  '() { (Array[Rational]) -> void } -> Array[Rational]',
+                      [1r, 2r, 3r], :permutation do end
+    assert_send_type  '() -> Enumerator[Array[Rational], Array[Rational]]',
+                      [1r, 2r, 3r], :permutation
+
+    with_int(2).and_nil do |count|
+      assert_send_type  '(int?) { (Array[Rational]) -> void } -> Array[Rational]',
+                        [1r, 2r, 3r], :permutation, count do end
+    end
+
+    # Unfortunately ruby 4.0 and before had a bug where `Array#permutation` with a `nil`
+    # argument didn't have a correct size. cf https://github.com/ruby/ruby/pull/17197.
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Enumerator[Array[Rational], Array[Rational]]',
+                        [1r, 2r, 3r], :permutation, count
+    end
+    if_ruby '4.2'... do
+      assert_send_type  '(nil) -> Enumerator[Array[Rational], Array[Rational]]',
+                        [1r, 2r, 3r], :permutation, nil
+    end
   end
 
   def test_pop
@@ -755,15 +883,30 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_reject!
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], :reject! do |ele| ele > 2 ? :truthy : nil end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], :reject! do false end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]?]',
+                      [], :reject!
   end
 
   def test_repeated_combination
-    omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) { (Array[Rational]) -> void } -> Array[Rational]',
+                        [1r, 2r, 3r], :repeated_combination, count do end
+      assert_send_type  '(int) -> Enumerator[Array[Rational], Array[Rational]]',
+                        [1r, 2r, 3r], :repeated_combination, count
+    end
   end
 
   def test_repeated_permutation
-    omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) { (Array[Rational]) -> void } -> Array[Rational]',
+                        [1r, 2r, 3r], :repeated_permutation, count do end
+      assert_send_type  '(int) -> Enumerator[Array[Rational], Array[Rational]]',
+                        [1r, 2r, 3r], :repeated_permutation, count
+    end
   end
 
   def test_replace(method: :replace)
@@ -792,15 +935,42 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_reverse_each
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> void } -> Array[Rational]',
+                      [1r, 2r, 3r], :reverse_each do end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], :reverse_each
   end
 
   def test_rfind
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Rational',
+                      [1r, 2r, 3r], :rfind do it > 2 ? :truthy : nil end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], :rfind do false end
+    assert_send_type  '() -> Enumerator[Rational, Rational?]',
+                      [1r, 2r, 3r], :rfind
+
+    assert_send_type  '(Enumerable::_NotFound[String]) { (Rational) -> boolish } -> Rational',
+                      [1r, 2r, 3r], :rfind, ->{ "" } do it > 2 ? :truthy : nil end
+    assert_send_type  '(Enumerable::_NotFound[String]) { (Rational) -> boolish } -> String',
+                      [1r, 2r, 3r], :rfind, ->{ "" } do false end
+    assert_send_type  '(Enumerable::_NotFound[String]) -> Enumerator[Rational, Rational | String]',
+                      [1r, 2r, 3r], :rfind, ->{ "" }
   end
 
   def test_rindex
-    omit 'todo'
+    with_untyped.and 2r do |untyped|
+      next unless defined? untyped.==
+      assert_send_type  '(untyped) -> Integer?',
+                        [1r, 2r, 3r], :rindex, untyped
+    end
+
+    assert_send_type  '() { (Rational) -> boolish } -> Integer',
+                      [1r, 2r, 3r], :rindex do :true end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], :rindex do false end
+
+    assert_send_type  '() -> Enumerator[Rational, Integer?]',
+                      [1r, 2r, 3r], :rindex
   end
 
   def test_rotate
@@ -857,7 +1027,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_select(method: :select)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], method do |ele| ele > 2 ? :truthy : nil end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], method
   end
 
   def test_filter
@@ -865,7 +1038,12 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_select!(method: :select!)
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], method do |ele| ele > 2 ? :truthy : nil end
+    assert_send_type  '() { (Rational) -> boolish } -> nil',
+                      [1r, 2r, 3r], method do true end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]?]',
+                      [], method
   end
 
   def test_filter!
@@ -942,7 +1120,27 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_sort_by!
-    omit 'todo'
+    ary = 10.times.map { |x| Rational(x) }.shuffle
+
+    assert_send_type  '() { (Rational) -> Comparable::_WithSpaceshipOperator } -> Array[Rational]',
+                      ary, :sort_by! do |x|
+                        bs = BlankSlate.new
+                        ::Kernel.instance_method(:instance_variable_set).bind_call(bs, :@x, x)
+                        def bs.x = @x
+                        def bs.<=>(r)
+                          cmp = BlankSlate.new
+                          ::Kernel.instance_method(:instance_variable_set)
+                            .bind_call(cmp, :@cmp, @x <=> r.x)
+                          def cmp.<(x) = 0.equal?(x) ? @cmp < 0 : fail
+                          def cmp.>(x) = 0.equal?(x) ? @cmp > 0 : fail
+                          cmp
+                        end
+                        bs
+                      end
+
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      ary, :sort_by!
+
   end
 
   def test_sum
@@ -983,7 +1181,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_take_while
-    omit 'todo'
+    assert_send_type  '() { (Rational) -> boolish } -> Array[Rational]',
+                      [1r, 2r, 3r], :take_while do |ele| ele <= 2 ? :truthy : nil end
+    assert_send_type  '() -> Enumerator[Rational, Array[Rational]]',
+                      [1r, 2r, 3r], :take_while
   end
 
   def test_to_a

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -53,36 +53,97 @@ class ArrayInstanceTest < Test::Unit::TestCase
 
   testing 'Array[Rational]'
 
+  class ArraySubclass < Array
+  end
+
   def test_op_and
-    omit 'todo'
+    with_array [1r, 1i] do |other|
+      assert_send_type  '(array[untyped]) -> Array[Rational]',
+                        [1r, 2r], :&, other
+    end
   end
 
-  def test_op_mul
-    omit 'todo'
+  def test_op_times
+    with_string do |sep|
+      assert_send_type  '(string) -> String',
+                        [1r, 2r], :*, sep
+    end
+
+    with_int 3 do |n|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :*, n
+    end
   end
 
-  def test_op_add
-    omit 'todo'
+  def test_op_plus
+    with_array 3r, 4r do |ary|
+      assert_send_type  '(array[Rational]) -> Array[Rational]',
+                        [1r, 2r], :+, ary
+    end
+
+    with_array 'a', 'b' do |ary|
+      assert_send_type  '(array[String]) -> Array[Rational | String]',
+                        [1r, 2r], :+, ary
+    end
   end
 
   def test_op_sub
-    omit 'todo'
+    with_array 1r, 3r do |ary|
+      assert_send_type  '(array[Rational]) -> Array[Rational]',
+                        [1r, 2r], :-, ary
+    end
+
+    with_untyped do |untyped|
+      with_array untyped do |ary|
+        assert_send_type  '(array[untyped]) -> Array[Rational]',
+                          [1r, 2r], :-, ary
+      end
+    end
   end
 
   def test_op_lsh
-    omit 'todo'
+    assert_send_type '(Rational) -> Array[Rational]',
+                     [1r, 2r, 3r], :<<, 4r
+
+    assert_send_type '(Rational) -> ArrayInstanceTest::ArraySubclass[Rational]',
+                     ArraySubclass.new([1r, 2r, 3r]), :<<, 4r
   end
 
   def test_op_cmp
-    omit 'todo'
+    with_untyped.and [2r], [1r, 3r], [1r, 2r], [1r, 0r] do |other|
+      assert_send_type  '(untyped) -> Integer?',
+                        [1r, 2r], :<=>, other
+    end
   end
 
   def test_op_eq
-    omit 'todo'
+    with_untyped.and [1r] do |untyped|
+      assert_send_type  '(untyped) -> bool',
+                        [1r], :==, untyped
+    end
   end
 
   def test_op_aref(method: :[])
-    omit 'todo'
+    with_int 1 do |index|
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r], method, index
+      assert_send_type  '(int) -> nil',
+                        [1r], method, index
+    end
+
+    with_int 2 do |start|
+      with_int 1 do |length|
+        assert_send_type  '(int, int) -> Array[Rational]',
+                          [1r, 2r, 3r], method, start, length
+        assert_send_type  '(int, int) -> nil',
+                          [1r], method, start, length
+      end
+    end
+
+    with_range with_int(2).and_nil, with_int(1).and_nil do |range|
+      assert_send_type  '(range[int?]) -> Array[Rational]?',
+                        [1r, 2r, 3r], method, range
+    end
   end
 
   def test_slice
@@ -90,7 +151,32 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_aset
-    omit 'todo'
+    with_int 1 do |index|
+      assert_send_type  '(int, Rational) -> Rational',
+                        [1r, 2r], :[]=, index, 3r
+    end
+
+    with_range with_int(2).and_nil, with_int(1).and_nil do |range|
+      with_array 4r do |ary|
+        assert_send_type  '[T < _ToAry[Rational]] (range[int?], T) -> T',
+                          [1r, 2r, 3r], :[]=, range, ary
+      end
+
+      assert_send_type  '(range[int?], Rational) -> Rational',
+                        [1r, 2r, 3r], :[]=, range, 4r
+    end
+
+    with_int 2 do |start|
+      with_int 1 do |length|
+        with_array 4r do |ary|
+          assert_send_type  '[T < _ToAry[Rational]] (int, int, T) -> T',
+                            [1r, 2r, 3r], :[]=, start, length, ary
+        end
+
+        assert_send_type  '(int, int, Rational) -> Rational',
+                          [1r, 2r, 3r], :[]=, start, length, 4r
+      end
+    end
   end
 
   def test_all?
@@ -474,7 +560,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_or
-    omit 'todo'
+    with_array 1r, 1i do |other|
+      assert_send_type  '(array[Complex]) -> Array[Rational | Complex]',
+                        [1r, 2r], :|, other
+    end
   end
 
   def test_initialize_copy

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -532,7 +532,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_replace(method: :replace)
-    omit 'todo'
+    with_array 3r, 4r do |array|
+      assert_send_type  '(array[Rational]) -> Array[Rational]',
+                        [1r, 2r], method, array
+    end
   end
 
   def test_reverse
@@ -705,11 +708,22 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_to_h
-    omit 'todo'
+    assert_send_type  '() -> Hash[untyped, untyped]',
+                      [], :to_h
+    assert_send_type  '() -> Hash[untyped, untyped]',
+                      [[:a, 1]], :to_h
+
+    assert_send_type  '() { (Rational) -> Hash::_Pair[Rational, Complex] } -> Hash[Rational, Complex]',
+                      [1r, 2r], :to_h do |x| ToArray.new(x, x.i) end
   end
 
   def test_transpose
-    omit 'todo'
+    assert_send_type  '() -> Array[Array[Rational]]',
+                      [], :transpose
+    assert_send_type  '() -> Array[Array[Rational]]',
+                      [[1r]], :transpose
+    assert_send_type  '() -> Array[Array[Rational]]',
+                      [[1r, 2r, 3r], [4r, 5r, 6r]], :transpose
   end
 
   def test_union
@@ -753,6 +767,7 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_initialize_copy
+    assert_visibility :private, :initialize_copy
     test_replace(method: :initialize_copy)
   end
 

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -475,11 +475,27 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_flatten
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[untyped]',
+                      [[1r, 2r]], :flatten
+
+    with_int(1).and_nil do |level|
+      assert_send_type  '(int?) -> Array[untyped]',
+                        [[1r, 2r]], :flatten, level
+    end
   end
 
   def test_flatten!
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> nil',
+                      ArraySubclass.new([1r, 2r]), :flatten!
+    assert_send_type  '() -> ArrayInstanceTest::ArraySubclass[untyped]',
+                      ArraySubclass.new([[1r, 2r]]), :flatten!
+
+    with_int(1).and_nil do |level|
+      assert_send_type  '(int?) -> nil',
+                        ArraySubclass.new([1r, 2r]), :flatten!, level
+      assert_send_type  '(int?) -> ArrayInstanceTest::ArraySubclass[untyped]',
+                        ArraySubclass.new([[1r, 2r]]), :flatten!, level
+    end
   end
 
   def test_hash
@@ -490,7 +506,11 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_include?
-    omit 'todo -- non-enumerable'
+    with_untyped.and 1r do |untyped|
+      next unless defined? untyped.==
+      assert_send_type  '(top) -> bool',
+                        [1r, 2r], :include?, untyped
+    end
   end
 
   def test_insert
@@ -517,7 +537,13 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_join
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> String',
+                      [1r, 2r], :join
+
+    with_string("x").and_nil do |sep|
+      assert_send_type  '(string?) -> String',
+                        [1r, 2r], :join, sep
+    end
   end
 
   def test_keep_if
@@ -629,7 +655,31 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_product
-    omit 'todo -- non-enumerable'
+    assert_send_type  '() -> Array[[Rational]]',
+                      [1r, 2r], :product
+    assert_send_type  '() { ([Rational]) -> void } -> ArrayInstanceTest::ArraySubclass[Rational]',
+                      ArraySubclass.new([1r, 2r]), :product do end
+
+    with_array 1i, 2i do |array1|
+      assert_send_type  '(array[Complex]) -> Array[[Rational, Complex]]',
+                        [1r, 2r], :product, array1
+      assert_send_type  '(array[Complex]) { ([Rational, Complex]) -> void } -> ArrayInstanceTest::ArraySubclass[Rational]',
+                        ArraySubclass.new([1r, 2r]), :product, array1 do end
+
+      with_array 1.0, 2.0 do |array2|
+        assert_send_type  '(array[Complex], array[Float]) -> Array[[Rational, Complex, Float]]',
+                          [1r, 2r], :product, array1, array2
+        assert_send_type  '(array[Complex], array[Float]) { ([Rational, Complex, Float]) -> void } -> ArrayInstanceTest::ArraySubclass[Rational]',
+                          ArraySubclass.new([1r, 2r]), :product, array1, array2 do end
+
+        with_array 1, 2 do |array3|
+          assert_send_type  '(*array[Complex | Float | Integer]) -> Array[Array[Rational | Complex | Float | Integer]]',
+                            [1r, 2r], :product, array1, array2, array3
+          assert_send_type  '(*array[Complex | Float | Integer]) { (Array[Rational | Complex | Float | Integer]) -> void } -> ArrayInstanceTest::ArraySubclass[Rational]',
+                            ArraySubclass.new([1r, 2r]), :product, array1, array2, array3 do end
+        end
+      end
+    end
   end
 
   def test_push(method: :push)
@@ -812,7 +862,10 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_take
-    omit 'todo -- non-enumerable'
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :take, count
+    end
   end
 
   def test_take_while

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -3,35 +3,48 @@ require_relative "test_helper"
 class ArraySingletonTest < Test::Unit::TestCase
   include TestHelper
 
-  testing "singleton(::Array)"
+  testing 'singleton(::Array)'
 
   def test_new
-    assert_send_type "() -> ::Array[untyped]",
+    assert_send_type '() -> Array[untyped]',
                      Array, :new
-    assert_send_type "(Array[Integer]) -> ::Array[Integer]",
-                     Array, :new, [1,2,3]
-    assert_send_type "(Integer) -> Array[untyped]",
-                     Array, :new, 3
-    assert_send_type "(ToInt) -> Array[untyped]",
-                     Array, :new, ToInt.new(3)
-    assert_send_type "(ToInt, String) -> Array[String]",
-                     Array, :new, ToInt.new(3), ""
-    assert_send_type "(ToInt) { (Integer) -> :foo } -> Array[:foo]",
-                     Array, :new, ToInt.new(3) do :foo end
+    with_array 1r, 2r do |array|
+      assert_send_type  '(array[Rational]) -> Array[Rational]',
+                        Array, :new, array
+    end
+
+    with_int 5 do |size|
+      assert_send_type '(int) -> Array[nil]',
+                       Array, :new, size
+      assert_send_type '(int, Rational) -> Array[Rational]',
+                       Array, :new, size, 1r
+      assert_send_type '(int) { (Integer) -> Rational } -> Array[Rational]',
+                       Array, :new, size do it.to_r end
+    end
   end
 
-  def test_square_bracket
-    assert_send_type "() -> Array[untyped]",
-                     Array, :[]
-    assert_send_type "(Integer, String) -> Array[Integer | String]",
-                     Array, :[], 1, "2"
+  def test_op_aref
+    assert_send_type  '() -> Array[untyped]',
+                      Array, :[]
+    assert_send_type '(Rational, String) -> Array[Rational | String]',
+                     Array, :[], 1r, '2'
   end
 
   def test_try_convert
-    assert_send_type "(Integer) -> nil",
-                     Array, :try_convert, 3
-    assert_send_type "(ToArray) -> Array[Integer]",
-                     Array, :try_convert, ToArray.new(1,2,3)
+    with [1r, 2r], Class.new(Array).new([1r, 2r]) do |subclass|
+      assert_send_type  '[A < Array[U], U] (A) -> A',
+                        Array, :try_convert, subclass
+    end
+
+    with_array 1r, 2r do |ary|
+      assert_send_type  '[U] (array[U]) -> Array[U]',
+                        Array, :try_convert, ary
+    end
+
+    with_untyped.and [1r, 2r] do |untyped|
+      assert_send_type '[U] (untyped) -> Array[U]?',
+                       Array, :try_convert, untyped
+    end
   end
 end
 

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -179,8 +179,26 @@ class ArrayInstanceTest < Test::Unit::TestCase
     end
   end
 
+  def test_any?
+    assert_send_type '() -> bool',
+                     [], :any?
+    assert_send_type '() -> bool',
+                     [1r, 2r, 3r], :any?
+    assert_send_type '(singleton(Rational)) -> bool',
+                     [1r, 2r, 3r], :any?, Rational
+    assert_send_type '() { (Rational) -> boolish } -> bool',
+                     [1r, 2r, 3r], :any? do :true end
+  end
+
   def test_all?
-    omit 'todo'
+    assert_send_type '() -> bool',
+                     [], :all?
+    assert_send_type '() -> bool',
+                     [1r, 2r, 3r], :all?
+    assert_send_type '(singleton(Rational)) -> bool',
+                     [1r, 2r, 3r], :all?, Rational
+    assert_send_type '() { (Rational) -> boolish } -> bool',
+                     [1r, 2r, 3r], :all? do :true end
   end
 
   def test_assoc
@@ -570,20 +588,30 @@ class ArrayInstanceTest < Test::Unit::TestCase
     test_replace(method: :initialize_copy)
   end
 
-  def test_any?
-    omit 'todo'
-  end
-
   def test_min
     omit 'todo'
   end
 
   def test_none?
-    omit 'todo'
+    assert_send_type '() -> bool',
+                     [], :none?
+    assert_send_type '() -> bool',
+                     [1r, 2r, 3r], :none?
+    assert_send_type '(singleton(Rational)) -> bool',
+                     [1r, 2r, 3r], :none?, Rational
+    assert_send_type '() { (Rational) -> boolish } -> bool',
+                     [1r, 2r, 3r], :none? do :true end
   end
 
   def test_one?
-    omit 'todo'
+    assert_send_type '() -> bool',
+                     [], :one?
+    assert_send_type '() -> bool',
+                     [1r, 2r, 3r], :one?
+    assert_send_type '(singleton(Rational)) -> bool',
+                     [1r, 2r, 3r], :one?, Rational
+    assert_send_type '() { (Rational) -> boolish } -> bool',
+                     [1r, 2r, 3r], :one? do :true end
   end
 
   def test_prepend

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -292,7 +292,18 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_count
-    omit 'todo'
+    assert_send_type  '() -> Integer',
+                      [], :count
+    assert_send_type  '() -> Integer',
+                      [1r], :count
+    assert_send_type  '() { (Rational) -> boolish } -> Integer',
+                      [1r, 2r, 3r], :count do |x| x >= 2 end
+
+    with_untyped.and 1r do |untyped|
+      next unless defined? untyped.==
+      assert_send_type  '(untyped) -> Integer',
+                        [1r, 2r], :count, untyped
+    end
   end
 
   def test_cycle
@@ -300,15 +311,30 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_deconstruct
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :deconstruct
+    assert_send_type  '() -> ArrayInstanceTest::ArraySubclass[Rational]',
+                      ArraySubclass.new([1r, 2r]), :deconstruct
   end
 
   def test_delete
-    omit 'todo'
+    with_untyped.and 1r do |untyped|
+      next unless defined? untyped.==
+
+      assert_send_type  '(untyped) -> Rational?',
+                        [1r], :delete, untyped
+      assert_send_type  '[S] (S) { (S) -> Complex } -> (Rational | Complex) ',
+                        [1r], :delete, untyped do 1i end
+    end
   end
 
   def test_delete_at
-    omit 'todo'
+    with_int 2 do |index|
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r, 3r], :delete_at, index
+      assert_send_type  '(int) -> nil',
+                        [1r, 2r], :delete_at, index
+    end
   end
 
   def test_delete_if(method: :delete_if)
@@ -316,15 +342,41 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_difference
-    omit 'todo'
+    assert_send_type  '() -> Array[Rational]',
+                      [1r, 2r], :difference
+
+    with_array 2r, 3r do |array1|
+      with_array 1, :a, 'b' do |array2|
+        assert_send_type  '(*array[untyped]) -> Array[Rational]',
+                          [1r, 2r], :difference, array1, array2
+      end
+    end
   end
 
   def test_dig
-    omit 'todo'
+    with_int 2 do |index|
+      assert_send_type  '(int) -> nil',
+                        [1r, 2r], :dig, index
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r, 3r], :dig, index
+
+      assert_send_type  '(int, untyped) -> untyped',
+                        [1r, [3]], :dig, index, 0
+      assert_send_type  '(int, untyped, *untyped) -> untyped',
+                        [1r, [[3]]], :dig, index, 0, 0
+
+      assert_send_type  '(int, untyped) -> untyped',
+                        [1r, 2r, [3]], :dig, index, 0
+      assert_send_type  '(int, untyped, *untyped) -> untyped',
+                        [1r, 2r, [[3]]], :dig, index, 0, 0
+    end
   end
 
   def test_drop
-    omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Array[Rational]',
+                        [1r, 2r], :drop, count
+    end
   end
 
   def test_drop_while
@@ -347,11 +399,27 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_eql?
-    omit 'todo'
+    with_untyped.and [1r] do |untyped|
+      assert_send_type  '(untyped) -> bool',
+                        [1r], :eql?, untyped
+    end
   end
 
   def test_fetch
-    omit 'todo'
+    with_int 2 do |index|
+      assert_send_type  '(int) -> Rational',
+                        [1r, 2r, 3r], :fetch, index
+
+      assert_send_type  '(int, Complex) -> Complex',
+                        [1r, 2r], :fetch, index, 1i
+      assert_send_type  '(int, Complex) -> Rational',
+                        [1r, 2r, 3r], :fetch, index, 1i
+
+      assert_send_type  '[I < _ToInt] (I) { (I) -> Complex } -> Complex',
+                        [1r, 2r], :fetch, index do 1i end
+      assert_send_type  '[I < _ToInt] (I) { (I) -> Complex } -> Rational',
+                        [1r, 2r, 3r], :fetch, index do 1i end
+    end
   end
 
   def test_fetch_values
@@ -531,7 +599,17 @@ class ArrayInstanceTest < Test::Unit::TestCase
   end
 
   def test_pack
-    omit 'todo'
+    with_string 'ccc' do |fmt|
+      assert_send_type  '(string) -> String',
+                        [1, 2, 3], :pack, fmt
+
+      assert_send_type  '(string, buffer: nil) -> String',
+                        [1, 2, 3], :pack, fmt, buffer: nil
+      assert_send_type  '(string, buffer: String) -> String',
+                        [1, 2, 3], :pack, fmt, buffer: +''
+      refute_send_type  '(string, buffer: _ToStr) -> String',
+                        [1,2,3], :pack, fmt, buffer: ToStr.new(+'')
+    end
   end
 
   def test_permutation

--- a/test/stdlib/Array_test.rb
+++ b/test/stdlib/Array_test.rb
@@ -6,6 +6,7 @@ class ArraySingletonTest < Test::Unit::TestCase
   testing 'singleton(Array)'
 
   def test_new
+    # Technically array has its own `Array.new` defined, but we don't actually define that as a signatuer
     assert_send_type '() -> Array[untyped]',
                      Array, :new
     with_array 1r, 2r do |array|


### PR DESCRIPTION
This PR completely updates `Array`'s signatures, and rewrites the test harness to work with it.

Note that there's some `# where E: ...` comments strewn about in the code. This marks places where, when we eventually get around to implementing the `where` clause, we should implement them in the Array.