### PR TITLE
Add stdlib signature tests for #2967

### DIFF
--- a/test/stdlib/Etc_test.rb
+++ b/test/stdlib/Etc_test.rb
@@ -111,3 +111,68 @@ class EtcSingletonTest < Test::Unit::TestCase
                       Etc, :uname
   end
 end
+
+class EtcGroupSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  library "etc"
+  testing "singleton(::Etc::Group)"
+
+  def test_each
+    assert_send_type  "() { (::Etc::Group) -> void } -> singleton(::Etc::Group)",
+                      Etc::Group, :each do |_g| end
+    assert_send_type  "() -> ::Enumerator[::Etc::Group]",
+                      Etc::Group, :each
+  end
+end
+
+class EtcPasswdSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  library "etc"
+  testing "singleton(::Etc::Passwd)"
+
+  def test_each
+    assert_send_type  "() { (::Etc::Passwd) -> void } -> singleton(::Etc::Passwd)",
+                      Etc::Passwd, :each do |_u| end
+    assert_send_type  "() -> ::Enumerator[::Etc::Passwd]",
+                      Etc::Passwd, :each
+  end
+end
+
+class EtcPasswdInstanceTest < Test::Unit::TestCase
+  include TestHelper
+
+  library "etc"
+  testing "::Etc::Passwd"
+
+  def test_age
+    omit "no age member on this platform" unless Etc::Passwd.members.include?(:age)
+    pw = Etc.getpwuid
+
+    assert_send_type  "() -> ::Integer",
+                      pw, :age
+    assert_send_type  "(::Integer) -> void",
+                      pw, :age=, pw.age
+  end
+
+  def test_comment
+    omit "no comment member on this platform" unless Etc::Passwd.members.include?(:comment)
+    pw = Etc.getpwuid
+
+    assert_send_type  "() -> ::String",
+                      pw, :comment
+    assert_send_type  "(::String) -> void",
+                      pw, :comment=, pw.comment
+  end
+
+  def test_quota
+    omit "no quota member on this platform" unless Etc::Passwd.members.include?(:quota)
+    pw = Etc.getpwuid
+
+    assert_send_type  "() -> ::Integer",
+                      pw, :quota
+    assert_send_type  "(::Integer) -> void",
+                      pw, :quota=, pw.quota
+  end
+end

--- a/test/stdlib/IO_test.rb
+++ b/test/stdlib/IO_test.rb
@@ -1,5 +1,6 @@
 require_relative "test_helper"
 require 'tempfile'
+require 'etc'
 
 require "io/wait"
 
@@ -225,6 +226,15 @@ class IOInstanceTest < Test::Unit::TestCase
                          io, :<<, Object.new
       end
     end
+  end
+
+  def test_pathconf
+    IO.pipe do |r, w|
+      assert_send_type "(Integer) -> Integer",
+                       w, :pathconf, Etc::PC_PIPE_BUF
+    end
+  rescue NotImplementedError
+    omit "Not implemented"
   end
 
   def test_advise

--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -39,6 +39,23 @@ class StringIOTest < StdlibTest
   end
 end
 
+class StringIOSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing 'singleton(::StringIO)'
+
+  def test_open
+    assert_send_type "() -> ::StringIO",
+                     StringIO, :open
+    assert_send_type "(::String) -> ::StringIO",
+                     StringIO, :open, "abc"
+    assert_send_type "(::String, ::String) -> ::StringIO",
+                     StringIO, :open, "abc", "r"
+    assert_send_type "() { (::StringIO) -> ::Integer } -> ::Integer",
+                     StringIO, :open do |io| io.write("a") end
+  end
+end
+
 class StringIOTypeTest < Test::Unit::TestCase
   include TestHelper
 
@@ -84,5 +101,75 @@ class StringIOTypeTest < Test::Unit::TestCase
                       StringIO.new("\n"), :readlines, chomp: true
     assert_send_type  "(::String sep, ::Integer limit, chomp: boolish) -> ::Array[::String]",
                       StringIO.new("\n"), :readlines, "\n", 1, chomp: true
+  end
+
+  def test_pread
+    assert_send_type "(Integer, Integer) -> String",
+                     StringIO.new("abcdef"), :pread, 3, 0
+    assert_send_type "(Integer, Integer, String) -> String",
+                     StringIO.new("abcdef"), :pread, 3, 0, +"buf"
+  end
+
+  def test_read_nonblock
+    assert_send_type "(int) -> String",
+                     StringIO.new("abc"), :read_nonblock, 2
+    assert_send_type "(int, string) -> String",
+                     StringIO.new("abc"), :read_nonblock, 2, +"buf"
+    assert_send_type "(int, exception: true) -> String",
+                     StringIO.new("abc"), :read_nonblock, 2, exception: true
+    assert_send_type "(int, exception: false) -> String",
+                     StringIO.new("abc"), :read_nonblock, 2, exception: false
+    assert_send_type "(int, exception: false) -> nil",
+                     StringIO.new(""), :read_nonblock, 2, exception: false
+  end
+
+  def test_write_nonblock
+    assert_send_type "(_ToS) -> Integer",
+                     StringIO.new(+""), :write_nonblock, "abc"
+    assert_send_type "(_ToS, exception: true) -> Integer",
+                     StringIO.new(+""), :write_nonblock, "abc", exception: true
+    assert_send_type "(_ToS, exception: false) -> Integer",
+                     StringIO.new(+""), :write_nonblock, "abc", exception: false
+  end
+
+  def test_sysread
+    assert_send_type "(Integer) -> String",
+                     StringIO.new("abc"), :sysread, 2
+    assert_send_type "(Integer, String) -> String",
+                     StringIO.new("abc"), :sysread, 2, +"buf"
+  end
+
+  def test_ungetc
+    assert_send_type "(String) -> nil",
+                     StringIO.new(+"abc"), :ungetc, "x"
+    assert_send_type "(Integer) -> nil",
+                     StringIO.new(+"abc"), :ungetc, 65
+  end
+
+  def test_set_encoding_by_bom
+    assert_send_type "() -> Encoding",
+                     StringIO.new("\u{FEFF}abc"), :set_encoding_by_bom
+    assert_send_type "() -> nil",
+                     StringIO.new("abc"), :set_encoding_by_bom
+  end
+
+  def test_fcntl
+    assert_send_type_error "(*untyped) -> bot", NotImplementedError,
+                           StringIO.new("abc"), :fcntl, 1, 1
+  end
+
+  def test_fsync
+    assert_send_type "() -> Integer",
+                     StringIO.new("abc"), :fsync
+  end
+
+  def test_internal_encoding
+    assert_send_type "() -> nil",
+                     StringIO.new("abc"), :internal_encoding
+  end
+
+  def test_external_encoding
+    assert_send_type "() -> Encoding",
+                     StringIO.new("abc"), :external_encoding
   end
 end


### PR DESCRIPTION
## Summary

Add runtime signature tests for the core/stdlib signature corrections in #2967.

## Coverage

- `IO#pathconf`
- `StringIO.open` (non-block form added in #2967), `StringIO#pread`, `read_nonblock` (with `exception:` literal split), `write_nonblock`, `sysread`, `ungetc` (String / Integer), `fcntl` (always raises `NotImplementedError`), `fsync`, `internal_encoding`, `external_encoding`, `set_encoding_by_bom`
- `Etc::Group.each` / `Etc::Passwd.each` block & Enumerator overloads
- `Etc::Passwd#age` / `comment` / `quota` getters & setters (skipped on platforms where the member is absent)

## Not covered (intentional)

- `Etc.sysconf` / `Etc.systmpdir` nil branch — not reachable in the test environment, but the existing non-nil cases conform to the widened `Integer?` / `String?` signature
- `StringIO#external_encoding` nil branch — same reason
- `Digest::Class` changes — covered by raap, not by hand-written runtime tests

Generated with [Claude Code](https://claude.com/claude-code)