### PR TITLE
Support `%a{implicitly-returns-nil}` on `MatchData#[]`

### DIFF
--- a/core/match_data.rbs
+++ b/core/match_data.rbs
@@ -92,7 +92,7 @@ class MatchData
   #     #<MatchData "hoge" foo:nil foo:"oge" foo:nil>
   #     m[:foo] #=> "oge"
   #
-  def []: (capture backref, ?nil) -> String?
+  def []: %a{implicitly-returns-nil} (capture backref, ?nil) -> String
         | (int start, int length) -> Array[String?]
         | (range[int?] range) -> Array[String?]
 


### PR DESCRIPTION
In the following case, even though the return value of `Regexp.last_match` cannot possibly be `nil`, the type still retains the possibility of being `nil`.

```rb
case type
when /\AArray<(?<inner_type>.+)>\z/
  inner_type = Regexp.last_match[:inner_type]
end
```

Just like `Array#[]` and others, it would be more practical to make the possibility of `nil` implicit.