### PR TITLE
ruby-rbs-sys: support wasm32 targets

### DIFF
--- a/rust/ruby-rbs-sys/build.rs
+++ b/rust/ruby-rbs-sys/build.rs
@@ -11,21 +11,45 @@ fn main() -> Result<(), Box<dyn Error>> {
     let include = vendor_rbs.join("include");
     let c_src = vendor_rbs.join("src");
 
-    build(&include, &c_src)?;
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_wasm = target.contains("wasm32");
 
-    let bindings = generate_bindings(&include)?;
+    build(&include, &c_src, is_wasm)?;
+
+    let bindings = generate_bindings(&include, is_wasm)?;
     write_bindings(&bindings)?;
 
     Ok(())
 }
 
-fn build(include_dir: &Path, src_dir: &Path) -> Result<(), Box<dyn Error>> {
+fn build(include_dir: &Path, src_dir: &Path, is_wasm: bool) -> Result<(), Box<dyn Error>> {
     let mut build = cc::Build::new();
 
     build.include(include_dir);
 
     // Suppress unused parameter warnings from C code
     build.flag_if_supported("-Wno-unused-parameter");
+
+    // Cross-compile the C parser to wasm with the WASI SDK's clang. Only the C
+    // compile targets wasm; bindgen (below) still runs against the host, since
+    // the resulting #[repr(C)] declarations are layout-portable.
+    if is_wasm {
+        let wasi_sdk = PathBuf::from(
+            env::var("WASI_SDK_PATH").expect("WASI_SDK_PATH must be set for wasm builds"),
+        );
+        build.compiler(wasi_sdk.join("bin").join("clang"));
+
+        let sysroot = wasi_sdk.join("share").join("wasi-sysroot");
+        build.flag(&format!("--sysroot={}", sysroot.display()));
+        build.include(sysroot.join("include"));
+
+        println!(
+            "cargo:rustc-link-search=native={}",
+            sysroot.join("lib/wasm32-wasi").display()
+        );
+        build.define("_WASI_EMULATED_MMAN", "1");
+        println!("cargo:rustc-link-lib=wasi-emulated-mman");
+    }
 
     build.files(source_files(src_dir)?);
     build.try_compile("rbs")?;
@@ -64,8 +88,11 @@ fn source_files<P: AsRef<Path>>(root_dir: P) -> Result<Vec<String>, Box<dyn Erro
     Ok(files)
 }
 
-fn generate_bindings(include_path: &Path) -> Result<bindgen::Bindings, Box<dyn Error>> {
-    let bindings = bindgen::Builder::default()
+fn generate_bindings(
+    include_path: &Path,
+    is_wasm: bool,
+) -> Result<bindgen::Bindings, Box<dyn Error>> {
+    let mut builder = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg(format!("-I{}", include_path.display()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
@@ -170,7 +197,22 @@ fn generate_bindings(include_path: &Path) -> Result<bindgen::Bindings, Box<dyn E
         // Constant pool functions
         .allowlist_function("rbs_constant_pool_free")
         .allowlist_function("rbs_constant_pool_id_to_constant")
-        .allowlist_function("rbs_constant_pool_init")
+        .allowlist_function("rbs_constant_pool_init");
+
+    if is_wasm {
+        // Generate the FFI declarations for the HOST target rather than the wasm
+        // target: host bindgen is reliable, whereas wasm-target bindgen is
+        // libclang-fragile (drops functions / emits opaque structs). The emitted
+        // #[repr(C)] structs are layout-portable, so they compile correctly for
+        // wasm32. Drop the layout assertions, which would otherwise hardcode the
+        // host sizes and fail when recompiled for wasm.
+        let host = env::var("HOST").expect("HOST is not set");
+        builder = builder
+            .clang_arg(format!("--target={host}"))
+            .layout_tests(false);
+    }
+
+    let bindings = builder
         .generate()
         .map_err(|_| "Unable to generate rbs bindings")?;
 


### PR DESCRIPTION
## What

Teach `ruby-rbs-sys`'s build script to support `wasm32-*` targets:

- Compile the vendored RBS C parser with the WASI SDK's clang (via `WASI_SDK_PATH`).
- Generate the FFI bindings against the **host** target (`--target=$HOST`, `layout_tests(false)`) rather than the wasm target.

This mirrors `ruby-prism-sys`'s existing wasm build support.

## Why

Running bindgen against the wasm target is libclang-version-fragile. Across libclangs I see two distinct failures, both on `wasm32-wasip1`:

- some libclangs drop *all* `rbs_*` function declarations;
- others emit the forward-referenced node structs (`rbs_namespace`, `rbs_type_name`, `rbs_ast_symbol`, `rbs_types_block`, `rbs_ast_declarations_class_super`) as opaque, so the generated layout assertions overflow (`E0080`).

The generated `#[repr(C)]` declarations are layout-portable, so generating them for the host and compiling them for `wasm32` is both correct and reliable. The C parser is still compiled for wasm by the WASI SDK clang.

## Testing

- `cargo build -p ruby-rbs-sys --target wasm32-wasip1` and `cargo build -p ruby-rbs --target wasm32-wasip1` both succeed.
- Runtime: a cdylib calling `rbs_parser_new` → `rbs_parse_signature` → walking `signature.declarations` (and the high-level `ruby_rbs::node::parse`) runs correctly under a WASI runtime.
- Native builds are unchanged — the wasm-specific configuration is gated on the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)