### PR TITLE
Add missing dependency for `environment_loader.rb` and `repository.rb`

### DIFF
--- a/lib/rbs/environment_loader.rb
+++ b/lib/rbs/environment_loader.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "pathname" unless defined?(Pathname)
 
 module RBS
   class EnvironmentLoader

--- a/lib/rbs/repository.rb
+++ b/lib/rbs/repository.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "pathname" unless defined?(Pathname)
 
 module RBS
   class Repository


### PR DESCRIPTION
I tried to use Solargraph and that got me into an error that seemed to be caused by rbs:

```
$ solargraph 
/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rbs-4.0.2/lib/rbs/environment_loader.rb:26:in `<class:EnvironmentLoader>': undefined method `Pathname' for class RBS::EnvironmentLoader (NoMethodError)

    DEFAULT_CORE_ROOT = Pathname(_ = __dir__) + "../../core"
                        ^^^^^^^^
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rbs-4.0.2/lib/rbs/environment_loader.rb:4:in `<module:RBS>'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rbs-4.0.2/lib/rbs/environment_loader.rb:3:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rbs-4.0.2/lib/rbs.rb:40:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/sord-7.1.0/lib/sord/resolver.rb:3:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/sord-7.1.0/lib/sord/type_converter.rb:4:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/sord-7.1.0/lib/sord/generator.rb:3:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/sord-7.1.0/lib/sord.rb:3:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/solargraph-0.60.0/lib/solargraph/shell.rb:7:in `<top (required)>'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from <internal:/Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:139:in `require'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/solargraph-0.60.0/bin/solargraph:9:in `<top (required)>'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems.rb:305:in `load'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/lib/ruby/site_ruby/3.3.0/rubygems.rb:305:in `activate_and_load_bin_path'
	from /Users/<username>/.local/share/mise/installs/ruby/3.3.11/bin/solargraph:36:in `<main>'
```

It turns out, the file `environment_loader.rb` was using `Pathname` without requiring it:
```rb
DEFAULT_CORE_ROOT = Pathname(_ = __dir__) + "../../core"
```

Therefore, I added the following line at the top of the file. `repository.rb` seemed to have a similar problem, so I added the same line for this file too:
```
require "pathname" unless defined?(Pathname)
```

I'm quite new to Ruby, so please be kind. Thanks.
