### PR TITLE
Update `Integer`, phase 2

### DIFF
--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -93,6 +93,8 @@
 #     given value.
 #
 class Integer < Numeric
+  # TODO: `undef self.new`
+
   # <!--
   #   rdoc-file=numeric.c
   #   - Integer.sqrt(numeric) -> integer
@@ -421,7 +423,7 @@ class Integer < Numeric
   #
   # Related: Integer#eql? (requires `other` to be an Integer).
   #
-  def ==: (untyped) -> bool
+  def ==: (untyped other) -> bool
 
   # <!--
   #   rdoc-file=numeric.c
@@ -434,7 +436,7 @@ class Integer < Numeric
   #
   # Related: Integer#eql? (requires `other` to be an Integer).
   #
-  def ===: (untyped) -> bool
+  alias === ==
 
   # <!--
   #   rdoc-file=numeric.c
@@ -687,8 +689,7 @@ class Integer < Numeric
   #      -5|     100000|                  0
   # Related: Integer#floor.
   #
-  def ceil: () -> Integer
-          | (int digits) -> (Integer | Float)
+  def ceil: (?int digits) -> Integer
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -726,7 +727,7 @@ class Integer < Numeric
   #
   # Related: Integer#ord.
   #
-  def chr: (?encoding) -> String
+  def chr: (?encoding encoding) -> String
 
   # <!--
   #   rdoc-file=bignum.c
@@ -749,7 +750,7 @@ class Integer < Numeric
   # -->
   # Returns `1`.
   #
-  def denominator: () -> Integer
+  def denominator: () -> 1
 
   # <!--
   #   rdoc-file=numeric.c
@@ -764,7 +765,7 @@ class Integer < Numeric
   #
   # Raises an exception if `self` is negative or `base` is less than 2.
   #
-  def digits: (?int base) -> ::Array[Integer]
+  def digits: (?int base) -> Array[Integer]
 
   # <!--
   #   rdoc-file=numeric.c
@@ -971,7 +972,7 @@ class Integer < Numeric
   #   - magnitude()
   # -->
   #
-  def magnitude: () -> Integer
+  alias magnitude abs
 
   # <!-- rdoc-file=numeric.c -->
   # Returns `self` modulo `other` as a real numeric (Integer, Float, or Rational).
@@ -1009,7 +1010,7 @@ class Integer < Numeric
   #
   # Related: Integer#pred (predecessor value).
   #
-  def next: () -> Integer
+  alias next succ
 
   # <!--
   #   rdoc-file=numeric.c
@@ -1040,7 +1041,7 @@ class Integer < Numeric
   # -->
   # Returns `self`.
   #
-  def numerator: () -> Integer
+  def numerator: () -> self
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -1056,7 +1057,7 @@ class Integer < Numeric
   # -->
   # Returns `self`; intended for compatibility to character literals in Ruby 1.9.
   #
-  def ord: () -> Integer
+  def ord: () -> self
 
   def polar: () -> [ Integer, Integer | Float ]
 
@@ -1180,8 +1181,7 @@ class Integer < Numeric
   #
   # Related: Integer#truncate.
   #
-  def round: (?half: :up | :down | :even) -> Integer
-           | (int digits, ?half: :up | :down | :even) -> (Integer | Float)
+  def round: (?int digits, ?half: Numeric::round_mode) -> Integer
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -1226,8 +1226,8 @@ class Integer < Numeric
   #
   # With no block given, returns an Enumerator.
   #
-  def times: () { (Integer) -> void } -> self
-           | () -> ::Enumerator[Integer, self]
+  def times: () { (Integer i) -> void } -> self
+           | () -> Enumerator[Integer, self]
 
   # <!--
   #   rdoc-file=numeric.c
@@ -1251,7 +1251,7 @@ class Integer < Numeric
   # -->
   # Returns `self` (which is already an Integer).
   #
-  def to_i: () -> Integer
+  def to_i: () -> self
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -1289,43 +1289,7 @@ class Integer < Numeric
   #
   # Raises an exception if `base` is out of range.
   #
-  def to_s: () -> String
-          | (2) -> String
-          | (3) -> String
-          | (4) -> String
-          | (5) -> String
-          | (6) -> String
-          | (7) -> String
-          | (8) -> String
-          | (9) -> String
-          | (10) -> String
-          | (11) -> String
-          | (12) -> String
-          | (13) -> String
-          | (14) -> String
-          | (15) -> String
-          | (16) -> String
-          | (17) -> String
-          | (18) -> String
-          | (19) -> String
-          | (20) -> String
-          | (21) -> String
-          | (22) -> String
-          | (23) -> String
-          | (24) -> String
-          | (25) -> String
-          | (26) -> String
-          | (27) -> String
-          | (28) -> String
-          | (29) -> String
-          | (30) -> String
-          | (31) -> String
-          | (32) -> String
-          | (33) -> String
-          | (34) -> String
-          | (35) -> String
-          | (36) -> String
-          | (int base) -> String
+  def to_s: (?int base) -> String
 
   # <!--
   #   rdoc-file=numeric.c
@@ -1348,8 +1312,7 @@ class Integer < Numeric
   #
   # Related: Integer#round.
   #
-  def truncate: () -> Integer
-              | (int ndigits) -> Integer
+  def truncate: (?int ndigits) -> Integer
 
   # <!--
   #   rdoc-file=numeric.c

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -520,9 +520,9 @@ class Integer < Numeric
   #
   # Raises an exception if the slice cannot be constructed.
   #
-  def []: (int) -> Integer
-        | (int i, int len) -> Integer
-        | (Range[int]) -> Integer
+  def []: (int offset) -> (0 | 1)
+        | (int offset, int size) -> Integer
+        | (range[int?] range) -> Integer # Technically needs to have things beyond `int` (eg `<=>` and `coerce`), but too cumbersome to annotate
 
   # <!--
   #   rdoc-file=numeric.c
@@ -819,7 +819,6 @@ class Integer < Numeric
     def divmod: (O other) -> R
   end
 
-
   # <!--
   #   rdoc-file=numeric.c
   #   - downto(limit) {|i| ... } -> self
@@ -838,8 +837,10 @@ class Integer < Numeric
   #
   # With no block given, returns an Enumerator.
   #
-  def downto: (Numeric limit) { (Integer) -> void } -> Integer
-            | (Numeric limit) -> ::Enumerator[Integer, self]
+  def downto: (Integer limit) { (Integer i) -> void } -> self
+            | (Integer limit) -> Enumerator[Integer, self]
+            | [S] (Numeric::_Coerce[self, RBS::Ops::_LessThan[S, boolish], S] other) { (Integer i) -> void } -> self
+            | [S] (Numeric::_Coerce[self, RBS::Ops::_LessThan[S, boolish], S] other) -> Enumerator[Integer, self] # Technically, need more bounds for `size`?
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -1341,8 +1342,10 @@ class Integer < Numeric
   #
   # With no block given, returns an Enumerator.
   #
-  def upto: (Numeric limit) { (Integer) -> void } -> Integer
-          | (Numeric limit) -> ::Enumerator[Integer, self]
+  def upto: (Integer limit) { (Integer i) -> void } -> self
+          | (Integer limit) -> Enumerator[Integer, self]
+          | [S] (Numeric::_Coerce[self, RBS::Ops::_GreaterThan[S, boolish], S] other) { (Integer i) -> void } -> self
+          | [S] (Numeric::_Coerce[self, RBS::Ops::_GreaterThan[S, boolish], S] other) -> Enumerator[Integer, self] # Technically, need more bounds for `size`?
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -175,7 +175,7 @@ class Integer < Numeric
   #     10 % Rational(3, 1) # => (1/1)
   #
   def %: (Integer other) -> Integer
-       | [O < RBS::Ops::_Modulo[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Modulo[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -191,7 +191,7 @@ class Integer < Numeric
   # Related: Integer#| (bitwise OR), Integer#^ (bitwise EXCLUSIVE OR).
   #
   def &: (Integer other) -> Integer
-       | [O < RBS::Ops::_And[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_And[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -207,7 +207,7 @@ class Integer < Numeric
   #     4 * Complex(2, 0)  # => (8+0i)
   #
   def *: (Integer other) -> Integer
-       | [O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Times[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -254,7 +254,7 @@ class Integer < Numeric
   #     -2 ** Rational(-3, 1) # => (-1/8)
   #
   def **: (Integer other) -> Integer
-        | [O < RBS::Ops::_Power[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+        | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Power[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -274,7 +274,7 @@ class Integer < Numeric
   #     1 + 3.14           # => 4.140000000000001
   #
   def +: (Integer other) -> Integer
-       | [O < RBS::Ops::_Add[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Add[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -290,7 +290,7 @@ class Integer < Numeric
   #     4 - Complex(2, 0)  # => (2+0i)
   #
   def -: (Integer other) -> Integer
-       | [O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Subtract[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -324,7 +324,7 @@ class Integer < Numeric
   #     4 / Complex(3, 0)  # => ((4/3)+0i)
   #
   def /: (Integer other) -> Integer
-       | [O < RBS::Ops::_Divide[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Divide[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -340,7 +340,7 @@ class Integer < Numeric
   #     1 < Rational(1, 2) # => false
   #
   def <: (Integer other) -> bool
-       | [O < RBS::Ops::_LessThan[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_LessThan[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -375,7 +375,7 @@ class Integer < Numeric
   #     Raises an exception if the comparison cannot be made.
   #
   def <=: (Integer other) -> bool
-        | [O < RBS::Ops::_LessThanOrEqual[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+        | [S, R] (Numeric::_Coerce[self, RBS::Ops::_LessThanOrEqual[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -444,7 +444,7 @@ class Integer < Numeric
   #     Raises an exception if the comparison cannot be made.
   #
   def >: (Integer other) -> bool
-       | [O < RBS::Ops::_GreaterThan[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_GreaterThan[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -462,7 +462,7 @@ class Integer < Numeric
   # Raises an exception if the comparison cannot be made.
   #
   def >=: (Integer other) -> bool
-        | [O < RBS::Ops::_GreaterThanOrEquaul[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+        | [S, R] (Numeric::_Coerce[self, RBS::Ops::_GreaterThanOrEqual[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -538,7 +538,7 @@ class Integer < Numeric
   # Related: Integer#& (bitwise AND), Integer#| (bitwise OR).
   #
   def ^: (Integer other) -> Integer
-       | [O < RBS::Ops::_Xor[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Xor[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -702,6 +702,8 @@ class Integer < Numeric
   #     3.ceildiv(1.2) # => 3
   #
   def ceildiv: (Numeric other) -> Integer
+  # def ceildiv: (Integer other) -> Integer
+  #            | [S, R] (Numeric::_Coerce[0, _Div[S, RBS::Ops::_UnaryNeg[R]], S] other) -> R2
 
   # <!--
   #   rdoc-file=numeric.c
@@ -778,7 +780,13 @@ class Integer < Numeric
   #
   # Raises an exception if `numeric` does not have method `div`.
   #
-  def div: (Numeric) -> Integer
+  def div: (Integer other) -> Integer
+         | [S, R] (Numeric::_Coerce[self, _Div[S, R], S] other) -> R
+
+  # An interface for defining the `div` method. Used in `Integer#div`
+  interface _Div[O, R]
+    def div: (O other) -> R
+  end
 
   # <!--
   #   rdoc-file=numeric.c
@@ -852,7 +860,13 @@ class Integer < Numeric
   #
   # Raises an exception if `numeric` cannot be converted to a Float.
   #
-  def fdiv: (Numeric) -> Float
+  def fdiv: (Integer other) -> Float
+          | [S] (Numeric::_Coerce[self, _FDiv[S], S] other) -> Float
+
+  # An interface for defining the `div` method. Used in `Integer#div`
+  interface _FDiv[O]
+    def fdiv: (O other) -> _ToF
+  end
 
   # <!--
   #   rdoc-file=numeric.c
@@ -1068,11 +1082,8 @@ class Integer < Numeric
   #     a.pow(b)     #=> same as a**b
   #     a.pow(b, m)  #=> same as (a**b) % m, but avoids huge temporary values
   #
-  def pow: (Integer other) -> (Integer | Rational)
-         | (Integer other, Integer modulo) -> Integer
-         | (Float) -> (Float | Complex)
-         | (Rational) -> (Float | Rational | Complex)
-         | (Complex) -> Complex
+  def pow: (Integer other, ?Integer m) -> Integer
+         | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Power[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -1125,8 +1136,8 @@ class Integer < Numeric
   #     13.remainder(4.0)            # => 1.0
   #     13.remainder(Rational(4, 1)) # => (1/1)
   #
-  def remainder: (Integer) -> Integer
-               | (Float) -> Float
+  def remainder: (Integer other) -> Integer
+               | (Float) -> Float # TODO: this is technically `| ...`, but these branches need to be here until numeric is fixed.
                | (Rational) -> Rational
                | (Numeric) -> Numeric
 
@@ -1352,7 +1363,7 @@ class Integer < Numeric
   # Related: Integer#& (bitwise AND), Integer#^ (bitwise EXCLUSIVE OR).
   #
   def |: (Integer other) -> Integer
-       | [O < RBS::Ops::_Or[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Or[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -190,7 +190,8 @@ class Integer < Numeric
   #
   # Related: Integer#| (bitwise OR), Integer#^ (bitwise EXCLUSIVE OR).
   #
-  def &: (Integer) -> Integer
+  def &: (Integer other) -> Integer
+       | [O < RBS::Ops::_And[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -356,7 +357,7 @@ class Integer < Numeric
   #
   # Related: Integer#>>.
   #
-  def <<: (int) -> Integer
+  def <<: (int count) -> Integer
 
   # <!--
   #   rdoc-file=numeric.c
@@ -478,7 +479,7 @@ class Integer < Numeric
   #
   # Related: Integer#<<.
   #
-  def >>: (int) -> Integer
+  def >>: (int count) -> Integer
 
   # <!--
   #   rdoc-file=numeric.c
@@ -536,7 +537,8 @@ class Integer < Numeric
   #
   # Related: Integer#& (bitwise AND), Integer#| (bitwise OR).
   #
-  def ^: (Integer) -> Integer
+  def ^: (Integer other) -> Integer
+       | [O < RBS::Ops::_Xor[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -1349,7 +1351,8 @@ class Integer < Numeric
   #
   # Related: Integer#& (bitwise AND), Integer#^ (bitwise EXCLUSIVE OR).
   #
-  def |: (Integer) -> Integer
+  def |: (Integer other) -> Integer
+       | [O < RBS::Ops::_Or[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -174,10 +174,8 @@ class Integer < Numeric
   #     10 % 3.0            # => 1.0
   #     10 % Rational(3, 1) # => (1/1)
   #
-  def %: (Float) -> Float
-       | (Rational) -> Rational
-       | (Integer) -> Integer
-       | (Numeric) -> Numeric
+  def %: (Integer other) -> Integer
+       | [O < RBS::Ops::_Modulo[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -207,10 +205,8 @@ class Integer < Numeric
   #     4 * Rational(1, 3) # => (4/3)
   #     4 * Complex(2, 0)  # => (8+0i)
   #
-  def *: (Float) -> Float
-       | (Rational) -> Rational
-       | (Complex) -> Complex
-       | (Integer) -> Integer
+  def *: (Integer other) -> Integer
+       | [O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -256,10 +252,8 @@ class Integer < Numeric
   #     2 ** Rational(-3, 1)  # => (1/8)
   #     -2 ** Rational(-3, 1) # => (-1/8)
   #
-  def **: (Integer) -> Numeric
-        | (Float) -> Numeric
-        | (Rational) -> Numeric
-        | (Complex) -> Complex
+  def **: (Integer other) -> Integer
+        | [O < RBS::Ops::_Power[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -278,10 +272,8 @@ class Integer < Numeric
   #
   #     1 + 3.14           # => 4.140000000000001
   #
-  def +: (Integer) -> Integer
-       | (Float) -> Float
-       | (Rational) -> Rational
-       | (Complex) -> Complex
+  def +: (Integer other) -> Integer
+       | [O < RBS::Ops::_Add[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -296,10 +288,8 @@ class Integer < Numeric
   #     4 - Rational(2, 1) # => (2/1)
   #     4 - Complex(2, 0)  # => (2+0i)
   #
-  def -: (Integer) -> Integer
-       | (Float) -> Float
-       | (Rational) -> Rational
-       | (Complex) -> Complex
+  def -: (Integer other) -> Integer
+       | [O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.rb
@@ -332,10 +322,8 @@ class Integer < Numeric
   #     4 / Rational(3, 1) # => (4/3)
   #     4 / Complex(3, 0)  # => ((4/3)+0i)
   #
-  def /: (Integer) -> Integer
-       | (Float) -> Float
-       | (Rational) -> Rational
-       | (Complex) -> Complex
+  def /: (Integer other) -> Integer
+       | [O < RBS::Ops::_Divide[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -742,7 +730,8 @@ class Integer < Numeric
   #
   #     (0x3FFFFFFFFFFFFFFF+1).coerce(42)   #=> [42, 4611686018427387904]
   #
-  def coerce: (Numeric) -> [ Numeric, Numeric ]
+  def coerce: (Integer numeric) -> [Integer, self]
+            | (_ToF float) -> [Float, Float]
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -338,7 +338,8 @@ class Integer < Numeric
   #     1 < 0.5            # => false
   #     1 < Rational(1, 2) # => false
   #
-  def <: (Numeric) -> bool
+  def <: (Integer other) -> bool
+       | [O < RBS::Ops::_LessThan[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -372,7 +373,8 @@ class Integer < Numeric
   #
   #     Raises an exception if the comparison cannot be made.
   #
-  def <=: (Numeric) -> bool
+  def <=: (Integer other) -> bool
+        | [O < RBS::Ops::_LessThanOrEqual[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -440,7 +442,8 @@ class Integer < Numeric
   #
   #     Raises an exception if the comparison cannot be made.
   #
-  def >: (Numeric) -> bool
+  def >: (Integer other) -> bool
+       | [O < RBS::Ops::_GreaterThan[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -457,7 +460,8 @@ class Integer < Numeric
   #
   # Raises an exception if the comparison cannot be made.
   #
-  def >=: (Numeric) -> bool
+  def >=: (Integer other) -> bool
+        | [O < RBS::Ops::_GreaterThanOrEquaul[S, R], S, R] (Numeric::_Coerce[self, O, S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -701,9 +701,8 @@ class Integer < Numeric
   #
   #     3.ceildiv(1.2) # => 3
   #
-  def ceildiv: (Numeric other) -> Integer
-  # def ceildiv: (Integer other) -> Integer
-  #            | [S, R] (Numeric::_Coerce[0, _Div[S, RBS::Ops::_UnaryNeg[R]], S] other) -> R2
+  def ceildiv: (Integer other) -> Integer
+             | [S, R] (Numeric::_Coerce[0, _Div[S, RBS::Ops::_UnaryNeg[R]], S] other) -> R
 
   # <!--
   #   rdoc-file=numeric.c
@@ -812,10 +811,14 @@ class Integer < Numeric
   #     13.divmod(4.0)            # => [3, 1.0]
   #     13.divmod(Rational(4, 1)) # => [3, (1/1)]
   #
-  def divmod: (Integer) -> [ Integer, Integer ]
-            | (Float) -> [ Integer, Float ]
-            | (Rational) -> [ Integer, Rational ]
-            | (Numeric) -> [ Numeric, Numeric ]
+  def divmod: (Integer other) -> [ Integer, Integer ]
+            | [S, R] (Numeric::_Coerce[self, _DivMod[S, R], S] other) -> R
+
+  # An interface for defining the `divmod` method. Used in `Integer#divmod`
+  interface _DivMod[O, R]
+    def divmod: (O other) -> R
+  end
+
 
   # <!--
   #   rdoc-file=numeric.c

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -913,7 +913,7 @@ class Integer < Numeric
   #     3.gcd(-7)                   #=> 1
   #     ((1<<31)-1).gcd((1<<61)-1)  #=> 1
   #
-  def gcd: (Integer) -> Integer
+  def gcd: (Integer other_int) -> Integer
 
   # <!--
   #   rdoc-file=rational.c
@@ -927,7 +927,7 @@ class Integer < Numeric
   #     3.gcdlcm(-7)                   #=> [1, 21]
   #     ((1<<31)-1).gcdlcm((1<<61)-1)  #=> [1, 4951760154835678088235319297]
   #
-  def gcdlcm: (Integer) -> [ Integer, Integer ]
+  def gcdlcm: (Integer other_int) -> [ Integer, Integer ]
 
   # <!-- rdoc-file=numeric.c -->
   # Returns a string containing the place-value representation of `self` in radix
@@ -965,7 +965,7 @@ class Integer < Numeric
   #     3.lcm(-7)                   #=> 21
   #     ((1<<31)-1).lcm((1<<61)-1)  #=> 4951760154835678088235319297
   #
-  def lcm: (Integer) -> Integer
+  def lcm: (Integer other_int) -> Integer
 
   # <!--
   #   rdoc-file=numeric.rb

--- a/core/integer.rbs
+++ b/core/integer.rbs
@@ -402,8 +402,8 @@ class Integer < Numeric
   # Class Integer includes module Comparable, each of whose methods uses
   # Integer#<=> for comparison.
   #
-  def <=>: (Integer | Rational) -> Integer
-         | (untyped) -> Integer?
+  def <=>: (Integer | Rational other) -> (-1 | 0 | 1)
+         | (untyped other) -> Integer? # todo: technically uses same coerce mechanism as other methods. That'd get rid of `| Rational`.
 
   # <!-- rdoc-file=numeric.c -->
   # Returns `true` if `self` is numerically equal to `other`; `false` otherwise.

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -161,6 +161,11 @@ class Numeric
   # The direction you can round
   type round_mode = :up | :down | :even | 'up' | 'down' | 'even' | string | nil
 
+  # An interface that indicates a type can be coerced.
+  interface _Coerce[O, Other, Self]
+    def coerce: (O other) -> [Other, Self]
+  end
+
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> real_numeric

--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -158,6 +158,9 @@
 class Numeric
   include Comparable
 
+  # The direction you can round
+  type round_mode = :up | :down | :even | 'up' | 'down' | 'even' | string | nil
+
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> real_numeric

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -44,7 +44,11 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_and
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :&, 12
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :&, Coercable.for_op(:&)
   end
 
   def test_op_mul
@@ -136,7 +140,10 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_lsh
-    # omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Integer',
+                        38, :<<, count
+    end
   end
 
   def test_op_leq
@@ -203,7 +210,10 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_rsh
-    # omit 'todo'
+    with_int 2 do |count|
+      assert_send_type  '(int) -> Integer',
+                        38, :>>, count
+    end
   end
 
   def test_op_aref
@@ -211,7 +221,11 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_xor
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :^, 12
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :^, Coercable.for_op(:^)
   end
 
   def test_abs(method: :magnitude)
@@ -506,7 +520,11 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_or
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :|, 12
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :|, Coercable.for_op(:|)
   end
 
   def test_op_not

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -39,8 +39,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
                       38, method, 12.0
     # Notably not `Complex` as complex doesn't define `%`
 
-    assert_send_type  '[O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, method, Coercable.new('fmt: %s', &:to_s)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, method, Coercable.for_op(:%)
   end
 
   def test_op_and
@@ -57,8 +57,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
     assert_send_type  '(Complex) -> Complex',
                       38, :*, 12i
 
-    assert_send_type  '[O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :*, Coercable.new(%w[a b], &:to_s)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :*, Coercable.for_op(:*)
   end
 
   def test_op_pow
@@ -71,8 +71,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
     assert_send_type  '(Complex) -> Complex',
                       38, :**, 12i
 
-    assert_send_type  '[O < RBS::Ops::_Power[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :**, Coercable.new(10i, &:i)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :**, Coercable.for_op(:**)
   end
 
   def test_op_add
@@ -85,8 +85,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
     assert_send_type  '(Complex) -> Complex',
                       38, :+, 12i
 
-    assert_send_type  '[O < RBS::Ops::_Add[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :+, Coercable.new('foo', &:to_s)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :+, Coercable.for_op(:+)
   end
 
   def test_op_sub
@@ -99,8 +99,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
     assert_send_type  '(Complex) -> Complex',
                       38, :-, 12i
 
-    assert_send_type  '[O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :-, Coercable.new([3], &:digits)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :-, Coercable.for_op(:-)
   end
 
   def test_op_uneg
@@ -118,8 +118,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
     assert_send_type  '(Complex) -> Complex',
                       38, :/, 12i
 
-    assert_send_type  '[O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :/, Coercable.new(10i, &:i)
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :/, Coercable.for_op(:/)
   end
 
   def test_op_lt
@@ -131,8 +131,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
                       38, :<, 12.0
     # Notably not `Complex` as complex doesn't define `<`
 
-    assert_send_type  '[O < RBS::Ops::_LessThan[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :<, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :<, Coercable.for_op(:<)
   end
 
   def test_op_lsh
@@ -148,12 +148,20 @@ class IntegerInstanceTest < Test::Unit::TestCase
                       38, :<=, 12.0
     # Notably not `Complex` as complex doesn't define `<=`
 
-    assert_send_type  '[O < RBS::Ops::_LessThanOrEqual[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :<=, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :<=, Coercable.for_op(:<=)
   end
 
   def test_op_cmp
-    # omit 'todo'
+    assert_send_type  '(Integer) -> (-1 | 0 | 1)',
+                      38, :<=>, 12
+    assert_send_type  '(Rational) -> (-1 | 0 | 1)',
+                      38, :<=>, 12r
+
+    with_untyped.and 12, 12r, 12.0, 12i, Coercable.new(Set[8, 4]){ |n| n.digits.to_set } do |other|
+      assert_send_type  '(untyped) -> Integer?',
+                        38, :<=>, other
+    end
   end
 
   def test_op_eq(method: :==)
@@ -177,8 +185,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
                       38, :>, 12.0
     # Notably not `Complex` as complex doesn't define `>`
 
-    assert_send_type  '[O < RBS::Ops::_GreaterThan[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :>, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :>, Coercable.for_op(:>)
   end
 
   def test_op_geq
@@ -190,8 +198,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
                       38, :>=, 12.0
     # Notably not `Complex` as complex doesn't define `>`
 
-    assert_send_type  '[O < RBS::Ops::_GreaterThanOrEqual[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
-                      38, :>=, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :>=, Coercable.for_op(:>=)
   end
 
   def test_op_rsh

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -270,22 +270,18 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_ceildiv
-    # assert_send_type  '(Integer) -> Integer',
-    #                   38, :ceildiv, 12
-    # assert_send_type  '(Rational) -> Integer',
-    #                   38, :ceildiv, 12r
-    # assert_send_type  '(Float) -> Integer',
-    #                   38, :ceildiv, 12.0
-    # # Notably not `Complex` as complex doesn't define `div`
+    assert_send_type  '(Integer) -> Integer',
+                      38, :ceildiv, 12
+    assert_send_type  '(Rational) -> Integer',
+                      38, :ceildiv, 12r
+    assert_send_type  '(Float) -> Integer',
+                      38, :ceildiv, 12.0
+    # Notably not `Complex` as complex doesn't define `div`
 
-    # assert_send_type  '(Coercable) -> Coercable::OpReturn',
-    #                   38, :div, Coercable.for_op(:-, result: (
-
-    # ))
-
-    #          | [O < _Div[S, RBS::Ops::_UnaryNeg[R]], S, R] (Numeric::_Coerce[0, O, S] other) -> R2
-
-    # omit 'todo'
+    uneg = BlankSlate.new
+    def uneg.-@ = ::Coercable::OpReturn.new
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :ceildiv, Coercable.for_op(:-, result: Coercable.for_op(:div, result: uneg))
   end
 
   def test_chr
@@ -337,7 +333,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_divmod
-    # omit 'todo'
+    assert_send_type  '(Integer) -> [Integer, Integer]',
+                      38, :divmod, 12
+    assert_send_type  '(Rational) -> [Integer, Rational]',
+                      38, :divmod, 12r
+    assert_send_type  '(Float) -> [Integer, Float]',
+                      38, :divmod, 12.0
+    # Notably not `Complex` as complex doesn't define `divmod`
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :divmod, Coercable.for_op(:divmod)
   end
 
   def test_downto

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -217,7 +217,30 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_aref
-    # omit 'todo'
+    with_int 3 do |offset|
+      assert_send_type  '(int) -> (0 | 1)',
+                        38, :[], offset
+
+      with_int 5 do |size|
+        assert_send_type  '(int, int) -> Integer',
+                          38, :[], offset, size
+      end
+    end
+
+    assert_send_type  '(range[int?]) -> Integer',
+                      38, :[], 3..nil
+    assert_send_type  '(range[int?]) -> Integer',
+                      38, :[], nil..0
+    assert_send_type  '(range[int?]) -> Integer',
+                      38, :[], 1r..3r
+    assert_send_type  '(range[int?]) -> Integer',
+                      38, :[], 1.0..3.0
+
+    start = ToInt.new(1)
+    def start.<=>(other) = to_int <=> other.to_int
+    def start.coerce(other) = [other.to_int, to_int]
+    assert_send_type  '(range[int?]) -> Integer',
+                      38, :[], CustomRange.new(start, ToInt.new(3))
   end
 
   def test_op_xor
@@ -346,7 +369,26 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_downto
-    # omit 'todo'
+    assert_send_type  '(Integer) { (Integer) -> void } -> 38',
+                      38, :downto, 35 do end
+    assert_send_type  '(Integer) -> Enumerator[Integer, 38]',
+                      38, :downto, 35
+    assert_send_type  '(Rational) { (Integer) -> void } -> 38',
+                      38, :downto, 35r do end
+    assert_send_type  '(Rational) -> Enumerator[Integer, 38]',
+                      38, :downto, 35r
+    assert_send_type  '(Float) { (Integer) -> void } -> 38',
+                      38, :downto, 35.0 do end
+    assert_send_type  '(Float) -> Enumerator[Integer, 38]',
+                      38, :downto, 35.0
+
+    assert_send_type  '(Coercable) { (Integer) -> void } -> 38',
+                      38, :downto, Coercable.for_op(:<) { it.__value__ < 35 } do end
+
+    coercable = Coercable.for_op(:<) { it.__value__ < 35 }
+    def coercable.-(rhs) = 35 - rhs # Required by `Enumerator#size`, which the unit test harness uses
+    assert_send_type  '(Coercable) -> Enumerator[Integer, 38]',
+                      38, :downto, coercable
   end
 
   def test_even?
@@ -568,7 +610,26 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_upto
-    # omit 'todo'
+    assert_send_type  '(Integer) { (Integer) -> void } -> 38',
+                      38, :upto, 40 do end
+    assert_send_type  '(Integer) -> Enumerator[Integer, 38]',
+                      38, :upto, 40
+    assert_send_type  '(Rational) { (Integer) -> void } -> 38',
+                      38, :upto, 40r do end
+    assert_send_type  '(Rational) -> Enumerator[Integer, 38]',
+                      38, :upto, 40r
+    assert_send_type  '(Float) { (Integer) -> void } -> 38',
+                      38, :upto, 40.0 do end
+    assert_send_type  '(Float) -> Enumerator[Integer, 38]',
+                      38, :upto, 40.0
+
+    assert_send_type  '(Coercable) { (Integer) -> void } -> 38',
+                      38, :upto, Coercable.for_op(:>) { it.__value__ > 40 } do end
+
+    coercable = Coercable.for_op(:>) { it.__value__ > 40 }
+    def coercable.-(rhs) = 40 - rhs # Required by `Enumerator#size`, which the unit test harness uses
+    assert_send_type  '(Coercable) -> Enumerator[Integer, 38]',
+                      38, :upto, coercable
   end
 
   def test_zero?

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -123,7 +123,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_lt
-    # omit 'todo'
+    assert_send_type  '(Integer) -> bool',
+                      38, :<, 12
+    assert_send_type  '(Rational) -> bool',
+                      38, :<, 12r
+    assert_send_type  '(Float) -> bool',
+                      38, :<, 12.0
+    # Notably not `Complex` as complex doesn't define `<`
+
+    assert_send_type  '[O < RBS::Ops::_LessThan[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :<, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
   end
 
   def test_op_lsh
@@ -131,7 +140,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_leq
-    # omit 'todo'
+    assert_send_type  '(Integer) -> bool',
+                      38, :<=, 12
+    assert_send_type  '(Rational) -> bool',
+                      38, :<=, 12r
+    assert_send_type  '(Float) -> bool',
+                      38, :<=, 12.0
+    # Notably not `Complex` as complex doesn't define `<=`
+
+    assert_send_type  '[O < RBS::Ops::_LessThanOrEqual[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :<=, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
   end
 
   def test_op_cmp
@@ -151,11 +169,29 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_gt
-    # omit 'todo'
+    assert_send_type  '(Integer) -> bool',
+                      38, :>, 12
+    assert_send_type  '(Rational) -> bool',
+                      38, :>, 12r
+    assert_send_type  '(Float) -> bool',
+                      38, :>, 12.0
+    # Notably not `Complex` as complex doesn't define `>`
+
+    assert_send_type  '[O < RBS::Ops::_GreaterThan[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :>, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
   end
 
   def test_op_geq
-    # omit 'todo'
+    assert_send_type  '(Integer) -> bool',
+                      38, :>=, 12
+    assert_send_type  '(Rational) -> bool',
+                      38, :>=, 12r
+    assert_send_type  '(Float) -> bool',
+                      38, :>=, 12.0
+    # Notably not `Complex` as complex doesn't define `>`
+
+    assert_send_type  '[O < RBS::Ops::_GreaterThanOrEqual[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :>=, Coercable.new(Set[8, 4]){ |n| n.digits.to_set }
   end
 
   def test_op_rsh

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -270,6 +270,21 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_ceildiv
+    # assert_send_type  '(Integer) -> Integer',
+    #                   38, :ceildiv, 12
+    # assert_send_type  '(Rational) -> Integer',
+    #                   38, :ceildiv, 12r
+    # assert_send_type  '(Float) -> Integer',
+    #                   38, :ceildiv, 12.0
+    # # Notably not `Complex` as complex doesn't define `div`
+
+    # assert_send_type  '(Coercable) -> Coercable::OpReturn',
+    #                   38, :div, Coercable.for_op(:-, result: (
+
+    # ))
+
+    #          | [O < _Div[S, RBS::Ops::_UnaryNeg[R]], S, R] (Numeric::_Coerce[0, O, S] other) -> R2
+
     # omit 'todo'
   end
 
@@ -309,7 +324,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_div
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :div, 12
+    assert_send_type  '(Rational) -> Integer',
+                      38, :div, 12r
+    assert_send_type  '(Float) -> Integer',
+                      38, :div, 12.0
+    # Notably not `Complex` as complex doesn't define `div`
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :div, Coercable.for_op(:div)
   end
 
   def test_divmod
@@ -328,7 +352,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_fdiv
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Float',
+                      38, :fdiv, 12
+    assert_send_type  '(Rational) -> Float',
+                      38, :fdiv, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :fdiv, 12.0
+    # Notably not `Complex` as complex doesn't define `fdiv`
+
+    assert_send_type  '(Coercable) -> Float',
+                      38, :fdiv, Coercable.for_op(:fdiv, result: ToF.new(3.4))
   end
 
   def test_floor
@@ -409,7 +442,20 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_pow
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :pow, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :pow, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :pow, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :pow, 12i
+
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      38, :pow, Coercable.for_op(:**)
+
+    assert_send_type  '(Integer, Integer) -> Integer',
+                      38, :pow, 12, 34
   end
 
   def test_pred
@@ -428,7 +474,15 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_remainder
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :remainder, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :remainder, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :remainder, 12.0
+    # Notably not `Complex` as complex doesn't define `%`
+
+    # TODO: when `Numeric#remainder` is finished, update this with more "coerce" edge cases
   end
 
   def test_round

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -1,5 +1,396 @@
-require_relative "test_helper"
+require_relative 'test_helper'
 
+class IntegerSingletonTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing 'singleton(Integer)'
+
+  def test_sqrt
+    with_int 38 do |int|
+      assert_send_type  '(int) -> Integer',
+                        Integer, :sqrt, int
+    end
+  end
+
+  def test_try_convert
+    with_int 1 do |int|
+      assert_send_type  '(int) -> Integer',
+                        Integer, :try_convert, int
+    end
+
+    with_untyped do |untyped|
+      assert_send_type '(untyped) -> Integer?',
+                       Integer, :try_convert, untyped
+    end
+  end
+end
+
+class IntegerInstanceTest < Test::Unit::TestCase
+  include TestHelper
+
+  testing 'Integer'
+
+  def test_op_mod
+    omit 'todo'
+  end
+
+  def test_op_and
+    omit 'todo'
+  end
+
+  def test_op_mul
+    omit 'todo'
+  end
+
+  def test_op_pow
+    omit 'todo'
+  end
+
+  def test_op_add
+    omit 'todo'
+  end
+
+  def test_op_sub
+    omit 'todo'
+  end
+
+  def test_op_uneg
+    assert_send_type  '() -> Integer',
+                      38, :-@
+  end
+
+  def test_op_div
+    omit 'todo'
+  end
+
+  def test_op_lt
+    omit 'todo'
+  end
+
+  def test_op_lsh
+    omit 'todo'
+  end
+
+  def test_op_leq
+    omit 'todo'
+  end
+
+  def test_op_cmp
+    omit 'todo'
+  end
+
+  def test_op_eq(method: :==)
+    with_untyped.and 38 do |other|
+      next unless defined? other.== # even for the `===` case heh
+      assert_send_type  '(untyped) -> bool',
+                        38, method, other
+    end
+  end
+
+  def test_op_eqq
+    test_op_eq(method: :===)
+  end
+
+  def test_op_gt
+    omit 'todo'
+  end
+
+  def test_op_geq
+    omit 'todo'
+  end
+
+  def test_op_rsh
+    omit 'todo'
+  end
+
+  def test_op_aref
+    omit 'todo'
+  end
+
+  def test_op_xor
+    omit 'todo'
+  end
+
+  def test_abs(method: :magnitude)
+    assert_send_type  '() -> Integer',
+                      38, method
+    assert_send_type  '() -> Integer',
+                      -38, method
+  end
+
+  def test_allbits?
+    with_int 1 do |mask|
+      assert_send_type  '(int) -> bool',
+                        0, :allbits?, mask
+      assert_send_type  '(int) -> bool',
+                        1, :allbits?, mask
+    end
+  end
+
+  def test_anybits?
+    with_int 1 do |mask|
+      assert_send_type  '(int) -> bool',
+                        0, :anybits?, mask
+      assert_send_type  '(int) -> bool',
+                        1, :anybits?, mask
+    end
+  end
+
+  def test_bit_length
+    assert_send_type  '() -> Integer',
+                      38, :bit_length
+    assert_send_type  '() -> Integer',
+                      3838, :bit_length
+  end
+
+  def test_ceil
+    assert_send_type  '() -> Integer',
+                      38, :ceil
+    with_int(-1) do |digits|
+      assert_send_type  '(int) -> Integer',
+                        38, :ceil, digits
+    end
+  end
+
+  def test_ceildiv
+    omit 'todo'
+  end
+
+  def test_chr
+    assert_send_type  '() -> String',
+                      38, :chr
+
+    with_encoding do |encoding|
+      assert_send_type  '(encoding) -> String',
+                        38, :chr, encoding
+    end
+  end
+
+  def test_coerce
+    omit 'todo'
+  end
+
+  def test_denominator
+    assert_send_type  '() -> 1',
+                      38, :denominator
+  end
+
+  def test_digits
+    assert_send_type  '() -> Array[Integer]',
+                      38, :digits
+
+    with_int 5 do |base|
+      assert_send_type  '(int) -> Array[Integer]',
+                        38, :digits, base
+    end
+  end
+
+  def test_div
+    omit 'todo'
+  end
+
+  def test_divmod
+    omit 'todo'
+  end
+
+  def test_downto
+    omit 'todo'
+  end
+
+  def test_even?
+    assert_send_type  '() -> bool',
+                      38, :even?
+    assert_send_type  '() -> bool',
+                      39, :even?
+  end
+
+  def test_fdiv
+    omit 'todo'
+  end
+
+  def test_floor
+    assert_send_type  '() -> Integer',
+                      38, :floor
+    with_int(-1) do |digits|
+      assert_send_type  '(int) -> Integer',
+                        38, :floor, digits
+    end
+  end
+
+  def test_gcd
+    omit 'todo'
+  end
+
+  def test_gcdlcm
+    omit 'todo'
+  end
+
+  def test_inspect
+    test_to_s(method: :inspect)
+  end
+
+  def test_integer?
+    assert_send_type  '() -> true',
+                      38, :integer?
+  end
+
+  def test_lcm
+    omit 'todo'
+  end
+
+  def test_magnitude
+    test_abs(method: :magnitude)
+  end
+
+  def test_modulo
+    omit 'todo'
+  end
+
+  def test_next
+    test_succ(method: :next)
+  end
+
+  def test_nobits?
+    with_int 1 do |mask|
+      assert_send_type  '(int) -> bool',
+                        0, :nobits?, mask
+      assert_send_type  '(int) -> bool',
+                        1, :nobits?, mask
+    end
+  end
+
+  def test_numerator
+    assert_send_type  '() -> 38',
+                      38, :numerator
+  end
+
+  def test_odd?
+    assert_send_type  '() -> bool',
+                      38, :odd?
+    assert_send_type  '() -> bool',
+                      39, :odd?
+  end
+
+  def test_ord
+    assert_send_type  '() -> 38',
+                      38, :ord
+  end
+
+  def test_pow
+    omit 'todo'
+  end
+
+  def test_pred
+    assert_send_type  '() -> Integer',
+                      1, :pred
+  end
+
+  def test_rationalize
+    omit 'todo'
+  end
+
+  def test_remainder
+    omit 'todo'
+  end
+
+  def test_round
+    assert_send_type  '() -> Integer',
+                      38, :round
+
+    with_round_mode do |mode|
+      assert_send_type  '(half: Numeric::round_mode) -> Integer',
+                        38, :round, half: mode
+    end
+
+    with_int(-1) do |digits|
+      assert_send_type  '(int) -> Integer',
+                        38, :round, digits
+
+      with_round_mode do |mode|
+        assert_send_type  '(int, half: Numeric::round_mode) -> Integer',
+                          38, :round, digits, half: mode
+      end
+    end
+  end
+
+  def test_size
+    assert_send_type  '() -> Integer',
+                      38, :size
+    assert_send_type  '() -> Integer',
+                      3838, :size
+  end
+
+  def test_succ(method: :succ)
+    assert_send_type  '() -> Integer',
+                      1, method
+  end
+
+  def test_times
+    assert_send_type  '() { (Integer) -> 38',
+                      38, :times do end
+    assert_send_type  '() -> Enumerator[Integer, 38]',
+                      38, :times
+  end
+
+  def test_to_f
+    assert_send_type  '() -> Float',
+                      38, :to_f
+  end
+
+  def test_to_i(method: :to_i)
+    assert_send_type  '() -> 38',
+                      38, method
+  end
+
+  def test_to_int
+    test_to_i(method: :to_int)
+  end
+
+  def test_to_r
+    omit 'todo'
+  end
+
+  def test_to_s(method: :to_s)
+    assert_send_type  '() -> String',
+                      38, method
+
+    with_int 8 do |base|
+      assert_send_type  '(int) -> String',
+                        38, method, base
+    end
+  end
+
+  def test_truncate
+    assert_send_type  '() -> Integer',
+                      38, :truncate
+    with_int(-1) do |digits|
+      assert_send_type  '(int) -> Integer',
+                        38, :truncate, digits
+    end
+  end
+
+  def test_upto
+    omit 'todo'
+  end
+
+  def test_zero?
+    assert_send_type  '() -> Integer',
+                      0, :zero?
+    assert_send_type  '() -> Integer',
+                      38, :zero?
+  end
+
+  def test_op_or
+    omit 'todo'
+  end
+
+  def test_op_not
+    assert_send_type  '() -> Integer',
+                      38, :~
+  end
+end
+
+__END__
 class IntegerTest < StdlibTest
   target Integer
 

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -30,7 +30,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
 
   testing 'Integer'
 
-  def test_op_mod
+  def test_op_mod(method: :%)
     omit 'todo'
   end
 
@@ -218,11 +218,17 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_gcd
-    omit 'todo'
+    assert_send_type  '() -> Integer',
+                      38, :gcd, 2
+    refute_send_type  '(_ToInt) -> Integer',
+                      39, :gcd, ToInt.new(2) # explicitly only supports ints
   end
 
   def test_gcdlcm
-    omit 'todo'
+    assert_send_type  '() -> [Integer, Integer]',
+                      38, :gcdlcm, 2
+    refute_send_type  '(_ToInt) -> [Integer, Integer]',
+                      39, :gcdlcm, ToInt.new(2) # explicitly only supports ints
   end
 
   def test_inspect
@@ -235,7 +241,10 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_lcm
-    omit 'todo'
+    assert_send_type  '() -> Integer',
+                      38, :lcm, 2
+    refute_send_type  '(_ToInt) -> Integer',
+                      39, :lcm, ToInt.new(2) # explicitly only supports ints
   end
 
   def test_magnitude
@@ -243,7 +252,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_modulo
-    omit 'todo'
+    test_op_mod(method: :modulo)
   end
 
   def test_next
@@ -286,7 +295,13 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_rationalize
-    omit 'todo'
+    assert_send_type  '() -> Rational',
+                      38, :rationalize
+
+    with Numeric.new do |eps|
+      assert_send_type  '(Numeric) -> Rational',
+                        38, :rationalize, eps
+    end
   end
 
   def test_remainder
@@ -347,7 +362,8 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_to_r
-    omit 'todo'
+    assert_send_type  '() -> Rational',
+                      38, :to_r
   end
 
   def test_to_s(method: :to_s)
@@ -387,390 +403,5 @@ class IntegerInstanceTest < Test::Unit::TestCase
   def test_op_not
     assert_send_type  '() -> Integer',
                       38, :~
-  end
-end
-
-__END__
-class IntegerTest < StdlibTest
-  target Integer
-
-  def test_sqrt
-    Integer.sqrt(4)
-    Integer.sqrt(4.0)
-    Integer.sqrt(4/1r)
-    Integer.sqrt(ToInt.new)
-  end
-
-  def test_modulo
-    3 % 1
-    3 % 1.1
-    3 % 1.5r
-  end
-
-  def test_bitwise_ops
-    3 & 1
-    1 ^ 3
-  end
-
-  def test_calc
-    3 * 1
-    3 * 1.0
-    3 * (1r/3)
-
-    3 - 1
-    3 - 0.1
-    3 - 1r
-    3 - 1.to_c
-
-    1 ** 1
-    2 ** 2.1
-    3 ** 3r
-    3 ** 10.to_c
-
-    3 + 1
-    3 + 1.0
-    3 + (1r/3)
-    3 + 10.to_c
-
-    3 / 1
-    3 / 1.0
-    3 / (1r/3)
-    30 / 10.to_c
-  end
-
-  def test_compare
-    3 < 1
-    3 < 1.0
-    3 < 1r
-
-    1 > 1
-    1 > 1.0
-    1 > 1r
-
-    1 <= 3
-    1 <= 1.3
-    1 <= 3r
-
-    1 >= 3
-    1 >= 1.3
-    1 >= 3r
-
-    1 <=> 1
-    1 <=> 1.0
-    1 <=> 3r
-
-    3 === 3.0
-    3 === ""
-  end
-
-  def test_shift
-    1 << 30
-    1 << 30.to_f
-    1 << ToInt.new
-
-    1 >> 30
-    1 >> 30.to_f
-    1 >> ToInt.new
-  end
-
-  def test_aref
-    3[0]
-    3[0.3]
-    3[ToInt.new]
-
-    3[1,2]
-    3[1...3]
-  end
-
-  def test_to_s
-    1.to_s
-    1.to_s(2)
-    1.to_s(3)
-    1.to_s(4)
-    1.to_s(5)
-    1.to_s(6)
-    1.to_s(7)
-    1.to_s(8)
-    1.to_s(9)
-    1.to_s(10)
-    1.to_s(11)
-    1.to_s(12)
-    1.to_s(13)
-    1.to_s(14)
-    1.to_s(15)
-    1.to_s(16)
-    1.to_s(17)
-    1.to_s(18)
-    1.to_s(19)
-    1.to_s(20)
-    1.to_s(21)
-    1.to_s(22)
-    1.to_s(23)
-    1.to_s(24)
-    1.to_s(25)
-    1.to_s(26)
-    1.to_s(27)
-    1.to_s(28)
-    1.to_s(29)
-    1.to_s(30)
-    1.to_s(31)
-    1.to_s(32)
-    1.to_s(33)
-    1.to_s(34)
-    1.to_s(35)
-    1.to_s(36)
-    30.to_s(ToInt.new)
-  end
-
-  def test_abs_abs2
-    3.abs
-    3.abs2
-  end
-
-  def test_allbits?
-    1.allbits?(1)
-    2.allbits?(1)
-    3.allbits?(ToInt.new)
-  end
-
-  def test_angle
-    3.angle()
-  end
-
-  def test_anybits?
-    0xf0.anybits?(0xf)
-    0xf1.anybits?(0xf)
-    0xf1.anybits?(ToInt.new)
-  end
-
-  def test_arg
-    3.arg
-  end
-
-  def test_bit_length
-    3.bit_length
-  end
-
-  def test_ceil
-    3.ceil
-    3.ceil(10)
-    3.ceil(ToInt.new)
-  end
-
-  def test_ceildiv
-    3.ceildiv(10)
-    3.ceildiv(1.3)
-  end
-
-  def test_chr
-    3.chr
-    3.chr(Encoding::UTF_8)
-    3.chr("UTF-7")
-    3.chr(ToStr.new("ASCII-8BIT"))
-  end
-
-  def test_conj
-    3.conj
-  end
-
-  def test_denominator
-    3.denominator
-  end
-
-  def test_digits
-    3.digits
-    3.digits(3)
-    3.digits(3.0)
-    30.digits(ToInt.new)
-  end
-
-  def test_div
-    30.div(10)
-  end
-
-  def test_div_mod
-    3.divmod(3)
-    40.divmod(1.0)
-    30.divmod(30r)
-  end
-
-  def test_down_to
-    30.downto(1) {}
-    30.downto(31)
-    30.downto(4.2)
-  end
-
-  def test_even?
-    30.even?
-  end
-
-  def test_fdiv
-    30.fdiv(30)
-    30.fdiv(3r)
-    30.fdiv(3.1)
-  end
-
-  def test_finite?
-    30.finite?
-  end
-
-  def test_floor
-    30.floor
-    30.floor(3)
-    30.floor(ToInt.new)
-  end
-
-  def test_gcd
-    30.gcd(1)
-  end
-
-  def test_gcdlcm
-    30.gcdlcm(31)
-  end
-
-  def test_lcm
-    30.lcm(50)
-  end
-
-  def test_magnitude
-    30.magnitude
-  end
-
-  def test_modulo_
-    30.modulo(30)
-    30.modulo(3.1)
-    30.modulo(3r/5)
-  end
-
-  def test_next
-    30.next
-  end
-
-  def test_nobits?
-    0xf0.nobits?(0xf)
-    0xf1.nobits?(0xf)
-    30.nobits?(ToInt.new)
-  end
-
-  def test_nonzero?
-    30.nonzero?
-    0.nonzero?
-  end
-
-  def test_numerator
-    30.numerator
-  end
-
-  def test_pow
-    1.pow(30)
-    1.pow(2.0)
-    1.pow(30.to_c)
-    3.pow(3, 5)
-  end
-
-  def test_quo
-    3.quo(1)
-    3.quo(2.1)
-    3.quo(4r/5)
-    3.quo(10.to_c)
-  end
-
-  def test_rationalize
-    3.rationalize
-    3.rationalize(30)
-  end
-
-  def test_remainder
-    3.remainder(1)
-    3.remainder(1.3)
-    3.remainder(1r/3)
-  end
-
-  def test_round
-    13.round()
-    13.round(half: :up)
-    14.round(-1, half: :down)
-    15.round(ToInt.new)
-  end
-
-  def test_step
-    3.step { break }
-    3.step
-    3.step(10, 2) {}
-    3.step(10, 2)
-    3.step(10, 1.1) {}
-    3.step(10, 1.1)
-
-    3.step(to: 30) { break }
-    3.step(to: 30)
-    3.step(to: 30, by: 100) {}
-    3.step(to: 30, by: 100)
-    3.step(to: 30, by: 10.0) {}
-    3.step(to: 30, by: 10.0)
-  end
-
-  def test_times
-    3.times {}
-    3.times
-  end
-
-  def test_truncate
-    100.truncate
-    100.truncate(10)
-    100.truncate(ToInt.new(-2))
-  end
-
-  def test_upto
-    5.upto(10) {}
-    5.upto(10.1) {}
-  end
-end
-
-
-class IntegerSingletonTest < Test::Unit::TestCase
-  include TestHelper
-
-  testing "singleton(::Integer)"
-
-  def test_try_convert
-    assert_send_type(
-      "(Integer) -> Integer",
-      Integer, :try_convert, 10
-    )
-    assert_send_type(
-      "(ToInt) -> Integer",
-      Integer, :try_convert, ToInt.new(10)
-    )
-    assert_send_type(
-      "(String) -> nil",
-      Integer, :try_convert, "10"
-    )
-  end
-end
-
-class IntegerInstanceTest < Test::Unit::TestCase
-  include TestHelper
-
-  testing "::Integer"
-
-  def test_pow
-    assert_send_type "(Integer) -> Integer",
-                     1, :pow, 2
-    assert_send_type "(Integer) -> Rational",
-                     -2, :pow, -1
-    assert_send_type "(Integer, Integer) -> Integer",
-                     1, :pow, 2, 10
-    assert_send_type "(Float) -> Float",
-                     1, :pow, 1.0
-    assert_send_type "(Float) -> Complex",
-                     -9, :pow, 0.1
-    assert_send_type "(Rational) -> Float",
-                     2, :pow, 1/2r
-    assert_send_type "(Rational) -> Rational",
-                     1, :pow, 1r
-    assert_send_type "(Rational) -> Complex",
-                     -3, :pow, -4/3r
-    assert_send_type "(Complex) -> Complex",
-                     1, :pow, 1i
   end
 end

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -31,7 +31,16 @@ class IntegerInstanceTest < Test::Unit::TestCase
   testing 'Integer'
 
   def test_op_mod(method: :%)
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, method, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, method, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, method, 12.0
+    # Notably not `Complex` as complex doesn't define `%`
+
+    assert_send_type  '[O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, method, Coercable.new('fmt: %s', &:to_s)
   end
 
   def test_op_and
@@ -39,19 +48,59 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_mul
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :*, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :*, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :*, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :*, 12i
+
+    assert_send_type  '[O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :*, Coercable.new(%w[a b], &:to_s)
   end
 
   def test_op_pow
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :**, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :**, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :**, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :**, 12i
+
+    assert_send_type  '[O < RBS::Ops::_Power[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :**, Coercable.new(10i, &:i)
   end
 
   def test_op_add
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :+, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :+, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :+, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :+, 12i
+
+    assert_send_type  '[O < RBS::Ops::_Add[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :+, Coercable.new('foo', &:to_s)
   end
 
   def test_op_sub
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :-, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :-, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :-, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :-, 12i
+
+    assert_send_type  '[O < RBS::Ops::_Subtract[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :-, Coercable.new([3], &:digits)
   end
 
   def test_op_uneg
@@ -60,7 +109,17 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_div
-    # omit 'todo'
+    assert_send_type  '(Integer) -> Integer',
+                      38, :/, 12
+    assert_send_type  '(Rational) -> Rational',
+                      38, :/, 12r
+    assert_send_type  '(Float) -> Float',
+                      38, :/, 12.0
+    assert_send_type  '(Complex) -> Complex',
+                      38, :/, 12i
+
+    assert_send_type  '[O < RBS::Ops::_Times[S, R], S, R] (Numeric::_Coerce[38, O, S]) -> R',
+                      38, :/, Coercable.new(10i, &:i)
   end
 
   def test_op_lt
@@ -167,7 +226,13 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_coerce
-    # omit 'todo'
+    assert_send_type  '(Integer) -> [Integer, 38]',
+                      38, :coerce, 4
+
+    with_float do |float|
+      assert_send_type  '(_ToF) -> [Float, Float]',
+                        38, :coerce, float
+    end
   end
 
   def test_denominator

--- a/test/stdlib/Integer_test.rb
+++ b/test/stdlib/Integer_test.rb
@@ -31,27 +31,27 @@ class IntegerInstanceTest < Test::Unit::TestCase
   testing 'Integer'
 
   def test_op_mod(method: :%)
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_and
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_mul
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_pow
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_add
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_sub
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_uneg
@@ -60,23 +60,23 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_div
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_lt
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_lsh
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_leq
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_cmp
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_eq(method: :==)
@@ -92,23 +92,23 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_gt
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_geq
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_rsh
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_aref
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_xor
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_abs(method: :magnitude)
@@ -153,7 +153,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_ceildiv
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_chr
@@ -167,7 +167,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_coerce
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_denominator
@@ -186,15 +186,15 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_div
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_divmod
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_downto
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_even?
@@ -205,7 +205,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_fdiv
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_floor
@@ -218,14 +218,14 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_gcd
-    assert_send_type  '() -> Integer',
+    assert_send_type  '(Integer) -> Integer',
                       38, :gcd, 2
     refute_send_type  '(_ToInt) -> Integer',
                       39, :gcd, ToInt.new(2) # explicitly only supports ints
   end
 
   def test_gcdlcm
-    assert_send_type  '() -> [Integer, Integer]',
+    assert_send_type  '(Integer) -> [Integer, Integer]',
                       38, :gcdlcm, 2
     refute_send_type  '(_ToInt) -> [Integer, Integer]',
                       39, :gcdlcm, ToInt.new(2) # explicitly only supports ints
@@ -241,7 +241,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_lcm
-    assert_send_type  '() -> Integer',
+    assert_send_type  '(Integer) -> Integer',
                       38, :lcm, 2
     refute_send_type  '(_ToInt) -> Integer',
                       39, :lcm, ToInt.new(2) # explicitly only supports ints
@@ -286,7 +286,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_pow
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_pred
@@ -305,7 +305,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_remainder
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_round
@@ -341,7 +341,7 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_times
-    assert_send_type  '() { (Integer) -> 38',
+    assert_send_type  '() { (Integer) -> void } -> 38',
                       38, :times do end
     assert_send_type  '() -> Enumerator[Integer, 38]',
                       38, :times
@@ -386,18 +386,18 @@ class IntegerInstanceTest < Test::Unit::TestCase
   end
 
   def test_upto
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_zero?
-    assert_send_type  '() -> Integer',
+    assert_send_type  '() -> bool',
                       0, :zero?
-    assert_send_type  '() -> Integer',
+    assert_send_type  '() -> bool',
                       38, :zero?
   end
 
   def test_op_or
-    omit 'todo'
+    # omit 'todo'
   end
 
   def test_op_not

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -81,6 +81,24 @@ module WithStdlibAliases
 end
 
 class Coercable < RBS::UnitTest::Convertibles::BlankSlate
+  class OpReturn < ::RBS::UnitTest::Convertibles::BlankSlate
+  end
+
+  class CoerceOther < ::RBS::UnitTest::Convertibles::BlankSlate
+  end
+
+  class CoerceSelf < ::RBS::UnitTest::Convertibles::BlankSlate
+    def initialize(method = nil)
+      if method
+        ::Kernel.instance_method(:define_singleton_method).bind_call(self, method) { |other| OpReturn.new }
+      end
+    end
+  end
+
+  def self.for_op(method)
+    new(CoerceSelf.new(method)){ |x| CoerceOther.new }
+  end
+
   def initialize(self_ret, &converter)
     @self_ret = self_ret
     @converter = converter || ->(x) { x }

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -41,6 +41,15 @@ module VersionHelper
 end
 
 module WithStdlibAliases
+  def with_round_mode(&block)
+    block.call(nil)
+
+    %i[up down even].each do |mode|
+      block.call(mode)
+      with_string(mode.to_s, &block)
+    end
+  end
+
   def with_timeout(seconds: 1, nanoseconds: 0)
     unless block_given?
       return RBS::UnitTest::WithAliases::WithEnum.new(

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -85,16 +85,26 @@ class Coercable < RBS::UnitTest::Convertibles::BlankSlate
   end
 
   class CoerceOther < ::RBS::UnitTest::Convertibles::BlankSlate
+    attr_reader :__value__
+    def initialize(value) = @__value__ = value
   end
 
   class CoerceSelf < ::RBS::UnitTest::Convertibles::BlankSlate
-    def initialize(method, result:)
-      ::Kernel.instance_method(:define_singleton_method).bind_call(self, method) { |other| result }
+    def initialize(method, &block)
+      ::Kernel.instance_method(:define_singleton_method).bind_call(self, method, &block)
     end
   end
 
-  def self.for_op(method, result: OpReturn.new)
-    new(CoerceSelf.new(method, result:)){ |x| CoerceOther.new }
+  def self.for_op(method, result: noresult = true, &block)
+    if block_given?
+      unless noresult
+        raise ArgumentError, "cannot provide both a block and a result"
+      end
+    else
+      block = proc { |other| noresult ? OpReturn.new : result }
+    end
+
+    new(CoerceSelf.new(method, &block)) { |x| CoerceOther.new(x) }
   end
 
   def initialize(self_ret, &converter)

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -80,6 +80,17 @@ module WithStdlibAliases
   end
 end
 
+class Coercable < RBS::UnitTest::Convertibles::BlankSlate
+  def initialize(self_ret, &converter)
+    @self_ret = self_ret
+    @converter = converter || ->(x) { x }
+  end
+
+  def coerce(rhs)
+    [@self_ret, @converter.(rhs)]
+  end
+end
+
 class Writer
   attr_reader :buffer
 

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -88,15 +88,13 @@ class Coercable < RBS::UnitTest::Convertibles::BlankSlate
   end
 
   class CoerceSelf < ::RBS::UnitTest::Convertibles::BlankSlate
-    def initialize(method = nil)
-      if method
-        ::Kernel.instance_method(:define_singleton_method).bind_call(self, method) { |other| OpReturn.new }
-      end
+    def initialize(method, result:)
+      ::Kernel.instance_method(:define_singleton_method).bind_call(self, method) { |other| result }
     end
   end
 
-  def self.for_op(method)
-    new(CoerceSelf.new(method)){ |x| CoerceOther.new }
+  def self.for_op(method, result: OpReturn.new)
+    new(CoerceSelf.new(method, result:)){ |x| CoerceOther.new }
   end
 
   def initialize(self_ret, &converter)


### PR DESCRIPTION
This is the second phase for updating `Integer` (phase one is #2995).

Here, we finish off the rest of the methods, including the ones which required `coerce`. The `_Coerce` interface (which is on `Numeric`) actually slots quite nicely:

```rbs
class Numeric
  interface _Coerce[O, Other, Self]
    def coerce: (O other) -> [Other, Self]
  end
end

class Integer < Numeric
  def +: (Integer other) -> Integer
       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Add[S, R], S] other) -> R
end
```

We don't even need separate cases for other numerics, as coerce works!