### PR TITLE
Fix flaky DirSingletonTest GC failures in test_fchdir and test_for_fd

### DIFF
--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -104,7 +104,8 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_fchdir
-    fd = Dir.new(Dir.pwd).fileno
+    dir = Dir.new(Dir.pwd)
+    fd = dir.fileno
 
     with_int(fd) do |int|
       assert_send_type(
@@ -117,6 +118,8 @@ class DirSingletonTest < Test::Unit::TestCase
         Dir, :fchdir, int, &proc { "string" }
       )
     end
+  ensure
+    dir&.close
   end
 
   def test_foreach

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -133,7 +133,8 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_for_fd
-    fd = Dir.new(Dir.pwd).fileno
+    dir = Dir.new(Dir.pwd)
+    fd = dir.fileno
 
     with_int(fd) do |int|
       assert_send_type(
@@ -141,6 +142,8 @@ class DirSingletonTest < Test::Unit::TestCase
         Dir, :for_fd, int
       )
     end
+  ensure
+    dir&.close
   end
 
   def test_getwd


### PR DESCRIPTION
The `Dir` created by `Dir.new(Dir.pwd).fileno` in `test_fchdir` and `test_for_fd` was only referenced long enough to read its fileno, so it became collectable right away. When GC ran before the descriptor was used it got closed, making the later `Dir.fchdir(fd)` and `Dir.for_fd(fd)` calls fail with `Errno::EBADF`.

This surfaced on `ruby/ruby` ZJIT CI running `make test-bundled-gems` with `--enable-zjit=dev --zjit-call-threshold=1`, where allocation and GC timing shifted enough to expose it. Keep the Dir in a local and close it in ensure so the descriptor stays valid for the whole test.

https://github.com/ruby/ruby/actions/runs/27735384476/job/82051097840
