### PR TITLE
Backport test fixes to 4.0.x

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,6 +63,9 @@ jobs:
         if: ${{ contains(matrix.ruby, 'head') }}
         run: |
           bundle config set force_ruby_platform true
+      - name: Ignore Gemfile.lock's BUNDLED WITH on ruby-head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: bundle config set --local version system
       - name: Skip installing type checkers
         if: ${{ ! contains(matrix.job, 'typecheck_test') }}
         run: |
@@ -106,6 +109,9 @@ jobs:
         if: ${{ contains(matrix.ruby, 'head') }}
         run: |
           bundle config set force_ruby_platform true
+      - name: Ignore Gemfile.lock's BUNDLED WITH on ruby-head
+        if: ${{ contains(matrix.ruby, 'head') }}
+        run: bundle config set --local version system
       - name: bin/setup
         run: |
           bin/setup

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,9 @@ jobs:
             bundled_gems = JSON.parse(res)["gems"].map{_1["gem"]}
             system "gem uninstall #{bundled_gems.join(" ")} --force", exception: true
           '
+      - name: Ignore Gemfile.lock's BUNDLED WITH on dev Ruby
+        if: ${{ matrix.ruby == 'ucrt' || matrix.ruby == 'mswin' }}
+        run: bundle config set --local version system
       - name: bundle install
         run: |
           bundle config set without profilers libs

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -104,7 +104,8 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_fchdir
-    fd = Dir.new(Dir.pwd).fileno
+    dir = Dir.new(Dir.pwd)
+    fd = dir.fileno
 
     with_int(fd) do |int|
       assert_send_type(
@@ -117,6 +118,8 @@ class DirSingletonTest < Test::Unit::TestCase
         Dir, :fchdir, int, &proc { "string" }
       )
     end
+  ensure
+    dir&.close
   end
 
   def test_foreach

--- a/test/stdlib/Dir_test.rb
+++ b/test/stdlib/Dir_test.rb
@@ -133,7 +133,8 @@ class DirSingletonTest < Test::Unit::TestCase
   end
 
   def test_for_fd
-    fd = Dir.new(Dir.pwd).fileno
+    dir = Dir.new(Dir.pwd)
+    fd = dir.fileno
 
     with_int(fd) do |int|
       assert_send_type(
@@ -141,6 +142,8 @@ class DirSingletonTest < Test::Unit::TestCase
         Dir, :for_fd, int
       )
     end
+  ensure
+    dir&.close
   end
 
   def test_getwd

--- a/test/stdlib/zlib/GzipReader_test.rb
+++ b/test/stdlib/zlib/GzipReader_test.rb
@@ -29,7 +29,7 @@ class ZlibGzipReaderSingletonTest < Test::Unit::TestCase
       path = File.join(tmpdir, "test.gz")
       Zlib::GzipWriter.open(path) { _1.puts "hello" }
 
-      File.open(path) do |io|
+      File.open(path, "rb") do |io|
         assert_send_type "(IO io) -> Zlib::GzipReader",
                          Zlib::GzipReader, :wrap, io
 


### PR DESCRIPTION
## Summary

Backport test fixes needed for the 4.0.x release branch.

Original PRs:

- https://github.com/ruby/rbs/pull/2981
- https://github.com/ruby/rbs/pull/3004

## Changes

- Open compressed test fixtures in binary mode for `Zlib::GzipReader.wrap`.
- Make `DirSingletonTest#test_fchdir` and `DirSingletonTest#test_for_fd` robust against aggressive GC.

## Testing

Not run locally. This will be tested in CI.