### PR TITLE
Run the test suite on JRuby (JRuby support, step 4)

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -10,9 +10,13 @@ on:
       - "include/**"
       - "src/**"
       - "wasm/**"
-      - "lib/rbs/wasm/**"
-      - "lib/rbs.rb"
+      - "lib/**"
+      - "sig/**"
+      - "core/**"
+      - "stdlib/**"
+      - "test/**"
       - "Rakefile"
+      - "rbs.gemspec"
 
 permissions:
   contents: read
@@ -58,8 +62,6 @@ jobs:
           ruby-version: jruby
           bundler: none
       - name: Install runtime and test gems
-        run: gem install prism test-unit --no-document
-      - name: Run RBS's parser on JRuby
-        run: |
-          jruby -Ilib -Itest test/rbs/wasm/jruby_parser_test.rb
-          jruby -Ilib -Itest test/rbs/parser_test.rb
+        run: gem install prism rake rake-compiler test-unit rdoc rspec minitest json-schema pry --no-document
+      - name: Run the test suite on JRuby
+        run: jruby -S rake test

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,14 @@ test_config = lambda do |t|
   end
 end
 
-Rake::TestTask.new(test: :compile, &test_config)
+if RUBY_ENGINE == "jruby"
+  # JRuby runs the parser in WebAssembly instead of the C extension, so there is
+  # nothing to compile. The wasm runtime must be assembled first with
+  # `rake wasm:jruby_setup` (which needs CRuby + the WASI SDK).
+  Rake::TestTask.new(:test, &test_config)
+else
+  Rake::TestTask.new(test: :compile, &test_config)
+end
 
 multitask :default => [:test, :stdlib_test, :typecheck_test, :rubocop, :validate, :test_doc]
 

--- a/lib/rbs.rb
+++ b/lib/rbs.rb
@@ -4,7 +4,11 @@ require "rbs/version"
 
 require "set"
 require "json"
-require "pathname" unless defined?(Pathname)
+# Always require pathname: `Pathname()` (Kernel#Pathname) is only defined once
+# pathname is loaded. Guarding on `defined?(Pathname)` is wrong because another
+# library (e.g. Bundler) can define the Pathname constant without that method,
+# which left RBS::EnvironmentLoader's `Pathname(...)` undefined on JRuby.
+require "pathname"
 require "pp"
 require "logger"
 require "tsort"

--- a/lib/rbs/wasm/location.rb
+++ b/lib/rbs/wasm/location.rb
@@ -55,7 +55,7 @@ module RBS
         return range && Location.new(@buffer, range[0], range[1])
       end
 
-      nil
+      raise "Unknown child name given: #{name}"
     end
   end
 end

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -36,11 +36,17 @@ Gem::Specification.new do |spec|
     end
   end
 
-  # JRuby cannot load the MRI C extension. The `java` platform gem ships the
-  # prebuilt WebAssembly parser and the Chicory jars instead (assembled by
-  # `rake wasm:jruby_setup`), and RBS loads the WebAssembly-backed parser.
-  if ENV["RBS_PLATFORM"] == "java" || (defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby")
-    spec.platform = "java"
+  # JRuby cannot load the MRI C extension. On JRuby (and in the `java` platform
+  # gem, built with RBS_PLATFORM=java) RBS runs the WebAssembly-backed parser, so
+  # ship the prebuilt parser and the Chicory jars (assembled by
+  # `rake wasm:jruby_setup`) and skip the C extension.
+  building_java_gem = ENV["RBS_PLATFORM"] == "java"
+  on_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby"
+
+  if building_java_gem || on_jruby
+    # Only stamp the platform when building the release gem; leave it unset for
+    # local development on JRuby so it still matches a `ruby` platform lockfile.
+    spec.platform = "java" if building_java_gem
     spec.files += Dir.chdir(File.expand_path('..', __FILE__)) do
       Dir.glob("lib/rbs/wasm/rbs_parser.wasm") + Dir.glob("lib/rbs/wasm/jars/*.jar")
     end

--- a/test/rbs/ast/ruby/comment_block_test.rb
+++ b/test/rbs/ast/ruby/comment_block_test.rb
@@ -61,6 +61,7 @@ class RBS::AST::Ruby::CommentBlockTest < Test::Unit::TestCase
 
   def test_build
     omit_on_truffle_ruby! "`Prism::Location#start_line_slice` returns `nil` on TruffleRuby's prism"
+    omit_on_jruby! "`Prism::Location#start_line_slice` returns `nil` on JRuby's prism"
 
     buffer, comments = parse_comments(<<~RUBY)
       # Comment1
@@ -191,6 +192,7 @@ class RBS::AST::Ruby::CommentBlockTest < Test::Unit::TestCase
 
   def test_trailing_annotation
     omit_on_truffle_ruby! "`Prism::Location#start_line_slice` returns `nil` on TruffleRuby's prism"
+    omit_on_jruby! "`Prism::Location#start_line_slice` returns `nil` on JRuby's prism"
 
     buffer, comments = parse_comments(<<~RUBY)
       foo #: String
@@ -223,6 +225,7 @@ class RBS::AST::Ruby::CommentBlockTest < Test::Unit::TestCase
 
   def test_trailing_annotation_type_application
     omit_on_truffle_ruby! "`Prism::Location#start_line_slice` returns `nil` on TruffleRuby's prism"
+    omit_on_jruby! "`Prism::Location#start_line_slice` returns `nil` on JRuby's prism"
 
     buffer, comments = parse_comments(<<~RUBY)
       foo #[String]

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -892,6 +892,7 @@ singleton(::BasicObject)
 
   def test_prototype_no_parser
     omit_on_truffle_ruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on TruffleRuby"
+    omit_on_jruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on JRuby"
 
     Dir.mktmpdir do |dir|
       with_cli do |cli|
@@ -910,6 +911,7 @@ singleton(::BasicObject)
 
   def test_prototype_batch
     omit_on_truffle_ruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on TruffleRuby"
+    omit_on_jruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on JRuby"
 
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
@@ -973,6 +975,7 @@ Processing `Gemfile`...
 
   def test_prototype_batch_outer
     omit_on_truffle_ruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on TruffleRuby"
+    omit_on_jruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on JRuby"
 
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
@@ -1001,6 +1004,7 @@ Processing `test/a_test.rb`...
 
   def test_prototype_batch_syntax_error
     omit_on_truffle_ruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on TruffleRuby"
+    omit_on_jruby! "`rbs prototype` requires `RubyVM::AbstractSyntaxTree`, which is not available on JRuby"
 
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
@@ -1051,6 +1055,7 @@ Processing `lib`...
 
   def test_test
     omit_on_truffle_ruby! "`rbs test` relies on `TracePoint` `:end` event, which is not supported on TruffleRuby"
+    omit_on_jruby! "`rbs test` relies on `TracePoint` `:end` event, which is not supported on JRuby"
 
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)
@@ -1078,6 +1083,8 @@ Processing `lib`...
   end
 
   def test_collection_install
+    omit_on_jruby! "`rbs collection install` runs `bundle install`, which builds native gem extensions that do not compile on JRuby"
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)
@@ -1144,6 +1151,8 @@ Processing `lib`...
   end
 
   def test_collection_update
+    omit_on_jruby! "`rbs collection update` runs `bundle install`, which builds native gem extensions that do not compile on JRuby"
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)
@@ -1167,6 +1176,8 @@ Processing `lib`...
   end
 
   def test_collection_install_gemspec
+    omit_on_jruby! "`rbs collection install` runs `bundle install`, which builds native gem extensions that do not compile on JRuby"
+
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
         dir = Pathname(dir)

--- a/test/rbs/node_usage_test.rb
+++ b/test/rbs/node_usage_test.rb
@@ -9,6 +9,7 @@ class RBS::NodeUsageTest < Test::Unit::TestCase
 
   def test_conditional
     omit_on_truffle_ruby! "`RubyVM::AbstractSyntaxTree` is not available on TruffleRuby"
+    omit_on_jruby! "`RubyVM::AbstractSyntaxTree` is not available on JRuby"
 
     NodeUsage.new(parse(<<~RB))
       def block

--- a/test/rbs/rb_prototype_test.rb
+++ b/test/rbs/rb_prototype_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class RBS::RbPrototypeTest < Test::Unit::TestCase
   omit_on_truffle_ruby! "`RubyVM::AbstractSyntaxTree` is not available on TruffleRuby"
+  omit_on_jruby! "`RubyVM::AbstractSyntaxTree` is not available on JRuby"
 
   RB = RBS::Prototype::RB
 

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class RBS::RbiPrototypeTest < Test::Unit::TestCase
   omit_on_truffle_ruby! "`RubyVM::AbstractSyntaxTree` is not available on TruffleRuby"
+  omit_on_jruby! "`RubyVM::AbstractSyntaxTree` is not available on JRuby"
 
   RBI = RBS::Prototype::RBI
 

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class RBS::RuntimePrototypeTest < Test::Unit::TestCase
   omit_on_truffle_ruby! "`RubyVM::AbstractSyntaxTree` is not available on TruffleRuby"
+  omit_on_jruby! "`RubyVM::AbstractSyntaxTree` is not available on JRuby"
 
   Runtime = RBS::Prototype::Runtime
   DefinitionBuilder = RBS::DefinitionBuilder

--- a/test/rbs/test/runtime_test_test.rb
+++ b/test/rbs/test/runtime_test_test.rb
@@ -6,6 +6,7 @@ return unless Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
 
 class RBS::Test::RuntimeTestTest < Test::Unit::TestCase
   omit_on_truffle_ruby! "`rbs test` relies on `TracePoint` `:end` event, which is not supported on TruffleRuby"
+  omit_on_jruby! "`rbs test` relies on `TracePoint` `:end` event, which is not supported on JRuby"
 
   include TestHelper
 

--- a/test/rbs/test/type_check_test.rb
+++ b/test/rbs/test/type_check_test.rb
@@ -11,6 +11,7 @@ class RBS::Test::TypeCheckTest < Test::Unit::TestCase
 
   def test_type_check
     omit_on_truffle_ruby! "Type checking a block-less `loop` Enumerator behaves differently on TruffleRuby"
+    omit_on_jruby! "Type checking a block-less `loop` Enumerator behaves differently on JRuby"
 
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF
@@ -337,6 +338,7 @@ EOF
 
   def test_type_check_enumerator_sampling
     omit_on_truffle_ruby! "Type checking a block-less `loop` Enumerator behaves differently on TruffleRuby"
+    omit_on_jruby! "Type checking a block-less `loop` Enumerator behaves differently on JRuby"
 
     SignatureManager.new do |manager|
       manager.build do |env|


### PR DESCRIPTION
**Stacked on #3000** (step 3). Review/merge that first; this PR's diff is against it.

Makes `rake test` run on JRuby, skipping the cases that can't work there — mirroring how the suite already handles TruffleRuby.

## Result

```
$ jruby -S rake test
971 tests, 7819 assertions, 0 failures, 0 errors, 116 omissions
```

The full non-stdlib suite passes on JRuby (JRuby 10.0.6.0, verified locally). The 116 omissions are the genuinely-incompatible tests. No effect on CRuby (the `omit_on_jruby!` calls are no-ops there).

## Two real bugs this surfaced

- **`lib/rbs.rb`** — `require "pathname" unless defined?(Pathname)` skipped loading pathname when another library (Bundler) had already defined the `Pathname` *constant*, leaving `Kernel#Pathname` undefined. `RBS::EnvironmentLoader` uses `Pathname(...)` at load time, so requiring RBS after Bundler (as `test_helper` does) raised `NoMethodError` on JRuby. Now requires it unconditionally (`require` is idempotent).
- **`lib/rbs/wasm/location.rb`** — the pure-Ruby `RBS::Location#[]` returned `nil` for an unknown child name; the C extension raises. Now matches.

## Making `rake test` work on JRuby

- **Rakefile** — the `test` task no longer depends on `:compile` on JRuby (there is no C extension to build; `rake wasm:jruby_setup` assembles the wasm runtime instead).
- **gemspec** — only stamps the `java` platform when actually building the release gem (`RBS_PLATFORM=java`); on JRuby it otherwise stays a `ruby`-platform gem so local development matches a `ruby` lockfile, while still skipping the C extension and shipping the wasm + jars.

## Skips (`omit_on_jruby!`, alongside the existing `omit_on_truffle_ruby!`)

| Tests | Reason |
| --- | --- |
| `Rb/Rbi/RuntimePrototypeTest`, `NodeUsageTest`, `cli prototype` | `RubyVM::AbstractSyntaxTree` not on JRuby |
| `Test::RuntimeTestTest`, `cli test` | `rbs test` needs the `TracePoint :end` event |
| `CommentBlockTest` (3) | `Prism::Location#start_line_slice` returns nil on JRuby's prism |
| `TypeCheckTest` (2) | block-less `loop` Enumerator type-checks differently |
| `cli collection install/update` | runs `bundle install`, which builds native gem extensions that don't compile on JRuby |

## CI

The `jruby` job now assembles the runtime and runs `jruby -S rake test` (instead of just two parser test files), and triggers on lib/test/sig changes. The test gems it needs are all pure Ruby; the native-extension dev tools in the main Gemfile (irb → io-console, activesupport → bigdecimal, ...) aren't installed, which is why the job uses `gem install` rather than the full bundle.

https://claude.ai/code/session_01LTveMt3NLbYHEboXuzAKpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTveMt3NLbYHEboXuzAKpA)_