### PR TITLE
Fix Lint/DuplicateMethods in StringIO_test.rb

### DIFF
--- a/test/stdlib/StringIO_test.rb
+++ b/test/stdlib/StringIO_test.rb
@@ -75,24 +75,9 @@ class StringIOTypeTest < Test::Unit::TestCase
                      StringIO.new("a"), :read, 1, nil
   end
 
-  def test_pread
-    assert_send_type "(::Integer, ::Integer, nil) -> ::String",
-                     StringIO.new("a"), :pread, 1, 0, nil
-  end
-
-  def test_read_nonblock
-    assert_send_type "(::int, nil) -> ::String?",
-                     StringIO.new("a"), :read_nonblock, 1, nil
-  end
-
   def test_readpartial
     assert_send_type "(::int, nil) -> ::String",
                      StringIO.new("a"), :readpartial, 1, nil
-  end
-
-  def test_sysread
-    assert_send_type "(::Integer, nil) -> ::String",
-                     StringIO.new("a"), :sysread, 1, nil
   end
 
   def test_truncate
@@ -135,6 +120,8 @@ class StringIOTypeTest < Test::Unit::TestCase
                      StringIO.new("abcdef"), :pread, 3, 0
     assert_send_type "(Integer, Integer, String) -> String",
                      StringIO.new("abcdef"), :pread, 3, 0, +"buf"
+    assert_send_type "(::Integer, ::Integer, nil) -> ::String",
+                     StringIO.new("a"), :pread, 1, 0, nil
   end
 
   def test_read_nonblock
@@ -148,6 +135,8 @@ class StringIOTypeTest < Test::Unit::TestCase
                      StringIO.new("abc"), :read_nonblock, 2, exception: false
     assert_send_type "(int, exception: false) -> nil",
                      StringIO.new(""), :read_nonblock, 2, exception: false
+    assert_send_type "(::int, nil) -> ::String?",
+                     StringIO.new("a"), :read_nonblock, 1, nil
   end
 
   def test_write_nonblock
@@ -164,6 +153,8 @@ class StringIOTypeTest < Test::Unit::TestCase
                      StringIO.new("abc"), :sysread, 2
     assert_send_type "(Integer, String) -> String",
                      StringIO.new("abc"), :sysread, 2, +"buf"
+    assert_send_type "(::Integer, nil) -> ::String",
+                     StringIO.new("a"), :sysread, 1, nil
   end
 
   def test_ungetc


### PR DESCRIPTION
## Summary

master's CI ("Ruby" job) is failing on RuboCop with `Lint/DuplicateMethods`:

```
Lint/DuplicateMethods: Method `StringIOTypeTest#test_pread` is defined at both test/stdlib/StringIO_test.rb:78 and test/stdlib/StringIO_test.rb:133.
Lint/DuplicateMethods: Method `StringIOTypeTest#test_read_nonblock` is defined at both test/stdlib/StringIO_test.rb:83 and test/stdlib/StringIO_test.rb:140.
Lint/DuplicateMethods: Method `StringIOTypeTest#test_sysread` is defined at both test/stdlib/StringIO_test.rb:93 and test/stdlib/StringIO_test.rb:162.
```

## Cause

This is a merge skew (semantic conflict) between two PRs that were each green on their own:

- `test_pread` / `test_read_nonblock` / `test_sysread` (the full-argument variants) were already on master via commit `4de713c` ("Add stdlib signature tests for #2967").
- #3002 ("Allow nil output buffers for reader methods") added methods of the same name (the `nil` output buffer variants) in commit `1914368`.

#3002's branch last synced master at a point that did **not** yet contain `4de713c`, so RuboCop saw no duplicate when #3002's CI ran. The duplicate only materialized once #3002 was merged into the current master, and CI is not re-run against the post-merge state.

## Fix

Merge the `nil` output buffer assertions into the existing methods and drop the duplicate definitions. No test coverage is lost.

- `ruby -c`: Syntax OK
- No duplicate method names remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9NBHdAQGQbyDV7M8MiTLF)_