### PR TITLE
Version 4.1.0.pre.2 and JRuby release tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Keep the build context small. .git is intentionally NOT ignored: rbs.gemspec
+# builds its file list with `git ls-files`.
+#
+# Safe to ignore here: untracked/generated paths, and tracked paths the gemspec
+# already rejects (so `gem build` does not expect them on disk). Do NOT ignore a
+# tracked path the gemspec ships — `gem build` would fail with "... are not
+# files". .vscode/ and benchmark/ are tracked but rejected by the gemspec.
+.vscode/
+benchmark/
+
+# Editor / tooling / worktree copies (untracked; each is a full repo clone)
+.claude/
+trees/
+.devcontainer/
+.idea/
+.ruby-lsp/
+.yardoc/
+doc/
+datasets/
+tmp/
+
+# Build artifacts — rebuilt inside the image by `rake wasm:jruby_setup`
+lib/rbs/wasm/*.wasm
+lib/rbs/wasm/jars/
+*.gem
+ext/**/*.o
+ext/**/*.so
+ext/**/*.bundle
+*.log
+
+# Local scratch / experiment files
+flamegraph.html
+gc.html
+foo.rbs
+sorted.json
+string.json
+Gemfile-*
+gemfiles/

--- a/Dockerfile.jruby
+++ b/Dockerfile.jruby
@@ -1,0 +1,54 @@
+# JRuby verification image for RBS.
+#
+# RBS can't load its MRI C extension on JRuby, so it parses through a
+# WebAssembly build of the parser (see lib/rbs/wasm and docs/wasm_serialization.md).
+# This single-stage image installs the WASI SDK, compiles rbs_parser.wasm and
+# vendors the Chicory/ASM jars into lib/rbs/wasm/, then runs the test suite on
+# JRuby. It mirrors .github/workflows/jruby.yml but is fully self-contained.
+#
+#   docker build -f Dockerfile.jruby -t rbs-jruby .
+#   docker run --rm rbs-jruby                                  # run the test suite
+#   docker run --rm -e RBS_PLATFORM=java rbs-jruby \
+#     gem build rbs.gemspec                                    # build the -java gem
+#
+# Bundler is intentionally not used: the development Gemfile pulls in CRuby-only
+# C extensions (bigdecimal, stackprof, ...) that cannot build on JRuby. The few
+# gems the suite needs are installed directly, exactly as the CI does.
+
+FROM jruby:10.0.6-jdk21
+
+# Keep in sync with .github/workflows/wasm.yml and .github/workflows/jruby.yml.
+ARG WASI_SDK_VERSION=33
+ARG WASI_SDK_RELEASE=33.0
+
+# build-essential supplies cc/make: on JRuby the prism gem builds libprism.so
+# (loaded via FFI) instead of an MRI C extension, so it needs a C toolchain.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# The WASI SDK provides clang, the wasi-libc sysroot and the wasm32 compiler-rt
+# builtins that `rake wasm:build` needs to compile src/**/*.c to WebAssembly.
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64 | amd64)  wasi_arch=x86_64 ;; \
+      aarch64 | arm64) wasi_arch=arm64  ;; \
+      *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    mkdir -p /opt/wasi-sdk; \
+    curl -fsSL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_RELEASE}-${wasi_arch}-linux.tar.gz" \
+      | tar xz --strip-components=1 -C /opt/wasi-sdk
+ENV WASI_SDK_PATH=/opt/wasi-sdk
+
+# Runtime/test gems the suite needs on JRuby (same set as the jruby.yml CI).
+RUN gem install prism rake rake-compiler test-unit rdoc rspec minitest json-schema pry --no-document
+
+WORKDIR /rbs
+COPY . .
+
+# Assemble the JRuby runtime: compile rbs_parser.wasm and download the
+# Chicory + ASM jars into lib/rbs/wasm/. Runs on JRuby (clang is a subprocess,
+# so the build is engine independent).
+RUN rake wasm:jruby_setup
+
+CMD ["rake", "test"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.0.pre.1)
+    rbs (4.1.0.pre.2)
       logger
       prism (>= 1.6.0)
       tsort

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,67 @@
+# Releasing RBS
+
+Each release ships **two gems**:
+
+| Gem | Platform | Parser | How it is built |
+| --- | --- | --- | --- |
+| `rbs-X.Y.Z.gem` | `ruby` (MRI) | C extension | `rake release` (re-builds it) |
+| `rbs-X.Y.Z-java.gem` | `java` (JRuby) | WebAssembly (`lib/rbs/wasm`) | Docker image, pushed manually |
+
+The `-java` gem contains no native code — just `rbs_parser.wasm` plus the
+Chicory/ASM jars — so it can be built once in any environment and runs on every
+JRuby.
+
+## Prerequisites
+
+- Push rights to the `rbs` gem on RubyGems (`gem signin`). If your account has
+  MFA enabled, `gem push` / `rake release` will prompt for an OTP.
+- Docker, for the `-java` gem. The WASI SDK is baked into the image, so there is
+  nothing to install on the host.
+
+## Steps
+
+### 1. Release the `ruby` gem
+
+Once the version is bumped and committed, run on CRuby:
+
+```console
+$ bundle exec rake release
+```
+
+This re-builds the `ruby`-platform gem and then:
+
+- creates the tag `vX.Y.Z`,
+- pushes the current branch and the tag to `origin`,
+- pushes the gem to RubyGems,
+- runs `release:note`, which opens a GitHub **draft** release (with
+  `--prerelease` for `*.pre.*` versions) and prints the remaining manual steps.
+
+### 2. Build and push the `java` gem
+
+The `java` gem is not built by `rake release`, so build and push it manually:
+
+```console
+# Build from the committed state (the gemspec's file list comes from `git ls-files`).
+$ docker build -f Dockerfile.jruby -t rbs-jruby .
+
+# Assemble rbs_parser.wasm + jars and build the -java gem into ./pkg on the host.
+$ docker run --rm -e RBS_PLATFORM=java -v "$PWD/pkg:/out" rbs-jruby \
+    gem build rbs.gemspec -o /out/rbs-X.Y.Z-java.gem
+
+$ gem push pkg/rbs-X.Y.Z-java.gem
+```
+
+Optionally confirm it installs and runs on JRuby before pushing:
+
+```console
+$ docker run --rm -v "$PWD/pkg:/pkg" -w /tmp rbs-jruby bash -c \
+    'gem install /pkg/rbs-X.Y.Z-java.gem && ruby -e "require %q{rbs}; puts [RUBY_ENGINE, RBS::VERSION].join(%q{ })"'
+```
+
+## Notes
+
+- Prereleases (`X.Y.Z.pre.N`) are only installed with `gem install rbs --pre`;
+  a plain `gem install rbs` is unaffected. On JRuby, `gem install rbs [--pre]`
+  resolves to the `-java` gem automatically.
+- The Dockerfile pins the WASI SDK / Chicory / ASM versions to match the
+  `wasm` and `jruby` CI workflows. Keep them in sync when bumping.

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.0.pre.1"
+  VERSION = "4.1.0.pre.2"
 end

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject do |f|
       [
-        %r{^(test|spec|features|bin|steep|benchmark|templates|rust)/},
+        %r{^(test|spec|features|bin|steep|benchmark|templates|rust|\.vscode)/},
         /Gemfile/,
       ].any? {|r| f.match(r) }
     end


### PR DESCRIPTION
Brings `master` up to the released `4.1.0.pre.2` and adds the tooling/docs for the JRuby (`-java`) gem.

## Changes

- **Version 4.1.0.pre.2** — `lib/rbs/version.rb` and `Gemfile.lock`. (The `4.1.0.pre.2` gems for both `ruby` and `java` platforms are already on RubyGems; this catches `master` up to the tagged commit.)
- **Fix gemspec to exclude `.vscode`** — `.vscode/` was tracked but not rejected by `rbs.gemspec`, so it was being shipped in the gem. Now excluded from both platform gems.
- **`Dockerfile.jruby` + `.dockerignore`** — single-stage JRuby image that installs the WASI SDK, runs `rake wasm:jruby_setup` (compiles `rbs_parser.wasm` and vendors the Chicory/ASM jars), runs the suite, and can build the `-java` gem with `RBS_PLATFORM=java gem build`. Lets the JRuby gem be built and verified without a WASI SDK on the host.
- **`docs/release.md`** — documents the two-gem release procedure (`rake release` for the `ruby` gem, Docker build + `gem push` for the `java` gem).

## Verified

- `docker build -f Dockerfile.jruby` succeeds; `rake wasm:jruby_setup` runs on JRuby.
- RBS parses a signature on JRuby through the WebAssembly parser.
- `RBS_PLATFORM=java gem build rbs.gemspec` produces `rbs-4.1.0.pre.2-java.gem` (platform `java`, no C extension, bundling `rbs_parser.wasm` + 10 jars, and no `.vscode`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)