### PR TITLE
Clean up `Rational` signatures

### DIFF
--- a/core/numeric.rbs
+++ b/core/numeric.rbs
@@ -161,6 +161,11 @@ class Numeric
   # The direction you can round
   type round_mode = :up | :down | :even | 'up' | 'down' | 'even' | string | nil
 
+  # An interface that indicates a type can be coerced.
+  interface _Coerce[O, Other, Self]
+    def coerce: (O other) -> [Other, Self]
+  end
+
   # <!--
   #   rdoc-file=numeric.c
   #   - self % other -> real_numeric

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -135,7 +135,7 @@ class Rational < Numeric
   #     -(1/3r)   # => (-1/3)
   #     -(-1/3r)  # => (1/3)
   #
-  def -@: () -> Rational
+  def -@: () -> instance
 
   # <!--
   #   rdoc-file=rational.c
@@ -206,7 +206,7 @@ class Rational < Numeric
   #     (1/2r).abs    #=> (1/2)
   #     (-1/2r).abs   #=> (1/2)
   #
-  def abs: () -> Rational
+  def abs: () -> instance
 
   # <!--
   #   rdoc-file=rational.c
@@ -460,7 +460,7 @@ class Rational < Numeric
   #     Rational(2).to_r      #=> (2/1)
   #     Rational(-8, 6).to_r  #=> (-4/3)
   #
-  def to_r: () -> Rational
+  def to_r: () -> self
 
   # <!--
   #   rdoc-file=rational.c
@@ -499,4 +499,6 @@ class Rational < Numeric
   #
   def truncate: () -> Integer
               | (Integer ndigits) -> (Integer | Rational)
+
+  private def marshal_dump: () -> [ Integer, Integer ]
 end

--- a/core/rational.rbs
+++ b/core/rational.rbs
@@ -64,9 +64,9 @@ class Rational < Numeric
   #     Rational(900)   * Rational(1)     #=> (900/1)
   #     Rational(-2, 9) * Rational(-9, 2) #=> (1/1)
   #
-  def *: (Integer) -> Rational
-       | (Rational) -> Rational
-       | [T < Numeric](T) -> T
+  def *: (Integer | Rational other) -> instance
+       | (Float other) -> Float
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Times[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=rational.c
@@ -81,8 +81,13 @@ class Rational < Numeric
   #     Rational(1, 2) ** 0               #=> (1/1)
   #     Rational(1, 2) ** 0.0             #=> 1.0
   #
-  def **: (Complex) -> Complex
-        | (Numeric) -> Numeric
+  def **: (Integer exponent) -> instance
+        | (Rational exponent) -> (instance | Float | Complex) # `instance` only for special-cases like `**0r`
+        | (Float exponent) -> (Float | Complex)
+        | (Complex exponent) -> (instance | Complex) # instance only for special-cases like `**0i`
+        | [S, R] ((Numeric & Numeric::_Coerce[self, RBS::Ops::_Power[S, R], S]) other) -> (R | Rational)
+        | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Power[S, R], S] other) -> R
+
 
   # <!--
   #   rdoc-file=rational.c
@@ -106,9 +111,9 @@ class Rational < Numeric
   #     Rational(2, 3) + 1.0 # => 1.6666666666666665
   #     Rational(2, 3) + Complex(1.0, 0.0) # => (1.6666666666666665+0.0i)
   #
-  def +: (Float) -> Float
-       | (Complex) -> Complex
-       | (Numeric) -> Rational
+  def +: (Integer | Rational other) -> instance
+       | (Float other) -> Float
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Add[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=rational.c
@@ -122,9 +127,9 @@ class Rational < Numeric
   #     Rational(9, 8)  - 4                #=> (-23/8)
   #     Rational(20, 9) - 9.8              #=> -7.577777777777778
   #
-  def -: (Float) -> Float
-       | (Complex) -> Complex
-       | (Numeric) -> Rational
+  def -: (Integer | Rational other) -> instance
+       | (Float other) -> Float
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Subtract[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=rational.c
@@ -149,9 +154,9 @@ class Rational < Numeric
   #     Rational(9, 8)  / 4                #=> (9/32)
   #     Rational(20, 9) / 9.8              #=> 0.22675736961451246
   #
-  def /: (Float) -> Float
-       | (Complex) -> Complex
-       | (Numeric) -> Rational
+  def /: (Integer | Rational other) -> instance
+       | (Float other) -> Float
+       | [S, R] (Numeric::_Coerce[self, RBS::Ops::_Divide[S, R], S] other) -> R
 
   # <!--
   #   rdoc-file=rational.c
@@ -179,8 +184,8 @@ class Rational < Numeric
   # Class Rational includes module Comparable, each of whose methods uses
   # Rational#<=> for comparison.
   #
-  def <=>: (Integer | Rational) -> Integer
-         | (untyped) -> Integer?
+  def <=>: (Integer | Rational other) -> (-1 | 0 | 1)
+         | (untyped other) -> Integer?
 
   # <!--
   #   rdoc-file=rational.c
@@ -194,7 +199,7 @@ class Rational < Numeric
   #     Rational('1/3') == 0.33             #=> false
   #     Rational('1/2') == '1/2'            #=> false
   #
-  def ==: (untyped) -> bool
+  def ==: (untyped object) -> bool
 
   # <!--
   #   rdoc-file=rational.c
@@ -232,9 +237,11 @@ class Rational < Numeric
   #     Rational('-123.456').ceil(-1)       #=> -120
   #
   def ceil: () -> Integer
-          | (Integer digits) -> (Integer | Rational)
+          | (Integer ndigits) -> (Integer | instance)
 
-  def coerce: (Numeric) -> [ Numeric, Numeric ]
+  def coerce: (Integer | Rational other) -> [ instance, self ]
+            | (Float other) -> [ Float, Float ]
+            | (Complex other) -> ([ Complex, Complex ] | [ instance, self ])
 
   # <!--
   #   rdoc-file=rational.c
@@ -262,7 +269,8 @@ class Rational < Numeric
   #     Rational(2, 3).fdiv(0.5)     #=> 1.3333333333333333
   #     Rational(2).fdiv(3)          #=> 0.6666666666666666
   #
-  def fdiv: (Numeric) -> Float
+  def fdiv: (Integer | Rational | Float | Complex other) -> Float
+          | [S] ((Numeric::_Coerce[self, RBS::Ops::_Times[S, _ToF], S] & RBS::Ops::_Equal[0]) other) -> Float
 
   # <!--
   #   rdoc-file=rational.c
@@ -288,7 +296,7 @@ class Rational < Numeric
   #     Rational('-123.456').floor(-1)       #=> -130
   #
   def floor: () -> Integer
-           | (Integer digits) -> (Integer | Rational)
+           | (Integer ndigits) -> (Integer | instance)
 
   # <!--
   #   rdoc-file=rational.c
@@ -360,9 +368,7 @@ class Rational < Numeric
   #     Rational(9, 8)  / 4                #=> (9/32)
   #     Rational(20, 9) / 9.8              #=> 0.22675736961451246
   #
-  def quo: (Float) -> Float
-         | (Complex) -> Complex
-         | (Numeric) -> Rational
+  alias quo /
 
   # <!--
   #   rdoc-file=rational.c
@@ -377,7 +383,8 @@ class Rational < Numeric
   #     r.rationalize(Rational('0.01'))  #=> (3/10)
   #     r.rationalize(Rational('0.1'))   #=> (1/3)
   #
-  def rationalize: (?Numeric eps) -> Rational
+  def rationalize: () -> self
+                | (Numeric eps) -> instance # technically has a more specific one, but it yields a segfault.
 
   def rect: () -> [ Rational, Numeric ]
 
@@ -419,8 +426,8 @@ class Rational < Numeric
   #     Rational(-25, 100).round(1, half: :down) #=> (-1/5)
   #     Rational(-25, 100).round(1, half: :even) #=> (-1/5)
   #
-  def round: (?half: :up | :down | :even) -> Integer
-           | (Integer digits, ?half: :up | :down | :even) -> (Integer | Rational)
+  def round: (?half: Numeric::round_mode) -> Integer
+           | (Integer digits, ?half: Numeric::round_mode) -> (Integer | Rational)
 
   # <!--
   #   rdoc-file=rational.c
@@ -498,7 +505,7 @@ class Rational < Numeric
   #     Rational('-123.456').truncate(-1)       #=> -120
   #
   def truncate: () -> Integer
-              | (Integer ndigits) -> (Integer | Rational)
+              | (Integer ndigits) -> (Integer | instance)
 
   private def marshal_dump: () -> [ Integer, Integer ]
 end

--- a/test/stdlib/Rational_test.rb
+++ b/test/stdlib/Rational_test.rb
@@ -6,19 +6,80 @@ class RationalInstanceTest < Test::Unit::TestCase
   testing 'Rational'
 
   def test_op_mul
-    omit
+    assert_send_type  '(Integer) -> Rational',
+                      3/8r, :*, 38
+    assert_send_type  '(Rational) -> Rational',
+                      3/8r, :*, -9/13r
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :*, 12.34
+    assert_send_type  '(Complex) -> Complex',
+                      3/8r, :*, 12-34i
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      3/8r, :*, Coercable.for_op(:*)
+  end
+
+  class MyZeroNumeric < Numeric
+    def ==(other) = 0 == other ? true : super
   end
 
   def test_op_pow
-    omit
+    # Technically, the rational code for `**` has a branch for integer exponents when `Integer#**`
+    # returns `Float`. That's no longer a thing (now that `exponent is too large` is raised), so the
+    # branch is dead code
+    assert_send_type  '(Integer) -> Rational',
+                      3/8r, :**, 24
+
+    assert_send_type  '(Rational) -> Rational',
+                      3/8r, :**, 0r
+    assert_send_type  '(Rational) -> Float',
+                      3/8r, :**, 1/2r
+    assert_send_type  '(Rational) -> Complex',
+                      -3/8r, :**, 1/2r
+
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :**, 0.0
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :**, 0.5
+    assert_send_type  '(Float) -> Complex',
+                      -3/8r, :**, 0.5
+
+    assert_send_type  '(Complex) -> Rational',
+                      3/8r, :**, 0i
+    assert_send_type  '(Complex) -> Complex',
+                      3/8r, :**, 0.5+0i
+    assert_send_type  '(Complex) -> Complex',
+                      -3/8r, :**, 0.5i
+
+    assert_send_type  '(RationalInstanceTest::MyZeroNumeric) -> Rational',
+                      3/8r, :**, MyZeroNumeric.new
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      3/8r, :**, Coercable.for_op(:**)
   end
 
   def test_op_add
-    omit
+    assert_send_type  '(Integer) -> Rational',
+                      3/8r, :+, 38
+    assert_send_type  '(Rational) -> Rational',
+                      3/8r, :+, -9/13r
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :+, 12.34
+    assert_send_type  '(Complex) -> Complex',
+                      3/8r, :+, 12-34i
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      3/8r, :+, Coercable.for_op(:+)
   end
 
   def test_op_sub
-    omit
+    assert_send_type  '(Integer) -> Rational',
+                      3/8r, :-, 38
+    assert_send_type  '(Rational) -> Rational',
+                      3/8r, :-, -9/13r
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :-, 12.34
+    assert_send_type  '(Complex) -> Complex',
+                      3/8r, :-, 12-34i
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      3/8r, :-, Coercable.for_op(:-)
   end
 
   def test_op_uneg
@@ -26,16 +87,39 @@ class RationalInstanceTest < Test::Unit::TestCase
                       3/8r, :-@
   end
 
-  def test_op_div
-    omit
+  def test_op_div(method: :/)
+    assert_send_type  '(Integer) -> Rational',
+                      3/8r, method, 38
+    assert_send_type  '(Rational) -> Rational',
+                      3/8r, method, -9/13r
+    assert_send_type  '(Float) -> Float',
+                      3/8r, method, 12.34
+    assert_send_type  '(Complex) -> Complex',
+                      3/8r, method, 12-34i
+    assert_send_type  '(Coercable) -> Coercable::OpReturn',
+                      3/8r, method, Coercable.for_op(:/) # note not `.for_op(method)`
   end
 
   def test_op_cmp
-    omit
+    with -3, 0, 4, 5 do |num|
+      assert_send_type  '(Integer) -> (-1 | 0 | 1)',
+                        4/1r, :<=>, num
+      assert_send_type  '(Rational) -> (-1 | 0 | 1)',
+                        4/1r, :<=>, num.to_r
+    end
+
+    with_untyped.and 2, 3.4, 5/6r, 7+8i do |untyped|
+      assert_send_type  '(untyped) -> Integer?',
+                        3/8r, :<=>, untyped
+    end
   end
 
   def test_op_eq
-    omit
+    with_untyped.and 2, 2.0, 2r, 2+0i do |untyped|
+      next unless defined? untyped.==
+      assert_send_type  '(untyped) -> bool',
+                        2/1r, :==, untyped
+    end
   end
 
   def test_abs(method: :abs)
@@ -46,11 +130,25 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_ceil
-    omit
+    assert_send_type  '() -> Integer',
+                      38/3r, :ceil
+    assert_send_type  '(Integer) -> Rational',
+                      38/3r, :ceil, 2
+    assert_send_type  '(Integer) -> Integer',
+                      38/3r, :ceil, -2
   end
 
   def test_coerce
-    omit
+    assert_send_type  '(Integer) -> [Rational, Rational]',
+                      3/8r, :coerce, 12
+    assert_send_type  '(Rational) -> [Rational, Rational]',
+                      3/8r, :coerce, -9/13r
+    assert_send_type  '(Float) -> [Float, Float]',
+                      3/8r, :coerce, 3.4
+    assert_send_type  '(Complex) -> [Complex, Complex]',
+                      3/8r, :coerce, 1+2i
+    assert_send_type  '(Complex) -> [Rational, Rational]',
+                      3/8r, :coerce, 1.2+0i
   end
 
   def test_denominator
@@ -59,11 +157,30 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_fdiv
-    omit
+    assert_send_type  '(Integer) -> Float',
+                      3/8r, :fdiv, 12
+    assert_send_type  '(Rational) -> Float',
+                      3/8r, :fdiv, 12r
+    assert_send_type  '(Float) -> Float',
+                      3/8r, :fdiv, 1.2
+    assert_send_type  '(Complex) -> Float',
+                      3/8r, :fdiv, 2+0i
+
+    with_float 3.4 do |float|
+      coerce = Coercable.for_op(:/, result: float)
+      def coerce.==(r) = false
+      assert_send_type  '(Coercable) -> Float',
+                        3/8r, :fdiv, coerce
+    end
   end
 
   def test_floor
-    omit
+    assert_send_type  '() -> Integer',
+                      38/3r, :floor
+    assert_send_type  '(Integer) -> Rational',
+                      38/3r, :floor, 2
+    assert_send_type  '(Integer) -> Integer',
+                      38/3r, :floor, -2
   end
 
   def test_hash
@@ -100,15 +217,35 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_quo
-    omit
+    test_op_div(method: :quo)
   end
 
   def test_rationalize
-    omit
+    assert_send_type  '() -> Rational',
+                      3/8r, :rationalize
+
+    with 1, 1/5r, 0.001, 0.000004+0i do |eps|
+      assert_send_type  '(Numeric) -> Rational',
+                        3/8r, :rationalize, eps
+    end
   end
 
   def test_round
-    omit
+    assert_send_type  '() -> Integer',
+                      7/2r, :round
+
+    with_round_mode do |mode|
+      assert_send_type  '(half: Numeric::round_mode) -> Integer',
+                        7/2r, :round, half: mode
+    end
+
+    assert_send_type  '(Integer) -> Integer',
+                      7/2r, :round, -1
+
+    with_round_mode do |mode|
+      assert_send_type  '(Integer, half: Numeric::round_mode) -> Integer',
+                        7/2r, :round, -1, half: mode
+    end
   end
 
   def test_to_f
@@ -134,10 +271,18 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_truncate
-    omit
+    assert_send_type  '() -> Integer',
+                      38/3r, :truncate
+    assert_send_type  '(Integer) -> Rational',
+                      38/3r, :truncate, 2
+    assert_send_type  '(Integer) -> Integer',
+                      38/3r, :truncate, -2
   end
 
   def test_marshal_dump
-    omit
+    assert_visibility :private, :marshal_dump
+
+    assert_send_type  '() -> [Integer, Integer]',
+                      3/8r, :marshal_dump
   end
 end

--- a/test/stdlib/Rational_test.rb
+++ b/test/stdlib/Rational_test.rb
@@ -22,7 +22,8 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_op_uneg
-    omit
+    assert_send_type  '() -> Rational',
+                      3/8r, :-@
   end
 
   def test_op_div
@@ -37,8 +38,11 @@ class RationalInstanceTest < Test::Unit::TestCase
     omit
   end
 
-  def test_abs
-    omit
+  def test_abs(method: :abs)
+    assert_send_type  '() -> Rational',
+                      3/8r, method
+    assert_send_type  '() -> Rational',
+                      -3/8r, method
   end
 
   def test_ceil
@@ -50,7 +54,8 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_denominator
-    omit
+    assert_send_type  '() -> Integer',
+                      3/8r, :denominator
   end
 
   def test_fdiv
@@ -62,27 +67,36 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_hash
-    omit
+    assert_send_type  '() -> Integer',
+                      3/8r, :hash
   end
 
   def test_inspect
-    omit
+    assert_send_type  '() -> String',
+                      3/8r, :inspect
   end
 
   def test_magnitude
-    omit
+    test_abs(method: :magnitude)
   end
 
   def test_negative?
-    omit
+    assert_send_type  '() -> bool',
+                      3/8r, :negative?
+    assert_send_type  '() -> bool',
+                      -3/8r, :negative?
   end
 
   def test_numerator
-    omit
+    assert_send_type  '() -> Integer',
+                      3/8r, :numerator
   end
 
   def test_positive?
-    omit
+    assert_send_type  '() -> bool',
+                      3/8r, :positive?
+    assert_send_type  '() -> bool',
+                      -3/8r, :positive?
   end
 
   def test_quo
@@ -98,22 +112,32 @@ class RationalInstanceTest < Test::Unit::TestCase
   end
 
   def test_to_f
-    omit
+    assert_send_type  '() -> Float',
+                      3/8r, :to_f
   end
 
   def test_to_i
-    omit
+    assert_send_type  '() -> Integer',
+                      3/8r, :to_i
+    assert_send_type  '() -> Integer',
+                      -38/8r, :to_i
   end
 
   def test_to_r
-    omit
+    assert_send_type  '() -> Rational',
+                      3/8r, :to_r
   end
 
   def test_to_s
-    omit
+    assert_send_type  '() -> String',
+                      3/8r, :to_s
   end
 
   def test_truncate
+    omit
+  end
+
+  def test_marshal_dump
     omit
   end
 end

--- a/test/stdlib/Rational_test.rb
+++ b/test/stdlib/Rational_test.rb
@@ -1,191 +1,119 @@
-require_relative "test_helper"
-
-class RationalTest < StdlibTest
-  target Rational
-
-  def test_calc
-    10r % 10
-    10r % 1.3
-    10r % 2r
-
-    10r * 10
-    10r * 1.2
-    10r * 2r
-    10r * Complex.rect(1,2)
-
-    3r ** 2
-    3r ** 2.1
-    3r ** 2r
-    3r ** Complex.rect(1,2)
-
-    10r + 10
-    10r + 1.2
-    10r + 2r
-    10r + Complex.rect(1,2)
-
-    10r - 10
-    10r - 1.2
-    10r - 2r
-    10r - Complex.rect(1,2)
-
-    10r / 10
-    10r / 1.2
-    10r / 2r
-    10r / Complex.rect(1,2)
-  end
-
-  def test_compare
-    10r <=> 1
-    10r < 1
-    10r <= 3r
-    10r > 3.1
-    10r >= Complex.rect(1,0)
-  end
-
-  def test_eq
-    a = 31r
-
-    a == 1
-    a == Object.new
-  end
-
-  def test_abs
-    a = 31r
-
-    a.abs
-    a.abs2
-  end
-
-  def test_angle
-    a = 31r
-
-    a.angle
-    a.arg
-    -a.phase
-  end
-
-  def test_ceil
-    a = 312r/5
-
-    a.ceil
-    a.ceil(3)
-    # a.ceil(ToInt.new) # does not accept to_int
-  end
-
-  def test_denominator
-    a = 133r
-
-    a.denominator
-  end
-
-  def test_div
-    a = 123r
-
-    a.div(3)
-    a.div(3.1)
-    a.div(12r)
-
-    a.divmod(3)
-    a.divmod(3.1)
-    a.divmod(1r/5)
-  end
-
-  def test_fdiv
-    a = 3r/2
-
-    a.fdiv(3)
-    a.fdiv(3.1)
-    a.fdiv(1r/3)
-  end
-
-  def test_floor
-    a = 3r/2
-
-    a.floor()
-    a.floor(-1)
-    # a.floor(ToInt.new) # No to_int support
-  end
-
-  def test_modulo
-    a = 3r/2
-
-    a.modulo(2)
-    a.modulo(1.1)
-    a.modulo(a)
-  end
-
-  def test_numerator
-    a = 3r/2
-
-    a.numerator
-  end
-
-  def test_polar
-    31r.polar
-    (-31r/2).polar
-  end
-
-  def test_quo
-    a = 1/11r
-
-    a.quo(3)
-    a.quo(1.3)
-    a.quo(1r/3)
-    a.quo(Complex.rect(1,2))
-  end
-
-  def test_rationalize
-    a = 14r
-
-    a.rationalize
-    a.rationalize(3.11)
-  end
-
-  def test_reminder
-    a = 14r
-
-    a.remainder(3)
-    a.remainder(3.1)
-    a.remainder(3r/5)
-  end
-
-  def test_round
-    a = 1r/3
-
-    a.round(half: :up)
-    a.round(2, half: :up)
-    # a.round(ToInt.new(-2), half: :up) # to_int not supported
-  end
-
-  def test_step
-    a = 1r/3
-
-    a.step { break }
-    a.step(1, 2) { }
-    a.step(by: 3, to: 100) { }
-  end
-
-  def test_truncate
-    a = 1r/3
-
-    a.truncate
-    a.truncate(1)
-  end
-end
+require_relative 'test_helper'
 
 class RationalInstanceTest < Test::Unit::TestCase
   include TestHelper
 
-  testing "::Rational"
+  testing 'Rational'
 
-  def test_multiply
-    assert_send_type "(Integer) -> Rational",
-                      1r, :*, 1
-    assert_send_type "(Rational) -> Rational",
-                      1r, :*, 1r
-    assert_send_type "(Float) -> Float",
-                      1r, :*, 3.1
-    assert_send_type "(Complex) -> Complex",
-                      1, :*, Complex.rect(1,2)
+  def test_op_mul
+    omit
+  end
+
+  def test_op_pow
+    omit
+  end
+
+  def test_op_add
+    omit
+  end
+
+  def test_op_sub
+    omit
+  end
+
+  def test_op_uneg
+    omit
+  end
+
+  def test_op_div
+    omit
+  end
+
+  def test_op_cmp
+    omit
+  end
+
+  def test_op_eq
+    omit
+  end
+
+  def test_abs
+    omit
+  end
+
+  def test_ceil
+    omit
+  end
+
+  def test_coerce
+    omit
+  end
+
+  def test_denominator
+    omit
+  end
+
+  def test_fdiv
+    omit
+  end
+
+  def test_floor
+    omit
+  end
+
+  def test_hash
+    omit
+  end
+
+  def test_inspect
+    omit
+  end
+
+  def test_magnitude
+    omit
+  end
+
+  def test_negative?
+    omit
+  end
+
+  def test_numerator
+    omit
+  end
+
+  def test_positive?
+    omit
+  end
+
+  def test_quo
+    omit
+  end
+
+  def test_rationalize
+    omit
+  end
+
+  def test_round
+    omit
+  end
+
+  def test_to_f
+    omit
+  end
+
+  def test_to_i
+    omit
+  end
+
+  def test_to_r
+    omit
+  end
+
+  def test_to_s
+    omit
+  end
+
+  def test_truncate
+    omit
   end
 end

--- a/test/stdlib/test_helper.rb
+++ b/test/stdlib/test_helper.rb
@@ -80,6 +80,43 @@ module WithStdlibAliases
   end
 end
 
+class Coercable < RBS::UnitTest::Convertibles::BlankSlate
+  class OpReturn < ::RBS::UnitTest::Convertibles::BlankSlate
+  end
+
+  class CoerceOther < ::RBS::UnitTest::Convertibles::BlankSlate
+    attr_reader :__value__
+    def initialize(value) = @__value__ = value
+  end
+
+  class CoerceSelf < ::RBS::UnitTest::Convertibles::BlankSlate
+    def initialize(method, &block)
+      ::Kernel.instance_method(:define_singleton_method).bind_call(self, method, &block)
+    end
+  end
+
+  def self.for_op(method, result: noresult = true, &block)
+    if block_given?
+      unless noresult
+        raise ArgumentError, "cannot provide both a block and a result"
+      end
+    else
+      block = proc { |other| noresult ? OpReturn.new : result }
+    end
+
+    new(CoerceSelf.new(method, &block)) { |x| CoerceOther.new(x) }
+  end
+
+  def initialize(self_ret, &converter)
+    @self_ret = self_ret
+    @converter = converter || ->(x) { x }
+  end
+
+  def coerce(rhs)
+    [@self_ret, @converter.(rhs)]
+  end
+end
+
 class Writer
   attr_reader :buffer
 


### PR DESCRIPTION
This PR cleans up the signatures for `Rational`. 