### PR TITLE
Add CI workflow to release gems via Trusted Publishing

### DIFF
--- a/.github/workflows/release-gems.yml
+++ b/.github/workflows/release-gems.yml
@@ -4,6 +4,10 @@ name: Release gems
 # manual release process (forgetting the `java` platform gem, version typos,
 # releasing from a dirty/local environment).
 #
+# On a real run it pushes both platform gems, pushes the `vX.Y.Z` tag, and
+# creates a draft GitHub Release (notes drawn from CHANGELOG.md) for a human
+# to review and publish.
+#
 # This workflow targets the active development line on `master`. Maintenance
 # releases (e.g. 4.0.x cut from `aaa-4.0.x`) are released by hand with
 # `rake release` and intentionally do NOT use this workflow.
@@ -122,3 +126,28 @@ jobs:
         run: |
           git tag "v${RBS_VERSION}"
           git push origin "v${RBS_VERSION}"
+
+      # Mirrors `rake release:note`: a draft release whose notes are the top
+      # CHANGELOG.md section plus a link to the wiki release note. Left as a
+      # draft so a human reviews and publishes it.
+      - name: Create a draft GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          notes_file="$(mktemp)"
+          ruby -e '
+            version = ENV.fetch("RBS_VERSION")
+            major, minor, * = version.split(".")
+            content = File.read("CHANGELOG.md", encoding: "UTF-8")
+            section = content.scan(/^## \d.*?(?=^## \d)/m)[0] or abort "Could not find a release section in CHANGELOG.md"
+            body = section.sub(/^.*\n^.*\n/, "").rstrip
+            puts "[Release note](https://github.com/ruby/rbs/wiki/Release-Note-#{major}.#{minor})"
+            puts
+            puts body
+          ' > "$notes_file"
+          args=(--draft --verify-tag --title "${RBS_VERSION}" --notes-file "$notes_file")
+          if ruby -e 'exit Gem::Version.new(ENV.fetch("RBS_VERSION")).prerelease? ? 0 : 1'; then
+            args+=(--prerelease)
+          fi
+          gh release create "v${RBS_VERSION}" "${args[@]}"

--- a/.github/workflows/release-gems.yml
+++ b/.github/workflows/release-gems.yml
@@ -1,0 +1,124 @@
+name: Release gems
+
+# Publishes the `rbs` gem to RubyGems.org from CI to avoid mistakes in the
+# manual release process (forgetting the `java` platform gem, version typos,
+# releasing from a dirty/local environment).
+#
+# This workflow targets the active development line on `master`. Maintenance
+# releases (e.g. 4.0.x cut from `aaa-4.0.x`) are released by hand with
+# `rake release` and intentionally do NOT use this workflow.
+#
+# Prerequisite (one-time, on RubyGems.org): configure a Trusted Publisher for
+# the `rbs` gem with owner `ruby`, repository `rbs`, and workflow filename
+# `release-gems.yml`. No long-lived API token is stored as a secret.
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_version:
+        description: "Version you intend to release. Must match lib/rbs/version.rb (e.g. 4.1.0 or 4.1.0.pre.3)."
+        required: true
+        type: string
+      dry_run:
+        description: "Build and verify only. Do not push gems to RubyGems or push the git tag."
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+# Keep in sync with .github/workflows/wasm.yml and .github/workflows/jruby.yml.
+env:
+  WASI_SDK_VERSION: "33"
+  WASI_SDK_RELEASE: "33.0"
+
+concurrency:
+  group: release-gems
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish (ruby + java)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the git tag
+      id-token: write # RubyGems trusted publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v6
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+          bundler: none
+      - name: Update rubygems & bundler
+        run: gem update --system
+      - name: Install gems
+        run: |
+          bundle config set --local without libs:profilers
+          bundle install --jobs 4 --retry 3
+
+      - name: Verify version matches the input
+        run: |
+          file_version="$(ruby -e 'require "./lib/rbs/version"; print RBS::VERSION')"
+          if [ "$file_version" != "${{ inputs.expected_version }}" ]; then
+            echo "::error::lib/rbs/version.rb is '$file_version' but you requested '${{ inputs.expected_version }}'. Aborting."
+            exit 1
+          fi
+          echo "Releasing RBS $file_version (dry_run=${{ inputs.dry_run }})"
+          echo "RBS_VERSION=$file_version" >> "$GITHUB_ENV"
+
+      - name: Ensure the tag does not already exist
+        run: |
+          if git rev-parse "v${RBS_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${RBS_VERSION} already exists. Aborting."
+            exit 1
+          fi
+
+      # Build both platform gems BEFORE pushing either, so a release is
+      # all-or-nothing rather than leaving one platform behind.
+      - name: Build the ruby platform gem (C extension)
+        run: gem build rbs.gemspec
+
+      - name: Install the WASI SDK
+        run: |
+          url="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_RELEASE}-x86_64-linux.tar.gz"
+          mkdir -p "$HOME/wasi-sdk"
+          curl -sSL "$url" | tar xz --strip-components=1 -C "$HOME/wasi-sdk"
+          echo "WASI_SDK_PATH=$HOME/wasi-sdk" >> "$GITHUB_ENV"
+      - name: Assemble the JRuby runtime (rbs_parser.wasm + Chicory jars)
+        run: bundle exec rake wasm:jruby_setup
+      - name: Build the java platform gem (JRuby)
+        run: RBS_PLATFORM=java gem build rbs.gemspec
+
+      - name: Show built gems
+        run: ls -l "rbs-${RBS_VERSION}.gem" "rbs-${RBS_VERSION}-java.gem"
+
+      - name: Upload built gems as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gems
+          path: |
+            rbs-${{ env.RBS_VERSION }}.gem
+            rbs-${{ env.RBS_VERSION }}-java.gem
+          if-no-files-found: error
+
+      - name: Configure RubyGems trusted publishing
+        if: ${{ !inputs.dry_run }}
+        uses: rubygems/configure-rubygems-credentials@main
+
+      - name: Push gems to RubyGems.org
+        if: ${{ !inputs.dry_run }}
+        run: |
+          for gem in "rbs-${RBS_VERSION}.gem" "rbs-${RBS_VERSION}-java.gem"; do
+            echo "Pushing $gem"
+            gem push "$gem"
+          done
+
+      - name: Create and push the git tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git tag "v${RBS_VERSION}"
+          git push origin "v${RBS_VERSION}"


### PR DESCRIPTION
## Why

The `rbs` gem currently ships **two** platform variants — the default `ruby` gem (C extension) and the `java`/JRuby gem (bundling the WebAssembly parser + Chicory jars). `rake release` only handles the former, so the `java` gem must be built and pushed by hand. That manual step (plus version typos and releasing from a local environment) is exactly where release mistakes happen.

This adds a CI release workflow so publishing is reproducible and hard to get wrong.

## What

New `.github/workflows/release-gems.yml`, triggered manually via **`workflow_dispatch`**:

- **Branch = version selection.** Run it against `master`; the version is read from `lib/rbs/version.rb` (single source of truth — no free-form version input to mistype).
- **`expected_version` input** — you type the version you intend to ship; CI **fails if it doesn't match** `lib/rbs/version.rb`. Guards against running on the wrong commit.
- **`dry_run` input (default `true`)** — builds and verifies both gems but does **not** push. Lets you rehearse safely; flip to `false` for the real release.
- **Builds both platform gems before pushing either**, so a release is all-or-nothing instead of leaving one platform behind.
- **Refuses to run if the `vX.Y.Z` tag already exists.**
- **Trusted Publishing (OIDC)** via `rubygems/configure-rubygems-credentials` — no long-lived RubyGems API token stored as a secret.
- On a real run, pushes both gems and then the `vX.Y.Z` git tag.

The name is `release-gems.yml` (plural) to leave room for a separate crates.io release workflow later.

## Scope: master only

Maintenance releases (e.g. 4.0.x cut from `aaa-4.0.x`) intentionally **stay manual** via `rake release`. They're infrequent, and keeping this workflow on `master` only avoids having to backport the workflow file to each maintenance branch (a `workflow_dispatch` run uses the workflow definition from the selected branch).

## ⚠️ One-time prerequisite before the first real run

Configure a **Trusted Publisher** for the `rbs` gem on RubyGems.org:

- RubyGem: `rbs`
- Owner: `ruby`
- Repository: `rbs`
- Workflow filename: `release-gems.yml`

Until that's set up, use `dry_run: true` (which never touches RubyGems).

## Notes / possible follow-ups

- The GitHub draft-release note generation (`rake release:note`, built from `CHANGELOG.md`) is **not** included here yet; it can be wired in as a follow-up if desired.
- WASI SDK version is pinned to match `wasm.yml` / `jruby.yml` (`33.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FerVMqvEagsGmDSRv7Ecz3)_