### PR TITLE
Pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/bundle-update.yml
+++ b/.github/workflows/bundle-update.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: '4.0'
 

--- a/.github/workflows/bundle-update.yml
+++ b/.github/workflows/bundle-update.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '4.0'
 

--- a/.github/workflows/c-check.yml
+++ b/.github/workflows/c-check.yml
@@ -14,8 +14,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0"
           bundler-cache: none

--- a/.github/workflows/c-check.yml
+++ b/.github/workflows/c-check.yml
@@ -14,8 +14,8 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "4.0"
           bundler-cache: none

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -13,8 +13,8 @@ jobs:
     # env:
     #   RUBY_COMMIT: v4.0.0-preview2
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "4.0.1"
           bundler: none

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -13,8 +13,8 @@ jobs:
     # env:
     #   RUBY_COMMIT: v4.0.0-preview2
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "4.0.6"
           bundler: none

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Abort if blocker files are changed

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Abort if blocker files are changed

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -31,13 +31,13 @@ jobs:
     name: jruby
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       # Build the .wasm and fetch the Chicory jars with CRuby + the WASI SDK,
       # then run RBS itself on JRuby against those artifacts.
       - name: Set up Ruby (to assemble the WebAssembly runtime)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -57,7 +57,7 @@ jobs:
         run: bundle exec rake wasm:jruby_setup
 
       - name: Set up JRuby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: jruby
           bundler: none

--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -33,13 +33,13 @@ jobs:
     name: jruby
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       # Build the .wasm and fetch the Chicory jars with CRuby + the WASI SDK,
       # then run RBS itself on JRuby against those artifacts.
       - name: Set up Ruby (to assemble the WebAssembly runtime)
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -59,7 +59,7 @@ jobs:
         run: bundle exec rake wasm:jruby_setup
 
       - name: Set up JRuby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: jruby
           bundler: none

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Extract RBS::Version
         id: version
@@ -30,7 +30,7 @@ jobs:
           echo "RBS::VERSION = $version (major=$major, minor=$minor, patch=$patch)"
 
       - name: Check milestone
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-gems.yml
+++ b/.github/workflows/release-gems.yml
@@ -70,7 +70,7 @@ jobs:
       # The gemspec takes its file list from `git ls-files`, so both gems are built
       # from the committed state -- of the dispatched commit, since that is what is
       # checked out. The full history is needed to tell which branches contain it.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.commit }}
           fetch-depth: 0
@@ -113,7 +113,7 @@ jobs:
           fi
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -174,7 +174,7 @@ jobs:
       # from Maven during the install -- and parse something with it, so the
       # WebAssembly runtime is exercised end to end before anything is published.
       - name: Set up JRuby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: jruby
           bundler: none
@@ -190,14 +190,14 @@ jobs:
           '
 
       - name: Switch back to CRuby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
 
       # Uploaded before publishing, so a failed push still leaves the gems behind.
       # This is also where a dry run ends.
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gems
           path: pkg/*.gem
@@ -218,8 +218,7 @@ jobs:
 
       - name: Configure RubyGems credentials
         if: ${{ !inputs.dry_run }}
-        # No floating major tag on this action, so the exact release is pinned.
-        uses: rubygems/configure-rubygems-credentials@v2.1.0
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
 
       - name: Push the gems
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,8 +40,8 @@ jobs:
     env:
       RANDOMIZE_STDLIB_TEST_ORDER: "true"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
@@ -90,11 +90,11 @@ jobs:
       matrix:
         ruby: ['4.0', head]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install dependencies
         run: |
           brew install ruby-build
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
@@ -127,11 +127,11 @@ jobs:
       matrix:
         ruby: ['4.0', head]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install dependencies
         run: |
           brew install ruby-build
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,8 +40,8 @@ jobs:
     env:
       RANDOMIZE_STDLIB_TEST_ORDER: "true"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
@@ -90,11 +90,11 @@ jobs:
       matrix:
         ruby: ['4.0', head]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install dependencies
         run: |
           brew install ruby-build
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none
@@ -127,11 +127,11 @@ jobs:
       matrix:
         ruby: ['4.0', head]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install dependencies
         run: |
           brew install ruby-build
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,10 +24,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -43,7 +43,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -62,14 +62,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up git identity
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -85,7 +85,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -104,14 +104,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up git identity
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -127,7 +127,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -145,10 +145,10 @@ jobs:
     name: cargo:lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -165,7 +165,7 @@ jobs:
           rustup update --no-self-update stable
           rustup default stable
           rustup component add --toolchain stable clippy rustfmt
-      - uses: actions/cache@v5
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,10 +26,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -45,7 +45,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -64,14 +64,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up git identity
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -87,7 +87,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -106,14 +106,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up git identity
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -129,7 +129,7 @@ jobs:
         run: |
           rustup update --no-self-update stable
           rustup default stable
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry
@@ -147,10 +147,10 @@ jobs:
     name: cargo:lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -167,7 +167,7 @@ jobs:
           rustup update --no-self-update stable
           rustup default stable
           rustup component add --toolchain stable clippy rustfmt
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -24,8 +24,8 @@ jobs:
       # TruffleRuby warns and falls back to US-ASCII unless the locale is UTF-8.
       LANG: "en_US.UTF-8"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -24,8 +24,8 @@ jobs:
       # TruffleRuby warns and falls back to US-ASCII unless the locale is UTF-8.
       LANG: "en_US.UTF-8"
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler: none

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "3.4"
           bundler: none

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v7
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: "4.0"
           bundler: none

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -26,10 +26,10 @@ jobs:
     name: wasm:check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ruby
           bundler: none
@@ -46,7 +46,7 @@ jobs:
           curl -sSL "$url" | tar xz --strip-components=1 -C "$HOME/wasi-sdk"
           echo "WASI_SDK_PATH=$HOME/wasi-sdk" >> "$GITHUB_ENV"
       - name: Install wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
+        uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
         with:
           version: ${{ env.WASMTIME_VERSION }}
       - name: Build and smoke-test the WebAssembly module

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,10 +28,10 @@ jobs:
     name: wasm:check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ruby
           bundler: none
@@ -48,7 +48,7 @@ jobs:
           curl -sSL "$url" | tar xz --strip-components=1 -C "$HOME/wasi-sdk"
           echo "WASI_SDK_PATH=$HOME/wasi-sdk" >> "$GITHUB_ENV"
       - name: Install wasmtime
-        uses: bytecodealliance/actions/wasmtime/setup@v1
+        uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
         with:
           version: ${{ env.WASMTIME_VERSION }}
       - name: Build and smoke-test the WebAssembly module

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         ruby: ['3.4', ucrt, mswin]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: load ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: ${{ matrix.ruby }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         ruby: ['4.0', ucrt, mswin]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: load ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: ${{ matrix.ruby }}
 


### PR DESCRIPTION
Run pinact to replace mutable tag references (e.g. actions/checkout@v7) with their corresponding full commit SHAs, keeping the version tag as a trailing comment. Pinning to immutable SHAs prevents a compromised or retagged action from silently changing behavior in CI.

Generated with: pinact run (pinact v4.1.0)

