### PR TITLE
Rename parameter in rbs_intern_type_name for clarity

### DIFF
--- a/ext/rbs_extension/ast_translation.c
+++ b/ext/rbs_extension/ast_translation.c
@@ -196,8 +196,8 @@ static VALUE rbs_intern_namespace(rbs_translation_context_t ctx, rbs_namespace_t
     return rb_funcallv(RBS_Namespace, intern_brackets(), 2, args);
 }
 
-static VALUE rbs_intern_type_name(VALUE namespace, VALUE name) {
-    VALUE args[2] = { namespace, name };
+static VALUE rbs_intern_type_name(VALUE type_namespace, VALUE name) {
+    VALUE args[2] = { type_namespace, name };
     return rb_funcallv(RBS_TypeName, intern_brackets(), 2, args);
 }
 


### PR DESCRIPTION
## Summary
Improved code clarity by renaming a parameter in the `rbs_intern_type_name` function to better reflect its purpose.

## Key Changes
- Renamed the `namespace` parameter to `type_namespace` in the `rbs_intern_type_name` function
- Updated the corresponding variable reference in the function body to maintain consistency

## Implementation Details
This change makes the parameter name more explicit and descriptive, distinguishing it from other namespace-related parameters in the codebase. The rename clarifies that this namespace specifically relates to type names, improving code readability and reducing potential confusion when working with multiple namespace types.

https://claude.ai/code/session_013PkLsC6iM8VJgTB3aCrcXh