### PR TITLE
Add a dependency on tempfile.

### DIFF
--- a/stdlib/tempfile/0/manifest.yaml
+++ b/stdlib/tempfile/0/manifest.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - name: delegate
+  - name: tmpdir


### PR DESCRIPTION
`tempfile` requires the following libraries, which means its methods conform to the specification.

* delegate
* tmpdir

https://github.com/ruby/tempfile/blob/a7a8d0883998d146feb72da71a242e7c0427cf59/lib/tempfile.rb#L8-L9