### PR TITLE
Fix nested declarations in rbs prototype rbi

### DIFF
--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -9,10 +9,14 @@ module RBS
       attr_reader :modules
       attr_reader :last_sig
 
+      Context = Struct.new(:singleton, :visibility, keyword_init: true)
+
       def initialize
         @decls = []
 
         @modules = []
+        @contexts = []
+        @emitted_visibility = {}
       end
 
       def parse(string)
@@ -20,19 +24,17 @@ module RBS
         process RubyVM::AbstractSyntaxTree.parse(string), comments: comments
       end
 
-      def nested_name(name)
-        (current_namespace + const_to_name(name).to_namespace).to_type_name.relative!
-      end
-
-      def current_namespace
-        modules.inject(Namespace.empty) do |parent, mod|
-          parent + mod.name.to_namespace
+      def append_decl(decl)
+        if current_module
+          current_module.members << decl
+        else
+          decls << decl
         end
       end
 
       def push_class(name, super_class, comment:)
         class_decl = AST::Declarations::Class.new(
-          name: nested_name(name),
+          name: const_to_name(name),
           super_class: super_class && AST::Declarations::Class::Super.new(name: const_to_name(super_class), args: [], location: nil),
           type_params: [],
           members: [],
@@ -41,17 +43,20 @@ module RBS
           comment: comment
         )
 
+        append_decl class_decl
         modules << class_decl
-        decls << class_decl
+        @contexts << Context.new(singleton: false, visibility: :public)
+        @emitted_visibility[class_decl.object_id] = :public
 
         yield
       ensure
+        @contexts.pop
         modules.pop
       end
 
       def push_module(name, comment:)
         module_decl = AST::Declarations::Module.new(
-          name: nested_name(name),
+          name: const_to_name(name),
           type_params: [],
           members: [],
           annotations: [],
@@ -60,11 +65,14 @@ module RBS
           comment: comment
         )
 
+        append_decl module_decl
         modules << module_decl
-        decls << module_decl
+        @contexts << Context.new(singleton: false, visibility: :public)
+        @emitted_visibility[module_decl.object_id] = :public
 
         yield
       ensure
+        @contexts.pop
         modules.pop
       end
 
@@ -74,6 +82,34 @@ module RBS
 
       def current_module!
         current_module or raise
+      end
+
+      def current_context
+        @contexts.last
+      end
+
+      def current_context!
+        current_context or raise
+      end
+
+      def sync_visibility(visibility)
+        # RBS has no protected visibility. Private is the conservative fallback.
+        visibility = :private if visibility == :protected
+
+        mod = current_module!
+        return if @emitted_visibility[mod.object_id] == visibility
+
+        member = case visibility
+                 when :public
+                   AST::Members::Public.new(location: nil)
+                 when :private
+                   AST::Members::Private.new(location: nil)
+                 else
+                   raise "Unexpected visibility: #{visibility}"
+                 end
+
+        mod.members << member
+        @emitted_visibility[mod.object_id] = visibility
       end
 
       def push_sig(node)
@@ -107,6 +143,15 @@ module RBS
           push_module node.children[0], comment: comment do
             process node.children[1], outer: outer + [node], comments: comments
           end
+        when :SCLASS
+          if node.children[0].type == :SELF
+            @contexts << Context.new(singleton: true, visibility: :public)
+            begin
+              process node.children[1], outer: outer + [node], comments: comments
+            ensure
+              @contexts.pop
+            end
+          end
         when :FCALL
           case node.children[0]
           when :include
@@ -125,9 +170,9 @@ module RBS
             end
           when :extend
             each_arg node.children[1] do |arg|
-              if arg.type == :CONST || arg.type == :COLON2
+              if arg.type == :CONST || arg.type == :COLON2 || arg.type == :COLON3
                 name = const_to_name(arg)
-                unless name.to_s == "T::Generic" || name.to_s == "T::Sig"
+                unless ["T::Generic", "T::Helpers", "T::Sig"].include?(name.to_s.delete_prefix("::"))
                   member = AST::Members::Extend.new(
                     name: name,
                     args: [],
@@ -142,6 +187,10 @@ module RBS
           when :sig
             out = outer.last or raise
             push_sig out.children.last.children.last
+          when :attr_reader, :attr_writer, :attr_accessor
+            process_attribute node, comments: comments
+          when :private, :protected, :public
+            process_visibility node, outer: outer, comments: comments
           when :alias_method
             new, old = each_arg(node.children[1]).map {|x| x.children[0] }
             current_module!.members << AST::Members::Alias.new(
@@ -149,14 +198,20 @@ module RBS
               old_name: old,
               location: nil,
               annotations: [],
-              kind: :instance,
+              kind: current_context!.singleton ? :singleton : :instance,
               comment: nil
             )
+          end
+        when :VCALL
+          case node.children[0]
+          when :private, :protected, :public
+            current_context!.visibility = node.children[0]
           end
         when :DEFS
           sigs = pop_sig
 
           if sigs
+            sync_visibility(:public)
             comment = join_comments(sigs, comments)
 
             args = node.children[2]
@@ -178,6 +233,8 @@ module RBS
           sigs = pop_sig
 
           if sigs
+            context = current_context!
+            sync_visibility(context.visibility)
             comment = join_comments(sigs, comments)
 
             args = node.children[1]
@@ -188,7 +245,7 @@ module RBS
               location: nil,
               annotations: [],
               overloads: types.map {|type| AST::Members::MethodDefinition::Overload.new(annotations: [], method_type: type) },
-              kind: :instance,
+              kind: context.singleton ? :singleton : :instance,
               comment: comment,
               overloading: false,
               visibility: nil
@@ -222,11 +279,7 @@ module RBS
             end
           else
             name = node.children[0].yield_self do |n|
-              if n.is_a?(Symbol)
-                TypeName.new(namespace: current_namespace, name: n)
-              else
-                const_to_name(n)
-              end
+              n.is_a?(Symbol) ? TypeName.new(namespace: Namespace.empty, name: n) : const_to_name(n)
             end
             value_node = node.children.last
             type = if value_node && value_node.type == :CALL && value_node.children[1] == :let
@@ -235,7 +288,7 @@ module RBS
                    else
                      Types::Bases::Any.new(location: nil)
                    end
-            decls << AST::Declarations::Constant.new(
+            append_decl AST::Declarations::Constant.new(
               name: name,
               type: type,
               location: nil,
@@ -244,18 +297,106 @@ module RBS
             )
           end
         when :ALIAS
+          sync_visibility(current_context!.visibility)
           current_module!.members << AST::Members::Alias.new(
             new_name: node.children[0].children[0],
             old_name: node.children[1].children[0],
             location: nil,
             annotations: [],
-            kind: :instance,
+            kind: current_context!.singleton ? :singleton : :instance,
             comment: nil
           )
         else
           each_child node do |child|
             process child, outer: outer + [node], comments: comments
           end
+        end
+      end
+
+      def process_visibility(node, outer:, comments:)
+        visibility = node.children[0]
+        args = each_arg(node.children[1]).to_a
+        context = current_context!
+
+        if args.empty?
+          context.visibility = visibility
+        else
+          previous_visibility = context.visibility
+          context.visibility = visibility
+
+          begin
+            args.each do |arg|
+              if arg.type == :DEFN || arg.type == :DEFS
+                process arg, outer: outer + [node], comments: comments
+              end
+            end
+          ensure
+            context.visibility = previous_visibility
+          end
+        end
+      end
+
+      def process_attribute(node, comments:)
+        sigs = pop_sig
+        kind = node.children[0]
+        context = current_context!
+        sync_visibility(context.visibility)
+
+        type = attribute_type(kind, sigs)
+        comment = join_comments(sigs, comments) if sigs
+        member_class = case kind
+                       when :attr_reader
+                         AST::Members::AttrReader
+                       when :attr_writer
+                         AST::Members::AttrWriter
+                       when :attr_accessor
+                         AST::Members::AttrAccessor
+                       else
+                         raise "Unexpected attribute kind: #{kind}"
+                       end
+
+        each_arg node.children[1] do |arg|
+          if name = symbol_literal_node?(arg)
+            current_module!.members << member_class.new(
+              name: name,
+              type: type,
+              ivar_name: nil,
+              kind: context.singleton ? :singleton : :instance,
+              annotations: [],
+              location: nil,
+              comment: comment,
+              visibility: nil
+            )
+          end
+        end
+      end
+
+      def attribute_type(kind, sigs)
+        any = Types::Bases::Any.new(location: nil)
+        return any unless sigs
+
+        method_types = sigs.filter_map do |sig|
+          method_type(nil, sig, variables: current_module!.type_params, overloads: sigs.size)
+        end
+        function = method_types.last&.type
+        return any unless function.is_a?(Types::Function)
+
+        parameter_type = function.required_positionals.first&.type
+        return_type = function.return_type
+
+        case kind
+        when :attr_reader
+          return_type
+        when :attr_writer
+          parameter_type || return_type
+        when :attr_accessor
+          if return_type.is_a?(Types::Bases::Any) || return_type.is_a?(Types::Bases::Void)
+            parameter_type || any
+          else
+            return_type
+          end
+        else
+          any
         end
       end
 
@@ -463,8 +604,10 @@ module RBS
         case
         when type.is_a?(Types::ClassInstance) && type.name.name == BuiltinNames::BasicObject.name.name
           Types::Bases::Any.new(location: nil)
-        when type.is_a?(Types::ClassInstance) && type.name.to_s == "T::Boolean"
+        when type.is_a?(Types::ClassInstance) && type.name.to_s.delete_prefix("::") == "T::Boolean"
           Types::Bases::Bool.new(location: nil)
+        when type.is_a?(Types::ClassInstance) && type.name.to_s.delete_prefix("::") == "T::Class"
+          Types::Bases::Any.new(location: nil)
         else
           type
         end
@@ -482,6 +625,11 @@ module RBS
           Types::ClassInstance.new(name: const_to_name(type_node), args: [], location: nil)
         when call_node?(type_node, name: :[], receiver: -> (_) { true })
           # The type_node represents a type application
+          receiver = type_node.children[0]
+          if [:CONST, :COLON2, :COLON3].include?(receiver.type) && const_to_name(receiver).to_s.delete_prefix("::") == "T::Class"
+            return Types::Bases::Any.new(location: nil)
+          end
+
           type = type_of(type_node.children[0], variables: variables)
           type.is_a?(Types::ClassInstance) or raise
 
@@ -559,7 +707,7 @@ module RBS
 
           type_name = TypeName.new(name: node.children[1], namespace: namespace)
 
-          case type_name.to_s
+          case type_name.to_s.delete_prefix("::")
           when "T::Array"
             BuiltinNames::Array.name
           when "T::Hash"

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -9,7 +9,15 @@ module RBS
       attr_reader :modules
       attr_reader :last_sig
 
-      Context = Struct.new(:singleton, :visibility, keyword_init: true)
+      class Context
+        attr_accessor :singleton
+        attr_accessor :visibility
+
+        def initialize(singleton:, visibility:)
+          @singleton = singleton
+          @visibility = visibility
+        end
+      end
 
       def initialize
         @decls = []
@@ -25,8 +33,8 @@ module RBS
       end
 
       def append_decl(decl)
-        if current_module
-          current_module.members << decl
+        if mod = current_module
+          mod.members << decl
         else
           decls << decl
         end

--- a/lib/rbs/prototype/rbi.rb
+++ b/lib/rbs/prototype/rbi.rb
@@ -100,7 +100,20 @@ module RBS
         current_context or raise
       end
 
+      # Visibility of a member, given as `private def ...` in RBS
+      #
+      # Returns `nil` for members in a visibility _section_, which `sync_visibility` emits instead.
+      def member_visibility(context)
+        # RBS visibility sections don't apply to singleton members, so they need their own visibility.
+        if context.singleton && context.visibility != :public
+          :private
+        end
+      end
+
       def sync_visibility(visibility)
+        # Visibility sections don't apply to singleton members in RBS.
+        return if current_context!.singleton
+
         # RBS has no protected visibility. Private is the conservative fallback.
         visibility = :private if visibility == :protected
 
@@ -219,7 +232,6 @@ module RBS
           sigs = pop_sig
 
           if sigs
-            sync_visibility(:public)
             comment = join_comments(sigs, comments)
 
             args = node.children[2]
@@ -256,7 +268,7 @@ module RBS
               kind: context.singleton ? :singleton : :instance,
               comment: comment,
               overloading: false,
-              visibility: nil
+              visibility: member_visibility(context)
             )
           end
 
@@ -373,7 +385,7 @@ module RBS
               annotations: [],
               location: nil,
               comment: comment,
-              visibility: nil
+              visibility: member_visibility(context)
             )
           end
         end

--- a/sig/prototype/rbi.rbs
+++ b/sig/prototype/rbi.rbs
@@ -2,7 +2,17 @@ module RBS
   module Prototype
     class RBI
       include Helpers
-      
+
+      type visibility = :private | :protected | :public
+
+      class Context
+        attr_accessor singleton: bool
+
+        attr_accessor visibility: visibility
+
+        def initialize: (singleton: bool, visibility: visibility) -> void
+      end
+
       attr_reader decls: Array[AST::Declarations::t]
 
       type module_decl = AST::Declarations::Class | AST::Declarations::Module
@@ -13,13 +23,15 @@ module RBS
       # Last subsequent `sig` calls
       attr_reader last_sig: Array[RubyVM::AbstractSyntaxTree::Node]?
 
+      @contexts: Array[Context]
+
+      @emitted_visibility: Hash[Integer, visibility]
+
       def initialize: () -> void
 
       def parse: (String) -> void
 
-      def nested_name: (RubyVM::AbstractSyntaxTree::Node name) -> TypeName
-
-      def current_namespace: () -> Namespace
+      def append_decl: (AST::Declarations::t decl) -> void
 
       def push_class: (
         RubyVM::AbstractSyntaxTree::Node name,
@@ -35,6 +47,12 @@ module RBS
       # The inner most module/class definition, raises on toplevel
       def current_module!: () -> module_decl
 
+      def current_context: () -> Context?
+
+      def current_context!: () -> Context
+
+      def sync_visibility: (visibility) -> void
+
       # Put a `sig` call to current list.
       def push_sig: (RubyVM::AbstractSyntaxTree::Node node) -> void
 
@@ -44,6 +62,12 @@ module RBS
       def join_comments: (Array[RubyVM::AbstractSyntaxTree::Node] nodes, Hash[Integer, AST::Comment] comments) -> AST::Comment
 
       def process: (RubyVM::AbstractSyntaxTree::Node node, comments: Hash[Integer, AST::Comment], ?outer: Array[RubyVM::AbstractSyntaxTree::Node]) -> void
+
+      def process_visibility: (RubyVM::AbstractSyntaxTree::Node node, outer: Array[RubyVM::AbstractSyntaxTree::Node], comments: Hash[Integer, AST::Comment]) -> void
+
+      def process_attribute: (RubyVM::AbstractSyntaxTree::Node node, comments: Hash[Integer, AST::Comment]) -> void
+
+      def attribute_type: (:attr_reader | :attr_writer | :attr_accessor kind, Array[RubyVM::AbstractSyntaxTree::Node]? sigs) -> Types::t
 
       def method_type: (RubyVM::AbstractSyntaxTree::Node? args_node, RubyVM::AbstractSyntaxTree::Node? type_node, variables: Array[AST::TypeParam], overloads: Integer) -> MethodType?
 

--- a/sig/prototype/rbi.rbs
+++ b/sig/prototype/rbi.rbs
@@ -51,6 +51,11 @@ module RBS
 
       def current_context!: () -> Context
 
+      # Visibility of a member, given as `private def ...` in RBS
+      #
+      # Returns `nil` for members in a visibility _section_, which `sync_visibility` emits instead.
+      def member_visibility: (Context) -> AST::Members::visibility?
+
       def sync_visibility: (visibility) -> void
 
       # Put a `sig` call to current list.

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -70,9 +70,8 @@ end
 
     assert_write parser.decls, <<-EOF
 module Foo
-end
-
-module Foo::Bar
+  module Bar
+  end
 end
     EOF
   end
@@ -91,9 +90,8 @@ end
 
     assert_write parser.decls, <<-EOF
 module Foo
-end
-
-module Bar
+  module ::Bar
+  end
 end
     EOF
   end
@@ -112,11 +110,10 @@ end
 
     assert_write parser.decls, <<-EOF
 module Foo
+  ABBR_DAYNAMES: Array
+
+  ABBR_MONTHNAMES: Integer
 end
-
-Foo::ABBR_DAYNAMES: Array
-
-Foo::ABBR_MONTHNAMES: Integer
     EOF
   end
 
@@ -550,6 +547,251 @@ end
     EOF
   end
 
+  def test_nested_declarations_preserve_lexical_resolution
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Demo
+  class Parent; end
+  module Helpers; end
+  class Value; end
+
+  class Child < Parent
+    include Helpers
+
+    sig { params(value: Value).returns(Value) }
+    def convert(value); end
+  end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+module Demo
+  class Parent
+  end
+
+  module Helpers
+  end
+
+  class Value
+  end
+
+  class Child < Parent
+    include Helpers
+
+    def convert: (Value value) -> Value
+  end
+end
+    EOF
+  end
+
+  def test_nested_constant
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Demo
+  module Modes
+    VALUE = T.let(:value, Symbol)
+  end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+module Demo
+  module Modes
+    VALUE: Symbol
+  end
+end
+    EOF
+  end
+
+  def test_ignores_t_helpers
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Factory
+  extend T::Helpers
+  extend OtherHelpers
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+module Factory
+  extend OtherHelpers
+end
+    EOF
+  end
+
+  def test_t_class_falls_back_to_untyped
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Factory
+  sig do
+    type_parameters(:Config)
+      .params(config_class: T::Class[T.type_parameter(:Config)])
+      .returns(T.type_parameter(:Config))
+  end
+  def make(config_class); end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+module Factory
+  def make: [Config] (untyped config_class) -> Config
+end
+    EOF
+  end
+
+  def test_singleton_class_method
+    parser = RBI.new
+
+    parser.parse <<-EOF
+class Registry
+  class << self
+    sig { returns(T.attached_class) }
+    def build; end
+  end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Registry
+  def self.build: () -> instance
+end
+    EOF
+  end
+
+  def test_typed_attribute_consumes_signature
+    parser = RBI.new
+
+    parser.parse <<-EOF
+class Cache
+  sig { returns(T.nilable(Integer)) }
+  attr_reader :size
+
+  sig { returns(String) }
+  attr_accessor :name
+
+  sig { params(value: Integer).void }
+  attr_writer :count
+
+  sig { params(size: T.nilable(Integer)).void }
+  def initialize(size: nil); end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Cache
+  attr_reader size: Integer?
+
+  attr_accessor name: String
+
+  attr_writer count: Integer
+
+  def initialize: (?size: Integer? size) -> void
+end
+    EOF
+  end
+
+  def test_method_visibility
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Factory
+  private
+
+  sig { void }
+  def helper; end
+
+  public
+
+  sig { void }
+  def make; end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+module Factory
+  private
+
+  def helper: () -> void
+
+  public
+
+  def make: () -> void
+end
+    EOF
+  end
+
+  def test_generated_reproduction_can_be_loaded
+    parser = RBI.new
+
+    parser.parse <<-EOF
+module Demo
+  class Parent; end
+  module Helpers; end
+
+  class Child < Parent
+    include Helpers
+  end
+
+  module Modes
+    VALUE = T.let(:value, Symbol)
+  end
+
+  class Registry
+    class << self
+      sig { returns(T.attached_class) }
+      def build; end
+    end
+  end
+
+  class Cache
+    sig { returns(T.nilable(Integer)) }
+    attr_reader :size
+
+    sig { params(size: T.nilable(Integer)).void }
+    def initialize(size: nil); end
+  end
+
+  module Factory
+    extend T::Helpers
+
+    sig do
+      type_parameters(:Config)
+        .params(config_class: T::Class[T.type_parameter(:Config)])
+        .returns(T.type_parameter(:Config))
+    end
+    def make(config_class); end
+
+    private
+
+    sig { void }
+    def helper; end
+  end
+end
+    EOF
+
+    out = StringIO.new
+    RBS::Writer.new(out: out).write(parser.decls)
+    refute_match(/\bT::/, out.string)
+
+    SignatureManager.new do |manager|
+      manager.add_file("repro.rbs", out.string)
+      manager.build do |env|
+        builder = RBS::DefinitionBuilder.new(env: env)
+
+        ["::Demo::Child", "::Demo::Registry", "::Demo::Cache", "::Demo::Factory"].each do |name|
+          builder.build_instance(type_name(name))
+          builder.build_singleton(type_name(name))
+        end
+
+        assert_include env.constant_decls.keys, type_name("::Demo::Modes::VALUE")
+      end
+    end
+  end
+
   def test_masgn
     parser = RBI.new
 
@@ -561,13 +803,12 @@ end
 
     assert_write parser.decls, <<-EOF
 class Test
+  A: untyped
+
+  B: untyped
+
+  C: untyped
 end
-
-Test::A: untyped
-
-Test::B: untyped
-
-Test::C: untyped
     EOF
   end
 end

--- a/test/rbs/rbi_prototype_test.rb
+++ b/test/rbs/rbi_prototype_test.rb
@@ -724,6 +724,51 @@ end
     EOF
   end
 
+  def test_singleton_method_visibility
+    parser = RBI.new
+
+    parser.parse <<-EOF
+class Registry
+  private
+
+  sig { void }
+  def helper; end
+
+  sig { void }
+  def self.build; end
+
+  sig { void }
+  def setup; end
+
+  class << self
+    private
+
+    sig { void }
+    def internal; end
+
+    sig { returns(Integer) }
+    attr_reader :count
+  end
+end
+    EOF
+
+    assert_write parser.decls, <<-EOF
+class Registry
+  private
+
+  def helper: () -> void
+
+  def self.build: () -> void
+
+  def setup: () -> void
+
+  private def self.internal: () -> void
+
+  private attr_reader self.count: Integer
+end
+    EOF
+  end
+
   def test_generated_reproduction_can_be_loaded
     parser = RBI.new
 


### PR DESCRIPTION
## Summary

Fix `rbs prototype rbi` so nested Sorbet RBI declarations produce valid, semantically accurate RBS.

The converter previously flattened every class and module into a top-level declaration while leaving relative references unchanged. For example:

```ruby
module Demo
  class Parent; end
  class Child < Parent; end
end
```

was emitted as `class Demo::Child < Parent`, where `Parent` no longer resolves relative to `Demo`. The same problem affected mixins and types in method signatures.

This PR preserves the RBI's lexical declaration nesting using the existing nested-declaration representation in the RBS AST. It also fixes the related conversion bugs found in the same reproduction.

## Changes

- Preserve nested class and module declarations instead of flattening them.
  - Relative superclasses, mixins, and signature types retain their lexical resolution context.
  - Absolute and explicitly qualified declaration names remain intact.
- Emit nested constant declarations in their containing declaration.
  - This prevents duplicated paths such as `Demo::Demo::Modes::VALUE`.
- Ignore the Sorbet-only `T::Helpers` extension, alongside `T::Sig` and `T::Generic`.
- Convert `T::Class[...]` to `untyped`.
  - RBS has no exact generic equivalent for an arbitrary class object whose instances have the specified type.
  - Falling back avoids emitting an unresolved `T::Class` while not inventing an unsupported structural constraint.
- Track `class << self` context so contained definitions become singleton methods.
- Convert `attr_reader`, `attr_writer`, and `attr_accessor`, consuming their pending `sig`.
  - This prevents an attribute signature from becoming an overload on the following method.
- Track declaration visibility and emit `private`/`public` transitions.
  - RBS does not model `protected`, so it uses the conservative `private` fallback.

## Compatibility

This only changes RBI-to-RBS prototype conversion. It does not change the RBS language, parser, validator, or the meaning of existing `.rbs` files.

`RBS::Prototype::RBI#decls` now returns a nested AST for nested RBI declarations instead of a flattened list. For an empty declaration such as `module Foo; module Bar; end; end`, both forms define the same RBS constants, but callers that inspect the AST structure directly will observe the corrected shape. For declarations containing relative references, retaining that nesting is required for semantic correctness.

## Tests

Regression tests cover each behavior independently and load the complete reported reproduction into an RBS environment, building its instance and singleton definitions.

```text
bundle exec rake test TEST=test/rbs/rbi_prototype_test.rb
33 tests, 33 assertions, 0 failures, 0 errors

bundle exec rubocop lib/rbs/prototype/rbi.rb test/rbs/rbi_prototype_test.rb
2 files inspected, no offenses detected
```
