### PR TITLE
Guard against underflow when sysconf(_SC_PAGESIZE) returns 0

### DIFF
--- a/src/util/rbs_allocator.c
+++ b/src/util/rbs_allocator.c
@@ -39,15 +39,24 @@ typedef struct rbs_allocator_page {
     size_t used;
 } rbs_allocator_page_t;
 
+// Normalize a raw page size to a safe value for payload_size subtraction.
+// Falls back to 4096 when the raw value is <= 0 or smaller than the page
+// header struct, preventing underflow in rbs_allocator_init.
+// Internal API, intentionally omitted from the public header.
+size_t rbs_allocator_normalize_page_size(long raw) {
+    if (raw <= 0) return 4096;
+    size_t page_size = (size_t) raw;
+    if (page_size <= sizeof(rbs_allocator_page_t)) return 4096;
+    return page_size;
+}
+
 static size_t get_system_page_size(void) {
 #ifdef _WIN32
     SYSTEM_INFO si;
     GetSystemInfo(&si);
-    return si.dwPageSize;
+    return rbs_allocator_normalize_page_size((long) si.dwPageSize);
 #else
-    long sz = sysconf(_SC_PAGESIZE);
-    if (sz == -1) return 4096; // Fallback to the common 4KB page size
-    return (size_t) sz;
+    return rbs_allocator_normalize_page_size(sysconf(_SC_PAGESIZE));
 #endif
 }
 

--- a/wasm/rbs_wasm.c
+++ b/wasm/rbs_wasm.c
@@ -399,7 +399,19 @@ __attribute__((export_name("rbs_wasm_lex"))) int rbs_wasm_lex(const char *source
  *
  * @return 1 if the sample parsed successfully, 0 otherwise.
  */
+// Internal: defined in rbs_allocator.c, not declared in the public header.
+extern size_t rbs_allocator_normalize_page_size(long raw);
+
 __attribute__((export_name("rbs_wasm_selftest"))) int rbs_wasm_selftest(void) {
+    // Regression test: normalize_page_size must return a safe value
+    // (>= sizeof(rbs_allocator_page_t)) for inputs that would underflow
+    // payload_size. On WASI in a Rust cdylib, sysconf(_SC_PAGESIZE)
+    // returns 0; the normalization must catch that.
+    if (rbs_allocator_normalize_page_size(-1) != 4096) return 0;
+    if (rbs_allocator_normalize_page_size(0) != 4096) return 0;
+    if (rbs_allocator_normalize_page_size(1) != 4096) return 0;
+    if (rbs_allocator_normalize_page_size(65536) != 65536) return 0;
+
     static const char source[] =
         "class User\n"
         "  attr_reader name: String\n"


### PR DESCRIPTION
## Problem

On WASI in a Rust-linked wasm32 module, `sysconf(_SC_PAGESIZE)` returns **0** instead of -1. The existing fallback only checked for -1, so a 0 result flowed through to `rbs_allocator_init` where:

```c
allocator->default_page_payload_size = system_page_size - sizeof(rbs_allocator_page_t);
```

This underflowed to near `SIZE_MAX` (unsigned wraparound: `0 - 12 = 0xFFFFFFF4`). The subsequent `malloc(sizeof(header) + 0xFFFFFFF4)` wrapped to `malloc(0)`, allocating a zero-byte arena page. Arena sub-allocations overflowed into adjacent heap memory, corrupting the lexer's `string.start`/`string.end` pointers and causing parse failures.

The resulting corruption is memory-layout-dependent; in the Rust-linked cdylib it manifested when the constant pool's allocation overlapped the undersized arena page.

## Fix

Extract `rbs_allocator_normalize_page_size(long)` which falls back to 4096 when the raw value is `<= 0` or smaller than `sizeof(rbs_allocator_page_t)`. `get_system_page_size` routes through it on both POSIX and Windows paths.

## Regression test

The existing `rbs_wasm_selftest` (run via `rake wasm:check`) now calls `rbs_allocator_normalize_page_size` with synthetic inputs `-1`, `0`, `1`, and `65536`, verifying both fallback and pass-through paths.

**Mutation-verified** (`rake wasm:check`):
- ✅ **Green** (patched): `WebAssembly selftest passed.`
- ❌ **Red** (both guards removed → identity function): `WebAssembly selftest failed: rbs_wasm_selftest returned "0" (expected "1")` + `rake aborted!`
- ✅ **Green** (restored): `WebAssembly selftest passed.`

## Scope

- Upstream's standalone reactor build returns 65536 from `sysconf`, so the bug does not reproduce there. The fix is defensive and preserves behavior on all platforms with a valid page size.
- The bug was discovered and verified in a Rust cdylib linking the RBS C extension for `wasm32-wasip1` (Rubydex playground).