### PR TITLE
ci: fix the stuck merge queue, and run every CI workflow in it

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -17,6 +17,8 @@ on:
       - "test/**"
       - "Rakefile"
       - "rbs.gemspec"
+  # `merge_group` has no `paths` filter, so this runs on every queue entry.
+  merge_group: {}
 
 permissions:
   contents: read

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -3,6 +3,7 @@ name: Check milestone
 on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, milestoned, demilestoned, synchronize]
+  merge_group: {}
 
 permissions:
   contents: read
@@ -12,10 +13,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # The milestone is a property of the pull request, so there is nothing to
+      # check once it enters the merge queue. This job still has to run there
+      # because `check` is a required status check -- it just reports success
+      # without doing anything.
       - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
 
       - name: Extract RBS::Version
         id: version
+        if: github.event_name == 'pull_request'
         run: |
           # Extract version string from lib/rbs/version.rb
           version=$(ruby -e 'load "lib/rbs/version.rb"; print RBS::VERSION')
@@ -30,6 +37,7 @@ jobs:
           echo "RBS::VERSION = $version (major=$major, minor=$minor, patch=$patch)"
 
       - name: Check milestone
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - ".github/workflows/rust.yml"
       - "rust/**"
+  # `merge_group` has no `paths` filter, so this runs on every queue entry.
+  merge_group: {}
 
 env:
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -11,6 +11,8 @@ on:
       - "include/**"
       - "src/**"
       - "wasm/**"
+  # `merge_group` has no `paths` filter, so this runs on every queue entry.
+  merge_group: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

The merge queue is stuck: entries wait forever on `check` with *"Expected — Waiting for status to be reported"*.

`check` is the job of `.github/workflows/milestone.yml`, which triggered only on `pull_request`. Required status checks must also be reported for the queue's merge commit, so the check was never produced.

## Fix

- **`milestone.yml`**: add `merge_group: {}`, and guard the steps with `if: github.event_name == 'pull_request'`. A milestone is a property of the PR, so there is nothing to check in the queue — the job just reports success. (Guarding steps instead of the job gives an explicit `success` rather than `skipped`.)
- **`jruby.yml`, `wasm.yml`, `rust.yml`**: add `merge_group: {}` so they run against the merged result too. They are not required checks yet, but can be made so now.

Note: `merge_group` has no `paths` filter, so these three lose their path filtering in the queue and will run on every entry.