### PR TITLE
Declare Singleton::SingletonInstanceMethods

### DIFF
--- a/stdlib/singleton/0/singleton.rbs
+++ b/stdlib/singleton/0/singleton.rbs
@@ -124,6 +124,9 @@ module Singleton
   #
   def dup: () -> bot
 
+  module SingletonInstanceMethods
+  end
+
   module SingletonClassMethods
   end
 end

--- a/test/stdlib/singleton_test.rb
+++ b/test/stdlib/singleton_test.rb
@@ -15,4 +15,10 @@ class SingletonSingletonTest < Test::Unit::TestCase
     assert_send_type  '() -> SingletonSingletonTest::TestClass',
                       TestClass, :instance
   end
+
+  def test_singleton_instance_methods
+    omit "SingletonInstanceMethods is not available" unless Singleton.const_defined?(:SingletonInstanceMethods, false)
+
+    assert_const_type "Module", "Singleton::SingletonInstanceMethods"
+  end
 end


### PR DESCRIPTION
## Summary

Declare the internal `Singleton::SingletonInstanceMethods` module in the `singleton` stdlib signatures.

Ruby 3.4 and later expose this module as part of `Singleton`'s implementation. Reflection-based signature generators can therefore produce declarations such as:

```rbs
class Registry
  include Singleton::SingletonInstanceMethods
end
```

RBS currently treats this as an unknown mixin because only the related `Singleton::SingletonClassMethods` name is declared.

The new declaration is intentionally empty. Its methods are already represented directly on `Singleton`; registering the name prevents mechanically generated signatures from failing validation. This matches the existing treatment of `SingletonClassMethods`, added in #978.

## Tests

```text
2 tests, 9 assertions, 0 failures, 0 errors
```

The `singleton` library signatures also pass `rbs validate`.
