### PR TITLE
Fix template drift for ext/rbs_extension/ast_translation.c

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.0)
+    rbs (4.1.1.pre)
       logger
       prism (>= 1.6.0)
       tsort

--- a/Rakefile
+++ b/Rakefile
@@ -55,8 +55,15 @@ task :confirm_lexer => :lexer do
 end
 
 task :confirm_templates => :templates do
-  puts "Testing if generated code under include and src is updated with respect to templates"
-  sh "git diff --exit-code -- include src"
+  puts "Testing if generated code is updated with respect to templates"
+
+  # Every template generates the file it is named after: `templates/<path>.erb` generates `<path>`.
+  generated = Dir.glob("templates/**/*.erb").sort.map { _1.delete_prefix("templates/").delete_suffix(".erb") }
+
+  missing = generated.reject { File.exist?(_1) }
+  raise "Templates without a generated file: #{missing.join(", ")}. Is the `templates` task missing an entry?" unless missing.empty?
+
+  sh "git diff --exit-code -- #{generated.join(" ")}"
 end
 
 # Task to format C code using clang-format
@@ -145,6 +152,9 @@ rule %r{^src/(.*)\.c} => 'templates/%X.c.erb' do |t|
   puts "⚠️⚠️⚠️ #{t.name} is older than #{t.source}. You may need to run `rake templates` ⚠️⚠️⚠️"
 end
 rule %r{^include/(.*)\.c} => 'templates/%X.c.erb' do |t|
+  puts "⚠️⚠️⚠️ #{t.name} is older than #{t.source}. You may need to run `rake templates` ⚠️⚠️⚠️"
+end
+rule %r{^ext/(.*)\.c} => 'templates/%X.c.erb' do |t|
   puts "⚠️⚠️⚠️ #{t.name} is older than #{t.source}. You may need to run `rake templates` ⚠️⚠️⚠️"
 end
 

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.0"
+  VERSION = "4.1.1.pre"
 end

--- a/templates/ext/rbs_extension/ast_translation.c.erb
+++ b/templates/ext/rbs_extension/ast_translation.c.erb
@@ -133,8 +133,8 @@ static VALUE rbs_intern_namespace(rbs_translation_context_t ctx, rbs_namespace_t
     return rb_funcallv(RBS_Namespace, intern_brackets(), 2, args);
 }
 
-static VALUE rbs_intern_type_name(VALUE namespace, VALUE name) {
-    VALUE args[2] = { namespace, name };
+static VALUE rbs_intern_type_name(VALUE type_namespace, VALUE name) {
+    VALUE args[2] = { type_namespace, name };
     return rb_funcallv(RBS_TypeName, intern_brackets(), 2, args);
 }
 


### PR DESCRIPTION
`rake templates` reverted the `namespace` → `type_namespace` rename from 0af1d497, which only edited the generated `ext/rbs_extension/ast_translation.c` and not the template it comes from. `namespace` is a C++ keyword and breaks the `C99_compile` job, so apply the rename to the template too.

CI missed it because `confirm_templates` only diffed `include` and `src`. Every template generates the file it is named after, so derive the paths to check from `templates/**/*.erb` instead of naming directories — that covers `ext` and `lib/rbs/wasm/serialization_schema.rb`, and it cannot fall behind when a template is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)