### PR TITLE
Support forwarding parameters in method types

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -598,6 +598,9 @@ nodes:
       - name: rest_keywords
         c_type: rbs_node
         optional: true  # NULL when no double-splat (e.g., `() -> void` vs `(**String) -> void`)
+      - name: forwarding
+        c_type: rbs_node
+        optional: true  # NULL when no forwarding parameter (e.g., `() -> void` vs `(...) -> void`)
       - name: return_type
         c_type: rbs_node
   - name: RBS::Types::Function::Param
@@ -610,6 +613,8 @@ nodes:
         optional: true  # NULL when param is unnamed (e.g., `(String) -> void` vs `(String name) -> void`)
     locations:
       - optional: name
+  - name: RBS::Types::Function::ForwardingParam
+    rust_name: FunctionForwardingParamNode
   - name: RBS::Types::Interface
     rust_name: InterfaceTypeNode
     fields:

--- a/ext/rbs_extension/ast_translation.c
+++ b/ext/rbs_extension/ast_translation.c
@@ -1636,6 +1636,7 @@ VALUE rbs_struct_to_ruby_value(rbs_translation_context_t ctx, rbs_node_t *instan
         VALUE arg_required_keywords = rbs_hash_to_ruby_hash(ctx, node->required_keywords);
         VALUE arg_optional_keywords = rbs_hash_to_ruby_hash(ctx, node->optional_keywords);
         VALUE arg_rest_keywords = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) node->rest_keywords); // rbs_node
+        VALUE arg_forwarding = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) node->forwarding);       // rbs_node
         VALUE arg_return_type = rbs_struct_to_ruby_value(ctx, (rbs_node_t *) node->return_type);     // rbs_node
 
         // Claim the shared kwargs hash, clear it, fill it, and hand it to `.new`.
@@ -1649,8 +1650,22 @@ VALUE rbs_struct_to_ruby_value(rbs_translation_context_t ctx, rbs_node_t *instan
         rb_hash_aset(h, ID2SYM(rb_intern("required_keywords")), arg_required_keywords);
         rb_hash_aset(h, ID2SYM(rb_intern("optional_keywords")), arg_optional_keywords);
         rb_hash_aset(h, ID2SYM(rb_intern("rest_keywords")), arg_rest_keywords);
+        rb_hash_aset(h, ID2SYM(rb_intern("forwarding")), arg_forwarding);
         rb_hash_aset(h, ID2SYM(rb_intern("return_type")), arg_return_type);
         return CLASS_NEW_INSTANCE(RBS_Types_Function, 1, &h);
+    }
+    case RBS_TYPES_FUNCTION_FORWARDING_PARAM: {
+        rbs_types_function_forwarding_param_t *node = (rbs_types_function_forwarding_param_t *) instance;
+
+        // Compute child VALUEs into locals variables first, before any recursion into `rbs_struct_to_ruby_value()`.
+        VALUE arg_location = rbs_location_range_to_ruby_location(ctx, node->base.location);
+
+        // Claim the shared kwargs hash, clear it, fill it, and hand it to `.new`.
+        // Must not recurse between `rb_hash_clear()` and `CLASS_NEW_INSTANCE()`.
+        VALUE h = ctx.reusable_kwargs_hash;
+        rb_hash_clear(h);
+        rb_hash_aset(h, ID2SYM(rb_intern("location")), arg_location);
+        return CLASS_NEW_INSTANCE(RBS_Types_Function_ForwardingParam, 1, &h);
     }
     case RBS_TYPES_FUNCTION_PARAM: {
         rbs_types_function_param_t *node = (rbs_types_function_param_t *) instance;

--- a/ext/rbs_extension/class_constants.c
+++ b/ext/rbs_extension/class_constants.c
@@ -79,6 +79,7 @@ VALUE RBS_Types_Block;
 VALUE RBS_Types_ClassInstance;
 VALUE RBS_Types_ClassSingleton;
 VALUE RBS_Types_Function;
+VALUE RBS_Types_Function_ForwardingParam;
 VALUE RBS_Types_Function_Param;
 VALUE RBS_Types_Interface;
 VALUE RBS_Types_Intersection;
@@ -173,6 +174,7 @@ void rbs__init_constants(void) {
     IMPORT_CONSTANT(RBS_Types_ClassInstance, RBS_Types, "ClassInstance");
     IMPORT_CONSTANT(RBS_Types_ClassSingleton, RBS_Types, "ClassSingleton");
     IMPORT_CONSTANT(RBS_Types_Function, RBS_Types, "Function");
+    IMPORT_CONSTANT(RBS_Types_Function_ForwardingParam, RBS_Types_Function, "ForwardingParam");
     IMPORT_CONSTANT(RBS_Types_Function_Param, RBS_Types_Function, "Param");
     IMPORT_CONSTANT(RBS_Types_Interface, RBS_Types, "Interface");
     IMPORT_CONSTANT(RBS_Types_Intersection, RBS_Types, "Intersection");

--- a/ext/rbs_extension/class_constants.h
+++ b/ext/rbs_extension/class_constants.h
@@ -87,6 +87,7 @@ extern VALUE RBS_Types_Block;
 extern VALUE RBS_Types_ClassInstance;
 extern VALUE RBS_Types_ClassSingleton;
 extern VALUE RBS_Types_Function;
+extern VALUE RBS_Types_Function_ForwardingParam;
 extern VALUE RBS_Types_Function_Param;
 extern VALUE RBS_Types_Interface;
 extern VALUE RBS_Types_Intersection;

--- a/include/rbs/ast.h
+++ b/include/rbs/ast.h
@@ -125,18 +125,19 @@ enum rbs_node_type {
     RBS_TYPES_CLASS_INSTANCE = 63,
     RBS_TYPES_CLASS_SINGLETON = 64,
     RBS_TYPES_FUNCTION = 65,
-    RBS_TYPES_FUNCTION_PARAM = 66,
-    RBS_TYPES_INTERFACE = 67,
-    RBS_TYPES_INTERSECTION = 68,
-    RBS_TYPES_LITERAL = 69,
-    RBS_TYPES_OPTIONAL = 70,
-    RBS_TYPES_PROC = 71,
-    RBS_TYPES_RECORD = 72,
-    RBS_TYPES_RECORD_FIELD_TYPE = 73,
-    RBS_TYPES_TUPLE = 74,
-    RBS_TYPES_UNION = 75,
-    RBS_TYPES_UNTYPED_FUNCTION = 76,
-    RBS_TYPES_VARIABLE = 77,
+    RBS_TYPES_FUNCTION_FORWARDING_PARAM = 66,
+    RBS_TYPES_FUNCTION_PARAM = 67,
+    RBS_TYPES_INTERFACE = 68,
+    RBS_TYPES_INTERSECTION = 69,
+    RBS_TYPES_LITERAL = 70,
+    RBS_TYPES_OPTIONAL = 71,
+    RBS_TYPES_PROC = 72,
+    RBS_TYPES_RECORD = 73,
+    RBS_TYPES_RECORD_FIELD_TYPE = 74,
+    RBS_TYPES_TUPLE = 75,
+    RBS_TYPES_UNION = 76,
+    RBS_TYPES_UNTYPED_FUNCTION = 77,
+    RBS_TYPES_VARIABLE = 78,
     RBS_AST_SYMBOL,
 };
 
@@ -854,8 +855,14 @@ typedef struct rbs_types_function {
     struct rbs_hash *RBS_NONNULL required_keywords;
     struct rbs_hash *RBS_NONNULL optional_keywords;
     struct rbs_node *RBS_NULLABLE rest_keywords;
+    struct rbs_node *RBS_NULLABLE forwarding;
     struct rbs_node *RBS_NONNULL return_type;
 } rbs_types_function_t;
+
+typedef struct rbs_types_function_forwarding_param {
+    rbs_node_t base;
+
+} rbs_types_function_forwarding_param_t;
 
 typedef struct rbs_types_function_param {
     rbs_node_t base;
@@ -1030,7 +1037,8 @@ rbs_types_bases_void_t *RBS_NONNULL rbs_types_bases_void_new(rbs_allocator_t *RB
 rbs_types_block_t *RBS_NONNULL rbs_types_block_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required, rbs_node_t *RBS_NULLABLE self_type);
 rbs_types_class_instance_t *RBS_NONNULL rbs_types_class_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
 rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
-rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NONNULL return_type);
+rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NULLABLE forwarding, rbs_node_t *RBS_NONNULL return_type);
+rbs_types_function_forwarding_param_t *RBS_NONNULL rbs_types_function_forwarding_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location);
 rbs_types_function_param_t *RBS_NONNULL rbs_types_function_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_ast_symbol_t *RBS_NULLABLE name);
 rbs_types_interface_t *RBS_NONNULL rbs_types_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range);
 rbs_types_intersection_t *RBS_NONNULL rbs_types_intersection_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types);

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -959,6 +959,33 @@ module RBS
         end
       end
 
+      class ForwardingParam
+        attr_reader :location
+
+        def initialize(location:)
+          @location = location
+        end
+
+        def ==(other)
+          other.is_a?(ForwardingParam)
+        end
+
+        alias eql? ==
+
+        def hash
+          self.class.hash
+        end
+
+        def to_json(state = nil)
+          json = {} #: Hash[Symbol, untyped]
+          json.to_json(state)
+        end
+
+        def to_s
+          "..."
+        end
+      end
+
       attr_reader :required_positionals
       attr_reader :optional_positionals
       attr_reader :rest_positionals
@@ -966,9 +993,10 @@ module RBS
       attr_reader :required_keywords
       attr_reader :optional_keywords
       attr_reader :rest_keywords
+      attr_reader :forwarding
       attr_reader :return_type
 
-      def initialize(required_positionals:, optional_positionals:, rest_positionals:, trailing_positionals:, required_keywords:, optional_keywords:, rest_keywords:, return_type:)
+      def initialize(required_positionals:, optional_positionals:, rest_positionals:, trailing_positionals:, required_keywords:, optional_keywords:, rest_keywords:, return_type:, forwarding: nil)
         @return_type = return_type
         @required_positionals = required_positionals
         @optional_positionals = optional_positionals
@@ -977,6 +1005,7 @@ module RBS
         @required_keywords = required_keywords
         @optional_keywords = optional_keywords
         @rest_keywords = rest_keywords
+        @forwarding = forwarding
       end
 
       def ==(other)
@@ -988,6 +1017,7 @@ module RBS
           other.required_keywords == required_keywords &&
           other.optional_keywords == optional_keywords &&
           other.rest_keywords == rest_keywords &&
+          other.forwarding == forwarding &&
           other.return_type == return_type
       end
 
@@ -1002,6 +1032,7 @@ module RBS
           required_keywords.hash ^
           optional_keywords.hash ^
           rest_keywords.hash ^
+          forwarding.hash ^
           return_type.hash
       end
 
@@ -1043,6 +1074,7 @@ module RBS
             required_keywords: hmapv(required_keywords) {|param| param.map_type(&block) },
             optional_keywords: hmapv(optional_keywords) {|param| param.map_type(&block) },
             rest_keywords: rest_keywords&.yield_self {|param| param.map_type(&block) },
+            forwarding: forwarding,
             return_type: yield(return_type)
           )
         else
@@ -1110,6 +1142,7 @@ module RBS
           required_keywords: required_keywords,
           optional_keywords: optional_keywords,
           rest_keywords: rest_keywords,
+          forwarding: forwarding,
           return_type: return_type
         }.to_json(state)
       end
@@ -1129,6 +1162,7 @@ module RBS
           required_keywords: {},
           optional_keywords: {},
           rest_keywords: nil,
+          forwarding: nil,
           return_type: return_type
         )
       end
@@ -1142,12 +1176,13 @@ module RBS
           required_keywords: required_keywords,
           optional_keywords: optional_keywords,
           rest_keywords: rest_keywords,
+          forwarding: forwarding,
           return_type: type
         )
       end
 
       def update(required_positionals: self.required_positionals, optional_positionals: self.optional_positionals, rest_positionals: self.rest_positionals, trailing_positionals: self.trailing_positionals,
-                 required_keywords: self.required_keywords, optional_keywords: self.optional_keywords, rest_keywords: self.rest_keywords, return_type: self.return_type)
+                 required_keywords: self.required_keywords, optional_keywords: self.optional_keywords, rest_keywords: self.rest_keywords, forwarding: self.forwarding, return_type: self.return_type)
         Function.new(
           required_positionals: required_positionals,
           optional_positionals: optional_positionals,
@@ -1156,6 +1191,7 @@ module RBS
           required_keywords: required_keywords,
           optional_keywords: optional_keywords,
           rest_keywords: rest_keywords,
+          forwarding: forwarding,
           return_type: return_type
         )
       end
@@ -1167,6 +1203,7 @@ module RBS
           trailing_positionals.empty? &&
           required_keywords.empty? &&
           optional_keywords.empty? &&
+          !forwarding? &&
           !rest_keywords
       end
 
@@ -1175,6 +1212,7 @@ module RBS
         params = []
 
         params.push(*required_positionals.map(&:to_s))
+        params.push(forwarding.to_s) if forwarding
         params.push(*optional_positionals.map {|p| "?#{p}"})
         params.push("*#{rest_positionals}") if rest_positionals
         params.push(*trailing_positionals.map(&:to_s))
@@ -1183,6 +1221,10 @@ module RBS
         params.push("**#{rest_keywords}") if rest_keywords
 
         params.join(", ")
+      end
+
+      def forwarding?
+        !forwarding.nil?
       end
 
       def return_to_s

--- a/lib/rbs/wasm/serialization_schema.rb
+++ b/lib/rbs/wasm/serialization_schema.rb
@@ -23,7 +23,7 @@ module RBS
     # :bool, :location_range, :location_range_list, :attr_ivar_name, or
     # [:enum, [value_or_nil, ...]].
     module SerializationSchema
-      SYMBOL_TAG = 78
+      SYMBOL_TAG = 79
 
       SCHEMA = [
         nil, # tag 0 is reserved for NULL
@@ -91,7 +91,8 @@ module RBS
         [:node, "RBS::Types::Block", true, nil, [[:type, :node], [:required, :bool], [:self_type, :node]], false],
         [:node, "RBS::Types::ClassInstance", true, [[:name, true], [:args, false]], [[:name, :node], [:args, :node_list]], false],
         [:node, "RBS::Types::ClassSingleton", true, [[:name, true], [:args, false]], [[:name, :node], [:args, :node_list]], false],
-        [:node, "RBS::Types::Function", false, nil, [[:required_positionals, :node_list], [:optional_positionals, :node_list], [:rest_positionals, :node], [:trailing_positionals, :node_list], [:required_keywords, :hash], [:optional_keywords, :hash], [:rest_keywords, :node], [:return_type, :node]], false],
+        [:node, "RBS::Types::Function", false, nil, [[:required_positionals, :node_list], [:optional_positionals, :node_list], [:rest_positionals, :node], [:trailing_positionals, :node_list], [:required_keywords, :hash], [:optional_keywords, :hash], [:rest_keywords, :node], [:forwarding, :node], [:return_type, :node]], false],
+        [:node, "RBS::Types::Function::ForwardingParam", true, nil, nil, false],
         [:node, "RBS::Types::Function::Param", true, [[:name, false]], [[:type, :node], [:name, :node]], false],
         [:node, "RBS::Types::Interface", true, [[:name, true], [:args, false]], [[:name, :node], [:args, :node_list]], false],
         [:node, "RBS::Types::Intersection", true, nil, [[:types, :node_list]], false],

--- a/schema/function.json
+++ b/schema/function.json
@@ -78,10 +78,21 @@
         }
       ]
     },
+    "forwarding": {
+      "title": "Forwarding parameter",
+      "oneOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "return_type": {
       "title": "Return type of a function",
       "$ref": "types.json"
     }
   },
-  "required": ["required_positionals", "optional_positionals", "rest_positionals", "trailing_positionals", "required_keywords", "optional_keywords", "rest_keywords", "return_type"]
+  "required": ["required_positionals", "optional_positionals", "rest_positionals", "trailing_positionals", "required_keywords", "optional_keywords", "rest_keywords", "forwarding", "return_type"]
 }

--- a/sig/types.rbs
+++ b/sig/types.rbs
@@ -385,6 +385,12 @@ module RBS
                     | -> Enumerator[t, Param]
       end
 
+      class ForwardingParam
+        attr_reader location: Location?
+
+        def initialize: (location: Location) -> void
+      end
+
       attr_reader required_positionals: Array[Param]
       attr_reader optional_positionals: Array[Param]
       attr_reader rest_positionals: Param?
@@ -392,6 +398,7 @@ module RBS
       attr_reader required_keywords: Hash[Symbol, Param]
       attr_reader optional_keywords: Hash[Symbol, Param]
       attr_reader rest_keywords: Param?
+      attr_reader forwarding: ForwardingParam?
       attr_reader return_type: t
 
       def initialize: (required_positionals: Array[Param],
@@ -401,7 +408,8 @@ module RBS
                        required_keywords: Hash[Symbol, Param],
                        optional_keywords: Hash[Symbol, Param],
                        rest_keywords: Param?,
-                       return_type: t) -> void
+                       return_type: t,
+                       ?forwarding: ForwardingParam?) -> void
 
       def free_variables: (?Set[Symbol]) -> Set[Symbol]
 
@@ -431,9 +439,11 @@ module RBS
                    ?required_keywords: Hash[Symbol, Param],
                    ?optional_keywords: Hash[Symbol, Param],
                    ?rest_keywords: Param?,
+                   ?forwarding: ForwardingParam?,
                    ?return_type: t) -> Function
 
       def empty?: () -> bool
+      def forwarding?: () -> bool
 
       def param_to_s: () -> String
       def return_to_s: () -> String

--- a/src/ast.c
+++ b/src/ast.c
@@ -143,6 +143,8 @@ const char *RBS_NONNULL rbs_node_type_name(rbs_node_t *RBS_NONNULL node) {
         return "RBS::Types::ClassSingleton";
     case RBS_TYPES_FUNCTION:
         return "RBS::Types::Function";
+    case RBS_TYPES_FUNCTION_FORWARDING_PARAM:
+        return "RBS::Types::Function::ForwardingParam";
     case RBS_TYPES_FUNCTION_PARAM:
         return "RBS::Types::Function::Param";
     case RBS_TYPES_INTERFACE:
@@ -1430,7 +1432,7 @@ rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_alloc
     return instance;
 }
 #line 140 "templates/src/ast.c.erb"
-rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NONNULL return_type) {
+rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NULLABLE forwarding, rbs_node_t *RBS_NONNULL return_type) {
     rbs_types_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_t);
 
     *instance = (rbs_types_function_t) {
@@ -1445,7 +1447,21 @@ rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NO
         .required_keywords = required_keywords,
         .optional_keywords = optional_keywords,
         .rest_keywords = rest_keywords,
+        .forwarding = forwarding,
         .return_type = return_type,
+    };
+
+    return instance;
+}
+#line 140 "templates/src/ast.c.erb"
+rbs_types_function_forwarding_param_t *RBS_NONNULL rbs_types_function_forwarding_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
+    rbs_types_function_forwarding_param_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_forwarding_param_t);
+
+    *instance = (rbs_types_function_forwarding_param_t) {
+        .base = (rbs_node_t) {
+            .type = RBS_TYPES_FUNCTION_FORWARDING_PARAM,
+            .location = location,
+        },
     };
 
     return instance;

--- a/src/parser.c
+++ b/src/parser.c
@@ -124,6 +124,7 @@ typedef struct {
     rbs_hash_t *required_keywords;
     rbs_hash_t *optional_keywords;
     rbs_node_t *rest_keywords;
+    rbs_node_t *forwarding;
 } method_params;
 
 /**
@@ -487,10 +488,12 @@ static bool parser_advance_if(rbs_parser_t *parser, enum RBSTokenType type) {
 /*
   params ::= {} `)`
            | {} `?` `)`               -- Untyped function params (assign params.required = nil)
+           | {} `...` `)`             -- Forwarding params
            | <required_params> `)`
            | <required_params> `,` `)`
 
   required_params ::= {} function_param `,` <required_params>
+                    | {} function_param `,` `...`
                     | {} <function_param>
                     | {} <optional_params>
 
@@ -514,7 +517,7 @@ static bool parser_advance_if(rbs_parser_t *parser, enum RBSTokenType type) {
              | {} `**` <function_param>
 */
 RBS_NODISCARD
-static bool parse_params(rbs_parser_t *parser, method_params *params, bool self_allowed, bool classish_allowed) {
+static bool parse_params(rbs_parser_t *parser, method_params *params, bool forwarding_allowed, bool self_allowed, bool classish_allowed) {
     if (parser->next_token.type == pQUESTION && parser->next_token2.type == pRPAREN) {
         params->required_positionals = NULL;
         rbs_parser_advance(parser);
@@ -537,6 +540,19 @@ static bool parse_params(rbs_parser_t *parser, method_params *params, bool self_
         case pRPAREN:
             goto EOP;
 
+        case pDOT3: {
+            if (!forwarding_allowed) {
+                rbs_parser_set_error(parser, parser->next_token, true, "forwarding parameter is not allowed in this context");
+                return false;
+            }
+
+            rbs_parser_advance(parser);
+            params->forwarding = (rbs_node_t *) rbs_types_function_forwarding_param_new(
+                ALLOCATOR(),
+                rbs_location_range_current_token(parser)
+            );
+            goto EOP;
+        }
         default:
             if (is_keyword(parser)) {
                 goto PARSE_KEYWORDS;
@@ -713,6 +729,7 @@ static void initialize_method_params(method_params *params, rbs_allocator_t *all
         .required_keywords = rbs_hash_new(allocator),
         .optional_keywords = rbs_hash_new(allocator),
         .rest_keywords = NULL,
+        .forwarding = NULL,
     };
 }
 
@@ -749,7 +766,7 @@ typedef struct {
              | {} self_type_binding? `->` <optional>
 */
 RBS_NODISCARD
-static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool block_allowed, parse_function_result **result, bool self_allowed, bool classish_allowed) {
+static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool block_allowed, bool forwarding_allowed, parse_function_result **result, bool self_allowed, bool classish_allowed) {
     rbs_node_t *function = NULL;
     rbs_types_block_t *block = NULL;
     rbs_node_t *function_self_type = NULL;
@@ -761,7 +778,7 @@ static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool 
 
     if (parser->next_token.type == pLPAREN) {
         rbs_parser_advance(parser);
-        CHECK_PARSE(parse_params(parser, &params, self_allowed, classish_allowed));
+        CHECK_PARSE(parse_params(parser, &params, forwarding_allowed, self_allowed, classish_allowed));
         ADVANCE_ASSERT(parser, pRPAREN);
     }
 
@@ -779,8 +796,14 @@ static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool 
 
     bool required = true;
     rbs_range_t block_range;
+    bool has_block = parser->next_token.type == pLBRACE || (parser->next_token.type == pQUESTION && parser->next_token2.type == pLBRACE);
 
-    if (!block_allowed && (parser->next_token.type == pLBRACE || (parser->next_token.type == pQUESTION && parser->next_token2.type == pLBRACE))) {
+    if (params.forwarding && has_block) {
+        rbs_parser_set_error(parser, parser->next_token, true, "method type with forwarding parameter cannot have block");
+        return false;
+    }
+
+    if (!block_allowed && has_block) {
         rbs_parser_set_error(parser, parser->next_token, true, "block is not allowed in this context");
         return false;
     }
@@ -802,7 +825,7 @@ static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool 
 
         if (parser->next_token.type == pLPAREN) {
             rbs_parser_advance(parser);
-            CHECK_PARSE(parse_params(parser, &block_params, self_allowed, classish_allowed));
+            CHECK_PARSE(parse_params(parser, &block_params, false, self_allowed, classish_allowed));
             ADVANCE_ASSERT(parser, pRPAREN);
         }
 
@@ -831,6 +854,7 @@ static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool 
                 block_params.required_keywords,
                 block_params.optional_keywords,
                 block_params.rest_keywords,
+                block_params.forwarding,
                 block_return_type
             );
         }
@@ -856,6 +880,7 @@ static bool parse_function(rbs_parser_t *parser, bool accept_type_binding, bool 
             params.required_keywords,
             params.optional_keywords,
             params.rest_keywords,
+            params.forwarding,
             type
         );
     }
@@ -873,7 +898,7 @@ RBS_NODISCARD
 static bool parse_proc_type(rbs_parser_t *parser, rbs_types_proc_t **proc, bool self_allowed, bool classish_allowed) {
     rbs_position_t start = parser->current_token.range.start;
     parse_function_result *result = rbs_allocator_alloc(ALLOCATOR(), parse_function_result);
-    CHECK_PARSE(parse_function(parser, true, true, &result, self_allowed, classish_allowed));
+    CHECK_PARSE(parse_function(parser, true, true, false, &result, self_allowed, classish_allowed));
 
     rbs_position_t end = parser->current_token.range.end;
     rbs_location_range range = { .start_char = start.char_pos, .start_byte = start.byte_pos, .end_char = end.char_pos, .end_byte = end.byte_pos };
@@ -1605,7 +1630,7 @@ bool rbs_parse_method_type(rbs_parser_t *parser, rbs_method_type_t **method_type
     type_range.start = parser->next_token.range.start;
 
     parse_function_result *result = rbs_allocator_alloc(ALLOCATOR(), parse_function_result);
-    CHECK_PARSE(parse_function(parser, false, true, &result, true, classish_allowed));
+    CHECK_PARSE(parse_function(parser, false, true, true, &result, true, classish_allowed));
 
     CHECK_PARSE(parser_pop_typevar_table(parser));
 
@@ -4021,7 +4046,7 @@ static bool parse_inline_leading_annotation(rbs_parser_t *parser, rbs_ast_ruby_a
             type_range.start = parser->next_token.range.start;
 
             parse_function_result *result = rbs_allocator_alloc(ALLOCATOR(), parse_function_result);
-            if (!parse_function(parser, true, false, &result, true, true)) {
+            if (!parse_function(parser, true, false, false, &result, true, true)) {
                 return false;
             }
 

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -132,7 +132,7 @@ static void w_hash(rbs_serialize_state *state, rbs_hash_t *hash) {
 // The node tag written ahead of every node. Tag 0 is reserved for NULL, tags
 // 1..N are the nodes below (in the same order the Ruby schema is generated),
 // and the final tag is `rbs_ast_symbol`, which is not a config.yml node.
-#define RBS_SERIALIZE_TAG_SYMBOL 78
+#define RBS_SERIALIZE_TAG_SYMBOL 79
 
 static void serialize_node(rbs_serialize_state *state, rbs_node_t *instance) {
     if (instance == NULL) {
@@ -830,11 +830,18 @@ static void serialize_node(rbs_serialize_state *state, rbs_node_t *instance) {
         w_hash(state, node->required_keywords);
         w_hash(state, node->optional_keywords);
         serialize_node(state, (rbs_node_t *) node->rest_keywords);
+        serialize_node(state, (rbs_node_t *) node->forwarding);
         serialize_node(state, (rbs_node_t *) node->return_type);
         return;
     }
-    case RBS_TYPES_FUNCTION_PARAM: {
+    case RBS_TYPES_FUNCTION_FORWARDING_PARAM: {
         w_u8(state, 66);
+        rbs_types_function_forwarding_param_t *node = (rbs_types_function_forwarding_param_t *) instance;
+        w_loc_range(state, node->base.location);
+        return;
+    }
+    case RBS_TYPES_FUNCTION_PARAM: {
+        w_u8(state, 67);
         rbs_types_function_param_t *node = (rbs_types_function_param_t *) instance;
         w_loc_range(state, node->base.location);
         w_loc_range(state, node->name_range);
@@ -843,7 +850,7 @@ static void serialize_node(rbs_serialize_state *state, rbs_node_t *instance) {
         return;
     }
     case RBS_TYPES_INTERFACE: {
-        w_u8(state, 67);
+        w_u8(state, 68);
         rbs_types_interface_t *node = (rbs_types_interface_t *) instance;
         w_loc_range(state, node->base.location);
         w_loc_range(state, node->name_range);
@@ -853,28 +860,28 @@ static void serialize_node(rbs_serialize_state *state, rbs_node_t *instance) {
         return;
     }
     case RBS_TYPES_INTERSECTION: {
-        w_u8(state, 68);
+        w_u8(state, 69);
         rbs_types_intersection_t *node = (rbs_types_intersection_t *) instance;
         w_loc_range(state, node->base.location);
         w_node_list(state, node->types);
         return;
     }
     case RBS_TYPES_LITERAL: {
-        w_u8(state, 69);
+        w_u8(state, 70);
         rbs_types_literal_t *node = (rbs_types_literal_t *) instance;
         w_loc_range(state, node->base.location);
         serialize_node(state, (rbs_node_t *) node->literal);
         return;
     }
     case RBS_TYPES_OPTIONAL: {
-        w_u8(state, 70);
+        w_u8(state, 71);
         rbs_types_optional_t *node = (rbs_types_optional_t *) instance;
         w_loc_range(state, node->base.location);
         serialize_node(state, (rbs_node_t *) node->type);
         return;
     }
     case RBS_TYPES_PROC: {
-        w_u8(state, 71);
+        w_u8(state, 72);
         rbs_types_proc_t *node = (rbs_types_proc_t *) instance;
         w_loc_range(state, node->base.location);
         serialize_node(state, (rbs_node_t *) node->type);
@@ -883,41 +890,41 @@ static void serialize_node(rbs_serialize_state *state, rbs_node_t *instance) {
         return;
     }
     case RBS_TYPES_RECORD: {
-        w_u8(state, 72);
+        w_u8(state, 73);
         rbs_types_record_t *node = (rbs_types_record_t *) instance;
         w_loc_range(state, node->base.location);
         w_hash(state, node->all_fields);
         return;
     }
     case RBS_TYPES_RECORD_FIELD_TYPE: {
-        w_u8(state, 73);
+        w_u8(state, 74);
         rbs_types_record_field_type_t *node = (rbs_types_record_field_type_t *) instance;
         serialize_node(state, node->type);
         w_u8(state, node->required ? 1 : 0);
         return;
     }
     case RBS_TYPES_TUPLE: {
-        w_u8(state, 74);
+        w_u8(state, 75);
         rbs_types_tuple_t *node = (rbs_types_tuple_t *) instance;
         w_loc_range(state, node->base.location);
         w_node_list(state, node->types);
         return;
     }
     case RBS_TYPES_UNION: {
-        w_u8(state, 75);
+        w_u8(state, 76);
         rbs_types_union_t *node = (rbs_types_union_t *) instance;
         w_loc_range(state, node->base.location);
         w_node_list(state, node->types);
         return;
     }
     case RBS_TYPES_UNTYPED_FUNCTION: {
-        w_u8(state, 76);
+        w_u8(state, 77);
         rbs_types_untyped_function_t *node = (rbs_types_untyped_function_t *) instance;
         serialize_node(state, (rbs_node_t *) node->return_type);
         return;
     }
     case RBS_TYPES_VARIABLE: {
-        w_u8(state, 77);
+        w_u8(state, 78);
         rbs_types_variable_t *node = (rbs_types_variable_t *) instance;
         w_loc_range(state, node->base.location);
         serialize_node(state, (rbs_node_t *) node->name);

--- a/test/rbs/method_type_parsing_test.rb
+++ b/test/rbs/method_type_parsing_test.rb
@@ -48,6 +48,90 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
     end
   end
 
+  def test_forwarding_parameter
+    parse_method_type("(...) -> void").tap do |type|
+      assert_equal "(...) -> void", type.to_s
+      assert_instance_of Types::Function::ForwardingParam, type.type.forwarding
+      assert_equal "...", type.type.forwarding.location.source
+      assert_empty type.type.required_positionals
+      assert_nil type.block
+    end
+
+    parse_method_type("(String message, ...) -> void").tap do |type|
+      assert_equal "(String message, ...) -> void", type.to_s
+      assert_equal 1, type.type.required_positionals.size
+      assert_predicate type.type, :forwarding?
+      assert_instance_of Types::Function::ForwardingParam, type.type.forwarding
+    end
+  end
+
+  def test_forwarding_parameter_with_overload_continuation
+    _, _, declarations = parse_signature(<<~RBS)
+      class Foo
+        def foo: (...) -> void
+               | ...
+      end
+    RBS
+
+    method = declarations.fetch(0).members.fetch(0)
+    assert_predicate method, :overloading?
+    assert_predicate method.overloads.fetch(0).method_type.type, :forwarding?
+  end
+
+  def test_forwarding_parameter_rejects_nonleading_parameters
+    [
+      "(?String value, ...) -> void",
+      "(*String values, ...) -> void",
+      "(value: String, ...) -> void",
+      "(?value: String, ...) -> void",
+      "(**String values, ...) -> void",
+    ].each do |source|
+      assert_raise(RBS::ParsingError) do
+        parse_method_type(source)
+      end
+    end
+  end
+
+  def test_forwarding_parameter_must_be_last
+    [
+      "(..., String) -> void",
+      "(..., ...) -> void",
+      "(...,) -> void",
+    ].each do |source|
+      assert_raise(RBS::ParsingError) do
+        parse_method_type(source)
+      end
+    end
+  end
+
+  def test_forwarding_parameter_cannot_have_explicit_block
+    [
+      "(...) { () -> void } -> void",
+      "(...) ?{ () -> void } -> void",
+    ].each do |source|
+      assert_raise(RBS::ParsingError) do
+        parse_method_type(source)
+      end
+    end
+  end
+
+  def test_forwarding_parameter_is_not_allowed_in_block_types
+    assert_raise(RBS::ParsingError) do
+      parse_method_type("() { (...) -> void } -> void")
+    end
+  end
+
+  def test_forwarding_parameter_is_not_allowed_in_proc_types
+    [
+      "^(...) -> void",
+      "^(String, ...) -> void",
+    ].each do |source|
+      assert_raise(RBS::ParsingError) do
+        parse_type(source)
+      end
+    end
+  end
+
   def test_method_type_location
     Parser.parse_method_type("(untyped _)->void").yield_self do |type|
       assert_nil type.location[:type_params]

--- a/test/rbs/schema_test.rb
+++ b/test/rbs/schema_test.rb
@@ -120,6 +120,10 @@ class RBS::SchemaTest < Test::Unit::TestCase
     JSONValidator.method_type.validate!(
       parse_method_type("[G] (A a, ?B, *C, d: D, ?e: E e, **f) ?{ (G) -> void } -> String").to_json
     )
+
+    JSONValidator.method_type.validate!(
+      parse_method_type("(String message, ...) -> void").to_json
+    )
   end
 
   def test_decls

--- a/test/rbs/wasm/serialization_test.rb
+++ b/test/rbs/wasm/serialization_test.rb
@@ -109,6 +109,7 @@ class RBS::WASM::SerializationTest < Test::Unit::TestCase
       "(Integer) -> String",
       "[T] (T) -> T",
       "(Integer, ?String, *Symbol, foo: bool, ?bar: Integer, **untyped) -> void",
+      "(String message, ...) -> void",
       "() { (Integer) -> void } -> bool",
       "() ?{ () -> void } -> void",
       "[A, B < Comparable[A]] (A) -> B",


### PR DESCRIPTION
### Summary

Add parser and AST support for Ruby-style forwarding parameters in RBS method types.

```rbs
def request: (...) -> Response

def logged_request: (String message, ...) -> Response
```

RBS already uses `...` to retain existing overloads:

```rbs
def foo: (Integer) -> String
       | ...
```

The two forms are unambiguous because forwarding appears inside a parameter list, while overload continuation appears where a method type is expected.

### Implementation

Represent forwarding as an optional `RBS::Types::Function::ForwardingParam` node:

```ruby
function.forwarding # RBS::Types::Function::ForwardingParam | nil
```

The node preserves the location of `...` for diagnostics and syntax-aware tooling:

```ruby
function.forwarding.location.source # => "..."
```

The change updates:

- The C parser and generated AST
- Native and WASM AST translation and serialization
- Ruby types and RBS declarations
- JSON schemas

### Syntax restrictions

Forwarding must be the final parameter and may only follow required positional parameters.

Accepted:

```rbs
(...) -> void
(String message, ...) -> void
```

Rejected:

```rbs
(?String message, ...) -> void
(*String args, ...) -> void
(message: String, ...) -> void
(**String kwargs, ...) -> void
(..., String) -> void
```

Forwarding is also rejected in Proc and block parameter types:

```rbs
^(...) -> void
() { (...) -> void } -> void
```

Because forwarding includes the block, an additional explicit block is rejected:

```rbs
(...) { () -> void } -> void
(...) ?{ () -> void } -> void
```

The existing overload-continuation syntax continues to work alongside forwarding:

```rbs
def foo: (...) -> void
       | ...
```