### PR TITLE
Version 4.1.1.dev.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.1.pre)
+    rbs (4.1.1.dev.1)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.1.pre"
+  VERSION = "4.1.1.dev.1"
 end


### PR DESCRIPTION
Bumps `RBS::VERSION` to `4.1.1.dev.1`, a test release for the release automation, with `Gemfile.lock` regenerated.

`.dev.N` is a prerelease just like `.pre.N` — `gem install rbs` is unaffected, and `release:note` opens the GitHub release as a prerelease. `Rakefile` already lists `v*.dev*` in `GEM_PRERELEASE_TAGS`, so a `v4.1.1.dev.1` tag is skipped when `gem:changelog` picks the base of the 4.1.1 release proper, and the 4.1.1 changelog will still cover the whole cycle.

No `CHANGELOG.md` entry: this is a `.dev.N` release.

---
_Generated by [Claude Code](https://claude.ai/code/session_019aAfsFysWM2BMuPUPMFaze)_