### PR TITLE
Version 4.1.1.pre.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 4.1.1.pre.1 (2026-07-30)
+
+### Library changes
+
+* Include the trailing `?` in a keyword key's symbol location ([#3043](https://github.com/ruby/rbs/pull/3043))
+* Mark `type_name` as optional on the alias annotations ([#3039](https://github.com/ruby/rbs/pull/3039))
+
+### Miscellaneous
+
+* Fix template drift for ext/rbs_extension/ast_translation.c ([#3038](https://github.com/ruby/rbs/pull/3038))
+
 ## 4.1.0 (2026-07-27)
 
 RBS 4.1 ships with JRuby support. The RBS parser is written in plain C without depending on the Ruby C API, so it is compiled to WebAssembly and runs on a Wasm runtime, with the parsed AST serialized in a binary format and decoded into RBS objects. The full test suite runs on JRuby in CI.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.1.dev.1)
+    rbs (4.1.1.pre.1)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.1.dev.1"
+  VERSION = "4.1.1.pre.1"
 end


### PR DESCRIPTION
Prepares the 4.1.1.pre.1 release: `RBS::VERSION`, `Gemfile.lock`, and the changelog section.

The changelog starts from `v4.1.0` rather than the latest tag. `v4.1.1.dev.1` is a dev release, so it carries no changelog section of its own — the pull requests it shipped would otherwise go unwritten until 4.1.1 proper.

Once this is merged, tag the merge commit and dispatch [`release-gems.yml`](https://github.com/ruby/rbs/actions/workflows/release-gems.yml) against the `v4.1.1.pre.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)