### PR TITLE
Version 4.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 4.1.1.pre.1 (2026-07-30)
+## 4.1.1 (2026-07-30)
 
 ### Library changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.1.pre.1)
+    rbs (4.1.1)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.1.pre.1"
+  VERSION = "4.1.1"
 end


### PR DESCRIPTION
Prepares the 4.1.1 release: `RBS::VERSION`, `Gemfile.lock`, and the changelog section.

4.1.1 ships the same three pull requests as `4.1.1.pre.1`, so the `## 4.1.1.pre.1` heading is renamed to `## 4.1.1` rather than a new section being added — the notes the prerelease was published with stay on its own GitHub release.

Once this is merged, tag the merge commit and dispatch [`release-gems.yml`](https://github.com/ruby/rbs/actions/workflows/release-gems.yml) against the `v4.1.1` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)