### PR TITLE
Version 4.1.2.dev.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.1)
+    rbs (4.1.2.dev.1)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.1"
+  VERSION = "4.1.2.dev.1"
 end


### PR DESCRIPTION
Bumps `RBS::VERSION` to `4.1.2.dev.1`, a dev release cut from `master` after 4.1.1, with `Gemfile.lock` regenerated.

`.dev.N` is a prerelease, so `gem install rbs` is unaffected, and `Rakefile` lists `v*.dev*` in `GEM_PRERELEASE_TAGS` — the `v4.1.2.dev.1` tag is skipped when `gem:changelog` picks the base of the 4.1.2 release proper, so that changelog still covers the whole cycle.

No `CHANGELOG.md` entry and no GitHub release: this is a `.dev.N` release, and `rake gem:check_release[4.1.2.dev.1]` passes without one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhJnDiMKwunqnLpuXzRY7v)_