### PR TITLE
Unpin rdoc on the JRuby CI

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -64,12 +64,7 @@ jobs:
           ruby-version: jruby
           bundler: none
       - name: Install runtime and test gems
-        # rdoc 8.0.0 added a runtime dependency on rbs, which pulls the released
-        # C-extension rbs gem and fails to build on JRuby. Pin rdoc below 8 until
-        # a -java rbs gem is published.
-        run: |
-          gem install prism rake rake-compiler test-unit rspec minitest json-schema pry --no-document
-          gem install rdoc -v "< 8" --no-document
+        run: gem install prism rake rake-compiler test-unit rdoc rspec minitest json-schema pry --no-document
       # jar-dependencies resolves through the JVM, so download the Chicory/ASM
       # jars into ~/.m2 here on JRuby (jar-dependencies is not available in the
       # CRuby step above).


### PR DESCRIPTION
rdoc 8 needs `rbs >= 4.0.0`, which resolved to the C-extension gem when the pin went in. `gem install rdoc` now picks up `rbs-4.1.1-java`, so the pin is no longer needed.