### PR TITLE
Fix GC_test#test_enable leaving GC disabled for the rest of the suite

### DIFF
--- a/test/stdlib/GC_test.rb
+++ b/test/stdlib/GC_test.rb
@@ -44,12 +44,12 @@ class GCSingletonTest < Test::Unit::TestCase
   end
 
   def test_enable
-    was_enabled = GC.enable
+    was_disabled = GC.enable
 
     assert_send_type  '() -> bool',
                       GC, :enable
   ensure
-    GC.disable unless was_enabled
+    GC.disable if was_disabled
   end
 
   def test_start


### PR DESCRIPTION
`GC.enable` returns whether GC was *disabled* before the call (true when the call actually re-enabled GC), not whether it was enabled. The ensure clause `GC.disable unless was_enabled` therefore inverted the restore: in the common case where GC is enabled when the test starts, GC.enable returns false and the ensure clause disables GC permanently.

Every test that runs after GC_test then executes with GC turned off, so the whole stdlib test process accumulates garbage until exit. On the ruby/ruby Windows CI runners this reaches the process memory limit and the suite dies with NoMemoryError (deterministically), and on all platforms it silently changes what later tests exercise.

Rename the variable to what the value actually means and restore the previous state with `GC.disable if was_disabled`, mirroring test_disable.