### PR TITLE
Version 4.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 4.1.2 (2026-08-03)
+
+### Miscellaneous
+
+* Keep GC disabled during GC_test#test_stress_and_stress= ([#3061](https://github.com/ruby/rbs/pull/3061))
+* Fix GC_test#test_enable leaving GC disabled for the rest of the suite ([#3059](https://github.com/ruby/rbs/pull/3059))
+
 ## 4.1.1 (2026-07-30)
 
 ### Library changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.2.dev.1)
+    rbs (4.1.2)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.2.dev.1"
+  VERSION = "4.1.2"
 end


### PR DESCRIPTION
Prepares the 4.1.2 release proper: `RBS::VERSION` set to `4.1.2`, `Gemfile.lock` regenerated, and the 4.1.2 section added to `CHANGELOG.md`.

The section covers the whole cycle since 4.1.1, with the `4.1.2.dev.1` release in between folded into it, which is how a release proper is written up. Two pull requests, both Miscellaneous: #3059 and #3061, the stdlib test suite. The other six merged since 4.1.1 — #3053, #3054, #3055, #3056, #3057, #3058 — are labeled `skip-changelog` and left out.

Worth knowing before merging: **nothing in this release reaches the gem.** `test/` is excluded from `spec.files`, so `rbs-4.1.2.gem` is `rbs-4.1.1.gem` with a different version number. #3059 is still worth shipping the repository state for — it is what stops `GC_test` from leaving GC disabled for the rest of the stdlib suite, which was killing ruby/ruby's Windows CI with `NoMemoryError` — but it reaches ruby/ruby through the repository sync rather than through the gem.

`rake 'gem:check_release[4.1.2]'` passes on this branch.

This is step 1 only. Once merged, the release is cut by dispatching `Release gems` with the merge commit SHA and `4.1.2`.