### PR TITLE
Start 4.2 development

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.2)
+    rbs (4.2.0.dev)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.2"
+  VERSION = "4.2.0.dev"
 end


### PR DESCRIPTION
Moves the development line on `master` from 4.1 to 4.2, as described in [Starting a new minor](https://github.com/ruby/rbs/blob/master/docs/release.md#starting-a-new-minor).

`RBS::VERSION` goes to `4.2.0.dev` — the bare `.dev` form that names the version being developed towards rather than the one that shipped last. `Gemfile.lock` is regenerated by `bundle install`, which records the version too. Nothing else changes.

The other half of the move is already done: [`aaa-4.1.x`](https://github.com/ruby/rbs/tree/aaa-4.1.x) was branched at 2c39462, the commit before this one, so it carries `4.1.2` — the version its line was released under. Patch releases of 4.1 are cut from there from now on.

Please label this `skip-changelog`; it carries no change of its own and would otherwise show up in the next release's list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHHu1wodDoUBPi2Cs7yhCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHHu1wodDoUBPi2Cs7yhCn)_