### PR TITLE
Build the wasm module with -DNDEBUG

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -926,6 +926,12 @@ namespace :wasm do
 
   desc "Build the RBS parser as a WebAssembly module (requires WASI_SDK_PATH)"
   task :build do
+    # `-DNDEBUG` compiles out `RBS_ASSERT`, the same way ext/rbs_extension does
+    # for the MRI extension. The assertions sit in the lexer and the constant
+    # pool, so keeping them costs about 20% of parse time; set `DEBUG=1` to keep
+    # them when debugging the module itself.
+    debug_flags = ENV["DEBUG"] ? [] : ["-DNDEBUG"]
+
     mkdir_p WASM_DIR
     sh wasi_clang,
        "--target=wasm32-wasip1",
@@ -933,6 +939,7 @@ namespace :wasm do
        "-mexec-model=reactor",
        "-std=gnu11",
        "-O2",
+       *debug_flags,
        "-Wno-unused-parameter",
        "-I#{File.join(__dir__, "include")}",
        "-o", WASM_OUTPUT,

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -27,6 +27,11 @@ $ rake wasm:install_jars # download the Chicory/ASM jars into ~/.m2 (run on JRub
 
 The compiled `rbs_parser.wasm` is a build artifact and is not checked in.
 
+Like the MRI extension, the module is compiled with `-DNDEBUG`, which removes the
+`RBS_ASSERT` checks — they sit in the lexer and the constant pool, so leaving them
+in costs around 20% of parse time. `DEBUG=1 rake wasm:build` keeps them, which is
+what you want when debugging the parser itself through the module.
+
 The WASI SDK is needed for the *build*, not for running the result — the host clang already
 knows the `wasm32` target, but there is no wasm32 libc on a normal machine, so it picks up the
 host headers and fails on the first `#include`. That is what the SDK supplies, along with the


### PR DESCRIPTION
`rake wasm:build` was compiling the parser without `NDEBUG`, so every `RBS_ASSERT` survived into `rbs_parser.wasm` — unlike the MRI extension, which already drops them in `ext/rbs_extension/extconf.rb`.

It was up to 20% slower with `RBS_ASSERT` calls.

This adds `-DNDEBUG` to the wasm build, with `DEBUG=1 rake wasm:build` as the escape hatch for keeping the assertions, matching the `DEBUG` convention `extconf.rb` and the `prepare_bench` / `prepare_profiling` tasks already use.

## Measurements

Parsing `core/` + `stdlib/` (250 files, 4.3MB), best of 10, three rounds:

| | assert build | `-DNDEBUG` | |
| --- | --- | --- | --- |
| parse, V8 (Node WASI) | 75.7 / 75.9 / 77.3 ms | 61.9 / 62.6 / 62.8 ms | **-18%** |
| parse, wasmtime | 74.4 / 75.4 / 76.5 ms | 59.5 / 61.0 / 62.3 ms | **-20%** |
| lex only, wasmtime | 65.6 ms | 60.9 ms | -7% |
