### PR TITLE
Align type params across declarations in module-self types and superclass validation

### DIFF
--- a/lib/rbs/ast/declarations.rb
+++ b/lib/rbs/ast/declarations.rb
@@ -163,7 +163,7 @@ module RBS
           alias eql? ==
 
           def hash
-            self.class.hash ^ name.hash ^ args.hash ^ location.hash
+            self.class.hash ^ name.hash ^ args.hash
           end
 
           def to_json(state = nil)

--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -124,10 +124,13 @@ module RBS
       end
 
       entry = env.class_decls[type_name] or raise "Unknown name for build_instance: #{type_name}"
-      args = entry.type_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
 
       entry.each_decl do |decl|
-        subst_ = subst + Substitution.build(decl.type_params.each.map(&:name), args)
+        if align_params = entry.align_params(decl)
+          subst_ = subst + align_params
+        else
+          subst_ = subst
+        end
 
         decl.members.each do |member|
           case member

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -177,18 +177,11 @@ module RBS
 
         return if with_super_classes.size <= 1
 
-        entry_param_names = entry.type_params.map(&:name)
-
         super_types = with_super_classes.map do |decl|
           super_class = decl.super_class or raise
           args = super_class.args
 
-          decl_param_names = decl.type_params.map(&:name)
-          unless decl_param_names == entry_param_names || args.empty?
-            align_params = Substitution.build(
-              decl_param_names,
-              entry.type_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
-            )
+          if align_params = entry.align_params(decl)
             args = args.map {|type| type.sub(align_params) }
           end
 
@@ -486,10 +479,7 @@ module RBS
 
       def mixin_ancestors(entry, type_name, included_modules:, included_interfaces:, extended_modules:, prepended_modules:, extended_interfaces:)
         entry.each_decl do |decl|
-          align_params = Substitution.build(
-            decl.type_params.each.map(&:name),
-            entry.type_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
-          )
+          align_params = entry.align_params(decl)
 
           mixin_ancestors0(decl,
                            type_name,

--- a/lib/rbs/definition_builder/ancestor_builder.rb
+++ b/lib/rbs/definition_builder/ancestor_builder.rb
@@ -177,9 +177,22 @@ module RBS
 
         return if with_super_classes.size <= 1
 
+        entry_param_names = entry.type_params.map(&:name)
+
         super_types = with_super_classes.map do |decl|
           super_class = decl.super_class or raise
-          Types::ClassInstance.new(name: super_class.name, args: super_class.args, location: nil)
+          args = super_class.args
+
+          decl_param_names = decl.type_params.map(&:name)
+          unless decl_param_names == entry_param_names || args.empty?
+            align_params = Substitution.build(
+              decl_param_names,
+              entry.type_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
+            )
+            args = args.map {|type| type.sub(align_params) }
+          end
+
+          Types::ClassInstance.new(name: super_class.name, args: args, location: nil)
         end
 
         super_types.uniq!

--- a/lib/rbs/definition_builder/method_builder.rb
+++ b/lib/rbs/definition_builder/method_builder.rb
@@ -104,7 +104,7 @@ module RBS
             type = Types::ClassInstance.new(name: type_name, args: args, location: nil)
             Methods.new(type: type).tap do |methods|
               entry.each_decl do |decl|
-                subst = Substitution.build(decl.type_params.each.map(&:name), args)
+                subst = entry.align_params(decl)
                 case decl
                 when AST::Declarations::Base
                   each_rbs_member_with_accessibility(decl.members) do |member, accessibility|
@@ -115,14 +115,14 @@ module RBS
                         build_method(
                           methods,
                           type,
-                          member: member.update(overloads: member.overloads.map {|overload| overload.sub(subst) }),
+                          member: subst ? member.update(overloads: member.overloads.map {|overload| overload.sub(subst) }) : member,
                           accessibility: member.visibility || accessibility
                         )
                       when :singleton_instance
                         build_method(
                           methods,
                           type,
-                          member: member.update(overloads: member.overloads.map {|overload| overload.sub(subst) }),
+                          member: subst ? member.update(overloads: member.overloads.map {|overload| overload.sub(subst) }) : member,
                           accessibility: :private
                         )
                       end
@@ -130,7 +130,7 @@ module RBS
                       if member.kind == :instance
                         build_attribute(methods,
                                         type,
-                                        member: member.update(type: member.type.sub(subst)),
+                                        member: subst ? member.update(type: member.type.sub(subst)) : member,
                                         accessibility: member.visibility || accessibility)
                       end
                     when AST::Members::Alias

--- a/lib/rbs/environment/class_entry.rb
+++ b/lib/rbs/environment/class_entry.rb
@@ -64,6 +64,18 @@ module RBS
           end
         end
       end
+
+      def align_params(decl)
+        entry_params = type_params
+        decl_param_names = decl.type_params.map(&:name)
+
+        return nil if decl_param_names == entry_params.map(&:name)
+
+        Substitution.build(
+          decl_param_names,
+          entry_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
+        )
+      end
     end
   end
 end

--- a/lib/rbs/environment/module_entry.rb
+++ b/lib/rbs/environment/module_entry.rb
@@ -41,8 +41,31 @@ module RBS
       end
 
       def self_types
+        params = type_params
+        param_names = params.map(&:name)
+
         each_decl.flat_map do |decl|
-          decl.self_types
+          self_types = decl.self_types
+          decl_param_names = decl.type_params.map(&:name)
+
+          if self_types.empty? || decl_param_names == param_names
+            self_types
+          else
+            # The declaration uses different type parameter names from the primary declaration.
+            # Rename the type variables in the self types, so that they are aligned to `#type_params`.
+            subst = Substitution.build(
+              decl_param_names,
+              params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
+            )
+
+            self_types.map do |self_type|
+              AST::Declarations::Module::Self.new(
+                name: self_type.name,
+                args: self_type.args.map {|type| type.sub(subst) },
+                location: self_type.location
+              )
+            end
+          end
         end.uniq
       end
 

--- a/lib/rbs/environment/module_entry.rb
+++ b/lib/rbs/environment/module_entry.rb
@@ -41,23 +41,13 @@ module RBS
       end
 
       def self_types
-        params = type_params
-        param_names = params.map(&:name)
-
         each_decl.flat_map do |decl|
           self_types = decl.self_types
-          decl_param_names = decl.type_params.map(&:name)
+          subst = align_params(decl)
 
-          if self_types.empty? || decl_param_names == param_names
+          if self_types.empty? || subst.nil?
             self_types
           else
-            # The declaration uses different type parameter names from the primary declaration.
-            # Rename the type variables in the self types, so that they are aligned to `#type_params`.
-            subst = Substitution.build(
-              decl_param_names,
-              params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
-            )
-
             self_types.map do |self_type|
               AST::Declarations::Module::Self.new(
                 name: self_type.name,
@@ -67,6 +57,18 @@ module RBS
             end
           end
         end.uniq
+      end
+
+      def align_params(decl)
+        entry_params = type_params
+        decl_param_names = decl.type_params.map(&:name)
+
+        return nil if decl_param_names == entry_params.map(&:name)
+
+        Substitution.build(
+          decl_param_names,
+          entry_params.map {|param| Types::Variable.new(name: param.name, location: param.location) }
+        )
       end
 
       def validate_type_params

--- a/sig/environment/class_entry.rbs
+++ b/sig/environment/class_entry.rbs
@@ -45,6 +45,12 @@ module RBS
       # * Raises `GenericParameterMismatchError` if incompatible declaration is detected.
       #
       def validate_type_params: () -> void
+
+      # Returns a substitution that renames the type parameters of the declaration to the entry's type parameters (`#type_params`)
+      #
+      # Returns `nil` if the declaration uses the same type parameter names as `#type_params`.
+      #
+      def align_params: (declaration | ModuleEntry::declaration) -> Substitution?
     end
   end
 end

--- a/sig/environment/module_entry.rbs
+++ b/sig/environment/module_entry.rbs
@@ -44,6 +44,15 @@ module RBS
       #
       def validate_type_params: () -> void
 
+      # Returns the self types of the declarations
+      #
+      # The type variables in the self types are aligned to `#type_params`,
+      # so that the self types from declarations with different type parameter
+      # names can be compared and used with `#type_params`.
+      #
+      # Note that the returned objects may be different from the ones in the
+      # declarations, but `#location` points to the original declaration.
+      #
       def self_types: () -> Array[AST::Declarations::Module::Self]
     end
   end

--- a/sig/environment/module_entry.rbs
+++ b/sig/environment/module_entry.rbs
@@ -54,6 +54,12 @@ module RBS
       # declarations, but `#location` points to the original declaration.
       #
       def self_types: () -> Array[AST::Declarations::Module::Self]
+
+      # Returns a substitution that renames the type parameters of the declaration to the entry's type parameters (`#type_params`)
+      #
+      # Returns `nil` if the declaration uses the same type parameter names as `#type_params`.
+      #
+      def align_params: (declaration | ClassEntry::declaration) -> Substitution?
     end
   end
 end

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -452,6 +452,45 @@ end
     end
   end
 
+  def test_instance_ancestors_super_class_validation_renamed_params
+    SignatureManager.new do |manager|
+      manager.files.merge!(Pathname("foo.rbs") => <<-EOF)
+class Base[T]
+end
+
+class A[X] < Base[X]
+end
+
+class B[X] < Base[X]
+end
+
+class B[Y] < Base[Integer]
+end
+      EOF
+
+      manager.files.merge!(Pathname("foo2.rbs") => <<-EOF)
+class A[Y] < Base[Y]
+end
+      EOF
+
+      manager.build do |env|
+        builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+        # ::A is valid: the declarations declare the same superclass modulo type parameter renaming.
+        builder.one_instance_ancestors(type_name("::A")).tap do |a|
+          assert_equal Ancestor::Instance.new(name: type_name("::Base"), args: [parse_type("X", variables: [:X])], source: :super),
+                       a.super_class
+        end
+
+        # ::B is invalid: the superclass args are different.
+        error = assert_raises SuperclassMismatchError do
+          builder.one_instance_ancestors(type_name("::B"))
+        end
+        assert_equal error.name, type_name("::B")
+      end
+    end
+  end
+
   def test_singleton_ancestors
     SignatureManager.new do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF

--- a/test/rbs/ancestor_builder_test.rb
+++ b/test/rbs/ancestor_builder_test.rb
@@ -141,6 +141,51 @@ EOF
     end
   end
 
+  def test_one_ancestors_module_self_types_type_param_alignment
+    SignatureManager.new(system_builtin: true) do |manager|
+      manager.files[Pathname("a.rbs")] = <<EOF
+interface _EachItem[out T]
+end
+
+interface _FooItem[out T]
+end
+
+module M[out A] : _EachItem[A]
+end
+EOF
+      manager.files[Pathname("b.rbs")] = <<EOF
+module M[out B] : _EachItem[B], _FooItem[Array[B]]
+end
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder::AncestorBuilder.new(env: env)
+
+        builder.one_instance_ancestors(type_name("::M")).tap do |a|
+          assert_equal type_name("::M"), a.type_name
+          assert_equal [:A], a.params
+
+          # Type parameters in self types are renamed to the primary declaration's type parameters,
+          # and `_EachItem[A]`/`_EachItem[B]` are deduplicated
+          assert_equal [
+                         Ancestor::Instance.new(name: type_name("::_EachItem"), args: [parse_type("A", variables: [:A])], source: nil),
+                         Ancestor::Instance.new(name: type_name("::_FooItem"), args: [parse_type("::Array[A]", variables: [:A])], source: nil)
+                       ],
+                       a.self_types
+
+          # The source of each self type keeps pointing to the original declaration
+          a.self_types or raise
+          a.self_types.each do |self_type|
+            source = self_type.source
+            assert_instance_of AST::Declarations::Module::Self, source
+            location = source.location or raise
+            expected_file = source.name == type_name("::_FooItem") ? "b.rbs" : "a.rbs"
+            assert_equal expected_file, Pathname(location.buffer.name).basename.to_s
+          end
+        end
+      end
+    end
+  end
+
   def test_one_ancestors_module_no_self_type
     SignatureManager.new(system_builtin: true) do |manager|
       manager.files[Pathname("foo.rbs")] = <<EOF

--- a/test/rbs/definition_builder_test.rb
+++ b/test/rbs/definition_builder_test.rb
@@ -375,6 +375,36 @@ EOF
     end
   end
 
+  def test_build_instance_module_self_types_type_param_alignment
+    SignatureManager.new do |manager|
+      manager.files[Pathname("a.rbs")] = <<EOF
+interface _Reader[T]
+  def read: () -> T
+end
+
+module M[A] : _Reader[A]
+end
+EOF
+      manager.files[Pathname("b.rbs")] = <<EOF
+module M[B] : _Reader[B]
+end
+EOF
+      manager.build do |env|
+        builder = DefinitionBuilder.new(env: env)
+
+        builder.build_instance(type_name("::M")).tap do |definition|
+          assert_instance_of Definition, definition
+          assert_equal type_name("::M"), definition.type_name
+          assert_equal [:A], definition.type_params
+
+          # The self type from `b.rbs` is aligned to the primary declaration's type parameters
+          assert_equal Set[:read], Set.new(definition.methods.keys)
+          assert_method_definition definition.methods[:read], ["() -> A"], accessibility: :public
+        end
+      end
+    end
+  end
+
   def test_build_instance_class_basic_object
     SignatureManager.new do |manager|
       manager.build do |env|

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -368,6 +368,9 @@ end
 
 module Foo[X, Y]
 end
+
+module Foo[X]
+end
 EOF
 
     Environment::ModuleEntry.new(type_name("::Foo")).tap do |entry|
@@ -381,6 +384,16 @@ EOF
         subst or raise
         assert_equal RBS::Types::Variable.new(name: :A, location: nil), subst[RBS::Types::Variable.new(name: :X, location: nil)]
         assert_equal RBS::Types::Variable.new(name: :B, location: nil), subst[RBS::Types::Variable.new(name: :Y, location: nil)]
+      end
+    end
+
+    Environment::ModuleEntry.new(type_name("::Foo")).tap do |entry|
+      entry << [nil, decls[0]]
+      entry << [nil, decls[2]]
+
+      # The type params validation runs before the alignment, so the arity mismatch is detected first
+      assert_raises RBS::GenericParameterMismatchError do
+        entry.align_params(decls[2])
       end
     end
   end

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -361,6 +361,30 @@ EOF
     end
   end
 
+  def test_module_entry_align_params
+    _, _, decls = RBS::Parser.parse_signature(<<EOF)
+module Foo[A, B]
+end
+
+module Foo[X, Y]
+end
+EOF
+
+    Environment::ModuleEntry.new(type_name("::Foo")).tap do |entry|
+      entry << [nil, decls[0]]
+      entry << [nil, decls[1]]
+
+      # Aligned to the primary declaration's names, so no substitution is needed
+      assert_nil entry.align_params(decls[0])
+
+      entry.align_params(decls[1]).tap do |subst|
+        subst or raise
+        assert_equal RBS::Types::Variable.new(name: :A, location: nil), subst[RBS::Types::Variable.new(name: :X, location: nil)]
+        assert_equal RBS::Types::Variable.new(name: :B, location: nil), subst[RBS::Types::Variable.new(name: :Y, location: nil)]
+      end
+    end
+  end
+
   def test_absolute_type
     env = Environment.new
 

--- a/test/rbs/environment_test.rb
+++ b/test/rbs/environment_test.rb
@@ -316,6 +316,51 @@ EOF
     end
   end
 
+  def test_module_self_type_type_param_alignment
+    _, _, decls = RBS::Parser.parse_signature(<<EOF)
+interface _Animal[T]
+  def bark: () -> T
+end
+
+module Foo[A] : _Animal[A]
+end
+
+module Foo[B] : _Animal[B]
+end
+
+module Foo[C] : _Animal[Integer]
+end
+EOF
+
+    Environment.new.tap do |env|
+      decls.each do |decl|
+        env.insert_rbs_decl(decl, context: nil, namespace: RBS::Namespace.root)
+      end
+
+      foo = env.class_decls[type_name("::Foo")]
+
+      assert_equal [:A], foo.type_params.map(&:name)
+
+      # Self types are aligned to the primary declaration's type parameters, and
+      # `_Animal[A]` and `_Animal[B]` are deduplicated
+      assert_equal [
+                     RBS::AST::Declarations::Module::Self.new(
+                       name: type_name("_Animal"),
+                       args: [RBS::Types::Variable.new(name: :A, location: nil)],
+                       location: nil
+                     ),
+                     RBS::AST::Declarations::Module::Self.new(
+                       name: type_name("_Animal"),
+                       args: [RBS::Types::ClassInstance.new(name: type_name("Integer"), args: [], location: nil)],
+                       location: nil
+                     ),
+                   ], foo.self_types
+
+      # The locations of the self types point to the original declarations
+      assert_equal ["_Animal[A]", "_Animal[Integer]"], foo.self_types.map {|self_type| self_type.location&.source }
+    end
+  end
+
   def test_absolute_type
     env = Environment.new
 


### PR DESCRIPTION
When a module/class has multiple declarations with different (but compatible) type parameter names, the variables written in a non-primary declaration leaked through as free variables: `module M[A] : _Foo[A]` + `module M[B] : _Foo[B]` made `ModuleEntry#self_types` return `[_Foo[A], _Foo[B]]`, and `class C[A] < Base[A]` + `class C[B] < Base[B]` raised a false `SuperclassMismatchError`. This broke Steep's module self type check for every class including `Enumerable`, because rbs 4.1.2 renamed the core `Enumerable`'s type param `Elem` to `E` while `sig/shims/enumerable.rbs` still uses `Elem` (soutaro/steep#2256).

This PR renames the variables to the primary declaration's type parameter names in both places — the same alignment that methods, instance variables, and mixin arguments already receive — keeping the original `location`s. The substitution is extracted into `ModuleEntry#align_params` / `ClassEntry#align_params`, shared by all five call sites, and returns `nil` when the declaration already uses the entry's names. Also, `Module::Self#hash` no longer includes `location.hash`, matching `==`, so `.uniq` deduplicates equal self types across files.