### PR TITLE
Fix TypeParam.rename to substitute variables in bounds and default types

### DIFF
--- a/lib/rbs/ast/type_param.rb
+++ b/lib/rbs/ast/type_param.rb
@@ -114,7 +114,7 @@ module RBS
       def self.rename(params, new_names:)
         raise unless params.size == new_names.size
 
-        subst = Substitution.build(new_names, Types::Variable.build(new_names))
+        subst = Substitution.build(params.map(&:name), Types::Variable.build(new_names))
 
         params.map.with_index do |param, index|
           new_name = new_names[index]

--- a/test/rbs/ast/type_param_test.rb
+++ b/test/rbs/ast/type_param_test.rb
@@ -66,4 +66,28 @@ class RBS::AST::TypeParamTest < Test::Unit::TestCase
       assert_equal ["::Integer", "::Array[::Integer]", "::Array[::Array[::Integer]]"], args.map(&:to_s)
     end
   end
+
+  def test_rename
+    params = [
+      TypeParam.new(name: :A, variance: :covariant, upper_bound: nil, lower_bound: nil, location: nil),
+      TypeParam.new(
+        name: :B,
+        variance: :invariant,
+        upper_bound: parse_type("::Array[A]"),
+        lower_bound: nil,
+        default_type: parse_type("::Hash[A, B]"),
+        location: nil
+      ).unchecked!
+    ]
+
+    TypeParam.rename(params, new_names: [:X, :Y]).tap do |renamed|
+      assert_equal [:X, :Y], renamed.map(&:name)
+      assert_equal :covariant, renamed[0].variance
+      assert_equal :invariant, renamed[1].variance
+      assert_predicate renamed[1], :unchecked?
+
+      assert_equal parse_type("::Array[X]", variables: [:X]), renamed[1].upper_bound_type
+      assert_equal parse_type("::Hash[X, Y]", variables: [:X, :Y]), renamed[1].default_type
+    end
+  end
 end


### PR DESCRIPTION
`TypeParam.rename` built its substitution from the new names to themselves, making it an identity substitution, so type variables in upper/lower bounds and default types that reference other type parameters kept the old names. One visible consequence: `validate_type_params` raised a false `GenericParameterMismatchError` for compatible declarations like `module M[A, B < _Foo[A]]` and `module M[X, Y < _Foo[X]]`. The substitution now maps the old parameter names to the new variables.