### PR TITLE
Avoid eagerly inspecting call traces in type assertions

### DIFF
--- a/lib/rbs/unit_test/type_assertions.rb
+++ b/lib/rbs/unit_test/type_assertions.rb
@@ -180,11 +180,11 @@ module RBS
           )
           errors = typecheck.method_call(method, method_type, trace, errors: [])
 
-          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.inspect}"
+          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, -> { "Call trace does not match with given method type: #{trace.inspect}" }
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.any? {|es| es.empty? }, "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.any? {|es| es.empty? }, -> { "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           raise exception if exception
 
@@ -204,11 +204,11 @@ module RBS
           )
           errors = typecheck.method_call(method, method_type, trace, errors: [])
 
-          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.inspect}"
+          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, -> { "Call trace does not match with given method type: #{trace.inspect}" }
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.any? {|es| es.empty? }, "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.any? {|es| es.empty? }, -> { "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           # Use `instnace_of?` instead of `is_a?` as we want to check for _the exact exception class_.
           assert exception.instance_of? error_type
@@ -246,7 +246,7 @@ module RBS
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.all? {|es| es.size > 0 }, "Call trace unexpectedly matches one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.all? {|es| es.size > 0 }, -> { "Call trace unexpectedly matches one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           result
         end

--- a/sig/unit_test/type_assertions.rbs
+++ b/sig/unit_test/type_assertions.rbs
@@ -30,11 +30,11 @@ module RBS
       type target_type = Types::ClassInstance | Types::ClassSingleton
 
       interface _BaseAssertions
-        def assert: (untyped, ?String?) -> void
+        def assert: (untyped, ?(String | ^() -> String)?) -> void
 
         def refute: (untyped, ?String?) -> void
 
-        def assert_empty: (untyped, ?String?) -> void
+        def assert_empty: (untyped, ?(String | ^() -> String)?) -> void
 
         def assert_operator: (untyped, Symbol, *untyped) -> void
 


### PR DESCRIPTION
`RBS::UnitTest::TypeAssertions` eagerly interpolates `trace.inspect` into assertion messages, so the complete argument and return values are inspected even when the assertion succeeds.

This is problematic for `ObjectSpace.reachable_objects_from_root`: after the per-Ractor GC roots change in Ruby, the returned roots hash can be very large. Building its inspection string causes excessive peak memory usage and can raise `NoMemoryError` in the Windows `test-bundled-gems` job in ruby/ruby.

Pass assertion messages as procs so call traces and method definitions are formatted only when an assertion fails. Apply the same lazy formatting to `assert_send_type`, `assert_send_type_error`, and `refute_send_type`.