### PR TITLE
Backport #3074 to 4.1: Don't use Clang nullability qualifiers in strict ISO C mode

### DIFF
--- a/include/rbs/defines.h
+++ b/include/rbs/defines.h
@@ -87,8 +87,13 @@
  * Nullability annotations for pointer types.
  * Clang supports _Nullable and _Nonnull to indicate whether a pointer may be NULL.
  * On other compilers, these expand to nothing.
+ *
+ * They are Clang extensions, so a strict ISO C compilation rejects them with
+ * `-Wnullability-extension`, which is an error under `-pedantic-errors`. Expand
+ * them to nothing in that case, so that embedders compiling these headers with a
+ * conforming dialect (`-std=c99` and friends define `__STRICT_ANSI__`) still build.
  */
-#ifdef __clang__
+#if defined(__clang__) && !defined(__STRICT_ANSI__)
 #define RBS_NULLABLE _Nullable
 #define RBS_NONNULL _Nonnull
 #else


### PR DESCRIPTION
Backports #3074 to the `aaa-4.1.x` branch, cherry-picked with `-x`.

`_Nullable` and `_Nonnull` are Clang extensions, so compiling the rbs headers in a strict ISO C dialect emits `-Wnullability-extension`, which `-pedantic-errors` turns into an error:

```
include/rbs/ast.h:166:44: error: type nullability specifier '_Nonnull' is a Clang extension [-Werror,-Wnullability-extension]
  166 | void rbs_node_list_append(rbs_node_list_t *RBS_NONNULL list, rbs_node_t *RBS_NONNULL node);
      |                                            ^
include/rbs/defines.h:93:21: note: expanded from macro 'RBS_NONNULL'
   93 | #define RBS_NONNULL _Nonnull
```

CRuby's `omnibus compilations, #5` job builds with `-std=c99 -Werror=pedantic -pedantic-errors` (and c11/c17/c2x), so `ext/rbs_extension` fails to compile there once rbs 4.1.x is bundled — see ruby/ruby#18274. rbs 4.0.3 had no nullability macros, so this is new in 4.1.x, which makes the fix only reach CRuby through this branch.

The macros expand to nothing when `__STRICT_ANSI__` is defined, which is exactly the case where the qualifiers are rejected. Clang's default `-std=gnu*` dialects keep the annotations, so nothing is lost for the static analyzer.

The cherry-pick applied cleanly with no conflicts.

## Verification

* `clang -std=c99 -pedantic-errors -Werror` on `src/ast.c` fails on `aaa-4.1.x` as it stands and passes with this commit, and the same holds for `-std=c11` and `-std=c17`.
* `rake compile` and a parser smoke test pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAgPhpLrU9Z4bENCR9RUub)_