### PR TITLE
Backport #3073 to 4.1: Avoid eagerly inspecting call traces in type assertions

### DIFF
--- a/lib/rbs/unit_test/type_assertions.rb
+++ b/lib/rbs/unit_test/type_assertions.rb
@@ -180,11 +180,11 @@ module RBS
           )
           errors = typecheck.method_call(method, method_type, trace, errors: [])
 
-          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.inspect}"
+          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, -> { "Call trace does not match with given method type: #{trace.inspect}" }
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.any? {|es| es.empty? }, "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.any? {|es| es.empty? }, -> { "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           raise exception if exception
 
@@ -204,11 +204,11 @@ module RBS
           )
           errors = typecheck.method_call(method, method_type, trace, errors: [])
 
-          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, "Call trace does not match with given method type: #{trace.inspect}"
+          assert_empty errors.map {|x| RBS::Test::Errors.to_string(x) }, -> { "Call trace does not match with given method type: #{trace.inspect}" }
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.any? {|es| es.empty? }, "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.any? {|es| es.empty? }, -> { "Call trace does not match one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           # Use `instnace_of?` instead of `is_a?` as we want to check for _the exact exception class_.
           assert exception.instance_of? error_type
@@ -246,7 +246,7 @@ module RBS
 
           method_defs = method_defs(method)
           all_errors = method_defs.map {|t| typecheck.method_call(method, t.type, trace, errors: [], annotations: t.each_annotation.to_a) }
-          assert all_errors.all? {|es| es.size > 0 }, "Call trace unexpectedly matches one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}"
+          assert all_errors.all? {|es| es.size > 0 }, -> { "Call trace unexpectedly matches one of method definitions:\n  #{trace.inspect}\n  #{method_defs.map(&:type).join(" | ")}" }
 
           result
         end

--- a/sig/unit_test/type_assertions.rbs
+++ b/sig/unit_test/type_assertions.rbs
@@ -30,11 +30,11 @@ module RBS
       type target_type = Types::ClassInstance | Types::ClassSingleton
 
       interface _BaseAssertions
-        def assert: (untyped, ?String?) -> void
+        def assert: (untyped, ?(String | ^() -> String)?) -> void
 
         def refute: (untyped, ?String?) -> void
 
-        def assert_empty: (untyped, ?String?) -> void
+        def assert_empty: (untyped, ?(String | ^() -> String)?) -> void
 
         def assert_operator: (untyped, Symbol, *untyped) -> void
 


### PR DESCRIPTION
Backports #3073 to the `aaa-4.1.x` branch, cherry-picked with `-x`.

`RBS::UnitTest::TypeAssertions` eagerly interpolates `trace.inspect` into assertion messages, so the complete argument and return values are inspected even when the assertion succeeds.

This is problematic for `ObjectSpace.reachable_objects_from_root`: after the per-Ractor GC roots change in Ruby, the returned roots hash can be very large. Building its inspection string causes excessive peak memory usage and can raise `NoMemoryError` in the Windows `test-bundled-gems` job in ruby/ruby.

Assertion messages are passed as procs, so call traces and method definitions are formatted only when an assertion fails. The same lazy formatting is applied to `assert_send_type`, `assert_send_type_error`, and `refute_send_type`.

`lib/rbs/unit_test/` ships in the gem and is what CRuby's bundled-gem tests run against, so the fix reaches CRuby only through the 4.1 line — the same reason #3074 was backported in #3075.

The cherry-pick applied cleanly with no conflicts.

## Verification

* `test/stdlib/Integer_test.rb` passes on this branch (67 tests, 648 assertions), so the succeeding path still type-checks calls as before.
* A deliberately failing `assert_send_type` still renders the full diagnostic — the call trace and the `ReturnTypeError` detail — confirming the procs are called on failure.
* `steep check` reports no type error with the widened `_BaseAssertions#assert` / `#assert_empty` signatures.
* `rake test` was run with this commit applied to `aaa-4.1.x` and its failure set is identical to the unmodified branch's, with no new failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAgPhpLrU9Z4bENCR9RUub)_