### PR TITLE
Version 4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 4.1.3 (2026-08-10)
+
+### Miscellaneous
+
+* Don't use Clang nullability qualifiers in strict ISO C mode ([#3074](https://github.com/ruby/rbs/pull/3074), Backported in [#3075](https://github.com/ruby/rbs/pull/3075))
+* Avoid eagerly inspecting call traces in type assertions ([#3073](https://github.com/ruby/rbs/pull/3073), Backported in [#3076](https://github.com/ruby/rbs/pull/3076))
+
 ## 4.1.2 (2026-08-03)
 
 ### Miscellaneous

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.1.2)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.1.2"
+  VERSION = "4.1.3"
 end


### PR DESCRIPTION
Prepares the 4.1.3 release from `aaa-4.1.x`, following step 1 of [docs/release.md](https://github.com/ruby/rbs/blob/master/docs/release.md).

**This pull request needs the `skip-changelog` label** — it carries no change of its own, and without the label it shows up in the next release's list.

## What's in 4.1.3

Two backports, both fixing breakage that only reaches CRuby through the 4.1 line:

* #3074 (backported in #3075) — `_Nullable` / `_Nonnull` are Clang extensions, so `ext/rbs_extension` failed to compile under CRuby's `omnibus compilations` job, which builds with `-std=c99 -Werror=pedantic -pedantic-errors`. See ruby/ruby#18274.
* #3073 (backported in #3076) — `RBS::UnitTest::TypeAssertions` eagerly inspected call traces even when assertions passed, which could raise `NoMemoryError` in the Windows `test-bundled-gems` job in ruby/ruby.

Each changelog entry names the original pull request, where the change was written and reviewed, and annotates it with the backport that brought it onto this line:

```markdown
* Don't use Clang nullability qualifiers in strict ISO C mode ([#3074](https://github.com/ruby/rbs/pull/3074), Backported in [#3075](https://github.com/ruby/rbs/pull/3075))
```

This follows 3.5.2, the last release to carry backports written up this way. The annotation is what keeps the entry from reading as a mistake: #3074 and #3073 are pull requests against `master`, so they will appear in the changelog a second time when the next release of the development line ships, and without it the same link under two version headings looks like a 4.1-only change written into the wrong section. #1923 is the existing example of that pair — plain in 3.6.0.pre.1, annotated in 3.5.2.

Note that `rake gem:changelog` produces the plain form, so the annotations are added by hand.

## Contents

* `lib/rbs/version.rb` — `RBS::VERSION` set to `4.1.3`
* `Gemfile.lock` — regenerated with `bundle install`; only the `rbs (4.1.2)` → `rbs (4.1.3)` line changes
* `CHANGELOG.md` — a `## 4.1.3 (2026-08-10)` section with the two entries above under `### Miscellaneous`

No summary paragraph and no `**Updated classes/modules/methods:**` line, since those are for larger releases and `X.Y.0` respectively.

The date is 2026-08-10, the day this was prepared. Per docs/release.md it has to match the day the gem is released and the `vX.Y.Z` tag, so it needs fixing up before the workflow is dispatched if this sits for a few days.

## Verification

* `rake 'gem:check_release[4.1.3]'` → ✅ `4.1.3 is the version of this commit, and CHANGELOG.md documents it.`
* `gem build rbs.gemspec` produces `rbs-4.1.3.gem`.
* `rake compile` and a parser smoke test pass.
* `gem:tag`, `gem:check_release` and `gem:gh_release` are all present on this branch — docs/release.md notes those tasks come from the commit being released, so a release cut from `aaa-4.1.x` needs them here.

## After merging

Dispatch [`release-gems.yml`](https://github.com/ruby/rbs/blob/master/.github/workflows/release-gems.yml) with `commit` set to this pull request's merge commit SHA and `version` set to `4.1.3`, leaving the ref selector on `master`.

Two follow-ups belong on `master` rather than here, and are tracked separately:

* documenting the backport changelog format in docs/release.md, so the annotation is not rediscovered each patch release,
* adding the `## 4.1.3` section to `master`'s CHANGELOG.md, the way 4.0.3's section reached the 4.1 line.