### PR TITLE
Version 4.2.0.pre.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # CHANGELOG
 
+## 4.2.0.pre.1 (2026-08-18)
+
+### Language updates
+
+* Gate forwarding parameter syntax behind parser option ([#3087](https://github.com/ruby/rbs/pull/3087))
+* Support non-ASCII identifiers ([#3082](https://github.com/ruby/rbs/pull/3082))
+* Support forwarding parameters in method types ([#3042](https://github.com/ruby/rbs/pull/3042))
+
+### Library changes
+
+* Stop the lexer reading past the end of a byte_range ([#3040](https://github.com/ruby/rbs/pull/3040))
+* Exclude CR from comment tokens to fix an off-by-one Location#end_line on CRLF files ([#3069](https://github.com/ruby/rbs/pull/3069))
+* Handle the NULL parser in the WebAssembly shim ([#3085](https://github.com/ruby/rbs/pull/3085))
+* Reject a byte position the lexer cannot start on ([#3083](https://github.com/ruby/rbs/pull/3083))
+* Don't use Clang nullability qualifiers in strict ISO C mode ([#3074](https://github.com/ruby/rbs/pull/3074))
+* Avoid eagerly inspecting call traces in type assertions ([#3073](https://github.com/ruby/rbs/pull/3073))
+* Fix TypeParam.rename to substitute variables in bounds and default types ([#3068](https://github.com/ruby/rbs/pull/3068))
+* Extract per-declaration type param alignment into entry-level align_params ([#3070](https://github.com/ruby/rbs/pull/3070))
+* Align type params across declarations in module-self types and superclass validation ([#3067](https://github.com/ruby/rbs/pull/3067))
+* Build the wasm module with -DNDEBUG ([#3066](https://github.com/ruby/rbs/pull/3066))
+* Rename NODISCARD macro to RBS_NODISCARD ([#3065](https://github.com/ruby/rbs/pull/3065))
+
+### Miscellaneous
+
+* Skip JSON 2-only tests with JSON 3 ([#3084](https://github.com/ruby/rbs/pull/3084))
+* Pin GitHub Actions to commit hashes ([#3020](https://github.com/ruby/rbs/pull/3020))
+
 ## 4.1.3 (2026-08-10)
 
 ### Miscellaneous

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.2.0.dev)
+    rbs (4.2.0.pre.1)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.2.0.dev"
+  VERSION = "4.2.0.pre.1"
 end


### PR DESCRIPTION
Prepares the 4.2.0.pre.1 release: `RBS::VERSION` set to `4.2.0.pre.1`, `Gemfile.lock` regenerated, and the 4.2.0.pre.1 section added to `CHANGELOG.md`.

This is the first prerelease of the 4.2 line, so the section starts at `v4.1.2` — the latest tag reachable from `master` — which is what a prerelease documents. 16 pull requests, sorted into Language updates, Library changes and Miscellaneous. There is no Signature updates section: nothing under `core/` or `stdlib/` changed this cycle, and the one pull request that touched `test/stdlib/` (#3084) is a test-only change.

The section is the list of pull requests alone, with no summary paragraphs above it. A prerelease is a checkpoint in a cycle rather than the cycle itself, so summarizing it means writing the same summary twice — once here and again on the release proper that folds this list into it. #3091 writes that into `docs/release.md`; it is a separate pull request, and this one carries the three release files and nothing else.

Two of the entries, #3073 and #3074, are already released: 4.1.3 shipped them as backports from `aaa-4.1.x`. They are listed here under the pull requests they were written in, which is how the development line writes up a change that was backported — the 4.1.3 entries carry the `Backported in` annotation that tells the two occurrences apart.

Worth knowing before merging: **forwarding parameters are not usable in this prerelease.** #3042 added `(...)` to the parser and the AST, and #3087 then gated the syntax behind a `rbs_parser_options_t` flag that is off by default and not exposed to the public Ruby API, because nothing consumes `Types::Function#forwarding` yet. Both are listed under Language updates so the pair is visible; `(...)` stays a syntax error until the type checking semantics are settled.

Eight pull requests merged since `v4.1.2` are labeled `skip-changelog` and left out: #3063, #3064, #3071, #3078, #3079, #3080, #3086 and #3088.

The changelog list and the details it was sorted from come from the `Changelog` workflow, dispatched on `master` in both formats — [`list`](https://github.com/ruby/rbs/actions/runs/32117440113) and [`json`](https://github.com/ruby/rbs/actions/runs/32117447367).

`rake 'gem:check_release[4.2.0.pre.1]'` passes on this branch.

The date in the heading is 2026-08-18, the day this was prepared. It has to match the day the gem is released, so fix it up before step 2 if this sits for a few days.

This is step 1 only. Once merged, the release is cut by dispatching `Release gems` with the merge commit SHA and `4.2.0.pre.1`.