### PR TITLE
Write up a prerelease without summary paragraphs

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -101,7 +101,8 @@ The sections always appear in this order; delete the ones that end up empty, whi
 on a small release. Two things scale with the size of the release:
 
 - **Summary paragraphs**, above the first section. A patch release usually has none, 4.1.0 has four
-  paragraphs, and 4.0.0 has nine.
+  paragraphs, and 4.0.0 has nine. A prerelease has none whatever its size: the cycle it belongs to
+  is summarized once, on the release proper that folds it in.
 - **A list of the types whose signatures changed**, as the first line of `### Signature updates`,
   written as `**Updated classes/modules/methods:**` followed by the names in backticks. Used on
   `X.Y.0` releases only.


### PR DESCRIPTION
`docs/release.md` describes the summary above the sections as scaling with the size of the release, which says nothing about `X.Y.Z.pre.N`. A prerelease can carry a large section and still be a checkpoint in a cycle rather than the cycle itself, so summarizing one means writing that summary twice: once on the prerelease, and again on the release proper that folds its pull requests into its own section. This says a prerelease carries the list alone.

Split out of #3090, which is the first prerelease written up this way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LrJnRwFjCYw9h5U8LkRqqP)_