### PR TITLE
Omit forwarding parameter tests on JRuby

### DIFF
--- a/test/rbs/method_type_parsing_test.rb
+++ b/test/rbs/method_type_parsing_test.rb
@@ -83,6 +83,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     parse_method_type_with_forwarding("(...) -> void").tap do |type|
       assert_equal "(...) -> void", type.to_s
       assert_instance_of Types::Function::ForwardingParam, type.type.forwarding
@@ -100,6 +102,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter_with_overload_continuation
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     _, declarations = parse_signature_with_forwarding(<<~RBS)
       class Foo
         def foo: (...) -> void
@@ -113,6 +117,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter_rejects_nonleading_parameters
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     [
       "(?String value, ...) -> void",
       "(*String values, ...) -> void",
@@ -127,6 +133,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter_must_be_last
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     [
       "(..., String) -> void",
       "(..., ...) -> void",
@@ -139,6 +147,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter_cannot_have_explicit_block
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     [
       "(...) { () -> void } -> void",
       "(...) ?{ () -> void } -> void",
@@ -150,6 +160,8 @@ class RBS::MethodTypeParsingTest < Test::Unit::TestCase
   end
 
   def test_forwarding_parameter_is_not_allowed_in_block_types
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
+
     error = assert_raise(RBS::ParsingError) do
       parse_method_type_with_forwarding("() { (...) -> void } -> void")
     end

--- a/test/rbs/schema_test.rb
+++ b/test/rbs/schema_test.rb
@@ -120,6 +120,10 @@ class RBS::SchemaTest < Test::Unit::TestCase
     JSONValidator.method_type.validate!(
       parse_method_type("[G] (A a, ?B, *C, d: D, ?e: E e, **f) ?{ (G) -> void } -> String").to_json
     )
+  end
+
+  def test_method_type_schema_with_forwarding_parameter
+    omit_on_jruby! "The WebAssembly parser does not support forwarding parameter syntax"
 
     # Forwarding parameters are only parsed when explicitly enabled
     source = "(String message, ...) -> void"


### PR DESCRIPTION
The JRuby workflow has been failing since #3087 merged (e.g. [this run](https://github.com/ruby/rbs/actions/runs/32116748314) on the merge queue for #3040): the forwarding parameter tests call the private parser entry points with `enable_forwarding_params: true`, and the WebAssembly parser shim that JRuby loads deliberately rejects the option with `NotImplementedError` (`lib/rbs/wasm/parser.rb`). That produced 4 failures and 3 errors on every JRuby run.

This omits the seven affected tests on JRuby with `omit_on_jruby!`, following the existing pattern for C-extension-only paths (e.g. `test/rbs/wasm/serialization_test.rb`):

- `test/rbs/method_type_parsing_test.rb`: the six tests that parse with the forwarding option enabled. `test_forwarding_parameter_syntax_is_not_enabled_by_default` and `test_forwarding_parameter_is_not_allowed_in_proc_types` keep running on JRuby, since they go through the public API, which behaves the same on both parsers.
- `test/rbs/schema_test.rb`: the forwarding part of `test_method_type_schema` moves to its own test case (`test_method_type_schema_with_forwarding_parameter`) so the default method type schema coverage still runs on JRuby.

Both files pass on CRuby with the extension compiled, and no library code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KscuNdoWHSkZx3iLD2XcbZ)_