### PR TITLE
Make `rbs collection` say where the gem list comes from

### DIFF
--- a/docs/collection.md
+++ b/docs/collection.md
@@ -2,6 +2,17 @@
 
 `rbs collection` sub command manages third party gems' RBS. In short, it is `bundler` for RBS.
 
+## Quickstart
+
+In a project that has a `Gemfile.lock`:
+
+```console
+$ rbs collection init
+$ rbs collection install
+```
+
+`rbs collection` reads `Gemfile.lock`, so there is no list of dependencies to maintain. `rbs` and type checkers such as Steep load the installed RBS files automatically.
+
 ## Requirements
 
 * `git(1)`
@@ -17,33 +28,44 @@ First, generate the configuration file, `rbs_collection.yaml`, with `rbs collect
 $ rbs collection init
 created: rbs_collection.yaml
 
+rbs collection installs RBS files for the gems in your Gemfile.lock.
+Gems in Gemfile.lock don't need to be listed anywhere.
+
+Next steps:
+  $ echo "/.gem_rbs_collection/" >> .gitignore
+  $ rbs collection install    # writes rbs_collection.lock.yaml; keep it in version control
+
 $ cat rbs_collection.yaml
+# rbs collection installs RBS files for the gems in your Gemfile.lock.
+# Run `rbs collection install` to resolve them into rbs_collection.lock.yaml and install them.
+
 # Download sources
 sources:
-  - name: ruby/gem_rbs_collection
+  - type: git
+    name: ruby/gem_rbs_collection
     remote: https://github.com/ruby/gem_rbs_collection.git
     revision: main
     repo_dir: gems
+
+# You can specify local directories as sources also.
+# - type: local
+#   path: path/to/your/local/repository
 
 # A directory to install the downloaded RBSs
 path: .gem_rbs_collection
 
 # gems:
+#   # RBS for a library that doesn't appear in Gemfile.lock, such as a non-gem standard library.
+#   - name: socket
+#
 #   # If you want to avoid installing rbs files for gems, you can specify them here.
 #   - name: GEM_NAME
 #     ignore: true
 ```
 
-I also recommend updating `.gitignore`.
-
-```console
-$ echo /.gem_rbs_collection/ >> .gitignore
-```
-
 ### Install dependencies
 
 Then, install gems' RBS with `rbs collection install`! It copies RBS from [the gem RBS repository](https://github.com/ruby/gem_rbs_collection) to `.gem_rbs_collection/` directory by default.
-I recommend to ignore `.gem_rbs_collection/` from version control system, such as Git.
 
 ```console
 $ rbs collection install
@@ -86,9 +108,9 @@ sources:
 path: .gem_rbs_collection
 
 gems:
-  # If the Gemfile.lock doesn't contain csv gem but you use csv gem,
-  # you can write the gem name explicitly to install RBS of the gem.
-  - name: csv
+  # If the Gemfile.lock doesn't contain socket but you use it,
+  # you can write the library name explicitly to install RBS of the library.
+  - name: socket
 
   # If the Gemfile.lock contains nokogiri gem but you don't want to use the RBS,
   # you can ignore the gem.

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1104,6 +1104,9 @@ EOB
         end
 
         config_path.write(<<~'YAML')
+          # rbs collection installs RBS files for the gems in your Gemfile.lock.
+          # Run `rbs collection install` to resolve them into rbs_collection.lock.yaml and install them.
+
           # Download sources
           sources:
             - type: git
@@ -1120,11 +1123,23 @@ EOB
           path: .gem_rbs_collection
 
           # gems:
+          #   # RBS for a library that doesn't appear in Gemfile.lock, such as a non-gem standard library.
+          #   - name: socket
+          #
           #   # If you want to avoid installing rbs files for gems, you can specify them here.
           #   - name: GEM_NAME
           #     ignore: true
         YAML
-        stdout.puts "created: #{config_path}"
+        stdout.puts <<~MESSAGE
+          created: #{config_path}
+
+          rbs collection installs RBS files for the gems in your Gemfile.lock.
+          Gems in Gemfile.lock don't need to be listed anywhere.
+
+          Next steps:
+            $ echo "/.gem_rbs_collection/" >> .gitignore
+            $ rbs collection install    # writes rbs_collection.lock.yaml; keep it in version control
+        MESSAGE
       when 'clean'
         unless lock_path.exist?
           puts "#{lock_path} should exist to clean"

--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1089,17 +1089,30 @@ EOB
 
       case args[0]
       when 'install', 'instal', 'insta', 'inst', 'ins', 'in', 'i'
-        unless params[:frozen]
-          Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition)
+        if params[:frozen]
+          unless lock_path.exist?
+            if config_path.exist?
+              stderr.puts "#{lock_path} not found. Run `rbs collection install` without `--frozen` to generate it."
+            else
+              stderr.puts "#{lock_path} not found. Run `rbs collection init` and `rbs collection install` to generate it."
+            end
+            return 1
+          end
+        else
+          return 1 unless collection_config_available?(config_path)
+          definition = bundler_definition or return 1
+          Collection::Config.generate_lockfile(config_path: config_path, definition: definition)
         end
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'update', 'updat', 'upda', 'upd', 'up', 'u'
+        return 1 unless collection_config_available?(config_path)
+        definition = bundler_definition or return 1
         # TODO: Be aware of argv to update only specified gem
-        Collection::Config.generate_lockfile(config_path: config_path, definition: Bundler.definition, with_lockfile: false)
+        Collection::Config.generate_lockfile(config_path: config_path, definition: definition, with_lockfile: false)
         Collection::Installer.new(lockfile_path: lock_path, stdout: stdout).install_from_lockfile
       when 'init'
         if config_path.exist?
-          puts "#{config_path} already exists"
+          stderr.puts "#{config_path} already exists"
           return 1
         end
 
@@ -1142,18 +1155,36 @@ EOB
         MESSAGE
       when 'clean'
         unless lock_path.exist?
-          puts "#{lock_path} should exist to clean"
+          stderr.puts "#{lock_path} should exist to clean"
           return 1
         end
         Collection::Cleaner.new(lockfile_path: lock_path)
       when 'help', 'hel', 'he', 'h'
-        puts opts.help
+        stdout.puts opts.help
       else
-        puts opts.help
+        stdout.puts opts.help
         return 1
       end
 
       0
+    end
+
+    def collection_config_available?(config_path)
+      return true if config_path.exist?
+
+      stderr.puts "#{config_path} not found. Run `rbs collection init` to generate it."
+      false
+    end
+
+    def bundler_definition
+      definition = Bundler.definition
+      return definition if definition.lockfile.file?
+
+      stderr.puts "#{definition.lockfile} not found. Run `bundle install` to generate it."
+      nil
+    rescue Bundler::GemfileNotFound
+      stderr.puts "Gemfile not found. `rbs collection` reads the gems to install from Gemfile.lock."
+      nil
     end
 
     def collection_options(args)

--- a/sig/cli.rbs
+++ b/sig/cli.rbs
@@ -76,6 +76,12 @@ module RBS
 
     def run_collection: (Array[String], LibraryOptions) -> Integer
 
+    # Returns `true` if the collection config exists, otherwise prints a message to `stderr` and returns `false`
+    def collection_config_available?: (Pathname) -> bool
+
+    # Returns `nil` if `Gemfile` or `Gemfile.lock` is not found, after printing a message to `stderr`
+    def bundler_definition: () -> Bundler::Definition?
+
     def run_annotate: (Array[String], top) -> Integer
 
     def run_subtract: (Array[String], top) -> Integer

--- a/sig/shims/bundler.rbs
+++ b/sig/shims/bundler.rbs
@@ -1,4 +1,7 @@
 module Bundler
+  class GemfileNotFound < StandardError
+  end
+
   class LockfileParser
     def initialize: (String) -> void
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1082,6 +1082,30 @@ Processing `lib`...
     end
   end
 
+  def test_collection_init
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          assert_cli_success do
+            cli.run(%w(collection init))
+          end
+
+          config = Pathname(dir).join(RBS::Collection::Config::PATH).read
+          assert_match(/gems in your Gemfile\.lock/, config)
+          assert_match(/rbs collection install/, config)
+
+          yaml = YAML.load(config)
+          assert_equal ".gem_rbs_collection", yaml["path"]
+          assert_equal ["ruby/gem_rbs_collection"], yaml["sources"].map {|source| source["name"] }
+
+          assert_match(/created: .*rbs_collection\.yaml/, stdout.string)
+          assert_match(/gems in your Gemfile\.lock/, stdout.string)
+          assert_match(/\$ rbs collection install/, stdout.string)
+        end
+      end
+    end
+  end
+
   def test_collection_install
     omit_on_jruby! "`rbs collection install` runs `bundle install`, which builds native gem extensions that do not compile on JRuby"
 

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1106,6 +1106,110 @@ Processing `lib`...
     end
   end
 
+  def test_collection_install_without_config
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          refute_cli_success do
+            cli.run(%w(collection install))
+          end
+
+          assert_match(/rbs_collection\.yaml not found/, stderr.string)
+          assert_match(/rbs collection init/, stderr.string)
+        end
+      end
+    end
+  end
+
+  def test_collection_update_without_config
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          refute_cli_success do
+            cli.run(%w(collection update))
+          end
+
+          assert_match(/rbs_collection\.yaml not found/, stderr.string)
+          assert_match(/rbs collection init/, stderr.string)
+        end
+      end
+    end
+  end
+
+  def test_collection_install_without_gemfile
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Pathname(dir).join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources: []
+          path: .gem_rbs_collection
+        YAML
+
+        _stdout, stderr = run_rbs_collection("install", bundler: false) do |status|
+          refute_predicate status, :success?
+        end
+
+        assert_match(/Gemfile not found/, stderr)
+      end
+    end
+  end
+
+  def test_collection_install_without_gemfile_lock
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        dir = Pathname(dir)
+        dir.join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources: []
+          path: .gem_rbs_collection
+        YAML
+        dir.join("Gemfile").write(<<~RUBY)
+          source "https://rubygems.org"
+        RUBY
+
+        _stdout, stderr = run_rbs_collection("install", bundler: false) do |status|
+          refute_predicate status, :success?
+        end
+
+        assert_match(/Gemfile\.lock not found/, stderr)
+        assert_match(/bundle install/, stderr)
+      end
+    end
+  end
+
+  def test_collection_install_frozen_without_lockfile
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Pathname(dir).join(RBS::Collection::Config::PATH).write(<<~YAML)
+          sources: []
+          path: .gem_rbs_collection
+        YAML
+
+        with_cli do |cli|
+          refute_cli_success do
+            cli.run(%w(collection install --frozen))
+          end
+
+          assert_match(/rbs_collection\.lock\.yaml not found/, stderr.string)
+          assert_match(/without `--frozen`/, stderr.string)
+        end
+      end
+    end
+  end
+
+  def test_collection_install_frozen_without_config_and_lockfile
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        with_cli do |cli|
+          refute_cli_success do
+            cli.run(%w(collection install --frozen))
+          end
+
+          assert_match(/rbs_collection\.lock\.yaml not found/, stderr.string)
+          assert_match(/rbs collection init/, stderr.string)
+        end
+      end
+    end
+  end
+
   def test_collection_install
     omit_on_jruby! "`rbs collection install` runs `bundle install`, which builds native gem extensions that do not compile on JRuby"
 


### PR DESCRIPTION
Part of #3093.

Ask a coding agent to set up RBS and Steep in a project and it usually writes a Steepfile that lists every dependency with `library`, one gem per line. `rbs collection` exists so that nobody has to maintain that list -- it reads `Gemfile.lock`, and `rbs` and Steep load the installed RBS files on their own -- but nothing an agent (or a person) reads on the way there says so. This PR changes what `rbs collection` prints and writes. The `steep init` template, the other half of #3093, is https://github.com/soutaro/steep/pull/2269.

## `init` says where the gem list comes from

`rbs collection init` printed `created: rbs_collection.yaml` and nothing else: not the next command, not the fact that would stop someone from enumerating gems. The generated `rbs_collection.yaml` had the same gap -- comments for `sources`, `path` and `gems[].ignore`, none for "the gem list is read from `Gemfile.lock`". Now:

```console
$ rbs collection init
created: rbs_collection.yaml

rbs collection installs RBS files for the gems in your Gemfile.lock.
Gems in Gemfile.lock don't need to be listed anywhere.

Next steps:
  $ echo "/.gem_rbs_collection/" >> .gitignore
  $ rbs collection install    # writes rbs_collection.lock.yaml; keep it in version control
```

The generated config opens with the same two facts. Its commented-out `gems:` example showed only `ignore: true`; the other half -- adding an entry for a library that `Gemfile.lock` doesn't carry -- was documented only in `docs/collection.md`. The example is `socket`, a non-gem standard library (`NONGEM_STDLIBS`), rather than `pathname`, whose types moved to `core/pathname.rbs` in 8066053b, or `csv`, which is in `ALUMNI_STDLIBS` and warns when installed.

`docs/collection.md` gets a quickstart at the top, its `cat rbs_collection.yaml` block matches the generated file again (it had lost `type: git` and the local source comment), and the `.gitignore` paragraph that now duplicates the `init` output is gone.

## The missing-file paths no longer end in a backtrace

`exe/rbs` has no rescue, so every one of these printed a full backtrace, which reads as "`rbs collection` is broken" and sends people back to `library`. `init` now points at `rbs collection install`, so they are easier to reach than before.

| State | Before | After |
| --- | --- | --- |
| no `rbs_collection.yaml` (`install`, `update`) | `Errno::ENOENT` | names `rbs collection init` |
| no lock file under `--frozen` | `Errno::ENOENT` | says to run without `--frozen`, or to run `init` first when the config is missing too |
| no `Gemfile` | `Bundler::GemfileNotFound` | names `Gemfile.lock` |
| `Gemfile` but no `Gemfile.lock` | `undefined method 'specs' for nil` | names `bundle install` |

Raising `RBS::Collection::Config::CollectionNotAvailable`, which #3093 suggested, would keep the backtrace for the same reason, so these write to `stderr` and return 1 like the rest of `run_collection`.

**Observable change:** `already exists` and `should exist to clean` used `Kernel#puts`, which writes to the real `$stdout` and ignores the injected IO. Both are failures that return 1, so they move to `stderr`.

## Notes

* Non-gem standard libraries can be loaded either way -- listed under `gems:` here, or with `library` in a Steepfile -- so the two templates are not in conflict; each shows the option that belongs to it.
* Tests cover each of the four paths above, `--frozen` with neither file, and `--frozen` with a lock file and no config, which keeps working. `steep check` does not run in my environment (`steep/patch.rbs` defines `Module#ruby2_keywords`, which now collides with `core/module.rbs`, on `master` as well); with that one `signature` line removed it reports `No type error detected.`
