### PR TITLE
Drop runtime support for Ruby 3.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,6 @@ plugins:
   - rubocop-on-rbs
 
 AllCops:
-  TargetRubyVersion: 3.4
   DisabledByDefault: true
   Exclude:
     - 'vendor/bundle/**/*'

--- a/lib/rbs/prototype/helpers.rb
+++ b/lib/rbs/prototype/helpers.rb
@@ -5,58 +5,25 @@ module RBS
     module Helpers
       private
 
-      # Prism can't parse Ruby 3.2 code
-      if RUBY_VERSION >= "3.3"
-        def parse_comments(string, include_trailing:)
-          Prism.parse_comments(string, version: "current").yield_self do |prism_comments| # steep:ignore UnexpectedKeywordArgument
-            prism_comments.each_with_object({}) do |comment, hash| #$ Hash[Integer, AST::Comment]
-              # Skip EmbDoc comments
-              next unless comment.is_a?(Prism::InlineComment)
-              # skip like `module Foo # :nodoc:`
-              next if comment.trailing? && !include_trailing
+      def parse_comments(string, include_trailing:)
+        Prism.parse_comments(string, version: "current").yield_self do |prism_comments| # steep:ignore UnexpectedKeywordArgument
+          prism_comments.each_with_object({}) do |comment, hash| #$ Hash[Integer, AST::Comment]
+            # Skip EmbDoc comments
+            next unless comment.is_a?(Prism::InlineComment)
+            # skip like `module Foo # :nodoc:`
+            next if comment.trailing? && !include_trailing
 
-              line = comment.location.start_line
-              body = "#{comment.location.slice}\n"
-              body = body[2..-1] or raise
-              body = "\n" if body.empty?
+            line = comment.location.start_line
+            body = "#{comment.location.slice}\n"
+            body = body[2..-1] or raise
+            body = "\n" if body.empty?
 
-              comment = AST::Comment.new(string: body, location: nil)
-              if prev_comment = hash.delete(line - 1)
-                hash[line] = AST::Comment.new(string: prev_comment.string + comment.string,
-                                              location: nil)
-              else
-                hash[line] = comment
-              end
-            end
-          end
-        end
-      else
-        require "ripper"
-        def parse_comments(string, include_trailing:)
-          Ripper.lex(string).yield_self do |tokens|
-            code_lines = {} #: Hash[Integer, bool]
-            tokens.each.with_object({}) do |token, hash| #$ Hash[Integer, AST::Comment]
-              case token[1]
-              when :on_sp, :on_ignored_nl
-                # skip
-              when :on_comment
-                line = token[0][0]
-                # skip like `module Foo # :nodoc:`
-                next if code_lines[line] && !include_trailing
-                body = token[2][2..-1] or raise
-
-                body = "\n" if body.empty?
-
-                comment = AST::Comment.new(string: body, location: nil)
-                if prev_comment = hash.delete(line - 1)
-                  hash[line] = AST::Comment.new(string: prev_comment.string + comment.string,
-                                                location: nil)
-                else
-                  hash[line] = comment
-                end
-              else
-                code_lines[token[0][0]] = true
-              end
+            comment = AST::Comment.new(string: body, location: nil)
+            if prev_comment = hash.delete(line - 1)
+              hash[line] = AST::Comment.new(string: prev_comment.string + comment.string,
+                                            location: nil)
+            else
+              hash[line] = comment
             end
           end
         end

--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -527,7 +527,7 @@ module RBS
 
         generate_mixin(mod, decl, type_name, type_name_absolute)
 
-        unless mod < Struct || (RUBY_VERSION >= '3.2' && mod < Data)
+        unless mod < Struct || mod < Data
           generate_methods(mod, type_name, decl.members) unless outline
         end
 

--- a/lib/rbs/prototype/runtime/value_object_generator.rb
+++ b/lib/rbs/prototype/runtime/value_object_generator.rb
@@ -212,7 +212,6 @@ module RBS
 
       class DataGenerator < ValueObjectBase
         def self.generatable?(target)
-          return false unless RUBY_VERSION >= '3.2'
           return false unless target < Data
           # Avoid direct inherited class like `class Option < Data`
           return false unless target.respond_to?(:members)

--- a/rbs.gemspec
+++ b/rbs.gemspec
@@ -67,14 +67,10 @@ Gem::Specification.new do |spec|
     spec.extensions = %w{ext/rbs_extension/extconf.rb}
   end
 
-  if false
-    spec.required_ruby_version = ">= 3.4"
-  end
-
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
   spec.add_dependency "logger"
   spec.add_dependency "prism", ">= 1.6.0"
   spec.add_dependency "tsort"


### PR DESCRIPTION
Ruby 3.2 reached EOL on 2026-04-01, and CI has been running 3.3, 3.4, 4.0 and head for a while, so 3.2 was declared as supported without being tested. `required_ruby_version` becomes `>= 3.3`, which is what CI actually covers. Users still on 3.2 stay on the 4.1 line.

Closes #2830.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WR8tdzP1M9oyEKcyfLq69Z)_