### PR TITLE
docs: fix typo prefered -> preferred

### DIFF
--- a/docs/data_and_struct.md
+++ b/docs/data_and_struct.md
@@ -48,7 +48,7 @@ class Measure < Data.define(:amount, :unit)
 end
 ```
 
-@soutaro has prefered inheriting from `Data.define`, but you may find an extra annonymous class in `.ancestors` [^1].
+@soutaro has preferred inheriting from `Data.define`, but you may find an extra annonymous class in `.ancestors` [^1].
 
 ```ruby
 Measure.ancestors #=> [Measure, #<Class:0xOOF>, Data, ...]


### PR DESCRIPTION
One-word typo fix in `docs/data_and_struct.md:51`: "@soutaro has prefered inheriting from..." → "preferred".

Spelling only — the sentence still attributes the same position to @soutaro, unchanged.
