### PR TITLE
Start 4.3 development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,5 @@
 # CHANGELOG
 
-## 4.2.1.pre.1 (2026-08-26)
-
-### Library changes
-
-* Remove some obsolete ruby version guards ([#3100](https://github.com/ruby/rbs/pull/3100))
-
-#### rbs collection
-
-* Make `rbs collection` say where the gem list comes from ([#3094](https://github.com/ruby/rbs/pull/3094))
-
-### Miscellaneous
-
-* Run `bundle` with the Ruby running the tests ([#3099](https://github.com/ruby/rbs/pull/3099))
-* docs: fix typo prefered -> preferred ([#3098](https://github.com/ruby/rbs/pull/3098))
-
 ## 4.2.0 (2026-08-23)
 
 RBS 4.2 accepts non-ASCII characters in identifiers. Method names, instance variable names and parameter names can be written in any script, and other names may contain non-ASCII characters as long as they start with an ASCII letter, which is what tells a constant from a method name.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.2.0)
+    rbs (4.3.0.dev)
       logger
       prism (>= 1.6.0)
       tsort

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    rbs (4.2.1.pre.1)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.2.1.pre.1"
+  VERSION = "4.2.0"
 end

--- a/lib/rbs/version.rb
+++ b/lib/rbs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RBS
-  VERSION = "4.2.0"
+  VERSION = "4.3.0.dev"
 end


### PR DESCRIPTION
Bumps `master` to `4.3.0.dev`, so the version says 4.3 is what is being developed.

Built on top of #3103, which takes `master` back to `4.2.0`; merge that one first.