### PR TITLE
Bump net-protocol from 0.2.2 to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
       prism (~> 1.5)
     minitest-mock (5.27.0)
     mutex_m (0.3.0)
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol


### PR DESCRIPTION
## Problem

`test (head, stdlib_test rubocop)` fails on ruby-head with 8 errors, all in Net::HTTP / open-uri ([run](https://github.com/ruby/rbs/actions/runs/33056526924/job/98464589988)):

```
ArgumentError: wrong number of arguments (given 3, expected 1..2)
  net-protocol-0.2.2/lib/net/protocol.rb:194:in 'Net::BufferedIO#readuntil'
  ruby-head/lib/ruby/4.1.0+4/net/http/response.rb:164:in 'Net::HTTPResponse.read_line'
```

## Cause

ruby/net-http#325 (in ruby/ruby as https://github.com/ruby/ruby/commit/331568b2a) made `Net::HTTPResponse` use `readuntil(limit:)`, which requires net-protocol >= 0.3.0.

ruby-head ships 0.3.0 as a default gem, so it is consistent on its own. But `net/http` is a default gem too, so its dependency never reaches Bundler's resolution — our lock pinned 0.2.2 through `net-smtp`, which carries no lower bound, and the installed 0.2.2 shadowed ruby-head's 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
