### PR TITLE
Declare Net::ReadLimitExceeded added in net-protocol 0.3.0

### DIFF
--- a/stdlib/net-protocol/0/net-protocol.rbs
+++ b/stdlib/net-protocol/0/net-protocol.rbs
@@ -27,6 +27,13 @@ module Net
   class ProtoRetriableError < ProtocolError
   end
 
+  # <!-- rdoc-file=lib/net/protocol.rb -->
+  # ReadLimitExceeded, a subclass of ProtocolError, is raised if the terminator is
+  # not found within the byte limit given to Net::BufferedIO#readuntil.
+  #
+  class ReadLimitExceeded < ProtocolError
+  end
+
   class HTTPBadResponse < StandardError
   end
 


### PR DESCRIPTION
## What

net-protocol 0.3.0 adds `Net::ReadLimitExceeded`, raised when `Net::BufferedIO#readuntil` does not find the terminator within the byte limit it was given. Declare it in `stdlib/net-protocol/0/net-protocol.rbs`.

Added in ruby/net-protocol#67.

## Notes

`readuntil` itself gained a `limit:` keyword in the same release, but it needs no signature update: `Net::BufferedIO` is `:nodoc: internal use only` and is not declared in RBS.

The other addition in 0.3.0, `Net::Protocol::TCP_SOCKET_NEW_HAS_OPEN_TIMEOUT`, is a `private_constant`.

Independent of #3106, which bumps the lock to 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)