### PR TITLE
Compare RBS strings as binary data

### DIFF
--- a/src/string.c
+++ b/src/string.c
@@ -37,5 +37,5 @@ size_t rbs_string_len(const rbs_string_t self) {
 bool rbs_string_equal(const rbs_string_t lhs, const rbs_string_t rhs) {
     if (lhs.start == rhs.start && lhs.end == rhs.end) return true;
     if (rbs_string_len(lhs) != rbs_string_len(rhs)) return false;
-    return strncmp(lhs.start, rhs.start, rbs_string_len(lhs)) == 0;
+    return memcmp(lhs.start, rhs.start, rbs_string_len(lhs)) == 0;
 }


### PR DESCRIPTION
Summary: compare equal-length internal strings as binary data so embedded NUL bytes cannot hide a later difference.\n\nReproduction: two equal-length record keys differing after an embedded NUL collapse into one before this change. The focused native-parser model retains both after the change.\n\nVerification: focused baseline/fixed model, combined RBS 4.2.0 consumer models, native hash model, and RuboCop (738 files, zero offenses).\n\nCompatibility: no API or format change; ordinary strings retain existing behavior. No tests are added in this PR.