### PR TITLE
Use portable collection paths in cleaner

### DIFF
--- a/lib/rbs/collection/cleaner.rb
+++ b/lib/rbs/collection/cleaner.rb
@@ -11,9 +11,8 @@ module RBS
 
       def clean
         lock.repo_path.glob('*/*') do |dir|
-          *_, gem_name, version = dir.to_s.split('/')
-          gem_name or raise
-          version or raise
+          gem_name = dir.parent.basename.to_s
+          version = dir.basename.to_s
           next if needed? gem_name, version
 
           case


### PR DESCRIPTION
Summary: derive collection gem and version names through Pathname components instead of splitting paths on a slash. This preserves cleaning behavior on Windows-style path implementations.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.