### PR TITLE
Handle coreless singleton definitions

### DIFF
--- a/lib/rbs/definition_builder.rb
+++ b/lib/rbs/definition_builder.rb
@@ -346,7 +346,7 @@ module RBS
           if entry.is_a?(Environment::ClassEntry)
             new_method = definition.methods[:new]
 
-            if new_method.defs.all? {|d| d.defined_in == BuiltinNames::Class.name }
+            if new_method && new_method.defs.all? {|d| d.defined_in == BuiltinNames::Class.name }
               # The method is _untyped new_.
 
               alias_methods = definition.methods.each.with_object([]) do |entry, array|


### PR DESCRIPTION
Summary: tolerate a coreless class singleton definition without a synthesized new method. The existing core-backed constructor handling is unchanged.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.