### PR TITLE
Isolate mutable state in copied environments

### DIFF
--- a/lib/rbs/environment.rb
+++ b/lib/rbs/environment.rb
@@ -58,12 +58,13 @@ module RBS
 
     def initialize_copy(other)
       @sources = other.sources.dup
-      @class_decls = other.class_decls.dup
+      @class_decls = other.class_decls.transform_values(&:dup)
       @interface_decls = other.interface_decls.dup
       @type_alias_decls = other.type_alias_decls.dup
       @constant_decls = other.constant_decls.dup
       @global_decls = other.global_decls.dup
       @class_alias_decls = other.class_alias_decls.dup
+      @normalize_module_name_cache = other.instance_variable_get(:@normalize_module_name_cache).dup
     end
 
     def self.from_loader(loader)

--- a/lib/rbs/environment/class_entry.rb
+++ b/lib/rbs/environment/class_entry.rb
@@ -12,6 +12,10 @@ module RBS
         @context_decls = []
       end
 
+      def initialize_copy(other)
+        @context_decls = other.context_decls.dup
+      end
+
       def <<(context_decl)
         context_decls << context_decl
         @primary_decl = nil

--- a/lib/rbs/environment/class_entry.rb
+++ b/lib/rbs/environment/class_entry.rb
@@ -14,6 +14,7 @@ module RBS
 
       def initialize_copy(other)
         @context_decls = other.context_decls.dup
+        self
       end
 
       def <<(context_decl)

--- a/lib/rbs/environment/module_entry.rb
+++ b/lib/rbs/environment/module_entry.rb
@@ -12,6 +12,10 @@ module RBS
         @context_decls = []
       end
 
+      def initialize_copy(other)
+        @context_decls = other.context_decls.dup
+      end
+
       def <<(context_decl)
         context_decls << context_decl
         self

--- a/lib/rbs/environment/module_entry.rb
+++ b/lib/rbs/environment/module_entry.rb
@@ -14,6 +14,7 @@ module RBS
 
       def initialize_copy(other)
         @context_decls = other.context_decls.dup
+        self
       end
 
       def <<(context_decl)


### PR DESCRIPTION
Summary: duplicate class/module entry declaration arrays and the module-name normalization cache when copying an environment, preventing mutations in one copy from leaking into another.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.