### PR TITLE
Treat signature directory paths literally

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -990,7 +990,7 @@ Options:
       args.each do |file|
         path = Pathname(file)
         if path.directory?
-          Pathname.glob((path + "**/*.rbs").to_s).each do |path|
+          path.glob("**/*.rbs").each do |path|
             stdout.puts "Processing #{path}..."
             annotator.annotate_file(path)
           end

--- a/lib/rbs/file_finder.rb
+++ b/lib/rbs/file_finder.rb
@@ -12,7 +12,7 @@ module RBS
         yield path
 
       when path.directory?
-        paths = Pathname.glob("#{path}/**/*.rbs")
+        paths = path.glob("**/*.rbs")
 
         if skip_hidden
           paths.select! do |child|


### PR DESCRIPTION
Summary: use Pathname-relative globbing so directory names containing glob metacharacters are treated literally by file discovery and annotation.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.