### PR TITLE
Validate local collection symlink targets

### DIFF
--- a/lib/rbs/collection/config/lockfile.rb
+++ b/lib/rbs/collection/config/lockfile.rb
@@ -82,7 +82,9 @@ module RBS
               raise CollectionNotAvailable unless meta_path.exist?
               raise CollectionNotAvailable unless library_data(gem) == YAML.load(meta_path.read)
             when Sources::Local
-              raise CollectionNotAvailable unless fullpath.join(gem[:name], gem[:version]).symlink?
+              installed_path = fullpath.join(gem[:name], gem[:version])
+              source_path = source.full_path.join(gem[:name], gem[:version])
+              raise CollectionNotAvailable unless installed_path.symlink? && File.identical?(installed_path, source_path)
             end
           end
         end


### PR DESCRIPTION
Summary: require installed local collection symlinks to resolve to the configured source, rather than accepting any existing stale target.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.