### PR TITLE
Fail CLI queries for missing types

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -322,6 +322,7 @@ EOU
         end
       else
         stdout.puts "Cannot find class: #{type_name}"
+        return 1
       end
 
       0
@@ -380,6 +381,7 @@ EOU
         end
       else
         stdout.puts "Cannot find class: #{type_name}"
+        return 1
       end
 
       0


### PR DESCRIPTION
Summary: return a nonzero status from ancestors and methods queries when the requested type is missing, matching the emitted error instead of reporting success.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.