### PR TITLE
Maintain native hash lengths

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -273,6 +273,8 @@ void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs
         hash->tail->next = new_node;
         hash->tail = new_node;
     }
+
+    hash->length++;
 }
 
 rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {
@@ -294,7 +296,7 @@ rbs_ast_symbol_t *RBS_NONNULL rbs_ast_symbol_new(rbs_allocator_t *RBS_NONNULL al
     return instance;
 }
 
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_annotation_t *RBS_NONNULL rbs_ast_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_annotation_t);
 
@@ -308,7 +310,7 @@ rbs_ast_annotation_t *RBS_NONNULL rbs_ast_annotation_new(rbs_allocator_t *RBS_NO
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_bool_t *RBS_NONNULL rbs_ast_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool value) {
     rbs_ast_bool_t *instance = rbs_allocator_alloc(allocator, rbs_ast_bool_t);
 
@@ -322,7 +324,7 @@ rbs_ast_bool_t *RBS_NONNULL rbs_ast_bool_new(rbs_allocator_t *RBS_NONNULL alloca
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_comment_t *RBS_NONNULL rbs_ast_comment_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_comment_t *instance = rbs_allocator_alloc(allocator, rbs_ast_comment_t);
 
@@ -336,7 +338,7 @@ rbs_ast_comment_t *RBS_NONNULL rbs_ast_comment_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_class_t *RBS_NONNULL rbs_ast_declarations_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_ast_declarations_class_super_t *RBS_NULLABLE super_class, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_class_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_t);
 
@@ -360,7 +362,7 @@ rbs_ast_declarations_class_t *RBS_NONNULL rbs_ast_declarations_class_new(rbs_all
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_class_super_t *RBS_NONNULL rbs_ast_declarations_class_super_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_ast_declarations_class_super_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_super_t);
 
@@ -377,7 +379,7 @@ rbs_ast_declarations_class_super_t *RBS_NONNULL rbs_ast_declarations_class_super
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_class_alias_t *RBS_NONNULL rbs_ast_declarations_class_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
     rbs_ast_declarations_class_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_class_alias_t);
 
@@ -398,7 +400,7 @@ rbs_ast_declarations_class_alias_t *RBS_NONNULL rbs_ast_declarations_class_alias
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_constant_t *RBS_NONNULL rbs_ast_declarations_constant_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_declarations_constant_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_constant_t);
 
@@ -417,7 +419,7 @@ rbs_ast_declarations_constant_t *RBS_NONNULL rbs_ast_declarations_constant_new(r
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_global_t *RBS_NONNULL rbs_ast_declarations_global_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_declarations_global_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_global_t);
 
@@ -436,7 +438,7 @@ rbs_ast_declarations_global_t *RBS_NONNULL rbs_ast_declarations_global_new(rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_interface_t *RBS_NONNULL rbs_ast_declarations_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_interface_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_interface_t);
 
@@ -458,7 +460,7 @@ rbs_ast_declarations_interface_t *RBS_NONNULL rbs_ast_declarations_interface_new
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_module_t *RBS_NONNULL rbs_ast_declarations_module_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_list_t *RBS_NONNULL self_types, rbs_node_list_t *RBS_NONNULL members, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range end_range) {
     rbs_ast_declarations_module_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_t);
 
@@ -483,7 +485,7 @@ rbs_ast_declarations_module_t *RBS_NONNULL rbs_ast_declarations_module_new(rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_module_self_t *RBS_NONNULL rbs_ast_declarations_module_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_ast_declarations_module_self_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_self_t);
 
@@ -500,7 +502,7 @@ rbs_ast_declarations_module_self_t *RBS_NONNULL rbs_ast_declarations_module_self
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_module_alias_t *RBS_NONNULL rbs_ast_declarations_module_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL new_name, rbs_type_name_t *RBS_NONNULL old_name, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_node_list_t *RBS_NONNULL annotations, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range eq_range, rbs_location_range old_name_range) {
     rbs_ast_declarations_module_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_module_alias_t);
 
@@ -521,7 +523,7 @@ rbs_ast_declarations_module_alias_t *RBS_NONNULL rbs_ast_declarations_module_ali
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_declarations_type_alias_t *RBS_NONNULL rbs_ast_declarations_type_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range eq_range) {
     rbs_ast_declarations_type_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_declarations_type_alias_t);
 
@@ -543,7 +545,7 @@ rbs_ast_declarations_type_alias_t *RBS_NONNULL rbs_ast_declarations_type_alias_n
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_directives_use_t *RBS_NONNULL rbs_ast_directives_use_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL clauses, rbs_location_range keyword_range) {
     rbs_ast_directives_use_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_t);
 
@@ -558,7 +560,7 @@ rbs_ast_directives_use_t *RBS_NONNULL rbs_ast_directives_use_new(rbs_allocator_t
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_directives_use_single_clause_t *RBS_NONNULL rbs_ast_directives_use_single_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL type_name, rbs_ast_symbol_t *RBS_NULLABLE new_name, rbs_location_range type_name_range) {
     rbs_ast_directives_use_single_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_single_clause_t);
 
@@ -576,7 +578,7 @@ rbs_ast_directives_use_single_clause_t *RBS_NONNULL rbs_ast_directives_use_singl
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_directives_use_wildcard_clause_t *RBS_NONNULL rbs_ast_directives_use_wildcard_clause_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_location_range namespace_range, rbs_location_range star_range) {
     rbs_ast_directives_use_wildcard_clause_t *instance = rbs_allocator_alloc(allocator, rbs_ast_directives_use_wildcard_clause_t);
 
@@ -592,7 +594,7 @@ rbs_ast_directives_use_wildcard_clause_t *RBS_NONNULL rbs_ast_directives_use_wil
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_integer_t *RBS_NONNULL rbs_ast_integer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string_representation) {
     rbs_ast_integer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_integer_t);
 
@@ -606,7 +608,7 @@ rbs_ast_integer_t *RBS_NONNULL rbs_ast_integer_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_alias_t *RBS_NONNULL rbs_ast_members_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL new_name, rbs_ast_symbol_t *RBS_NONNULL old_name, enum rbs_alias_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range keyword_range, rbs_location_range new_name_range, rbs_location_range old_name_range) {
     rbs_ast_members_alias_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_alias_t);
 
@@ -629,7 +631,7 @@ rbs_ast_members_alias_t *RBS_NONNULL rbs_ast_members_alias_new(rbs_allocator_t *
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_attr_accessor_t *RBS_NONNULL rbs_ast_members_attr_accessor_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_accessor_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_accessor_t);
 
@@ -656,7 +658,7 @@ rbs_ast_members_attr_accessor_t *RBS_NONNULL rbs_ast_members_attr_accessor_new(r
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_attr_reader_t *RBS_NONNULL rbs_ast_members_attr_reader_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_reader_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_reader_t);
 
@@ -683,7 +685,7 @@ rbs_ast_members_attr_reader_t *RBS_NONNULL rbs_ast_members_attr_reader_new(rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_attr_writer_t *RBS_NONNULL rbs_ast_members_attr_writer_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_attr_ivar_name_t ivar_name, enum rbs_attribute_kind kind, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, enum rbs_attribute_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_attr_writer_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_attr_writer_t);
 
@@ -710,7 +712,7 @@ rbs_ast_members_attr_writer_t *RBS_NONNULL rbs_ast_members_attr_writer_new(rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_class_instance_variable_t *RBS_NONNULL rbs_ast_members_class_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_class_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_instance_variable_t);
 
@@ -729,7 +731,7 @@ rbs_ast_members_class_instance_variable_t *RBS_NONNULL rbs_ast_members_class_ins
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_class_variable_t *RBS_NONNULL rbs_ast_members_class_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_class_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_class_variable_t);
 
@@ -748,7 +750,7 @@ rbs_ast_members_class_variable_t *RBS_NONNULL rbs_ast_members_class_variable_new
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_extend_t *RBS_NONNULL rbs_ast_members_extend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_extend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_extend_t);
 
@@ -768,7 +770,7 @@ rbs_ast_members_extend_t *RBS_NONNULL rbs_ast_members_extend_new(rbs_allocator_t
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_include_t *RBS_NONNULL rbs_ast_members_include_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_include_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_include_t);
 
@@ -788,7 +790,7 @@ rbs_ast_members_include_t *RBS_NONNULL rbs_ast_members_include_new(rbs_allocator
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_instance_variable_t *RBS_NONNULL rbs_ast_members_instance_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, rbs_node_t *RBS_NONNULL type, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range colon_range) {
     rbs_ast_members_instance_variable_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_instance_variable_t);
 
@@ -807,7 +809,7 @@ rbs_ast_members_instance_variable_t *RBS_NONNULL rbs_ast_members_instance_variab
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_method_definition_t *RBS_NONNULL rbs_ast_members_method_definition_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_method_definition_kind kind, rbs_node_list_t *RBS_NONNULL overloads, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, bool overloading, enum rbs_method_definition_visibility visibility, rbs_location_range keyword_range, rbs_location_range name_range) {
     rbs_ast_members_method_definition_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_t);
 
@@ -832,7 +834,7 @@ rbs_ast_members_method_definition_t *RBS_NONNULL rbs_ast_members_method_definiti
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_method_definition_overload_t *RBS_NONNULL rbs_ast_members_method_definition_overload_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type) {
     rbs_ast_members_method_definition_overload_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_method_definition_overload_t);
 
@@ -847,7 +849,7 @@ rbs_ast_members_method_definition_overload_t *RBS_NONNULL rbs_ast_members_method
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_prepend_t *RBS_NONNULL rbs_ast_members_prepend_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_node_list_t *RBS_NONNULL annotations, rbs_ast_comment_t *RBS_NULLABLE comment, rbs_location_range name_range, rbs_location_range keyword_range) {
     rbs_ast_members_prepend_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_prepend_t);
 
@@ -867,7 +869,7 @@ rbs_ast_members_prepend_t *RBS_NONNULL rbs_ast_members_prepend_new(rbs_allocator
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_private_t *RBS_NONNULL rbs_ast_members_private_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_ast_members_private_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_private_t);
 
@@ -880,7 +882,7 @@ rbs_ast_members_private_t *RBS_NONNULL rbs_ast_members_private_new(rbs_allocator
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_members_public_t *RBS_NONNULL rbs_ast_members_public_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_ast_members_public_t *instance = rbs_allocator_alloc(allocator, rbs_ast_members_public_t);
 
@@ -893,7 +895,7 @@ rbs_ast_members_public_t *RBS_NONNULL rbs_ast_members_public_new(rbs_allocator_t
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_block_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_block_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range ampersand_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_location_range question_location, rbs_location_range type_location, rbs_node_t *RBS_NONNULL type_, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_block_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_block_param_type_annotation_t);
 
@@ -914,7 +916,7 @@ rbs_ast_ruby_annotations_block_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_class_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_class_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NULLABLE type_name, rbs_location_range type_name_location) {
     rbs_ast_ruby_annotations_class_alias_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_class_alias_annotation_t);
 
@@ -931,7 +933,7 @@ rbs_ast_ruby_annotations_class_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_anno
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_colon_method_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_colon_method_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL annotations, rbs_node_t *RBS_NONNULL method_type) {
     rbs_ast_ruby_annotations_colon_method_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_colon_method_type_annotation_t);
 
@@ -947,7 +949,7 @@ rbs_ast_ruby_annotations_colon_method_type_annotation_t *RBS_NONNULL rbs_ast_rub
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_double_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star2_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_double_splat_param_type_annotation_t);
 
@@ -966,7 +968,7 @@ rbs_ast_ruby_annotations_double_splat_param_type_annotation_t *RBS_NONNULL rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_instance_variable_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_instance_variable_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_ast_symbol_t *RBS_NONNULL ivar_name, rbs_location_range ivar_name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_instance_variable_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_instance_variable_annotation_t);
 
@@ -985,7 +987,7 @@ rbs_ast_ruby_annotations_instance_variable_annotation_t *RBS_NONNULL rbs_ast_rub
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_method_types_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_method_types_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL overloads, rbs_location_range_list_t *RBS_NONNULL vertical_bar_locations, rbs_location_range dot3_location) {
     rbs_ast_ruby_annotations_method_types_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_method_types_annotation_t);
 
@@ -1002,7 +1004,7 @@ rbs_ast_ruby_annotations_method_types_annotation_t *RBS_NONNULL rbs_ast_ruby_ann
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_module_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_alias_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_type_name_t *RBS_NULLABLE type_name, rbs_location_range type_name_location) {
     rbs_ast_ruby_annotations_module_alias_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_module_alias_annotation_t);
 
@@ -1019,7 +1021,7 @@ rbs_ast_ruby_annotations_module_alias_annotation_t *RBS_NONNULL rbs_ast_ruby_ann
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_module_self_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_module_self_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range keyword_location, rbs_location_range colon_location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range open_bracket_location, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL args_comma_locations, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_module_self_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_module_self_annotation_t);
 
@@ -1041,7 +1043,7 @@ rbs_ast_ruby_annotations_module_self_annotation_t *RBS_NONNULL rbs_ast_ruby_anno
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_node_type_assertion_t *RBS_NONNULL rbs_ast_ruby_annotations_node_type_assertion_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_t *RBS_NONNULL type) {
     rbs_ast_ruby_annotations_node_type_assertion_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_node_type_assertion_t);
 
@@ -1056,7 +1058,7 @@ rbs_ast_ruby_annotations_node_type_assertion_t *RBS_NONNULL rbs_ast_ruby_annotat
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_param_type_annotation_t);
 
@@ -1074,7 +1076,7 @@ rbs_ast_ruby_annotations_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annot
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_return_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_return_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range return_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL return_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_return_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_return_type_annotation_t);
 
@@ -1092,7 +1094,7 @@ rbs_ast_ruby_annotations_return_type_annotation_t *RBS_NONNULL rbs_ast_ruby_anno
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_skip_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_skip_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range skip_location, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_skip_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_skip_annotation_t);
 
@@ -1108,7 +1110,7 @@ rbs_ast_ruby_annotations_skip_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_splat_param_type_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_location_range star_location, rbs_location_range name_location, rbs_location_range colon_location, rbs_node_t *RBS_NONNULL param_type, rbs_location_range comment_location) {
     rbs_ast_ruby_annotations_splat_param_type_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_splat_param_type_annotation_t);
 
@@ -1127,7 +1129,7 @@ rbs_ast_ruby_annotations_splat_param_type_annotation_t *RBS_NONNULL rbs_ast_ruby
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_ruby_annotations_type_application_annotation_t *RBS_NONNULL rbs_ast_ruby_annotations_type_application_annotation_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_location_range prefix_location, rbs_node_list_t *RBS_NONNULL type_args, rbs_location_range close_bracket_location, rbs_location_range_list_t *RBS_NONNULL comma_locations) {
     rbs_ast_ruby_annotations_type_application_annotation_t *instance = rbs_allocator_alloc(allocator, rbs_ast_ruby_annotations_type_application_annotation_t);
 
@@ -1144,7 +1146,7 @@ rbs_ast_ruby_annotations_type_application_annotation_t *RBS_NONNULL rbs_ast_ruby
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_string_t *RBS_NONNULL rbs_ast_string_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_string_t string) {
     rbs_ast_string_t *instance = rbs_allocator_alloc(allocator, rbs_ast_string_t);
 
@@ -1158,7 +1160,7 @@ rbs_ast_string_t *RBS_NONNULL rbs_ast_string_new(rbs_allocator_t *RBS_NONNULL al
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_ast_type_param_t *RBS_NONNULL rbs_ast_type_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name, enum rbs_type_param_variance variance, rbs_node_t *RBS_NULLABLE upper_bound, rbs_node_t *RBS_NULLABLE lower_bound, rbs_node_t *RBS_NULLABLE default_type, bool unchecked, rbs_location_range name_range) {
     rbs_ast_type_param_t *instance = rbs_allocator_alloc(allocator, rbs_ast_type_param_t);
 
@@ -1183,7 +1185,7 @@ rbs_ast_type_param_t *RBS_NONNULL rbs_ast_type_param_new(rbs_allocator_t *RBS_NO
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_method_type_t *RBS_NONNULL rbs_method_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL type_params, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_location_range type_range) {
     rbs_method_type_t *instance = rbs_allocator_alloc(allocator, rbs_method_type_t);
 
@@ -1201,7 +1203,7 @@ rbs_method_type_t *RBS_NONNULL rbs_method_type_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_namespace_t *RBS_NONNULL rbs_namespace_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL path, bool absolute) {
     rbs_namespace_t *instance = rbs_allocator_alloc(allocator, rbs_namespace_t);
 
@@ -1216,7 +1218,7 @@ rbs_namespace_t *RBS_NONNULL rbs_namespace_new(rbs_allocator_t *RBS_NONNULL allo
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_signature_t *RBS_NONNULL rbs_signature_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL directives, rbs_node_list_t *RBS_NONNULL declarations) {
     rbs_signature_t *instance = rbs_allocator_alloc(allocator, rbs_signature_t);
 
@@ -1231,7 +1233,7 @@ rbs_signature_t *RBS_NONNULL rbs_signature_new(rbs_allocator_t *RBS_NONNULL allo
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_type_name_t *RBS_NONNULL rbs_type_name_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_namespace_t *RBS_NONNULL rbs_namespace, rbs_ast_symbol_t *RBS_NONNULL name) {
     rbs_type_name_t *instance = rbs_allocator_alloc(allocator, rbs_type_name_t);
 
@@ -1246,7 +1248,7 @@ rbs_type_name_t *RBS_NONNULL rbs_type_name_new(rbs_allocator_t *RBS_NONNULL allo
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_alias_t *RBS_NONNULL rbs_types_alias_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_alias_t *instance = rbs_allocator_alloc(allocator, rbs_types_alias_t);
 
@@ -1263,7 +1265,7 @@ rbs_types_alias_t *RBS_NONNULL rbs_types_alias_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_any_t *RBS_NONNULL rbs_types_bases_any_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, bool todo) {
     rbs_types_bases_any_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_any_t);
 
@@ -1277,7 +1279,7 @@ rbs_types_bases_any_t *RBS_NONNULL rbs_types_bases_any_new(rbs_allocator_t *RBS_
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_bool_t *RBS_NONNULL rbs_types_bases_bool_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_bool_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bool_t);
 
@@ -1290,7 +1292,7 @@ rbs_types_bases_bool_t *RBS_NONNULL rbs_types_bases_bool_new(rbs_allocator_t *RB
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_bottom_t *RBS_NONNULL rbs_types_bases_bottom_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_bottom_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_bottom_t);
 
@@ -1303,7 +1305,7 @@ rbs_types_bases_bottom_t *RBS_NONNULL rbs_types_bases_bottom_new(rbs_allocator_t
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_class_t *RBS_NONNULL rbs_types_bases_class_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_class_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_class_t);
 
@@ -1316,7 +1318,7 @@ rbs_types_bases_class_t *RBS_NONNULL rbs_types_bases_class_new(rbs_allocator_t *
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_instance_t *RBS_NONNULL rbs_types_bases_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_instance_t);
 
@@ -1329,7 +1331,7 @@ rbs_types_bases_instance_t *RBS_NONNULL rbs_types_bases_instance_new(rbs_allocat
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_nil_t *RBS_NONNULL rbs_types_bases_nil_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_nil_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_nil_t);
 
@@ -1342,7 +1344,7 @@ rbs_types_bases_nil_t *RBS_NONNULL rbs_types_bases_nil_new(rbs_allocator_t *RBS_
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_self_t *RBS_NONNULL rbs_types_bases_self_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_self_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_self_t);
 
@@ -1355,7 +1357,7 @@ rbs_types_bases_self_t *RBS_NONNULL rbs_types_bases_self_new(rbs_allocator_t *RB
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_top_t *RBS_NONNULL rbs_types_bases_top_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_top_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_top_t);
 
@@ -1368,7 +1370,7 @@ rbs_types_bases_top_t *RBS_NONNULL rbs_types_bases_top_new(rbs_allocator_t *RBS_
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_bases_void_t *RBS_NONNULL rbs_types_bases_void_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_bases_void_t *instance = rbs_allocator_alloc(allocator, rbs_types_bases_void_t);
 
@@ -1381,7 +1383,7 @@ rbs_types_bases_void_t *RBS_NONNULL rbs_types_bases_void_new(rbs_allocator_t *RB
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_block_t *RBS_NONNULL rbs_types_block_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required, rbs_node_t *RBS_NULLABLE self_type) {
     rbs_types_block_t *instance = rbs_allocator_alloc(allocator, rbs_types_block_t);
 
@@ -1397,7 +1399,7 @@ rbs_types_block_t *RBS_NONNULL rbs_types_block_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_class_instance_t *RBS_NONNULL rbs_types_class_instance_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_class_instance_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_instance_t);
 
@@ -1414,7 +1416,7 @@ rbs_types_class_instance_t *RBS_NONNULL rbs_types_class_instance_new(rbs_allocat
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_class_singleton_t *instance = rbs_allocator_alloc(allocator, rbs_types_class_singleton_t);
 
@@ -1431,7 +1433,7 @@ rbs_types_class_singleton_t *RBS_NONNULL rbs_types_class_singleton_new(rbs_alloc
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL required_positionals, rbs_node_list_t *RBS_NONNULL optional_positionals, rbs_node_t *RBS_NULLABLE rest_positionals, rbs_node_list_t *RBS_NONNULL trailing_positionals, rbs_hash_t *RBS_NONNULL required_keywords, rbs_hash_t *RBS_NONNULL optional_keywords, rbs_node_t *RBS_NULLABLE rest_keywords, rbs_node_t *RBS_NULLABLE forwarding, rbs_node_t *RBS_NONNULL return_type) {
     rbs_types_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_t);
 
@@ -1453,7 +1455,7 @@ rbs_types_function_t *RBS_NONNULL rbs_types_function_new(rbs_allocator_t *RBS_NO
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_function_forwarding_param_t *RBS_NONNULL rbs_types_function_forwarding_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location) {
     rbs_types_function_forwarding_param_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_forwarding_param_t);
 
@@ -1466,7 +1468,7 @@ rbs_types_function_forwarding_param_t *RBS_NONNULL rbs_types_function_forwarding
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_function_param_t *RBS_NONNULL rbs_types_function_param_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_ast_symbol_t *RBS_NULLABLE name) {
     rbs_types_function_param_t *instance = rbs_allocator_alloc(allocator, rbs_types_function_param_t);
 
@@ -1482,7 +1484,7 @@ rbs_types_function_param_t *RBS_NONNULL rbs_types_function_param_new(rbs_allocat
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_interface_t *RBS_NONNULL rbs_types_interface_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_type_name_t *RBS_NONNULL name, rbs_node_list_t *RBS_NONNULL args, rbs_location_range name_range) {
     rbs_types_interface_t *instance = rbs_allocator_alloc(allocator, rbs_types_interface_t);
 
@@ -1499,7 +1501,7 @@ rbs_types_interface_t *RBS_NONNULL rbs_types_interface_new(rbs_allocator_t *RBS_
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_intersection_t *RBS_NONNULL rbs_types_intersection_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_intersection_t *instance = rbs_allocator_alloc(allocator, rbs_types_intersection_t);
 
@@ -1513,7 +1515,7 @@ rbs_types_intersection_t *RBS_NONNULL rbs_types_intersection_new(rbs_allocator_t
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_literal_t *RBS_NONNULL rbs_types_literal_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL literal) {
     rbs_types_literal_t *instance = rbs_allocator_alloc(allocator, rbs_types_literal_t);
 
@@ -1527,7 +1529,7 @@ rbs_types_literal_t *RBS_NONNULL rbs_types_literal_new(rbs_allocator_t *RBS_NONN
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_optional_t *RBS_NONNULL rbs_types_optional_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type) {
     rbs_types_optional_t *instance = rbs_allocator_alloc(allocator, rbs_types_optional_t);
 
@@ -1541,7 +1543,7 @@ rbs_types_optional_t *RBS_NONNULL rbs_types_optional_new(rbs_allocator_t *RBS_NO
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_proc_t *RBS_NONNULL rbs_types_proc_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, rbs_types_block_t *RBS_NULLABLE block, rbs_node_t *RBS_NULLABLE self_type) {
     rbs_types_proc_t *instance = rbs_allocator_alloc(allocator, rbs_types_proc_t);
 
@@ -1557,7 +1559,7 @@ rbs_types_proc_t *RBS_NONNULL rbs_types_proc_new(rbs_allocator_t *RBS_NONNULL al
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_record_t *RBS_NONNULL rbs_types_record_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_hash_t *RBS_NONNULL all_fields) {
     rbs_types_record_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_t);
 
@@ -1571,7 +1573,7 @@ rbs_types_record_t *RBS_NONNULL rbs_types_record_new(rbs_allocator_t *RBS_NONNUL
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_record_field_type_t *RBS_NONNULL rbs_types_record_field_type_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL type, bool required) {
     rbs_types_record_field_type_t *instance = rbs_allocator_alloc(allocator, rbs_types_record_field_type_t);
 
@@ -1586,7 +1588,7 @@ rbs_types_record_field_type_t *RBS_NONNULL rbs_types_record_field_type_new(rbs_a
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_tuple_t *RBS_NONNULL rbs_types_tuple_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_tuple_t *instance = rbs_allocator_alloc(allocator, rbs_types_tuple_t);
 
@@ -1600,7 +1602,7 @@ rbs_types_tuple_t *RBS_NONNULL rbs_types_tuple_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_union_t *RBS_NONNULL rbs_types_union_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_list_t *RBS_NONNULL types) {
     rbs_types_union_t *instance = rbs_allocator_alloc(allocator, rbs_types_union_t);
 
@@ -1614,7 +1616,7 @@ rbs_types_union_t *RBS_NONNULL rbs_types_union_new(rbs_allocator_t *RBS_NONNULL 
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_untyped_function_t *RBS_NONNULL rbs_types_untyped_function_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_node_t *RBS_NONNULL return_type) {
     rbs_types_untyped_function_t *instance = rbs_allocator_alloc(allocator, rbs_types_untyped_function_t);
 
@@ -1628,7 +1630,7 @@ rbs_types_untyped_function_t *RBS_NONNULL rbs_types_untyped_function_new(rbs_all
 
     return instance;
 }
-#line 140 "templates/src/ast.c.erb"
+#line 142 "templates/src/ast.c.erb"
 rbs_types_variable_t *RBS_NONNULL rbs_types_variable_new(rbs_allocator_t *RBS_NONNULL allocator, rbs_location_range location, rbs_ast_symbol_t *RBS_NONNULL name) {
     rbs_types_variable_t *instance = rbs_allocator_alloc(allocator, rbs_types_variable_t);
 

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -115,13 +115,7 @@ static void w_hash(rbs_serialize_state *state, rbs_hash_t *hash) {
         return;
     }
 
-    // rbs_hash_t does not maintain its `length` field (unlike rbs_node_list_t),
-    // so count the entries by walking the list.
-    uint32_t count = 0;
-    for (rbs_hash_node_t *n = hash->head; n != NULL; n = n->next) {
-        count++;
-    }
-    w_u32(state, count);
+    w_u32(state, (uint32_t) hash->length);
 
     for (rbs_hash_node_t *n = hash->head; n != NULL; n = n->next) {
         serialize_node(state, n->key);

--- a/templates/src/ast.c.erb
+++ b/templates/src/ast.c.erb
@@ -114,6 +114,8 @@ void rbs_hash_set(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key, rbs
         hash->tail->next = new_node;
         hash->tail = new_node;
     }
+
+    hash->length++;
 }
 
 rbs_node_t *RBS_NULLABLE rbs_hash_get(rbs_hash_t *RBS_NONNULL hash, rbs_node_t *RBS_NONNULL key) {

--- a/templates/src/serialize.c.erb
+++ b/templates/src/serialize.c.erb
@@ -108,13 +108,7 @@ static void w_hash(rbs_serialize_state *state, rbs_hash_t *hash) {
         return;
     }
 
-    // rbs_hash_t does not maintain its `length` field (unlike rbs_node_list_t),
-    // so count the entries by walking the list.
-    uint32_t count = 0;
-    for (rbs_hash_node_t *n = hash->head; n != NULL; n = n->next) {
-        count++;
-    }
-    w_u32(state, count);
+    w_u32(state, (uint32_t) hash->length);
 
     for (rbs_hash_node_t *n = hash->head; n != NULL; n = n->next) {
         serialize_node(state, n->key);


### PR DESCRIPTION
Summary: increment the native hash length only for newly inserted keys and serialize using the maintained count. Replacing a key no longer inflates the count.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.