### PR TITLE
Preserve missing accessor halves when subtracting

### DIFF
--- a/lib/rbs/subtractor.rb
+++ b/lib/rbs/subtractor.rb
@@ -50,11 +50,44 @@ module RBS
 
       context = _ = [context, decl.name]
       children = call(decl.each_decl.to_a, context: context) +
-        decl.each_member.reject { |m| member_exist?(owner, m, context: context) }
+        decl.each_member.filter_map { |m| subtract_member(owner, m, context: context) }
       children = filter_redundant_access_modifiers(children)
       return nil if children.empty?
 
       update_decl(decl, members: children)
+    end
+
+    private def subtract_member(owner, member, context:)
+      if member.is_a?(AST::Members::AttrAccessor)
+        reader_exists = method_exist?(owner, member.name, member.kind)
+        writer_exists = method_exist?(owner, :"#{member.name}=", member.kind)
+
+        case
+        when reader_exists && writer_exists
+          nil
+        when reader_exists
+          accessor_part(member, AST::Members::AttrWriter)
+        when writer_exists
+          accessor_part(member, AST::Members::AttrReader)
+        else
+          member
+        end
+      else
+        member unless member_exist?(owner, member, context: context)
+      end
+    end
+
+    private def accessor_part(member, member_class)
+      member_class.new(
+        name: member.name,
+        type: member.type,
+        ivar_name: member.ivar_name,
+        kind: member.kind,
+        annotations: member.annotations,
+        location: member.location,
+        comment: member.comment,
+        visibility: member.visibility
+      )
     end
 
     private def member_exist?(owner, member, context:)
@@ -67,9 +100,6 @@ module RBS
         method_exist?(owner, member.name, member.kind)
       when AST::Members::AttrWriter
         method_exist?(owner, :"#{member.name}=", member.kind)
-      when AST::Members::AttrAccessor
-        # TODO: It unexpectedly removes attr_accessor even if either reader or writer does not exist in the subtrahend.
-        method_exist?(owner, member.name, member.kind) || method_exist?(owner, :"#{member.name}=", member.kind)
       when AST::Members::InstanceVariable
         ivar_exist?(owner, member.name, :instance)
       when AST::Members::ClassInstanceVariable

--- a/sig/subtractor.rbs
+++ b/sig/subtractor.rbs
@@ -11,6 +11,10 @@ module RBS
 
     private def filter_members: (decl_with_members, context: Resolver::context) -> decl_with_members?
 
+    private def subtract_member: (TypeName owner, AST::Members::t member, context: Resolver::context) -> AST::Members::t?
+
+    private def accessor_part: (AST::Members::AttrAccessor member, singleton(AST::Members::AttrReader) | singleton(AST::Members::AttrWriter) member_class) -> (AST::Members::AttrReader | AST::Members::AttrWriter)
+
     private def member_exist?: (TypeName owner, AST::Members::t, context: Resolver::context) -> boolish
 
     private def method_exist?: (TypeName owner, Symbol method_name, AST::Members::MethodDefinition::kind) -> boolish

--- a/test/rbs/subtractor_test.rb
+++ b/test/rbs/subtractor_test.rb
@@ -419,6 +419,8 @@ class RBS::SubtractorTest < Test::Unit::TestCase
         attr_writer b: untyped
         attr_writer c: untyped
         attr_accessor d: untyped
+        attr_accessor e: untyped
+        attr_accessor f: untyped
       end
     RBS
 
@@ -428,6 +430,9 @@ class RBS::SubtractorTest < Test::Unit::TestCase
         def b=: (String) -> String
         def c: (String) -> String
         def d: (String) -> String
+        def e=: (String) -> String
+        def f: () -> String
+        def f=: (String) -> String
       end
     RBS
 
@@ -436,6 +441,8 @@ class RBS::SubtractorTest < Test::Unit::TestCase
     assert_subtracted <<~RBS, subtracted
       class C
         attr_writer c: untyped
+        attr_writer d: untyped
+        attr_reader e: untyped
       end
     RBS
   end


### PR DESCRIPTION
Summary: split an accessor when only its reader or writer already exists, so subtraction preserves the missing half and its metadata.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.