### PR TITLE
Check the filesystem root for collection config

### DIFF
--- a/lib/rbs/collection/config.rb
+++ b/lib/rbs/collection/config.rb
@@ -24,8 +24,8 @@ module RBS
         loop do
           config_path = current.join(PATH)
           return config_path if config_path.exist?
-          current = current.join('..')
           return nil if current.root?
+          current = current.join('..')
         end
       end
 


### PR DESCRIPTION
Summary: inspect the filesystem root itself before terminating upward collection configuration discovery.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.