### PR TITLE
Run collection cleaner from CLI

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1158,7 +1158,7 @@ EOB
           stderr.puts "#{lock_path} should exist to clean"
           return 1
         end
-        Collection::Cleaner.new(lockfile_path: lock_path)
+        Collection::Cleaner.new(lockfile_path: lock_path).clean
       when 'help', 'hel', 'he', 'h'
         stdout.puts opts.help
       else

--- a/test/rbs/cli_test.rb
+++ b/test/rbs/cli_test.rb
@@ -1734,6 +1734,42 @@ Processing `lib`...
     end
   end
 
+  def test_collection_clean
+    Dir.mktmpdir do |dir|
+      dir = Pathname(dir)
+
+      config_path = dir + RBS::Collection::Config::PATH
+      config_path.write("")
+
+      RBS::Collection::Config.to_lockfile_path(config_path).write(<<~YAML)
+        path: .gem_rbs_collection
+        gems:
+          - name: ast
+            version: "2.4"
+            source:
+              type: git
+              name: ruby/gem_rbs_collection
+              remote: https://github.com/ruby/gem_rbs_collection.git
+              revision: b4d3b346d9657543099a35a1fd20347e75b8c523
+              repo_dir: gems
+      YAML
+
+      collection_dir = dir + ".gem_rbs_collection"
+      (collection_dir + "ast/2.4").mkpath
+      (collection_dir + "ast/2.4/ast.rbs").write("class Ast end")
+      (collection_dir + "ast/2.3").mkpath
+      (collection_dir + "rainbow/3.0").mkpath
+
+      with_cli do |cli|
+        assert_cli_success cli.run(["--collection", config_path.to_s, "collection", "clean"])
+      end
+
+      assert_predicate(collection_dir + "ast/2.4/ast.rbs", :file?)
+      refute_predicate(collection_dir + "ast/2.3", :exist?)
+      refute_predicate(collection_dir + "rainbow/3.0", :exist?)
+    end
+  end
+
   def test_subtract
     Dir.mktmpdir do |dir|
       dir = Pathname(dir)


### PR DESCRIPTION
Summary: invoke the cleaner from the collection clean command instead of constructing it without performing cleanup.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.