### PR TITLE
Preserve runtime prototype keyword rest names

### DIFF
--- a/lib/rbs/prototype/runtime.rb
+++ b/lib/rbs/prototype/runtime.rb
@@ -211,7 +211,8 @@ module RBS
             name or raise
             optional_keywords[name] = Types::Function::Param.new(name: nil, type: untyped)
           when :keyrest
-            rest_keywords = Types::Function::Param.new(name: nil, type: untyped)
+            name = nil if name == :** # For `def f(...) end` syntax
+            rest_keywords = Types::Function::Param.new(name: name, type: untyped)
           when :block
             block = Types::Block.new(
               type: Types::Function.empty(untyped).update(rest_positionals: Types::Function::Param.new(name: nil, type: untyped)),

--- a/test/rbs/runtime_prototype_test.rb
+++ b/test/rbs/runtime_prototype_test.rb
@@ -81,7 +81,7 @@ module RBS
 
         alias bar foo
 
-        def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped) -> untyped
+        def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped d) -> untyped
 
         private
 
@@ -148,7 +148,7 @@ module RBS
 
         alias bar foo
 
-        def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped) -> untyped
+        def foo: (untyped foo, ?untyped bar, *untyped baz, untyped a, b: untyped, ?c: untyped, **untyped d) -> untyped
 
         private
 


### PR DESCRIPTION
Summary: retain named keyword-rest parameters in runtime prototypes while continuing to normalize the anonymous forwarding sentinel.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.