### PR TITLE
Preserve nested aliases when sorting

### DIFF
--- a/lib/rbs/sorter.rb
+++ b/lib/rbs/sorter.rb
@@ -50,6 +50,7 @@ module RBS
           instance_initialize_methods: [],
           public_instance_methods: [],
           private_instance_methods: [],
+          other_decls: [],
         } #: partitioned
 
         members = decl.members.map { |m| sort_decl m }


### PR DESCRIPTION
Summary: initialize the residual declaration partition so nested class, module, and type aliases are retained instead of being dropped or triggering an uninitialized value path.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.