### PR TITLE
Order repository versions semantically

### DIFF
--- a/lib/rbs/collection/sources/stdlib.rb
+++ b/lib/rbs/collection/sources/stdlib.rb
@@ -17,7 +17,7 @@ module RBS
         end
 
         def versions(name)
-          REPO.gems[name].versions.keys.map(&:to_s)
+          REPO.gems[name].version_names.map(&:to_s)
         end
 
         def install(dest:, name:, version:, stdout:)

--- a/lib/rbs/repository.rb
+++ b/lib/rbs/repository.rb
@@ -43,7 +43,7 @@ module RBS
       end
 
       def version_names
-        versions.keys.sort_by(&:version)
+        versions.keys.sort
       end
 
       def oldest_version


### PR DESCRIPTION
Summary: sort repository version objects before returning names so an unspecified stdlib version selects 10.0 after 2.0 rather than relying on filesystem order.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.