### PR TITLE
Propagate rbs test exit status

### DIFF
--- a/lib/rbs/cli.rb
+++ b/lib/rbs/cli.rb
@@ -1075,7 +1075,7 @@ EOB
       stdout.print(out)
       stderr.print(err)
 
-      status.to_i
+      status.exitstatus || 128 + (status.termsig or raise)
     end
 
     def run_collection(args, options)


### PR DESCRIPTION
Summary: return the child exit status, or the conventional signal-derived status, instead of the encoded wait status that can wrap to success at process exit.

Verification: focused baseline/fixed reproduction, combined RBS 4.2.0 consumer models, and RuboCop (738 files, zero offenses). No tests are added in this PR.

Compatibility: no public API removal or dependency/version change.