### PR TITLE
Require object values in serialization schemas

### DIFF
--- a/schema/function.json
+++ b/schema/function.json
@@ -22,6 +22,7 @@
       "required": ["type", "name"]
     }
   },
+  "type": "object",
   "properties": {
     "required_positionals": {
       "title": "Required positional parameters",

--- a/schema/members.json
+++ b/schema/members.json
@@ -77,6 +77,7 @@
     },
     "include": {
       "title": "Include mixin",
+      "type": "object",
       "properties": {
         "member": {
           "enum": ["include"]
@@ -107,6 +108,7 @@
     },
     "extend": {
       "title": "Extend mixin",
+      "type": "object",
       "properties": {
         "member": {
           "enum": ["extend"]
@@ -137,6 +139,7 @@
     },
     "prepend": {
       "title": "Prepend mixin",
+      "type": "object",
       "properties": {
         "member": {
           "enum": ["prepend"]
@@ -168,6 +171,7 @@
     "attribute": {
       "title": "Attribute definitions",
       "description": "`attr_reader`, `attr_accessor`, `attr_writer`",
+      "type": "object",
       "properties": {
         "member": {
           "type": "string",
@@ -232,6 +236,7 @@
     "alias": {
       "title": "Alias declaration",
       "description": "`alias to_s inspect`, `alias self.new self.allocate`, ...",
+      "type": "object",
       "properties": {
         "member": {
           "type": "string",


### PR DESCRIPTION
## Summary

- declare the function serialization payload as a JSON object
- declare include, extend, prepend, attribute, and alias members as JSON objects
- reject scalar, array, and null values that currently bypass `properties` and `required`

## Reproduction

Draft-04 validation ignores `properties` and `required` for non-object instances unless an object type is declared. As a result, the six affected definitions currently accept values such as `null`, `1`, `"value"`, and `[]` even though their serialized forms are objects.

## Verification

- existing schema suite: 11/11 passing
- external negative model: invalid primitive values are rejected and representative serialized objects remain accepted
- current primary plus stdlib suites: 4,140 tests / 66,231 assertions / 0 failures / 0 errors
- native build and complete signature validation
- all nine generated template outputs remain byte-identical
- Rust parser: 47 tests, formatting, and Clippy with warnings denied

No runtime or generated API behavior changes for valid serialized objects.
