### PR TITLE
Preserve CRLF boundaries when deleting comments

### DIFF
--- a/lib/rbs/rewriter.rb
+++ b/lib/rbs/rewriter.rb
@@ -43,7 +43,9 @@ module RBS
     def delete_comment(comment)
       location = comment.location or raise "Comment must have a location"
       line_start = location.start_pos - location.start_column
-      line_end = location.end_pos + 1
+      line_end = location.end_pos
+      line_end += 1 if buffer.content[line_end] == "\r"
+      line_end += 1 if buffer.content[line_end] == "\n"
       loc = Location.new(buffer, line_start, line_end)
       rewrite(loc, "")
     end


### PR DESCRIPTION
## Summary

`Rewriter#delete_comment` currently assumes every comment line ends with exactly one byte. That removes LF correctly, but removes only the carriage return from CRLF input and leaves a blank LF line behind. It can also extend one byte past a comment at EOF.

This change advances over the actual optional carriage-return and newline bytes instead of adding one unconditionally.

## Verification

- external LF, CRLF, and comment-at-EOF boundary models
- Rewriter tests: 20/20
- RDoc annotator tests: 10 tests / 13 assertions
- complete signature validation and native extension compilation
- release-based gem build/install: 568 files; native parser, schemas, and rewrite behavior pass

The behavior for ordinary LF comments remains unchanged.
