### PR TITLE
Complete Types::Block hash semantics

### DIFF
--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -1407,6 +1407,12 @@ module RBS
           other.self_type == self_type
       end
 
+      alias eql? ==
+
+      def hash
+        self.class.hash ^ type.hash ^ required.hash ^ self_type.hash
+      end
+
       def to_json(state = nil)
         {
           type: type,


### PR DESCRIPTION
## Summary

`RBS::Types::Block` implements value equality with `==`, but does not alias `eql?` or define a corresponding `hash`. Equal block types therefore behave as different Hash/Set keys, unlike the surrounding immutable type objects.

Add `eql?` and compute the hash from the same type, required flag, and self type used by equality.

## Verification

- baseline model reproduces the Hash-key miss; focused and cumulative candidates pass
- type tests: 3 tests / 44 assertions
- all 109 runtime files compile on Ruby 4.0.6
- focused candidate syntax, RuboCop, and diff checks pass

Source-only change; no test file is included.
