### PR TITLE
Validate present optional record fields at runtime

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -376,7 +376,10 @@ module RBS
             type.types.map.with_index {|ty, index| value(val[index], ty) }.all?
         when Types::Record
           Test::call(val, IS_AP, ::Hash) &&
-            type.fields.map {|key, type| value(val[key], type) }.all?
+            type.fields.all? {|key, type| value(val[key], type) } &&
+            type.optional_fields.all? do |key, type|
+              !val.key?(key) || value(val[key], type)
+            end
         when Types::Proc
           Test::call(val, IS_AP, ::Proc)
         else


### PR DESCRIPTION
## Summary

Runtime record validation checks required fields but ignores `optional_fields` entirely. A present optional field therefore passes even when its value is incompatible with the declared type.

Validate optional fields only when their key is present, preserving their optional presence contract.

## Verification

- baseline model accepts an invalid present optional value; focused and cumulative candidates reject it while accepting absent/valid values
- runtime type-checking tests: 15 tests / 302 assertions
- all 109 runtime files compile on Ruby 4.0.6
- focused candidate syntax, RuboCop, and diff checks pass

Source-only change; no test file is included.
