### PR TITLE
Accept open-ended typed ranges in runtime checks

### DIFF
--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -280,7 +280,9 @@ module RBS
               value(key, type.args[0]) && value(val[key], type.args[1])
             end
           when klass == ::Range
-            Test.call(val, IS_AP, klass) && value(val.begin, type.args[0]) && value(val.end, type.args[0])
+            Test.call(val, IS_AP, klass) &&
+              (val.begin.nil? || value(val.begin, type.args[0])) &&
+              (val.end.nil? || value(val.end, type.args[0]))
           when klass == ::Enumerator
             if Test.call(val, IS_AP, klass)
               case val.size

--- a/lib/rbs/test/type_check.rb
+++ b/lib/rbs/test/type_check.rb
@@ -281,8 +281,8 @@ module RBS
             end
           when klass == ::Range
             Test.call(val, IS_AP, klass) &&
-              (val.begin.nil? || value(val.begin, type.args[0])) &&
-              (val.end.nil? || value(val.end, type.args[0]))
+              (Test.call(val.begin, IS_AP, ::NilClass) || value(val.begin, type.args[0])) &&
+              (Test.call(val.end, IS_AP, ::NilClass) || value(val.end, type.args[0]))
           when klass == ::Enumerator
             if Test.call(val, IS_AP, klass)
               case val.size


### PR DESCRIPTION
## Summary

Runtime checking for `Range[T]` validates both endpoints as `T`. Beginless and endless ranges use `nil` for one endpoint, so valid `Range[Integer]` values such as `..10` and `1..` are rejected.

Treat a missing endpoint as the range boundary marker and validate only endpoints that are present. The nil check uses the runtime checker's `Test.call` primitive so it also supports minimal `BasicObject` endpoint doubles exercised by RBS.

## Verification

- baseline model rejects valid beginless/endless ranges; the corrected candidate accepts them while retaining endpoint type checks
- minimal endpoint-object model passes without calling `nil?` directly
- Ruby 4 stdlib: 3,072 tests / 56,465 assertions / 0 failures / 0 errors; CGI 2/20, Ractor 22/140, Encoding 45/1,394 also pass
- all 109 runtime files compile on Ruby 4.0.6
- focused candidate syntax, RuboCop, and diff checks pass

Source-only change; no test file is included.
