### PR TITLE
Restore scoped non-simple method type assertions

### DIFF
--- a/lib/rbs/unit_test/type_assertions.rb
+++ b/lib/rbs/unit_test/type_assertions.rb
@@ -354,11 +354,12 @@ module RBS
       end
 
       def allow_non_simple_method_type()
+        previous = @allows_non_simple_method_type
         begin
           @allows_non_simple_method_type = true
           yield
-        rescue
-          @allows_non_simple_method_type = false
+        ensure
+          @allows_non_simple_method_type = previous
         end
       end
 


### PR DESCRIPTION
## Summary

`allow_non_simple_method_type` resets its flag only through `rescue`. It therefore swallows exceptions raised by the caller, fails to restore state after a successful scope, and breaks nested scopes by resetting the outer allowance.

Capture the prior value and restore it in `ensure`, allowing exceptions to propagate normally.

## Verification

- baseline models reproduce exception swallowing, successful-state leakage, and nested-scope loss; focused and cumulative candidates restore all three contracts
- unit-test assertion coverage is included in the cumulative focused models
- all 109 runtime files compile on Ruby 4.0.6
- focused candidate syntax, RuboCop, and diff checks pass

Source-only change; no test file is included.
