### PR TITLE
Update Steep to 2.1 and drop the version constraints

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -24,7 +24,6 @@ target :lib do
   signature "stdlib/rdoc/0/"
   signature "stdlib/ripper/0"
   signature "stdlib/pp/0"
-  signature "steep/patch.rbs"
 
   # configure_code_diagnostics do |config|
   #   config[D::Ruby::MethodDefinitionMissing] = :hint

--- a/lib/rbs/method_type.rb
+++ b/lib/rbs/method_type.rb
@@ -129,12 +129,12 @@ module RBS
     end
 
     def with_nonreturn_void?
-      if type.with_nonreturn_void? # steep:ignore DeprecatedReference
+      if type.with_nonreturn_void?
         true
       else
         if block = block()
-          block.type.with_nonreturn_void? || # steep:ignore DeprecatedReference
-            block.self_type&.with_nonreturn_void? || # steep:ignore DeprecatedReference
+          block.type.with_nonreturn_void? ||
+            block.self_type&.with_nonreturn_void? ||
             false
         else
           false

--- a/lib/rbs/prototype/helpers.rb
+++ b/lib/rbs/prototype/helpers.rb
@@ -6,7 +6,7 @@ module RBS
       private
 
       def parse_comments(string, include_trailing:)
-        Prism.parse_comments(string, version: "current").yield_self do |prism_comments| # steep:ignore UnexpectedKeywordArgument
+        Prism.parse_comments(string, version: "current").yield_self do |prism_comments|
           prism_comments.each_with_object({}) do |comment, hash| #$ Hash[Integer, AST::Comment]
             # Skip EmbDoc comments
             next unless comment.is_a?(Prism::InlineComment)

--- a/lib/rbs/types.rb
+++ b/lib/rbs/types.rb
@@ -251,7 +251,7 @@ module RBS
             # `void` in immediate generics parameter is allowed
             false
           else
-            type.with_nonreturn_void? # steep:ignore DeprecatedReference
+            type.with_nonreturn_void?
           end
         end
       end
@@ -530,7 +530,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        each_type.any? {|type| type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        each_type.any? {|type| type.with_nonreturn_void? }
       end
     end
 
@@ -648,7 +648,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        each_type.any? {|type| type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        each_type.any? {|type| type.with_nonreturn_void? }
       end
     end
 
@@ -734,7 +734,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        each_type.any? {|type| type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        each_type.any? {|type| type.with_nonreturn_void? }
       end
     end
 
@@ -825,7 +825,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        each_type.any? {|type| type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        each_type.any? {|type| type.with_nonreturn_void? }
       end
     end
 
@@ -908,7 +908,7 @@ module RBS
       end
 
       def with_nonreturn_void?
-        each_type.any? {|type| type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        each_type.any? {|type| type.with_nonreturn_void? }
       end
     end
 
@@ -1278,13 +1278,13 @@ module RBS
       end
 
       def with_nonreturn_void?
-        if each_param.any? {|param| param.type.with_nonreturn_void? } # steep:ignore DeprecatedReference
+        if each_param.any? {|param| param.type.with_nonreturn_void? }
           true
         else
           if return_type.is_a?(Bases::Void)
             false
           else
-            return_type.with_nonreturn_void? # steep:ignore DeprecatedReference
+            return_type.with_nonreturn_void?
           end
         end
       end
@@ -1557,11 +1557,11 @@ module RBS
       end
 
       def with_nonreturn_void?
-        if type.with_nonreturn_void? || self_type&.with_nonreturn_void? # steep:ignore DeprecatedReference
+        if type.with_nonreturn_void? || self_type&.with_nonreturn_void?
           true
         else
           if block = block()
-            block.type.with_nonreturn_void? || block.self_type&.with_nonreturn_void? || false # steep:ignore DeprecatedReference
+            block.type.with_nonreturn_void? || block.self_type&.with_nonreturn_void? || false
           else
             false
           end

--- a/sig/unit_test/with_aliases.rbs
+++ b/sig/unit_test/with_aliases.rbs
@@ -73,10 +73,10 @@ module RBS
       def with_int: (?Integer value) { (int) -> void } -> void
                   | (?Integer value) -> WithEnum[int]
 
-      # Yields `::float` objects
+      # Yields `::_ToF` objects
       #
-      def with_float: (?Float value) { (float) -> void } -> void
-                    | (?Float value) -> WithEnum[float]
+      def with_float: (?Float value) { (_ToF) -> void } -> void
+                    | (?Float value) -> WithEnum[_ToF]
 
       # Yields `::string` objects
       #

--- a/steep/Gemfile
+++ b/steep/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rbs", "~> 3.9"
-gem "steep", "~> 1.10"
+gem "rbs"
+gem "steep"
 gem "ruby-lsp"
 gem "test-unit"

--- a/steep/Gemfile.lock
+++ b/steep/Gemfile.lock
@@ -1,30 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3.1)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     ast (2.4.3)
-    base64 (0.3.0)
-    bigdecimal (4.1.2)
     concurrent-ruby (1.3.8)
-    connection_pool (3.0.2)
     csv (3.3.6)
-    drb (2.2.3)
     ffi (1.17.4)
     fileutils (1.8.0)
-    i18n (1.15.2)
-      concurrent-ruby (~> 1.0)
     json (2.21.2)
     language_server-protocol (3.17.0.6)
     listen (3.10.0)
@@ -32,10 +13,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
-    mutex_m (0.3.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
@@ -46,16 +23,16 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.10.4)
+    rbs (4.2.0)
       logger
+      prism (>= 1.6.0)
       tsort
     ruby-lsp (0.26.11)
       language_server-protocol (~> 3.17.0)
       prism (>= 1.2, < 2.0)
       rbs (>= 3, < 5)
     securerandom (0.4.1)
-    steep (1.10.0)
-      activesupport (>= 5.1)
+    steep (2.1.0)
       concurrent-ruby (>= 1.1.10)
       csv (>= 3.0.9)
       fileutils (>= 1.1.0)
@@ -63,10 +40,10 @@ GEM
       language_server-protocol (>= 3.17.0.4, < 4.0)
       listen (~> 3.0)
       logger (>= 1.3.0)
-      mutex_m (>= 0.3.0)
-      parser (>= 3.1)
+      parser (>= 3.2)
+      prism (>= 0.25.0)
       rainbow (>= 2.2.2, < 4.0)
-      rbs (~> 3.9)
+      rbs (~> 4.2)
       securerandom (>= 0.1)
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
@@ -77,8 +54,6 @@ GEM
     test-unit (3.7.8)
       power_assert
     tsort (0.2.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -88,9 +63,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rbs (~> 3.9)
+  rbs
   ruby-lsp
-  steep (~> 1.10)
+  steep
   test-unit
 
 BUNDLED WITH

--- a/steep/patch.rbs
+++ b/steep/patch.rbs
@@ -1,9 +1,0 @@
-# Remove here if duplicated
-
-class Module
-  def ruby2_keywords: (*untyped) -> void
-end
-
-class Proc
-  def ruby2_keywords: () -> self
-end


### PR DESCRIPTION
`bin/steep` and the type check workflow run out of `steep/Gemfile`, whose `~>` constraints kept the weekly `bundle lock --update` on Steep 1.10 and RBS 3.9. This drops them so that the bundle follows the releases, which takes it to Steep 2.1 and RBS 4.2.