### PR TITLE
ruby-rbs-sys: support wasm32-wasip1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -184,3 +184,41 @@ jobs:
         run: |
           cd rust
           cargo clippy
+
+  wasm:
+    name: cargo:wasm
+    runs-on: ubuntu-latest
+    env:
+      # Keep these versions in sync with .github/workflows/wasm.yml.
+      WASI_SDK_VERSION: "33"
+      WASI_SDK_RELEASE: "33.0"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: ruby
+          bundler: none
+      - name: Update rubygems & bundler
+        run: gem update --system
+      - name: Install gems
+        run: |
+          bundle config set --local without libs:profilers
+          bundle install --jobs 4 --retry 3
+      - name: Set up vendored RBS source
+        run: bundle exec rake rust:rbs:sync
+      - name: Install Rust target
+        run: |
+          rustup update --no-self-update stable
+          rustup default stable
+          rustup target add wasm32-wasip1
+      - name: Install the WASI SDK
+        run: |
+          url="https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_RELEASE}-x86_64-linux.tar.gz"
+          mkdir -p "$RUNNER_TEMP/wasi-sdk"
+          curl -sSL "$url" | tar xz --strip-components=1 -C "$RUNNER_TEMP/wasi-sdk"
+          echo "WASI_SDK_PATH=$RUNNER_TEMP/wasi-sdk" >> "$GITHUB_ENV"
+      - name: Build Rust crates for wasm
+        working-directory: rust
+        run: cargo build --locked --target wasm32-wasip1 -p ruby-rbs-sys -p ruby-rbs

--- a/rust/ruby-rbs-sys/build.rs
+++ b/rust/ruby-rbs-sys/build.rs
@@ -11,21 +11,46 @@ fn main() -> Result<(), Box<dyn Error>> {
     let include = vendor_rbs.join("include");
     let c_src = vendor_rbs.join("src");
 
-    build(&include, &c_src)?;
+    let target = env::var("TARGET").unwrap_or_default();
+    let is_wasi = target.contains("wasm32") && target.contains("wasi");
 
-    let bindings = generate_bindings(&include)?;
+    build(&include, &c_src, is_wasi)?;
+
+    let bindings = generate_bindings(&include, is_wasi)?;
     write_bindings(&bindings)?;
 
     Ok(())
 }
 
-fn build(include_dir: &Path, src_dir: &Path) -> Result<(), Box<dyn Error>> {
+fn build(include_dir: &Path, src_dir: &Path, is_wasi: bool) -> Result<(), Box<dyn Error>> {
     let mut build = cc::Build::new();
 
     build.include(include_dir);
 
     // Suppress unused parameter warnings from C code
     build.flag_if_supported("-Wno-unused-parameter");
+
+    if is_wasi {
+        // Compile the C parser with the WASI SDK so that its headers and
+        // runtime support match the target platform.
+        println!("cargo:rerun-if-env-changed=WASI_SDK_PATH");
+
+        let wasi_sdk = PathBuf::from(
+            env::var("WASI_SDK_PATH").expect("WASI_SDK_PATH must be set for wasm builds"),
+        );
+        build.compiler(wasi_sdk.join("bin").join("clang"));
+
+        let sysroot = wasi_sdk.join("share").join("wasi-sysroot");
+        build.flag(format!("--sysroot={}", sysroot.display()));
+        build.include(sysroot.join("include"));
+
+        println!(
+            "cargo:rustc-link-search=native={}",
+            sysroot.join("lib/wasm32-wasi").display()
+        );
+        build.define("_WASI_EMULATED_MMAN", "1");
+        println!("cargo:rustc-link-lib=wasi-emulated-mman");
+    }
 
     build.files(source_files(src_dir)?);
     build.try_compile("rbs")?;
@@ -64,8 +89,11 @@ fn source_files<P: AsRef<Path>>(root_dir: P) -> Result<Vec<String>, Box<dyn Erro
     Ok(files)
 }
 
-fn generate_bindings(include_path: &Path) -> Result<bindgen::Bindings, Box<dyn Error>> {
-    let bindings = bindgen::Builder::default()
+fn generate_bindings(
+    include_path: &Path,
+    is_wasi: bool,
+) -> Result<bindgen::Bindings, Box<dyn Error>> {
+    let mut builder = bindgen::Builder::default()
         .header("wrapper.h")
         .clang_arg(format!("-I{}", include_path.display()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
@@ -172,7 +200,20 @@ fn generate_bindings(include_path: &Path) -> Result<bindgen::Bindings, Box<dyn E
         // Constant pool functions
         .allowlist_function("rbs_constant_pool_free")
         .allowlist_function("rbs_constant_pool_id_to_constant")
-        .allowlist_function("rbs_constant_pool_init")
+        .allowlist_function("rbs_constant_pool_init");
+
+    if is_wasi {
+        // wasm-target bindgen output depends on the libclang implementation
+        // and may drop declarations or make structs opaque. Generate the
+        // ABI declarations with the host target instead; rustc will compile
+        // them for the actual target. Host layout tests are not valid here.
+        let host = env::var("HOST").expect("HOST is not set");
+        builder = builder
+            .clang_arg(format!("--target={host}"))
+            .layout_tests(false);
+    }
+
+    let bindings = builder
         .generate()
         .map_err(|_| "Unable to generate rbs bindings")?;
 


### PR DESCRIPTION
## Summary

Add `wasm32-wasip1` build support for `ruby-rbs-sys` and `ruby-rbs`.

## Motivation

The vendored C parser needs to be compiled with the WASI SDK when the target is a WASI target.

In addition, bindgen output for wasm targets is sensitive to the libclang implementation. Depending on the environment, declarations may be dropped or forward-declared structs may be generated as opaque types.

For WASI builds, this change:

- compiles the C parser with the WASI SDK compiler and sysroot;
- generates bindings with the host target;
- disables bindgen layout tests, which are not valid for host-generated bindings.

Native builds retain the existing behavior. No public Rust API is changed.

## CI

Add a GitHub Actions job that builds both crates for `wasm32-wasip1`.

## Testing

- `git diff --check`
- `cargo fmt --all --manifest-path rust/Cargo.toml -- --check`
- `cargo test --locked --manifest-path rust/Cargo.toml` (52 tests passed)
- `RUSTFLAGS="-D warnings" cargo clippy --locked --manifest-path rust/Cargo.toml`

Follow-up to #2992; related to #2943.