### PR TITLE
Remove the resolved TODO from Sources::Local

### DIFF
--- a/lib/rbs/collection/sources/local.rb
+++ b/lib/rbs/collection/sources/local.rb
@@ -9,7 +9,6 @@ module RBS
         attr_reader :path, :full_path
 
         def initialize(path:, base_directory:)
-          # TODO: resolve relative path from dir of rbs_collection.yaml
           @path = Pathname(path)
           @full_path = base_directory / path
         end


### PR DESCRIPTION
`Sources::Local#initialize` carries a TODO asking to resolve a relative source path from the directory of `rbs_collection.yaml`. That was done three and a half years ago and the comment was left behind. This deletes it.

## Where the TODO came from

The comment arrived in 61dd0e44, a force-push of #854 dated 2022-02-11, where the constructor looked like this:

```ruby
def initialize(source_entry)
  # TODO: resolve relative path from dir of rbs_collection.yaml
  @path = Pathname(source_entry['path'])
end
```

The path really was taken as written and resolved against the working directory, so the TODO described the code accurately at the time.

## Where it was answered

86f4ec5f, pushed to the same PR on 2023-02-08, added the `base_directory:` keyword to `Sources.from_config_entry` and changed the body to `base_directory / path`:

```ruby
def initialize(path:, base_directory:)
  # TODO: resolve relative path from dir of rbs_collection.yaml
  @path = base_directory / path
end
```

`Config#sources` passes `@config_path.dirname` and `Lockfile.from_lockfile` passes `lockfile_path.dirname`, so from that commit on a relative path has been resolved from the directory holding the configuration, which is what the TODO asked for. Only the code was updated; the comment stayed.

#854 ran from 2021-12-23 to 2023-02-17 and its commits were squashed into 718997e8, so the TODO and the change that answered it landed in the same commit. That is why the leftover is not visible from `git log -L` on the file.

## Alternatives considered

#3124 removes the same comment, but also changes `@full_path` to `(base_directory / path).expand_path`. That is a separate change with its own behaviour: it only matters when `base_directory` is relative, which the `rbs` CLI never produces, since `config_path` is either an absolute path from `Config.find_config_path` or the expanded argument of `--collection`. It can be reached by callers that build a `Lockfile` with a relative path, such as Steep. Keeping the two apart lets this one land as the pure comment deletion it is, and leaves the `expand_path` question to be decided on its own merits with a test.

Close #3124

https://github.com/ruby/rbs/pull/854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSq3kKMB8ULhZrnL5urD7y
