### PR TITLE
Report a malformed class instance variable as a syntax error

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2350,7 +2350,7 @@ static bool parse_variable_member(rbs_parser_t *parser, rbs_position_t comment_p
         if (parser->next_token.type == tAIDENT || parser->next_token.type == kATRBS) {
             rbs_parser_advance(parser);
         } else {
-            rbs_parser_set_error(parser, parser->current_token, false, "Unexpected error");
+            rbs_parser_set_error(parser, parser->next_token, true, "unexpected token for class instance variable name");
             return false;
         }
 

--- a/test/rbs/errors_test.rb
+++ b/test/rbs/errors_test.rb
@@ -24,6 +24,29 @@ class RBS::ErrorsTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_signature_with_malformed_class_instance_variable
+    ["class M self.", "module M self.", "class M self.5", %q{class M self."x"}].each do |source|
+      assert_raises RBS::ParsingError, "#{source.inspect} should raise RBS::ParsingError" do
+        RBS::Parser.parse_signature(buffer(source))
+      end
+    end
+  end
+
+  def test_parse_signature_with_malformed_class_instance_variable_detailed_message
+    omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
+
+    assert_raises RBS::ParsingError do
+      RBS::Parser.parse_signature(buffer("class M self.5"))
+    end.tap do |exn|
+      assert_equal <<~DETAILED_MESSAGE, exn.detailed_message
+        test.rbs:1:13...1:14: Syntax error: unexpected token for class instance variable name, token=`5` (tINTEGER) (RBS::ParsingError)
+
+          class M self.5
+                       ^
+      DETAILED_MESSAGE
+    end
+  end
+
   def test_parse_type_with_parsing_error_detailed_message
     omit "Exception#detailed_message does not supported" unless Exception.method_defined?(:detailed_message)
 


### PR DESCRIPTION
Fixes #3148.

`class M self.` raises `RuntimeError: Unexpected error` instead of `RBS::ParsingError`, so it escapes `rescue RBS::ParsingError` and the CLI prints a raw Ruby backtrace. Every other malformed member in the same position reports correctly, and so does the same construct under `interface`:

| input | before |
| --- | --- |
| `class M <<<` | `RBS::ParsingError` with location and caret |
| `interface _I self.` | `RBS::ParsingError` |
| `class M self.` | **`RuntimeError: Unexpected error`** |
| `class M self.5` | **`RuntimeError: Unexpected error`** |

## Cause

`src/parser.c:2353`, in the `kSELF` branch of `parse_variable_member`, passes `false` for the `bool syntax_error` parameter (`include/rbs/parser.h:161`). `raise_error` in `ext/rbs_extension/main.c` then discards the location, token and message and raises a bare `RuntimeError`:

```c
if (!error->syntax_error) {
    rb_raise(rb_eRuntimeError, "Unexpected error");
}
```

49 other call sites in `src/parser.c` pass `true` and produce proper `RBS::ParsingError`s.

## Fix

Pass `syntax_error` with a specific message, in the wording used by the neighbouring sites.

The error is also set on `next_token` rather than `current_token`: the branch tests `parser->next_token.type`, so `next_token` is the offending token, and `current_token` would put the caret on the dot. Sibling sites that test `next_token` set the error on it the same way (lines 178, 288, 316, 325, 555, 665, 688, 704, 981).

## Scope — why only this one site

`src/parser.c` has 12 other `syntax_error = false` sites. I checked them empirically rather than by eye: I tagged each with a unique marker, temporarily stopped `main.c` from discarding `error->message`, rebuilt, and ran targeted probes plus 25,000 mutation-fuzz iterations over the bundled signatures. Only 2353 was reached from user input. The rest are defensive `default:` arms over already-exhausted enums — e.g. the switch at 2383 covers exactly the four token types its caller dispatches on — so they indicate a parser bug, and `RuntimeError` is the correct semantic there. Left untouched.

## Result

```
class M self.      1:13...1:13: unexpected token for class instance variable name, token=`` (pEOF)
module M self.     1:14...1:14: ... token=`` (pEOF)
class M self.5     1:13...1:14: ... token=`5` (tINTEGER)
class M self."x"   1:13...1:16: ... token=`"x"` (tDQSTRING)
```

CLI now prints a formatted error instead of a backtrace:

```
/tmp/bug.rbs:1:13...1:13: Syntax error: unexpected token for class instance variable name, token=`` (pEOF) (RBS::ParsingError)

  class M self.
               ^
```

Valid signatures are unchanged — `self.@x`, `@x` and `@@x` all still parse, and all 342 bundled `core/`, `stdlib/` and `sig/` files parse with no failures. Re-running the 25,000-input fuzz against the fixed build gives 23,649 `RBS::ParsingError` and 0 `RuntimeError`.

## Tests

Added two tests to `test/rbs/errors_test.rb`: one asserting `RBS::ParsingError` across the four malformed forms, one checking the exact `detailed_message` and caret position. Both fail with `RuntimeError(Unexpected error)` without the fix.

Full suite before: `999 tests, 8198 assertions, 0 failures, 0 errors`.
Full suite after: `1001 tests, 8204 assertions, 0 failures, 0 errors`.
